### PR TITLE
Images from PA api, don't have a baseImage rendition

### DIFF
--- a/scripts/superdesk-archive/views/single-item-preview.html
+++ b/scripts/superdesk-archive/views/single-item-preview.html
@@ -7,7 +7,7 @@
 
      <!-- picture preview -->
     <div class="full-preview" ng-if="item.type == 'picture'" sd-ratio-calc>
-        <div class="rendition" sd-item-rendition data-item="item" data-ratio="ratio" data-rendition="baseImage"></div>
+        <div class="rendition" sd-item-rendition data-item="item" data-ratio="ratio" data-rendition="original"></div>
     </div>
     
     <!-- text preview -->


### PR DESCRIPTION
I had only tested this dialog on an image I uploaded myself. There's no baseImage rendition for images from the PA images API.