### PR TITLE
ui: fix styling issue with sdTimezone component navigation.

### DIFF
--- a/scripts/superdesk/directives/sdTypeahead.js
+++ b/scripts/superdesk/directives/sdTypeahead.js
@@ -6,13 +6,11 @@
          * Typeahead direcitve
          *
          * Usage:
-         *  <div sd-typeahead items="subjects" term="subjectTerm" search="searchSubjects(term)" select="selectSubject(item)">
-         *      <ul>
-         *          <li typeahead-item="s" ng-repeat="s in subjects">
-         *              {{s.term}}
-         *          </li>
-         *      </ul>
-         *  </div>
+         *  <ul sd-typeahead items="subjects" term="subjectTerm" search="searchSubjects(term)" select="selectSubject(item)">
+         *      <li typeahead-item="s" ng-repeat="s in subjects">
+         *          {{s.term}}
+         *      </li>
+         *  </ul>
          *
          * Params:
          * @scope {Object} items - choice list

--- a/scripts/superdesk/views/sdTypeahead.html
+++ b/scripts/superdesk/views/sdTypeahead.html
@@ -2,7 +2,7 @@
     <div class="input-term">
         <input ng-model="term" ng-change="query()" tabindex="{{tabindex}}" type="text" ng-disabled="disabled" autocomplete="off" ng-click="$event.stopPropagation()" placeholder="{{placeholder}}">
     </div>
-    <div class="item-list" ng-transclude>
+    <ul class="item-list" ng-transclude>
 
-    </div>
+    </ul>
 </div>

--- a/styles/less/bootstrap.less
+++ b/styles/less/bootstrap.less
@@ -21,6 +21,7 @@
 @import "tables.less";
 
 // Components: common
+@import "sd-typeahead.less";
 @import "sd-icon-font.less";
 @import "dropdowns.less";
 

--- a/styles/less/sd-typeahead.less
+++ b/styles/less/sd-typeahead.less
@@ -1,0 +1,12 @@
+.sd-typeahead {
+	ul.item-list {
+		z-index: 9999;
+		li {
+			padding: 5px 10px;
+			&.active {
+				background-color: #5ea9c8;
+				color: #fff;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Addresses [SD-4145](https://dev.sourcefabric.org/browse/SD-4145).

- Navigating with arrow components is now visible in the dropdown:
<img width="501" alt="screen shot 2016-05-04 at 12 24 50 pm" src="https://cloud.githubusercontent.com/assets/6686356/15010181/79e066ac-11f3-11e6-8008-ae6455f7bd57.png">

- Timezone drop-down is on top of Publish/Send button