### PR TITLE
SD-4394 -- Remove afterClose function for macros

### DIFF
--- a/scripts/superdesk-authoring/macros/macros.js
+++ b/scripts/superdesk-authoring/macros/macros.js
@@ -155,12 +155,7 @@ angular.module('superdesk.authoring.macros', [
                 order: 6,
                 needEditable: true,
                 side: 'right',
-                display: {authoring: true, packages: true, killedItem: false, legalArchive: false, archived: false},
-                afterClose: function(scope) {
-                    if (scope && typeof scope.closePreview === 'function') {
-                        scope.closePreview();
-                    }
-                }
+                display: {authoring: true, packages: true, killedItem: false, legalArchive: false, archived: false}
             });
     }]);
 })();


### PR DESCRIPTION
It was causing an unwanted redo in the editor

It reverts partially #363, (@eozan if you can check please)

cc @ioanpocol 