### PR TITLE
fix(archive): fix resend action after canceling

### DIFF
--- a/scripts/superdesk-archive/directives.js
+++ b/scripts/superdesk-archive/directives.js
@@ -764,18 +764,21 @@
             function(adminPublishSettingsService, authoring, api, notify, gettext) {
                 return {
                     templateUrl: 'scripts/superdesk-archive/views/resend-configuration.html',
-                    scope: {
-                        'item': '='
-                    },
+                    scope: {item: '='},
                     link: function (scope, elem, attr) {
-                        scope.selectedSubscribers = {items: []};
                         scope.customSubscribers = [];
 
-                        adminPublishSettingsService.fetchSubscribers().then(function(items) {
-                            scope.subscribers = items._items;
-                            _.each(items._items, function(item) {
-                                scope.customSubscribers.push({'qcode': item._id, 'name': item.name});
-                            });
+                        scope.$watch('item', function(item) {
+                            scope.selectedSubscribers = {items: []};
+
+                            if (item && !scope.customSubscribers.length) {
+                                adminPublishSettingsService.fetchSubscribers().then(function(items) {
+                                    scope.subscribers = items._items;
+                                    _.each(items._items, function(item) {
+                                        scope.customSubscribers.push({'qcode': item._id, 'name': item.name});
+                                    });
+                                });
+                            }
                         });
 
                         function getSubscriberIds() {
@@ -802,10 +805,8 @@
                         };
 
                         scope.cancel = function() {
-                            scope.selectedSubscribers = {items: []};
-                            scope.item = false;
+                            scope.item = null;
                         };
-
                     }
                 };
             }

--- a/scripts/superdesk-archive/directives.js
+++ b/scripts/superdesk-archive/directives.js
@@ -766,13 +766,12 @@
                     templateUrl: 'scripts/superdesk-archive/views/resend-configuration.html',
                     scope: {item: '='},
                     link: function (scope, elem, attr) {
-                        scope.customSubscribers = [];
-
                         scope.$watch('item', function(item) {
                             scope.selectedSubscribers = {items: []};
 
-                            if (item && !scope.customSubscribers.length) {
+                            if (item && !scope.customSubscribers) {
                                 adminPublishSettingsService.fetchSubscribers().then(function(items) {
+                                    scope.customSubscribers = [];
                                     scope.subscribers = items._items;
                                     _.each(items._items, function(item) {
                                         scope.customSubscribers.push({'qcode': item._id, 'name': item.name});

--- a/scripts/superdesk-archive/views/resend-configuration.html
+++ b/scripts/superdesk-archive/views/resend-configuration.html
@@ -7,7 +7,7 @@
 
     <div class="modal-body">
         <fieldset>
-            <div class="field">
+            <div class="field" ng-show="customSubscribers">
                 <label translate>Select Subscribers</label>
                 <div class="term-editor"
                      sd-meta-terms

--- a/scripts/superdesk-archive/views/resend-configuration.html
+++ b/scripts/superdesk-archive/views/resend-configuration.html
@@ -1,12 +1,11 @@
-<form name="editForm">
 <div sd-modal data-model="item" class="resend-popup">
+    <form name="editForm">
     <div class="modal-header">
         <a href="" class="close" ng-click="cancel()"><i class="icon-close-small"></i></a>
         <h3 translate>Resend To</h3>
     </div>
 
     <div class="modal-body">
-        
         <fieldset>
             <div class="field">
                 <label translate>Select Subscribers</label>
@@ -17,10 +16,10 @@
                      data-unique="qcode"
                      data-list="customSubscribers"
                      data-header="true"
+                     data-reload-list="true"
                      ></div>
             </div>
         </fieldset>
-
     </div>
 
     <div class="modal-footer">
@@ -29,5 +28,5 @@
             ng-disabled="selectedSubscribers.items.length == 0" translate>Resend</button>
         <button id="cancel-edit-btn" type="button" class="btn pull-right" ng-click="cancel()" translate>Cancel</button>
     </div>
+    </form>
 </div>
-</form>

--- a/scripts/superdesk-authoring/metadata/metadata.js
+++ b/scripts/superdesk-authoring/metadata/metadata.js
@@ -507,6 +507,7 @@ function MetaTermsDirective(metadata, $filter, $timeout) {
             var includeParent = scope.includeParent === 'true' ? true : false;
             scope.combinedList = [];
 
+            scope.tree = {};
             scope.termPath = [];
 
             scope.$watch('unique', function(value) {

--- a/scripts/superdesk-monitoring/views/monitoring-view.html
+++ b/scripts/superdesk-monitoring/views/monitoring-view.html
@@ -130,5 +130,5 @@
     </section>
     <div sd-archived-item-kill ng-if="archived_kill" data-item="archived_kill"></div>
 
-    <div sd-resend-item ng-if="resend" data-item="resend"></div>
+    <div sd-resend-item data-item="resend"></div>
 </div>

--- a/scripts/superdesk-search/views/search-results.html
+++ b/scripts/superdesk-search/views/search-results.html
@@ -19,7 +19,7 @@
         </div>
 
         <div sd-archived-item-kill ng-if="selected.archived_kill" data-item="selected.archived_kill"></div>
-        <div sd-resend-item ng-if="selected.resend" data-item="selected.resend"></div>
+        <div sd-resend-item data-item="selected.resend"></div>
 
     </div>
 </div>


### PR DESCRIPTION
due to `ngIf` it created child scope so on cancel setting it to null
made this part of child scope so it wouldn't pick changes from parent

SD-4345

added also one more related fix for resend subscribers dropdown:
once subscribers got loaded it didn't trigger a watch in meta terms
directive so it wouldn't populate the list. so now when assigning
it first creates a new instance of the list. plus it will hide that
subscribers dropdown before it gets popuplated.

SD-4346