### PR TITLE
fix(spellcheck): fix spellcheck word replace

### DIFF
--- a/scripts/superdesk/editor2/editor.js
+++ b/scripts/superdesk/editor2/editor.js
@@ -456,7 +456,7 @@ function EditorService(spellcheck, $rootScope, $timeout, $q, _, renditionsServic
         var node = scope.node;
         var start = findWordNode(node, index, length);
         var characters = start.node.textContent.split('');
-        characters.splice(index, length, word);
+        characters.splice(start.offset, length, word);
         start.node.textContent = characters.join('');
     };
 

--- a/scripts/superdesk/editor2/editor.spec.js
+++ b/scripts/superdesk/editor2/editor.spec.js
@@ -49,6 +49,13 @@ describe('text editor', function() {
         expect(html).toBe('test <b>foo</b> error it');
     }));
 
+    it('can replace word in node', inject(function(editor, $q, $rootScope) {
+        var content = 'test <b>foo</b>';
+        var scope = createScope(content, $rootScope);
+        editor.replaceWord(scope, 5, 3, 'bars');
+        expect(scope.node.innerHTML).toBe('test <b>bars</b>');
+    }));
+
     xit('can findreplace', inject(function(editor, spellcheck, $q, $rootScope, $timeout) {
         spyOn(spellcheck, 'errors').and.returnValue($q.when([{word: 'test', index: 0}]));
         var scope = createScope('test foo and foo', $rootScope);


### PR DESCRIPTION
it was using global index within parent, so adding the word to
the end instead of where it belongs in case there was some markup