### PR TITLE
[SD-4270] - Auto publish should not be visible on frontend

### DIFF
--- a/scripts/superdesk-authoring/macros/macros.js
+++ b/scripts/superdesk-authoring/macros/macros.js
@@ -13,8 +13,8 @@ function MacrosService(api, notify) {
             }));
     };
 
-    this.getByDesk = function(desk) {
-        return api.query('macros', {'desk': desk})
+    this.getByDesk = function(desk, includeBackend) {
+        return api.query('macros', {'desk': desk, 'backend': !!includeBackend})
             .then(angular.bind(this, function(macros) {
                 this.macros = macros._items;
                 return this.macros;

--- a/scripts/superdesk-desks/desks.js
+++ b/scripts/superdesk-desks/desks.js
@@ -1081,8 +1081,8 @@
                     scope.statuses = tasks.statuses;
 
                     if (scope.desk.edit && scope.desk.edit._id) {
-                        macros.getByDesk(scope.desk.edit.name).then(function(macros) {
-                            scope.macros = macros;
+                        macros.getByDesk(scope.desk.edit.name, true).then(function(macros) {
+                            scope.macros = _.reject(macros, {action_type: 'interactive'});
                         });
                     }
 
@@ -1440,7 +1440,7 @@
             return {
                 link: function(scope) {
                     if (scope.desk && scope.desk.edit) {
-                        macros.getByDesk(scope.desk.edit.name).then(function(macros) {
+                        macros.getByDesk(scope.desk.edit.name, true).then(function(macros) {
                             scope.macros = macros;
                         });
                     } else {
@@ -1477,8 +1477,8 @@
                                 scope.deskStages = desks.deskStages;
                             });
                         } else if (scope.desk) {
-                            macros.getByDesk(desks.deskLookup[scope.desk].name).then(function(macros) {
-                                scope.deskMacros = macros;
+                            macros.getByDesk(desks.deskLookup[scope.desk].name, true).then(function(macros) {
+                                scope.deskMacros = _.filter(macros, {action_type: 'direct'});
                             });
 
                             if (_.findIndex(scope.deskStages[scope.desk], {_id: scope.stage}) === -1) {

--- a/scripts/superdesk-desks/styles/desks.less
+++ b/scripts/superdesk-desks/styles/desks.less
@@ -395,6 +395,14 @@
         right: 0;
     }
 
+    .modal-footer-relative {
+        position: relative;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        float: right;
+    }
+
     .stages {
         .col {
             position: absolute;

--- a/scripts/superdesk-desks/tests/sdDeskeditMacros-spec.js
+++ b/scripts/superdesk-desks/tests/sdDeskeditMacros-spec.js
@@ -70,7 +70,7 @@ describe('sdDeskeditMacros directive', function() {
         scope = $element.scope();
         scope.$digest();
 
-        expect(macros.getByDesk).toHaveBeenCalledWith('Desk D');
+        expect(macros.getByDesk).toHaveBeenCalledWith('Desk D', true);
     });
 
     it('stores macro list in scope when desk macros data is fetched',

--- a/scripts/superdesk-desks/views/actionpicker.html
+++ b/scripts/superdesk-desks/views/actionpicker.html
@@ -24,7 +24,7 @@
         <label for="macro" translate>Macro</label>
         <select
             id="macro" name="macro"
-            ng-options="m.name as m.label for m in deskMacros"
+            ng-options="m.name as m.name for m in deskMacros"
             ng-model="macro">
             <option value=""></option>
         </select>

--- a/scripts/superdesk-desks/views/desk-config-modal.html
+++ b/scripts/superdesk-desks/views/desk-config-modal.html
@@ -185,21 +185,21 @@
                                 <label>{{ :: 'Incoming Rule' | translate }}</label>
                                 <select ng-model="editStage.incoming_macro">
                                     <option value=""></option>
-                                    <option ng-repeat="macro in macros" ng-selected="editStage.incoming_macro === macro.name" value="{{macro.name}}">{{macro.label}}</option>
+                                    <option ng-repeat="macro in macros" ng-selected="editStage.incoming_macro === macro.name" value="{{macro.name}}">{{macro.name}}</option>
                                 </select>
                             </div>
                             <div class="field">
                                 <label>{{ :: 'Moved onto stage Rule' | translate }}</label>
                                 <select ng-model="editStage.onstage_macro">
                                     <option value=""></option>
-                                    <option ng-repeat="macro in macros" ng-selected="editStage.onstage_macro === macro.name" value="{{macro.name}}">{{macro.label}}</option>
+                                    <option ng-repeat="macro in macros" ng-selected="editStage.onstage_macro === macro.name" value="{{macro.name}}">{{macro.name}}</option>
                                 </select>
                             </div>
                             <div class="field">
                                 <label>{{ :: 'Outgoing Rule' | translate }}</label>
                                 <select ng-model="editStage.outgoing_macro">
                                     <option value=""></option>
-                                    <option ng-repeat="macro in macros" ng-selected="editStage.outgoing_macro === macro.name" value="{{macro.name}}">{{macro.label}}</option>
+                                    <option ng-repeat="macro in macros" ng-selected="editStage.outgoing_macro === macro.name" value="{{macro.name}}">{{macro.name}}</option>
                                 </select>
                             </div>
                         </div>
@@ -236,17 +236,15 @@
             </div>
         </div>
         <div sd-wizard-step data-title="{{ 'Macros' | translate }}" data-code="macros">
-            <div sd-deskedit-macros>
-                <div sd-shadow>
-                    <ul class="pills-list">
-                        <li ng-repeat="macro in macros">
-                            <h6 class="pull-left">{{ macro.label }}</h6>
-                        </li>
-                    </ul>
-                </div>
-                <div class="modal-footer">
-                    <button id="save" class="btn btn-primary" ng-click="save()" translate>Done</button>
-                </div>
+            <div class="content macros" sd-deskedit-macros>
+                <ul class="pills-list">
+                    <li ng-repeat="macro in macros">
+                        <h6 class="pull-left">{{:: macro.name }}</h6><span>[{{:: macro.access_type }}]<span><span>[{{:: macro.action_type }}]<span>
+                    </li>
+                </ul>
+            </div>
+            <div class="modal-footer-relative">
+                <button id="save" class="btn btn-primary" ng-click="save()" translate>Done</button>
             </div>
         </div>
 


### PR DESCRIPTION
1. Macro api accepts a new parameter `includeBackend`
  1. If `false` then api returns only frontend macros
  2. If `true` then api returns both frontend and backend macros
2. When macros are listed for routing and desk/stage settings only the relevant ones will be displayed:
  1. Stage settings won't list `interactive` macros
  2. Routing settingswon't list `interactive` or `background-thread` macros