### PR TITLE
fix(templates): avoid updating item when using helpline

### DIFF
--- a/scripts/superdesk-authoring/authoring.js
+++ b/scripts/superdesk-authoring/authoring.js
@@ -2464,8 +2464,8 @@
                         scope.item.body_footer = '';
                     }
 
-                    if (scope.item.body_footer_value) {
-                        scope.item.body_footer = scope.item.body_footer + scope.item.body_footer_value.value;
+                    if (scope.extra.body_footer_value) {
+                        scope.item.body_footer = scope.item.body_footer + '\n<p>' + scope.extra.body_footer_value.value + '</p>';
                         mainEditScope.dirty = true;
                         autosave.save(scope.item);
                     }
@@ -2476,6 +2476,8 @@
                         ddlHelpline[0].options[0].selected = true;
                     });
                 };
+
+                scope.extra = {}; // placeholder for fields not part of item
             }
         };
     }

--- a/scripts/superdesk-authoring/views/article-edit.html
+++ b/scripts/superdesk-authoring/views/article-edit.html
@@ -169,7 +169,7 @@
      order="{{schema.footer.order}}">
     <label translate>Helplines/Contact Information</label>
     <select id="helplines"
-            ng-model="item.body_footer_value"
+            ng-model="extra.body_footer_value"
             ng-disabled="!_editable"
             ng-options="f.name for f in metadata.footers track by f.name"
             ng-change="addHelplineToFooter()"


### PR DESCRIPTION
instead of putting tmp value on item, put it in extra fields,
so there is no need to delete it later on when saving.

also when adding a helpline info, put it together in a `<p></p>`
so it's not mixed when using multiple messages.

SD-3980

to actually save the template it requires https://github.com/superdesk/superdesk-core/pull/250