### PR TITLE
Tweaked the text and removed the license mistake

### DIFF
--- a/scripts/superdesk/menu/views/about.html
+++ b/scripts/superdesk/menu/views/about.html
@@ -12,7 +12,7 @@
       <h4>Superdesk v{{ :: version }}</h4>
       <p class="date-released"><span ng-show="releaseDate">Released on</span> {{ :: releaseDate }}</p>
       <p>
-        Sourcefabric's <a href="https://www.superdesk.org/en/" target="_blank"><b>Superdesk</b></a> is an open source end-to-end news creation, production, curation, distribution and publishing platform maintained by <a href="http://:superdesk@sourcefabric.org">Sourcefabric z.u.</a>, a nonprofit organisation whose primary mission is to make the best possible software for journalism.
+        <a href="https://www.superdesk.org" target="_blank"><b>Superdesk</b></a> is an open source end-to-end news creation, production, curation, distribution and publishing platform maintained by <a href="http://sourcefabric.org">Sourcefabric z.u.</a>, a nonprofit organisation whose primary purpose is to make the best possible software for journalism.
       </p>
       <p>
         Copyright (c) 2014 - {{ year }} Sourcefabric z.u. and contributors.<br>

--- a/scripts/superdesk/menu/views/about.html
+++ b/scripts/superdesk/menu/views/about.html
@@ -12,11 +12,11 @@
       <h4>Superdesk v{{ :: version }}</h4>
       <p class="date-released"><span ng-show="releaseDate">Released on</span> {{ :: releaseDate }}</p>
       <p>
-        Sourcefabric's <a href="https://www.superdesk.org/en/" target="_blank"><b>Superdesk</b></a> is an open source end-to-end news creation, production, curation, distribution and publishing platform maintained by a nonprofit organisation with the sole purpose of making the best possible software for journalism.
+        Sourcefabric's <a href="https://www.superdesk.org/en/" target="_blank"><b>Superdesk</b></a> is an open source end-to-end news creation, production, curation, distribution and publishing platform maintained by <a href="http://:superdesk@sourcefabric.org">Sourcefabric z.u.</a>, a nonprofit organisation whose primary mission is to make the best possible software for journalism.
       </p>
       <p>
         Copyright (c) 2014 - {{ year }} Sourcefabric z.u. and contributors.<br>
-        Superdesk is released under the <a href="https://www.gnu.org/licenses/gpl-3.0" target="_blank">open source license GPLv3</a>.
+        Superdesk is released under the <a href="https://www.gnu.org/licenses/agpl-3.0" target="_blank">open source license AGPLv3</a>.
       </p>
       <p>
         Looking for help or support?<br>


### PR DESCRIPTION
We had mistakenly referred to the GPL v3 license instead of AGPL. I fixed the reference contained in the About Superdesk modal.

Tweaked the text part talking about Sourcefabric.