### PR TITLE
Changed "Source" to "Originator" string

### DIFF
--- a/scripts/superdesk-archive/views/metadata-view.html
+++ b/scripts/superdesk-archive/views/metadata-view.html
@@ -23,7 +23,7 @@
         </dl>
 
         <dl ng-if="item.original_source">
-            <dt translate>Original source</dt>
+            <dt translate>Originator</dt>
             <dd>{{ item.original_source }}</dd>
         </dl>
         <dl>


### PR DESCRIPTION
To differentiate between original source and the default Source attached by Superdesk (as configured in Desks Settings).