### PR TITLE
[SD-4263] Fixing the issue where double click on ingested item and publishing failed.

### DIFF
--- a/scripts/superdesk-monitoring/monitoring.js
+++ b/scripts/superdesk-monitoring/monitoring.js
@@ -480,7 +480,7 @@
 
                 var criteria;
 
-                function edit(item, lock) {
+                function edit(item) {
                     if (item.state !== 'spiked'){
                         if (item._type === 'ingest') {
                             var intent = {action: 'list', type: 'ingest'},
@@ -488,7 +488,7 @@
 
                             activityService.start(activity, {data: {item: item}})
                                 .then(function (item) {
-                                    authoringWorkspace.edit(item, !lock);
+                                    authoringWorkspace.edit(item);
                                 });
                         } else if (item.type === 'composite' && item.package_type === 'takes') {
                             authoringWorkspace.view(item);


### PR DESCRIPTION
- `action` was getting set to `true` because of the lock parameter. `lock` parameter is not needed.