### PR TITLE
Img drag

### DIFF
--- a/scripts/superdesk-archive/directives.js
+++ b/scripts/superdesk-archive/directives.js
@@ -16,6 +16,14 @@
             var dt = event.dataTransfer || event.originalEvent.dataTransfer;
             dt.setData('application/superdesk.item.' + item.type, angular.toJson(item));
             dt.effectAllowed = 'link';
+
+            if (item.renditions && item.renditions.thumbnail) {
+                var img = new Image();
+                var rendition = item.renditions.thumbnail;
+                img.src = rendition.href;
+                img.width = rendition.width;
+                dt.setDragImage(img, rendition.width / 2, rendition.height / 2);
+            }
         };
     }
 


### PR DESCRIPTION
Chrome default list drag is broken in version 50. Nicer to just drag thumbnail around into editor.