### PR TITLE
Fixing the issues where closepreview called by authoring widgets causing autosave to loose changes.

### DIFF
--- a/scripts/superdesk-authoring/macros/macros.js
+++ b/scripts/superdesk-authoring/macros/macros.js
@@ -155,12 +155,7 @@ angular.module('superdesk.authoring.macros', [
                 order: 6,
                 needEditable: true,
                 side: 'right',
-                display: {authoring: true, packages: true, killedItem: false, legalArchive: false, archived: false},
-                afterClose: function(scope) {
-                    if (scope && typeof scope.closePreview === 'function') {
-                        scope.closePreview();
-                    }
-                }
+                display: {authoring: true, packages: true, killedItem: false, legalArchive: false, archived: false}
             });
     }]);
 })();

--- a/scripts/superdesk-authoring/versioning/history/history.js
+++ b/scripts/superdesk-authoring/versioning/history/history.js
@@ -44,10 +44,12 @@ function HistoryController($scope, authoring, api, notify, desks, archiveService
      * If there is no autosave then last one will make item editable
      */
     $scope.openVersion = function(version) {
-        if ($scope.item._editable) {
+        if ($scope.item._editable && !$scope.dirty) {
             $scope.selected = version;
             if (version === $scope.last && !$scope.item._autosave) {
-                $scope.closePreview();
+                if (!$scope._editable) {
+                    $scope.closePreview();
+                }
             } else {
                 $scope.preview(version);
             }

--- a/scripts/superdesk-authoring/versioning/history/views/history.html
+++ b/scripts/superdesk-authoring/versioning/history/views/history.html
@@ -3,7 +3,7 @@
         <li class="item"
             ng-class="{selected: selected === version}"
             ng-repeat="version in versions track by version._current_version"
-            ng-disabled="!item._editable">
+            ng-disabled="!item._editable || dirty">
 
             <div ng-if="version.operation == 'create'" ng-click="openVersion(version)">
                 {{ :: version.typeName }} <b>{{ :: version.unique_id }}</b>

--- a/scripts/superdesk-authoring/versioning/versioning.js
+++ b/scripts/superdesk-authoring/versioning/versioning.js
@@ -12,7 +12,12 @@ angular.module('superdesk.authoring.versioning', [])
                 template: 'scripts/superdesk-authoring/versioning/views/versioning.html',
                 order: 4,
                 side: 'right',
-                display: {authoring: true, packages: true, killedItem: true, legalArchive: true, archived: false}
+                display: {authoring: true, packages: true, killedItem: true, legalArchive: true, archived: false},
+                afterClose: function(scope) {
+                    if (scope && typeof scope.closePreview === 'function' && !scope._editable) {
+                        scope.closePreview();
+                    }
+                }
             });
     }]);
 

--- a/scripts/superdesk-authoring/versioning/versions/versions.js
+++ b/scripts/superdesk-authoring/versioning/versions/versions.js
@@ -41,23 +41,17 @@ function VersioningController($scope, authoring, api, notify, lock, desks, archi
     }
 
     /**
-     * Open autosaved version
-     */
-    $scope.openAutosave = function() {
-        $scope.selected = $scope.item._autosave;
-        $scope.closePreview();
-    };
-
-    /**
      * Open given version for preview
      *
      * If there is no autosave then last one will make item editable
      */
     $scope.openVersion = function (version) {
-        if ($scope.item._editable) {
+        if ($scope.item._editable && !$scope.dirty) {
             $scope.selected = version;
             if (version === $scope.last && !$scope.item._autosave) {
-                $scope.closePreview();
+                if (!$scope._editable) {
+                    $scope.closePreview();
+                }
             } else {
                 $scope.preview(version);
             }

--- a/scripts/superdesk-authoring/versioning/versions/views/versions.html
+++ b/scripts/superdesk-authoring/versioning/versions/views/versions.html
@@ -1,16 +1,6 @@
 <div class="article-versions" ng-controller="VersioningWidgetCtrl">
     <ul class="versions-list card-list">
-        <li class="item draft" ng-class="{selected: selected === item._autosave}" ng-if="item._autosave" ng-click="openAutosave()">
-            <div class="header">
-                <time title="{{ item._autosave._updated | date:'medium' }}">{{ item._autosave._updated | reldate }}</time>
-            </div>
-            <h6 ng-class="{'no-title': !item._autosave.headline}">{{ :: item._autosave.headline || ('Untitled' | translate) }}</h6>
-            <div class="footer">
-                <em translate>autosave</em>
-            </div>
-        </li>
-
-        <li class="item" ng-class="{selected: selected === version}" ng-repeat="version in versions" ng-click="openVersion(version)" ng-disabled="!item._editable">
+        <li class="item" ng-class="{selected: selected === version}" ng-repeat="version in versions" ng-click="openVersion(version)" ng-disabled="!item._editable || dirty">
             <div class="header">
                 <time title="{{ :: version.versioncreated | date:'medium' }}">{{ version.versioncreated|reldate }}</time>
                 <span class="user">{{ :: 'by' | translate }} {{ version.creator }}</span>
@@ -24,7 +14,7 @@
                 <em>{{ :: 'version' | translate }}: {{ version._current_version }}</em>
                 <div class="state-label state-{{ :: version.state}}">{{ :: version.state | translate }}</div>
                 <button class="btn btn-light btn-mini pull-right"
-                    ng-show="canRevert && !$first"
+                    ng-show="canRevert && !$first && !dirty"
                     ng-click="revert(version)"
                     translate>revert</button>
             </div>

--- a/scripts/superdesk-authoring/widgets/widgets.js
+++ b/scripts/superdesk-authoring/widgets/widgets.js
@@ -88,6 +88,7 @@ function WidgetsManagerCtrl($scope, $routeParams, authoringWidgets, archiveServi
         if ($scope.active && typeof $scope.active.afterClose === 'function') {
             $scope.active.afterClose($scope);
         }
+
         $scope.active = null;
     };
 


### PR DESCRIPTION
Problem was `closepreview` called by the `versioning` widget caused  autosave to loose changes. Made change so that you can preview versions only after used has saved changes.

@vied12 , @petrjasek  can you review the changes.