### PR TITLE
(fix) Fixing issues related to schedule and embargo dates.

### DIFF
--- a/scripts/superdesk-authoring/metadata/metadata.js
+++ b/scripts/superdesk-authoring/metadata/metadata.js
@@ -101,14 +101,7 @@ function MetadataCtrl(
 
     $scope.$watch('item.time_zone', function(newValue, oldValue) {
         if ((newValue || oldValue) && (newValue !== oldValue)) {
-            $scope.item.schedule_settings = {};
-
-            if (!$scope.item.time_zone) {
-                $scope.item.schedule_settings.time_zone = null;
-            } else {
-                $scope.item.schedule_settings.time_zone = $scope.item.time_zone;
-            }
-
+            setTimeZone();
             setPublishScheduleDate(newValue, oldValue);
             setEmbargoTS(newValue, oldValue);
 
@@ -118,6 +111,15 @@ function MetadataCtrl(
         }
     });
 
+    function setTimeZone() {
+        $scope.item.schedule_settings = {};
+        if (!$scope.item.time_zone) {
+            $scope.item.schedule_settings.time_zone = null;
+        } else {
+            $scope.item.schedule_settings.time_zone = $scope.item.time_zone;
+        }
+    }
+
     function setPublishScheduleDate(newValue, oldValue) {
         if ((newValue || oldValue) && (newValue !== oldValue)) {
             if ($scope.item.publish_schedule_date && $scope.item.publish_schedule_time) {
@@ -126,6 +128,7 @@ function MetadataCtrl(
                     $scope.item.publish_schedule_time,
                     $scope.item.time_zone
                 );
+                setTimeZone();
             } else {
                 $scope.item.publish_schedule = null;
             }
@@ -160,6 +163,7 @@ function MetadataCtrl(
                     $scope.item.embargo_time,
                     $scope.item.time_zone
                 );
+                setTimeZone();
             } else {
                 $scope.item.embargo = null;
             }
@@ -175,19 +179,26 @@ function MetadataCtrl(
      */
     function resolvePublishScheduleAndEmbargoTS() {
         var info;
-
+        var embargo = $scope.item.embargo, publish_schedule = $scope.item.publish_schedule;
         if ($scope.item.schedule_settings) {
             $scope.item.time_zone = $scope.item.schedule_settings.time_zone;
+            if ($scope.item.schedule_settings.utc_embargo) {
+                embargo = $scope.item.schedule_settings.utc_embargo;
+            }
+
+            if ($scope.item.schedule_settings.utc_publish_schedule) {
+                publish_schedule = $scope.item.schedule_settings.utc_publish_schedule;
+            }
         }
 
-        if ($scope.item.embargo) {
-            info = datetimeHelper.splitDateTime($scope.item.embargo, $scope.item.time_zone);
+        if (embargo) {
+            info = datetimeHelper.splitDateTime(embargo, $scope.item.time_zone);
             $scope.item.embargo_date = info.date;
             $scope.item.embargo_time = info.time;
         }
 
-        if ($scope.item.publish_schedule) {
-            info = datetimeHelper.splitDateTime($scope.item.publish_schedule, $scope.item.time_zone);
+        if (publish_schedule) {
+            info = datetimeHelper.splitDateTime(publish_schedule, $scope.item.time_zone);
             $scope.item.publish_schedule_date = info.date;
             $scope.item.publish_schedule_time = info.time;
         }

--- a/scripts/superdesk-authoring/views/send-item.html
+++ b/scripts/superdesk-authoring/views/send-item.html
@@ -36,10 +36,10 @@
             <label class="label--lite" translate>Embargo</label>
             <ul class="btn-list">
                 <li class="datepicker-input--dark">
-                    <div sd-datepicker ng-model="item.embargo_date" ng-disabled="!isEmbargoEditable()"></div>
+                    <div sd-datepicker ng-model="item.embargo_date"></div>
                 </li>
                 <li class="timepicker-input--dark">
-                    <div sd-timepicker ng-model="item.embargo_time" ng-disabled="!isEmbargoEditable()"></div>
+                    <div sd-timepicker ng-model="item.embargo_time"></div>
                 </li>
             </ul>
         </div>

--- a/scripts/superdesk-dashboard/workspace-tasks/tasks.js
+++ b/scripts/superdesk-dashboard/workspace-tasks/tasks.js
@@ -13,7 +13,7 @@ function TasksService(desks, $rootScope, api, datetimeHelper) {
 
     this.save = function(orig, task) {
         if (task.task.due_time) {
-            task.task.due_date = datetimeHelper.mergeDateTime(task.task.due_date, task.task.due_time).format();
+            task.task.due_date = datetimeHelper.mergeDateTime(task.task.due_date, task.task.due_time);
         }
         delete task.task.due_time;
         if (!task.task.user) {

--- a/scripts/superdesk/datetime/datetime.js
+++ b/scripts/superdesk/datetime/datetime.js
@@ -110,7 +110,6 @@
 
         /*
         * @param timestring 2016-03-01T04:45:00+0000.
-        * @param timezone Europe/London
         */
         this.greaterThanUTC = function(timestring) {
             return moment(timestring, 'YYYY-MM-DDTHH:mm:ssZZ') > moment.utc();

--- a/scripts/superdesk/datetime/datetime.js
+++ b/scripts/superdesk/datetime/datetime.js
@@ -107,6 +107,14 @@
             // return without timezone information, which is stored separately
             return moment.tz(merge_str, formatter, tz).format('YYYY-MM-DD[T]HH:mm:ss');
         };
+
+        /*
+        * @param timestring 2016-03-01T04:45:00+0000.
+        * @param timezone Europe/London
+        */
+        this.greaterThanUTC = function(timestring) {
+            return moment(timestring, 'YYYY-MM-DDTHH:mm:ssZZ') > moment.utc();
+        };
     }
 
     return angular.module('superdesk.datetime', [


### PR DESCRIPTION
- For `publish_schedule` and `embargo` validation is done using utc dates.
- `Embargo` can be modified while correcting the story.
- Remove `embargo` setting if embargo as lapsed or killed.