### PR TITLE
SD-4107 - ui(templates): removed restriction to view only desk templates

### DIFF
--- a/scripts/superdesk-templates/styles/templates.less
+++ b/scripts/superdesk-templates/styles/templates.less
@@ -1,4 +1,8 @@
 .template-card {
+    .card-box__header--dark {
+        background-color: #747c87;
+    }
+
     .card-box__content {
         min-height: 120px; /* should be big enough to fit in dropdown menu */
     }
@@ -11,5 +15,14 @@
         text-overflow: ellipsis;
         overflow: hidden;
         &:first-of-type { margin-right: 3px; }
+    }
+}
+
+.header {
+    .sortbar {
+        .lab { margin-top: -2px; }
+        margin: 3px 10px 0 0;
+        padding: 0 5px 0 0;
+        border-right: 2px dotted #bcbcbc;
     }
 }

--- a/scripts/superdesk-templates/templates.js
+++ b/scripts/superdesk-templates/templates.js
@@ -98,15 +98,12 @@
                 criteria.$or = [];
 
                 if (user) { // user private templates
-                    criteria.$or.push({user: user, is_public: false});
+                    criteria.$or.push({user: user});
                 }
 
                 if (desk) { // all non private desk templates
-                    criteria.$or.push({template_desk: desk, is_public: {$ne: false}});
+                    criteria.$or.push({template_desk: desk});
                 }
-            } else {
-                // only show public templates
-                criteria.is_public = {$ne: false};
             }
 
             if (!_.isEmpty(criteria)) {
@@ -312,8 +309,63 @@
                         true;
                 };
 
+                $scope.filters = [
+                    {label: gettext('All'), value: 'All'},
+                    {label: gettext('Personal'), value: 'Personal'},
+                    {label: gettext('No Desk'), value: 'None'}
+                ];
+
+                // holds the index of the active filter.
+                $scope.activeFilter = 0;
+
+                // sets the active filter to another index.
+                $scope.filterBy = function(idx) {
+                    $scope.activeFilter = idx;
+                };
+
+                // fetch all desks for the current user and add them to
+                // the list of filters.
+                desks.fetchCurrentUserDesks().then(function(desks) {
+                    $scope.filters = $scope.filters.concat(
+                        desks._items.map(function(d) {
+                            return {label: d.name, value: d._id};
+                        })
+                    );
+                });
+
                 fetchTemplates();
             }
+        };
+    }
+
+    /**
+     * @description Returns a function that allows filtering an array of
+     * templates by various criteria.
+     */
+    function FilterTemplatesFilter() {
+        /**
+         * @description Returns a new array based on the passed filter.
+         * @param {Array<Object>} all - Array of templates to filter.
+         * @param {Object} f - The filter. Contains keys 'label' and 'value'.
+         * If the 'value' is 'All', the entire array is returned. For 'None',
+         * only the items without a desk are returned. For 'Personal', only
+         * non-public items are returned, and every other value is a hash that
+         * represents the desk to filter by.
+         * @returns {Array<Object>} The filtered array.
+         */
+        return function(all, f) {
+            return (all || []).filter(function(item) {
+                switch (f.value) {
+                    case 'All':
+                        return all;
+                    case 'None':
+                        return item.is_public && typeof item.template_desk === 'undefined';
+                    case 'Personal':
+                        return !item.is_public;
+                    default:
+                        return item.template_desk === f.value;
+                }
+            });
         };
     }
 
@@ -472,6 +524,7 @@
 
     angular.module('superdesk.templates', ['superdesk.activity', 'superdesk.authoring', 'superdesk.preferences'])
         .service('templates', TemplatesService)
+        .filter('templatesBy', FilterTemplatesFilter)
         .directive('sdTemplates', TemplatesDirective)
         .directive('sdTemplateSelect', TemplateSelectDirective)
         .directive('sdTemplateList', TemplateListDirective)

--- a/scripts/superdesk-templates/templates.spec.js
+++ b/scripts/superdesk-templates/templates.spec.js
@@ -68,16 +68,14 @@ describe('templates', function() {
             templates.fetchTemplates();
             expect(api.query).toHaveBeenCalledWith('content_templates', {
                 max_results: 10,
-                page: 1,
-                where: '{"$and":[{"is_public":{"$ne":false}}]}'
+                page: 1
             });
         }));
         it('can fetch templates using page parameters', inject(function(api, templates) {
             templates.fetchTemplates(2, 25);
             expect(api.query).toHaveBeenCalledWith('content_templates', {
                 max_results: 25,
-                page: 2,
-                where: '{"$and":[{"is_public":{"$ne":false}}]}'
+                page: 2
             });
         }));
         it('can fetch templates using type parameter', inject(function(api, templates) {
@@ -85,7 +83,7 @@ describe('templates', function() {
             expect(api.query).toHaveBeenCalledWith('content_templates', {
                 max_results: 10,
                 page: 1,
-                where: '{"$and":[{"template_type":"create","is_public":{"$ne":false}}]}'
+                where: '{"$and":[{"template_type":"create"}]}'
             });
         }));
         it('can fetch templates using desk parameter', inject(function(api, templates) {
@@ -93,7 +91,7 @@ describe('templates', function() {
             expect(api.query).toHaveBeenCalledWith('content_templates', {
                 max_results: 10,
                 page: 1,
-                where: '{"$and":[{"$or":[{"template_desk":"desk1","is_public":{"$ne":false}}]}]}'
+                where: '{"$and":[{"$or":[{"template_desk":"desk1"}]}]}'
             });
         }));
         it('can fetch templates using personal desk parameter', inject(function(api, templates) {
@@ -101,7 +99,7 @@ describe('templates', function() {
             expect(api.query).toHaveBeenCalledWith('content_templates', {
                 max_results: 10,
                 page: 1,
-                where: '{"$and":[{"$or":[{"user":"foo","is_public":false}]}]}'
+                where: '{"$and":[{"$or":[{"user":"foo"}]}]}'
             });
         }));
         it('can fetch templates using keyword parameter', inject(function(api, templates) {
@@ -109,7 +107,7 @@ describe('templates', function() {
             expect(api.query).toHaveBeenCalledWith('content_templates', {
                 max_results: 10,
                 page: 1,
-                where: '{"$and":[{"template_name":{"$regex":"keyword","$options":"-i"},"is_public":{"$ne":false}}]}'
+                where: '{"$and":[{"template_name":{"$regex":"keyword","$options":"-i"}}]}'
             });
         }));
         it('can fetch templates by id', inject(function(api, templates) {
@@ -175,8 +173,8 @@ describe('templates', function() {
             var where = JSON.parse(args[1].where);
             expect(where.$and.length).toBe(1);
             var $or = where.$and[0].$or;
-            expect($or).toContain({is_public: {$ne: false}, template_desk: 'sports'});
-            expect($or).toContain({is_public: false, user: session.identity._id});
+            expect($or).toContain({template_desk: 'sports'});
+            expect($or).toContain({user: session.identity._id});
             $rootScope.$digest();
             var iscope = elem.isolateScope();
             expect(iscope.publicTemplates.length).toBe(2);

--- a/scripts/superdesk-templates/views/templates.html
+++ b/scripts/superdesk-templates/views/templates.html
@@ -1,15 +1,29 @@
 <div class="split-content">
   <div class="header">
     <h2 translate>Templates</h2>
-    <button class="btn btn-info pull-right" ng-click="edit()">
-      <i class="icon-plus-sign icon-white"></i> <span translate>Add New Template</span>
-    </button>
+    <div class="pull-right">
+        <div class="sortbar pull-left">
+           <span class="lab" translate>Filter:</span>
+           <div class="dropdown" dropdown sd-dropdown-position>
+             <button id="order_button" class="dropdown-toggle" dropdown-toggle>{{ filters[activeFilter].label | translate }} <b class="caret"></b>
+             </button>
+             <ul class="dropdown-menu left-submenu" id="order_selector">
+                <li ng-repeat="f in filters track by $index" ng-class="{active: activeFilter === $index}">
+                  <a href="" ng-click="filterBy($index)">{{ f.label | translate }}</a>
+                </li>
+             </ul>
+           </div>
+        </div>
+        <button class="btn btn-info" ng-click="edit()">
+          <i class="icon-plus-sign icon-white"></i> <span translate>Add New Template</span>
+        </button>
+    </div>
   </div>
 
   <div class="content">
       <div class="flex-grid box wrap-items small-2 medium-4 large-6">
-          <div class="flex-item card-box template-card" ng-repeat="template in content_templates._items track by template._id" ng-if="desks">
-              <div class="card-box__header">
+          <div class="flex-item card-box template-card" ng-repeat="template in content_templates._items | templatesBy:filters[activeFilter]" ng-if="desks">
+              <div class="card-box__header" ng-class="{'card-box__header--dark': !template.is_public}" >
                   <div class="dropdown" dropdown>
                       <button class="dropdown-toggle" dropdown-toggle>
                           <i class="icon-dots-vertical"></i>


### PR DESCRIPTION
- In /settings/templates management page, all templates can now be viewed
(both personal and desk).
- Added different styling for personal templates.
- Added a filter to show only personal or desk specific items.

See [issue SD-4107](https://dev.sourcefabric.org/browse/SD-4107).

Personal templates are shown in a different style (grey):
<img width="514" alt="screen shot 2016-04-28 at 2 34 44 pm" src="https://cloud.githubusercontent.com/assets/6686356/14884588/66ba1ae0-0d4e-11e6-92c6-b85d1b18ad99.png">

And a drop-down at the top right, next to the "Add New Template" button:
<img width="499" alt="screen shot 2016-04-29 at 3 28 11 pm" src="https://cloud.githubusercontent.com/assets/6686356/14915932/1abcaf28-0e1f-11e6-9e83-2774d3cb121e.png">

TODO:
- [x] Add visibility for personal templates.
- [x] Style non-public template differently.
- [x] Add a switch to view only desk templates.