### PR TITLE
Editor2 key shortcuts [SDPA-102]

### DIFF
--- a/scripts/superdesk-authoring/editor/find-replace.js
+++ b/scripts/superdesk-authoring/editor/find-replace.js
@@ -94,6 +94,7 @@ angular.module('superdesk.authoring.find-replace', ['superdesk.authoring.widgets
                 template: 'scripts/superdesk-authoring/editor/views/find-replace.html',
                 order: 2,
                 side: 'right',
+                keyboardShortcut: 'ctrl+f',
                 needEditable: true,
                 needUnlock: true,
                 display: {authoring: true, packages: false, killedItem: false, legalArchive: false, archived: false}

--- a/scripts/superdesk-authoring/editor/views/find-replace.html
+++ b/scripts/superdesk-authoring/editor/views/find-replace.html
@@ -5,6 +5,7 @@
             <label for="find-replace-what" translate>Find</label>
             <input type="text" class="form-control" id="find-replace-what"
                 ng-model="from"
+                sd-autofocus
                 ng-model-options="{debounce: 500}">
         </div>
         <div class="form-group field">

--- a/scripts/superdesk-authoring/widgets/widgets.js
+++ b/scripts/superdesk-authoring/widgets/widgets.js
@@ -40,14 +40,23 @@ function WidgetsManagerCtrl($scope, $routeParams, authoringWidgets, archiveServi
             return !!widget.display[display];
         });
 
-        /*
-         * Navigate throw right tab widgets with keyboard combination
-         * Combination: Ctrl + {{widget number}}
-         */
-        angular.forEach(_.sortBy($scope.widgets, 'order'), function (widget, index) {
-            keyboardManager.bind('ctrl+' + (index + 1), function () {
+        function bindKeyShortcutToWidget(shortcut, widget) {
+            keyboardManager.bind(shortcut, function () {
                 $scope.activate(widget);
             }, {inputDisabled: false});
+        }
+
+        /*
+         * Navigate throw right tab widgets with keyboard combination
+         * Combination: Ctrl + {{widget number}} and custom keys from `keyboardShortcut` property
+         */
+        angular.forEach(_.sortBy($scope.widgets, 'order'), function (widget, index) {
+            // binding ctrl + {{widget number}}
+            bindKeyShortcutToWidget('ctrl+' + (index + 1), widget);
+            // binding keys from `widget.keyboardShortcut` property
+            if (angular.isDefined(widget.keyboardShortcut)) {
+                bindKeyShortcutToWidget(widget.keyboardShortcut, widget);
+            }
             if ($location.search()[widget._id]) {
                 $scope.activate(widget);
             }

--- a/scripts/superdesk/editor2/editor.js
+++ b/scripts/superdesk/editor2/editor.js
@@ -1112,7 +1112,15 @@ angular.module('superdesk.editor2', [
                         var selectedParagraph = angular.element(scope.medium.getSelectedParentElement());
                         var paragraphToBeSelected = selectedParagraph[direction > 0 ? 'next' : 'prev']('p');
                         if (paragraphToBeSelected.length > 0) {
+                            // select the paragraph
                             scope.medium.selectElement(paragraphToBeSelected.get(0));
+                            // scroll to the paragraph
+                            var $scrollableParent = $('.page-content-container');
+                            var offset = $scrollableParent.scrollTop();
+                            offset += paragraphToBeSelected.position().top;
+                            offset += paragraphToBeSelected.closest('.block__container').offset().top;
+                            offset -= 100; //  margin to prevent the top bar to hide the selected paragraph
+                            $scrollableParent.scrollTop(offset);
                         }
                     }
 

--- a/scripts/superdesk/editor2/editor.spec.js
+++ b/scripts/superdesk/editor2/editor.spec.js
@@ -123,7 +123,6 @@ describe('text editor', function() {
 
     it('can check if keyboard event is important or not', inject(function(editor) {
         expect(editor.shouldIgnore({keyCode: 16})).toBe(true);
-        expect(editor.shouldIgnore({keyCode: 39})).toBe(true);
         expect(editor.shouldIgnore({shiftKey: true, ctrlKey: true, keyCode: 65})).toBe(true);
         expect(editor.shouldIgnore({keyCode: 65})).toBe(false);
     }));


### PR DESCRIPTION
- [x] `ctrl`+`⬆️`, `ctrl`+`⬇️` to navigate through the paragraphs in a block
- [x] `shift`+`F3` to reverse the case of the selected text
- [x] `ctrl`+`F` to open the search and replace widget

## Side notes
- Search and replace widget seems unable to find and replace text...