### PR TITLE
fix(authoring): close item when user editing it is removed from desk

### DIFF
--- a/scripts/superdesk-authoring/authoring.js
+++ b/scripts/superdesk-authoring/authoring.js
@@ -906,13 +906,13 @@
         'macros',
         '$timeout',
         '$q',
-        '$window',
         'modal',
         'archiveService',
-        'confirm'
+        'confirm',
+        'reloadService'
     ];
     function AuthoringDirective(superdesk, superdeskFlags, authoringWorkspace, notify, gettext, desks, authoring, api, session, lock,
-            privileges, content, $location, referrer, macros, $timeout, $q, $window, modal, archiveService, confirm) {
+            privileges, content, $location, referrer, macros, $timeout, $q, modal, archiveService, confirm, reloadService) {
         return {
             link: function($scope, elem, attrs) {
                 var _closing;
@@ -1318,11 +1318,12 @@
                     var changeMsg = msg;
                     authoring.saveWorkConfirmation($scope.origItem, $scope.item, $scope.dirty, changeMsg)
                     .then(function(res) {
+                        // after saving work make sure this item won't be open again
                         desks.setCurrentDeskId(null);
+                        $location.search('item', null);
+                        $location.search('action', null);
                     })
-                    ['finally'](function() {
-                        $window.location.reload(true);
-                    });
+                    ['finally'](reloadService.forceReload);
                 });
                 $scope.$on('item:lock', function(_e, data) {
                     if ($scope.item._id === data.item && !_closing &&
@@ -2320,7 +2321,8 @@
             'superdesk.authoring.packages',
             'superdesk.authoring.find-replace',
             'superdesk.authoring.macros',
-            'superdesk.desks'
+            'superdesk.desks',
+            'superdesk.notification'
         ])
 
         .service('authoring', AuthoringService)

--- a/scripts/superdesk-authoring/tests/authoring_spec.js
+++ b/scripts/superdesk-authoring/tests/authoring_spec.js
@@ -132,6 +132,23 @@ describe('authoring', function() {
         expect($scope.item._autosave).toBeNull();
     }));
 
+    it('can close item after save work confirm', inject(function($rootScope, $q, $location, authoring, reloadService) {
+        startAuthoring({headline: 'test'}, 'edit');
+        $location.search('item', 'foo');
+        $location.search('action', 'edit');
+        $rootScope.$digest();
+
+        spyOn(authoring, 'saveWorkConfirmation').and.returnValue($q.when());
+        spyOn(reloadService, 'forceReload');
+
+        $rootScope.$broadcast('savework', 'test');
+        $rootScope.$digest();
+
+        expect($location.search().item).toBe(undefined);
+        expect($location.search().action).toBe(undefined);
+        expect(reloadService.forceReload).toHaveBeenCalled();
+    }));
+
     /**
      * Start authoring ctrl for given item.
      *

--- a/scripts/superdesk-workspace/workspace.js
+++ b/scripts/superdesk-workspace/workspace.js
@@ -296,7 +296,7 @@
                         scope.wsList = _workspaces;
                         scope.workspaceType = activeWorkspace.type;
                         if (activeWorkspace.type === 'desk') {
-                            scope.selected = _.find(scope.desks, {_id: activeWorkspace.id});
+                            scope.selected = _.find(scope.desks, {_id: activeWorkspace.id}) || desks.getCurrentDesk();
                         } else if (activeWorkspace.type === 'workspace') {
                             scope.selected = _.find(scope.wsList, {_id: activeWorkspace.id});
                         } else {

--- a/scripts/superdesk/notification/notification.js
+++ b/scripts/superdesk/notification/notification.js
@@ -165,9 +165,13 @@
                 if (superdeskFlags.flags.authoring) {
                     _this.broadcast(gettext(result.message));
                 } else {
-                    $window.location.reload(true);
+                    this.forceReload();
                 }
             }
+        };
+
+        this.forceReload = function() {
+            return $window.location.reload(true);
         };
 
         this.broadcast = function(msg) {


### PR DESCRIPTION
currently it asks user to save his work into his private space,
but after reload user has still that item opened for edit - but is not able to save.

after fix user won't be on edit item page anymore, instead will be on item list page.

SD-2822