### PR TITLE
fix(authoring): prevent dropdown rendering if not visible

### DIFF
--- a/scripts/superdesk-authoring/metadata/metadata.js
+++ b/scripts/superdesk-authoring/metadata/metadata.js
@@ -184,8 +184,8 @@ function MetadataCtrl(
     resolvePublishScheduleAndEmbargoTS();
 }
 
-MetadropdownFocusDirective.$inject = ['$timeout', 'keyboardManager'];
-function MetadropdownFocusDirective($timeout, keyboardManager) {
+MetadropdownFocusDirective.$inject = ['keyboardManager'];
+function MetadropdownFocusDirective(keyboardManager) {
     return {
         require: 'dropdown',
         link: function(scope, elem, attrs, dropdown) {
@@ -235,8 +235,8 @@ function MetadropdownFocusDirective($timeout, keyboardManager) {
     };
 }
 
-MetadataDropdownDirective.$inject = ['$timeout', '$filter', 'keyboardManager'];
-function MetadataDropdownDirective($timeout, $filter, keyboardManager) {
+MetadataDropdownDirective.$inject = ['$filter', 'keyboardManager'];
+function MetadataDropdownDirective($filter, keyboardManager) {
     return {
         scope: {
             list: '=',
@@ -267,7 +267,7 @@ function MetadataDropdownDirective($timeout, $filter, keyboardManager) {
                 });
             };
 
-            $timeout(function() {
+            scope.$applyAsync(function() {
                 if (scope.list) {
                     if (scope.field === 'place') {
                         scope.places = _.groupBy(scope.list, 'group');
@@ -280,8 +280,8 @@ function MetadataDropdownDirective($timeout, $filter, keyboardManager) {
     };
 }
 
-MetadataWordsListEditingDirective.$inject = ['$timeout'];
-function MetadataWordsListEditingDirective($timeout) {
+MetadataWordsListEditingDirective.$inject = [];
+function MetadataWordsListEditingDirective() {
     return {
         scope: {
             item: '=',
@@ -296,7 +296,7 @@ function MetadataWordsListEditingDirective($timeout) {
             scope.words = [];
             scope.selectedTerm = '';
 
-            $timeout(function() {
+            scope.$applyAsync(function() {
                 element.find('input, select').addClass('line-input');
 
                 if (scope.list) {
@@ -532,8 +532,8 @@ function MetadataListEditingDirective(metadata, $filter, $timeout) {
     };
 }
 
-MetadataLocatorsDirective.$inject = ['$timeout'];
-function MetadataLocatorsDirective($timeout) {
+MetadataLocatorsDirective.$inject = [];
+function MetadataLocatorsDirective() {
     return {
         scope: {
             item: '=',
@@ -550,7 +550,7 @@ function MetadataLocatorsDirective($timeout) {
         link: function(scope, element) {
             scope.selectedTerm = '';
 
-            $timeout(function() {
+            scope.$applyAsync(function() {
                 if (scope.item) {
                     if (scope.fieldprefix && scope.item[scope.fieldprefix] && scope.item[scope.fieldprefix][scope.field]) {
                         scope.selectedTerm = scope.item[scope.fieldprefix][scope.field].city;
@@ -560,9 +560,14 @@ function MetadataLocatorsDirective($timeout) {
                 }
 
                 if (scope.list) {
-                    scope.locators = scope.list;
+                    setLocators(scope.list);
                 }
             });
+
+            function setLocators(list) {
+                scope.locators = list.slice(0, 20);
+                scope.total = list.length;
+            }
 
             /**
              * sdTypeahead directive invokes this method and is responsible for searching located object(s) where the
@@ -572,11 +577,11 @@ function MetadataLocatorsDirective($timeout) {
              */
             scope.searchLocator = function(locator_to_find) {
                 if (!locator_to_find) {
-                    scope.locators = scope.list;
+                    setLocators(scope.list);
                 } else {
-                    scope.locators = _.filter(scope.list, function(t) {
+                    setLocators(_.filter(scope.list, function(t) {
                         return ((t.city.toLowerCase().indexOf(locator_to_find.toLowerCase()) !== -1));
-                    });
+                    }));
                 }
 
                 scope.selectedTerm = locator_to_find;

--- a/scripts/superdesk-authoring/metadata/metadata.js
+++ b/scripts/superdesk-authoring/metadata/metadata.js
@@ -75,7 +75,7 @@ function MetadataCtrl(
             userPrefs;
 
         all = metadata.values.categories || [];
-        userPrefs = prefs['categories:preferred'].selected || {};
+        userPrefs = prefs['categories:preferred'].selected;
 
         // gather article's existing category codes
         itemCategories = $scope.item.anpa_category || [];
@@ -85,7 +85,7 @@ function MetadataCtrl(
         });
 
         filtered = _.filter(all, function (cat) {
-            return userPrefs[cat.qcode] && !assigned[cat.qcode];
+            return !assigned[cat.qcode] && (userPrefs == null || userPrefs[cat.qcode]);
         });
 
         $scope.availableCategories = _.sortBy(filtered, 'name');
@@ -549,6 +549,7 @@ function MetadataLocatorsDirective() {
         templateUrl: 'scripts/superdesk-authoring/metadata/views/metadata-locators.html',
         link: function(scope, element) {
             scope.selectedTerm = '';
+            scope.locators = [];
 
             scope.$applyAsync(function() {
                 if (scope.item) {
@@ -565,7 +566,7 @@ function MetadataLocatorsDirective() {
             });
 
             function setLocators(list) {
-                scope.locators = list.slice(0, 20);
+                scope.locators = list.slice(0, 10);
                 scope.total = list.length;
             }
 

--- a/scripts/superdesk-authoring/metadata/views/metadata-locators.html
+++ b/scripts/superdesk-authoring/metadata/views/metadata-locators.html
@@ -1,7 +1,6 @@
 <div class="term-editor data visible locators" ng-show="!header">
     <div sd-typeahead items="locators" term="selectedTerm" search="searchLocator(term)" select="selectLocator(item)" data-blur="selectLocator(item)" data-disabled="disabled">
         <ul>
-            <li ng-show="total > locators.length"><em translate>too many matches ({{ total }}),<br>showing first {{ locators.length }}</em></li>
             <li typeahead-item="t" ng-repeat="t in locators">
                 {{ :: t.city }}
                 <div class="country_state_info">{{:: t.state}}, {{:: t.country}}</div>

--- a/scripts/superdesk-authoring/metadata/views/metadata-locators.html
+++ b/scripts/superdesk-authoring/metadata/views/metadata-locators.html
@@ -1,7 +1,8 @@
 <div class="term-editor data visible locators" ng-show="!header">
     <div sd-typeahead items="locators" term="selectedTerm" search="searchLocator(term)" select="selectLocator(item)" data-blur="selectLocator(item)" data-disabled="disabled">
         <ul>
-            <li typeahead-item="t" ng-repeat="t in locators ">
+            <li ng-show="total > locators.length"><em translate>too many matches ({{ total }}),<br>showing first {{ locators.length }}</em></li>
+            <li typeahead-item="t" ng-repeat="t in locators">
                 {{ :: t.city }}
                 <div class="country_state_info">{{:: t.state}}, {{:: t.country}}</div>
             </li>

--- a/scripts/superdesk-authoring/metadata/views/metadata-terms.html
+++ b/scripts/superdesk-authoring/metadata/views/metadata-terms.html
@@ -1,21 +1,23 @@
 <div class="term-editor data visible" ng-if="!header">
     <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="selectTerm(item)" data-disabled="disabled">
-        <ul>
+        <ul ng-if="activeTerm">
             <li typeahead-item="t" ng-repeat="t in terms track by t[uniqueField]">{{ :: t.name }}</li>
         </ul>
     </div>
 </div>
 
 <div class="dropdown dropright dropdown-bigger dropdown-terms" dropdown sd-dropdown-focus sd-dropdown-position
-    tooltip="{{ allSelected ? 'All items selected' : ''  | translate }}" tooltip-placement= "left">
+    tooltip="{{ allSelected ? 'All items selected' : ''  | translate }}" tooltip-placement="left">
     <button class="dropdown-toggle" dropdown-toggle ng-disabled="disabled" ng-if="header && !disabled">
         <i class="icon-white icon-plus-large"></i>
     </button>
     <ul class="dropdown-menu nested-menu pull-right">
-        <li ng-show="!activeTerm && header">
-            <ul sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="selectTerm(item)" always-visible="header" data-disabled="disabled || allSelected">
-                <li typeahead-item="t" ng-repeat="t in terms track by t[uniqueField]" ng-if="!activeTree.length || activeList"><button>{{ :: t.name }}</button></li>
-            </ul>
+        <li ng-if="!activeTerm && header">
+            <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="selectTerm(item)" always-visible="header" data-disabled="disabled || allSelected">
+                <ul ng-if="!activeTree.length || activeList">
+                    <li typeahead-item="t" ng-repeat="t in terms track by t[uniqueField]"><button>{{ :: t.name }}</button></li>
+                </ul>
+            </div>
         </li>
         <li class="levelup" ng-if="activeTerm">
             <i class="backlink" ng-click="openParent(activeTerm, $event)"></i>

--- a/scripts/superdesk-search/search.js
+++ b/scripts/superdesk-search/search.js
@@ -1178,6 +1178,7 @@
             'multi',
             'desks',
             'familyService',
+            'Keys',
         function(
             $location,
             $document,
@@ -1195,7 +1196,8 @@
             activityService,
             multi,
             desks,
-            familyService
+            familyService,
+            Keys
         ) {
             return {
                 controllerAs: 'listController',
@@ -1888,14 +1890,6 @@
                                 React.createElement.apply(null, contents)
                             );
                         }
-                    });
-
-                    var Keys = Object.freeze({
-                        left: 37,
-                        up: 38,
-                        right: 39,
-                        down: 40,
-                        enter: 13
                     });
 
                     /**

--- a/scripts/superdesk/keyboard/keyboard.js
+++ b/scripts/superdesk/keyboard/keyboard.js
@@ -3,6 +3,15 @@
 
     return angular.module('superdesk.keyboard', ['gettext'])
 
+    .constant('Keys', Object.freeze({
+        left: 37,
+        up: 38,
+        right: 39,
+        down: 40,
+        enter: 13,
+        escape: 27
+    }))
+
     // unbind all keyboard shortcuts when switching route
     .run(['$rootScope', 'keyboardManager', function($rootScope, kb) {
 

--- a/scripts/superdesk/ui/ui.js
+++ b/scripts/superdesk/ui/ui.js
@@ -396,16 +396,8 @@
         };
     }
 
-    DropdownFocus.$inject = [];
-    function DropdownFocus() {
-        var Keys = Object.freeze({
-            left: 37,
-            up: 38,
-            right: 39,
-            down: 40,
-            enter: 13
-        });
-
+    DropdownFocus.$inject = ['Keys'];
+    function DropdownFocus(Keys) {
         return {
             require: 'dropdown',
             link: function (scope, elem, attrs, dropdown) {
@@ -468,7 +460,7 @@
                                         }
                                     } else {
                                         var buttonSet = elem.find('button:not([disabled]):not(.dropdown-toggle)');
-                                        if (buttonSet !== undefined) {
+                                        if (buttonSet[0] !== undefined) {
                                             buttonSet[0].focus();
                                         }
                                     }

--- a/styles/less/sf-additional.less
+++ b/styles/less/sf-additional.less
@@ -459,6 +459,10 @@
                     font-size: 12px;
                     font-weight: bold;
                 }
+
+                em {
+                    font-size: 11px;
+                }
             }
         }
     }


### PR DESCRIPTION
it does 2 things atm:
- limits number of cities visible in dropdown - user has to type more
- stops rendering of some dropdowns with subjectcodes if not needed

I think this terms dropdown with typeahead will need refactoring, it's still rendering some items even when not visible, but at least not all of them now.