### PR TITLE
fix(metadata): show all categories for users without prefs

### DIFF
--- a/scripts/superdesk-authoring/metadata/metadata.js
+++ b/scripts/superdesk-authoring/metadata/metadata.js
@@ -57,7 +57,7 @@ function MetadataCtrl(
         });
 
         filtered = _.filter(all, function (cat) {
-            return !assigned[cat.qcode] && (userPrefs == null || userPrefs[cat.qcode]);
+            return !assigned[cat.qcode] && (_.isEmpty(userPrefs) || userPrefs[cat.qcode]);
         });
 
         $scope.availableCategories = _.sortBy(filtered, 'name');

--- a/scripts/superdesk-authoring/metadata/tests/MetadataWidgetCtrl_spec.js
+++ b/scripts/superdesk-authoring/metadata/tests/MetadataWidgetCtrl_spec.js
@@ -74,6 +74,20 @@ describe('MetadataWidgetCtrl controller', function () {
             [{qcode: 'a'}, {qcode: 'c'}]
         );
     });
+
+    it('can pupulate list of categories for new users', function() {
+        metadata.values = {
+            categories: [
+                {qcode: 'a'}, {qcode: 'b'}, {qcode: 'c'}, {qcode: 'd'}
+            ]
+        };
+
+        metaInit.resolve();
+        prefsGet.resolve({'categories:preferred': {selected: {}}});
+        scope.$digest();
+
+        expect(scope.availableCategories.length).toBe(4);
+    });
 });
 
 describe('metadata list editing directive', function() {


### PR DESCRIPTION
before users set their preference regarding categories, they have
empty dropdown in authoring which prevents them from publishing.

so in case the preferences are empty list - show all categories.