### PR TITLE
fix(editor): avoid undo/redo operations after load

### DIFF
--- a/scripts/superdesk/editor/editor.js
+++ b/scripts/superdesk/editor/editor.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+var TYPING_CLASS = 'typing';
+
 /**
  * Escape given string for reg exp
  *
@@ -615,8 +617,10 @@ function EditorService(spellcheck, $rootScope, $timeout, $q) {
      * @param {Scope} scope
      */
     this.undo = function(scope) {
-        scope.history.selectPrev();
-        useHistory(scope);
+        if (scope.history.getIndex() > -1) {
+            scope.history.selectPrev();
+            useHistory(scope);
+        }
     };
 
     /**
@@ -625,8 +629,11 @@ function EditorService(spellcheck, $rootScope, $timeout, $q) {
      * @param {Scope} scope
      */
     this.redo = function(scope) {
+        var oldIndex = scope.history.getIndex();
         scope.history.selectNext();
-        useHistory(scope);
+        if (oldIndex !== scope.history.getIndex()) {
+            useHistory(scope);
+        }
     };
 
     /**
@@ -658,7 +665,6 @@ function EditorService(spellcheck, $rootScope, $timeout, $q) {
      * @param {Scope} scope
      */
     function useHistory(scope) {
-        var TYPING_CLASS = 'typing';
         var val = scope.history.get() || '';
         var checkVal = val.innerHTML ? clearRangy(angular.copy(val)).innerHTML : val;
         if (clean(scope.node).innerHTML !== checkVal) {
@@ -695,8 +701,6 @@ angular.module('superdesk.editor', ['superdesk.editor.spellcheck'])
             templateUrl: 'scripts/superdesk/editor/views/editor.html',
             link: function(scope, elem, attrs, ngModel) {
                 scope.model = ngModel;
-
-                var TYPING_CLASS = 'typing';
 
                 var editorElem;
                 var updateTimeout;
@@ -740,9 +744,14 @@ angular.module('superdesk.editor', ['superdesk.editor.spellcheck'])
                                 event.stopPropagation();
                             }
 
+                            if (event.ctrlKey && ctrlOperations[event.keyCode]) {
+                                event.preventDefault();
+                            }
+
                             if (editor.shouldIgnore(event)) {
                                 return;
                             }
+
                             cancelTimeout();
                         });
 

--- a/scripts/superdesk/editor/editor.spec.js
+++ b/scripts/superdesk/editor/editor.spec.js
@@ -98,6 +98,11 @@ describe('text editor', function() {
         editor.commit();
         expect(scope.model.$setViewValue).not.toHaveBeenCalled();
 
+        editor.undo(scope);
+        expect(scope.model.$setViewValue).not.toHaveBeenCalled();
+        editor.redo(scope);
+        expect(scope.model.$setViewValue).not.toHaveBeenCalled();
+
         scope.node.innerHTML = 'bar';
         editor.commit();
         expect(scope.model.$setViewValue).toHaveBeenCalledWith('bar');


### PR DESCRIPTION
it might try to replace node content with same value (with different
whitespace) but then there is no change so it won't trigger highlights rendering.

SD-4065