### PR TITLE
feat: make it possible to override template from core

### DIFF
--- a/scripts/superdesk/superdesk.js
+++ b/scripts/superdesk/superdesk.js
@@ -94,5 +94,6 @@
         }]);
 
     angular.module('superdesk.config', []);
+    angular.module('superdesk.templates-cache', []);
     angular.module('superdesk', modules);
 })();

--- a/tasks/options/connect.js
+++ b/tasks/options/connect.js
@@ -19,9 +19,9 @@ module.exports = function(grunt) {
 
                     // avoid 404 in dev server for templates
                     function mockTemplates(req, res, next) {
-                        if (req.url === '/templates-cache.js') {
-                            // return empty cache module
-                            return res.end('angular.module(\'superdesk.templates-cache\', []);');
+                        if (req.url.includes('templates-cache.js')) {
+                            // return empty
+                            return res.end('');
                         } else {
                             return next();
                         }

--- a/tasks/options/ngtemplates.js
+++ b/tasks/options/ngtemplates.js
@@ -1,24 +1,34 @@
 'use strict';
 
+var src = [
+    'scripts/**/*.html',
+    'scripts/**/*.svg'
+];
+
+var options = {
+    htmlmin: {
+        collapseWhitespace: true,
+        collapseBooleanAttributes: true
+    },
+    bootstrap: function(module, script) {
+        return '"use strict";' +
+            'angular.module("superdesk.templates-cache")' +
+            '.run([\'$templateCache\', function($templateCache) {' +
+            script + ' }]);';
+    }
+};
+
 module.exports = {
     app: {
+        cwd: '<%= appDir %>',
+        dest: '<%= distDir %>/app-templates-cache.js',
+        src: src,
+        options: options
+    },
+    core: {
         cwd: '<%= coreDir %>',
-        src: [
-            'scripts/**/*.html',
-            'scripts/**/*.svg'
-        ],
         dest: '<%= distDir %>/templates-cache.js',
-        options: {
-            htmlmin: {
-                collapseWhitespace: true,
-                collapseBooleanAttributes: true
-            },
-            bootstrap: function(module, script) {
-                return '"use strict";' +
-                    'angular.module("superdesk.templates-cache", [])' +
-                    '.run([\'$templateCache\', function($templateCache) {' +
-                    script + ' }]);';
-            }
-        }
+        src: src,
+        options: options
     }
 };


### PR DESCRIPTION
it will pick templates from app/scripts folder and put it into
templates cache. it has to have same filename there, so to override
`core/scripts/superdesk/menu/views/menu.html` you have to name it
`app/scripts/superdesk/menu/views/menu.html`.