### PR TITLE
[SD-4485][SD-4486] [SD-4463] Global Search Fixes.

### DIFF
--- a/scripts/superdesk-archive/views/metadata-view.html
+++ b/scripts/superdesk-archive/views/metadata-view.html
@@ -194,7 +194,7 @@
         <dd>{{ item.guid }}</dd>
     </dl>
     <dl ng-if="item.unique_name">
-        <dt translate>Unique ID</dt>
+        <dt translate>Unique Name</dt>
         <dd>{{ item.unique_name }}</dd>
     </dl>
     <dl>

--- a/scripts/superdesk-search/search.js
+++ b/scripts/superdesk-search/search.js
@@ -437,6 +437,9 @@
             return parameters;
         }
 
+        /*
+         * function to parse search input from the search bar.
+         */
         function initSelectedKeywords (keywords) {
             tags.selectedKeywords = [];
             while (keywords.indexOf('(') >= 0 && keywords.indexOf(')') > 0) {
@@ -1739,6 +1742,7 @@
                          */
                         function getQuery() {
                             var metas = [];
+                            var pattern = /[()]/g;
 
                             angular.forEach(scope.meta, function(val, key) {
                                 //checkbox boolean values.
@@ -1746,7 +1750,10 @@
                                     val = booleanToBinaryString(val);
                                 }
 
-                                val = val.replace(/[()]/g, '');
+                                if (typeof(val) === 'string') {
+                                    val = val.replace(pattern, '');
+                                }
+
                                 if (key === '_all') {
                                     metas.push(val.join(' '));
                                 } else {
@@ -1755,6 +1762,11 @@
                                             if (val) {
                                                 metas.push(key + ':(' + val + ')');
                                             }
+                                        } else if (angular.isArray(val)) {
+                                            angular.forEach(val, function(value) {
+                                                value = value.replace(pattern, '');
+                                                metas.push(key + ':(' + value + ')');
+                                            });
                                         } else {
                                             var subkey = getFirstKey(val);
                                             if (val[subkey]) {
@@ -1825,7 +1837,11 @@
                          * Converting to object and adding pre-selected subject codes to list in left sidebar
                          */
                         metadata
-                            .fetchSubjectcodes()
+                            .initialize()
+                            .then(function() {
+                                scope.keywords = metadata.values.keywords;
+                                return metadata.fetchSubjectcodes();
+                            })
                             .then(function () {
                                 scope.subjectcodes = metadata.values.subjectcodes;
                                 return tags.initSelectedFacets();

--- a/scripts/superdesk-search/search.js
+++ b/scripts/superdesk-search/search.js
@@ -210,10 +210,6 @@
                     query.post_filter({terms: {'anpa_category.name': JSON.parse(params.category)}});
                 }
 
-                if (params.keywords) {
-                    query.post_filter({terms: {'keywords': JSON.parse(params.keywords)}});
-                }
-
                 if (params.genre) {
                     query.post_filter({terms: {'genre.name': JSON.parse(params.genre)}});
                 }
@@ -396,7 +392,6 @@
         var FacetKeys = {
             'type': 1,
             'category': 1,
-            'keywords': 1,
             'urgency': 1,
             'priority': 1,
             'source': 1,
@@ -628,7 +623,6 @@
                             'source': {},
                             'credit': {},
                             'category': {},
-                            'keywords': {},
                             'urgency': {},
                             'priority': {},
                             'genre': {},
@@ -648,6 +642,8 @@
                                 return;
                             }
 
+                            initAggregations();
+
                             if (angular.isDefined(scope.items._aggregations.type)) {
                                 _.forEach(scope.items._aggregations.type.buckets, function(type) {
                                     scope.aggregations.type[type.key] = type.doc_count;
@@ -658,14 +654,6 @@
                                 _.forEach(scope.items._aggregations.category.buckets, function(cat) {
                                     if (cat.key !== '') {
                                         scope.aggregations.category[cat.key] = cat.doc_count;
-                                    }
-                                });
-                            }
-
-                            if (angular.isDefined(scope.items._aggregations.keywords)) {
-                                _.forEach(scope.items._aggregations.keywords.buckets, function(cat) {
-                                    if (cat.key !== '') {
-                                        scope.aggregations.keywords[cat.key] = cat.doc_count;
                                     }
                                 });
                             }
@@ -986,8 +974,15 @@
 
                     scope.repo = {
                         ingest: true, archive: true,
-                        published: true, archived: true
+                        published: true, archived: true,
+                        search: 'local'
                     };
+
+                    if ($location.search().repo &&
+                        !_.intersection($location.search().repo.split(','),
+                            ['archive', 'published', 'ingest', 'archived']).length) {
+                        scope.repo.search = $location.search().repo;
+                    }
 
                     scope.context = 'search';
                     scope.$on('item:deleted:archived', itemDelete);
@@ -1336,7 +1331,7 @@
                                 scope.item.label = 'location:';
                                 scope.item.value = 'workspace';
                             } else {
-                                if (scope.item._type === 'published' && scope.item.allow_post_publish_actions === false) {
+                                if (scope.item._type === 'archived') {
                                     scope.item.label = '';
                                     scope.item.value = 'archived';
                                 }

--- a/scripts/superdesk-search/styles/search.less
+++ b/scripts/superdesk-search/styles/search.less
@@ -273,3 +273,9 @@
         margin-right: 5px;
     }
 }
+
+.search-parameters {
+    .keywords {
+        .clearfix();
+    }
+}

--- a/scripts/superdesk-search/tests/search_spec.js
+++ b/scripts/superdesk-search/tests/search_spec.js
@@ -58,12 +58,6 @@ describe('search service', function() {
         expect(filters).toContain({term: {'original_creator': '123'}});
     }));
 
-    it('can create query for keywords', inject(function($rootScope, search) {
-        var criteria = search.query({keywords: '["FINANCE"]'}).getCriteria();
-        var postFilters = criteria.post_filter.and;
-        expect(postFilters).toContain({terms: {'keywords': ['FINANCE']}});
-    }));
-
     it('can create query for unique_name', inject(function($rootScope, search) {
         // only to desk is specified
         var criteria = search.query({unique_name: '123'}).getCriteria();

--- a/scripts/superdesk-search/views/item-search.html
+++ b/scripts/superdesk-search/views/item-search.html
@@ -17,7 +17,7 @@
             </label>
         </div>
     </fieldset>
-    <fieldset ng-show="repo.search === 'local'">
+    <fieldset class="search-parameters" ng-show="repo.search === 'local'">
         <div class="field">
             <label for="search-slugline">
                 {{:: 'Slugline' | translate}}
@@ -50,11 +50,10 @@
             </div>
         </div>
 
-
         <div class="multiple">
             <div class="field">
                 <label for="search-storyname">
-                    {{:: 'Story Name' | translate}}
+                    {{:: 'Unique Name' | translate}}
                 </label>
                 <input type="text" id="search-storyname" ng-model="fields.unique_name">
             </div>
@@ -65,12 +64,27 @@
                 <input type="text" id="search-storytext" ng-model="meta.body_html">
             </div>
         </div>
+
         <div class="field">
             <label for="search-byline">
                 {{:: 'Byline' | translate}}
             </label>
             <input type="text" id="search-byline" ng-model="meta.byline">
         </div>
+
+        <div class="field keywords">
+            <label for="search-keywords">
+                {{:: 'Keywords' | translate}}
+            </label>
+            <div id="search-keywords"
+                 sd-meta-words-list
+                 data-field="keywords"
+                 data-header="true"
+                 data-list="keywords"
+                 data-item="meta"
+            ></div>
+        </div>
+
         <div class="field" ng-if="repo.archive">
             <label for="search-creator">
                 {{:: 'Creator' | translate}}
@@ -81,6 +95,7 @@
             <option value="" label=""></option>
             </select>
         </div>
+
         <div class="field">
             <label for="from-desk">
                 {{:: 'From Desk' | translate}}

--- a/scripts/superdesk-search/views/search-facets.html
+++ b/scripts/superdesk-search/views/search-facets.html
@@ -41,7 +41,7 @@
                         <i class="filetype-icon-{{key}}"></i>
                         <span id="filetype-icon-{{key}}" class="sd-checkbox" ng-checked="hasFilter('type',key)"></span>
                     </span>
-                    <span>{{:: key | translate}} <i>{{:: value }}</i></span>
+                    <span>{{ key | translate}} <i>{{ value }}</i></span>
                 </li>
             </ul>
         </div>
@@ -50,7 +50,7 @@
             <ul class="filter-box">
                 <li ng-repeat="(key,value) in aggregations.desk" ng-click="toggleFilter('desk', value.id)">
                     <span class="sd-checkbox" ng-checked="hasFilter('desk', value.id)"></span>
-                    <span>{{:: key | translate}} <i>{{:: value.count }}</i></span>
+                    <span>{{ key | translate}} <i>{{ value.count }}</i></span>
                 </li>
             </ul>
         </div>
@@ -59,7 +59,7 @@
             <ul class="filter-box">
                 <li ng-repeat="(key,value) in aggregations.stage" ng-click="toggleFilter('stage', value.id)">
                     <span class="sd-checkbox" ng-checked="hasFilter('stage', key)"></span>
-                    <span>{{:: key | translate}} <i>{{:: value.count }}</i></span>
+                    <span>{{ key | translate}} <i>{{ value.count }}</i></span>
                 </li>
             </ul>
         </div>
@@ -68,7 +68,7 @@
             <ul class="filter-box">
                 <li ng-repeat="(key,value) in aggregations.source" ng-click="toggleFilter('source', key)">
                     <span class="sd-checkbox" ng-checked="hasFilter('source',key)"></span>
-                    <span>{{:: key | translate}} <i>{{:: value }}</i></span>
+                    <span>{{ key | translate}} <i>{{ value }}</i></span>
                 </li>
             </ul>
         </div>
@@ -77,7 +77,7 @@
             <ul class="filter-box">
                 <li ng-repeat="(key,value) in aggregations.credit" ng-click="toggleFilter('credit', key)">
                     <span class="sd-checkbox" ng-checked="hasFilter('credit',key)"></span>
-                    <span>{{:: key | translate}} <i>{{:: value.count }}</i></span>
+                    <span>{{ key | translate}} <i>{{ value.count }}</i></span>
                 </li>
             </ul>
         </div>
@@ -86,16 +86,7 @@
             <ul class="filter-box">
                 <li ng-repeat="(key,value) in aggregations.category" ng-click="toggleFilter('category', key)">
                     <span class="sd-checkbox" ng-checked="hasFilter('category',key)"></span>
-                    <span>{{:: key | translate}} <i>{{:: value }}</i></span>
-                </li>
-            </ul>
-        </div>
-
-        <div sd-toggle-box data-title="{{:: 'Keywords' | translate }}" ng-hide="isEmpty('keywords')" data-open="true">
-            <ul class="filter-box">
-                <li ng-repeat="(key,value) in aggregations.keywords" ng-click="toggleFilter('keywords', key)">
-                    <span class="sd-checkbox" ng-checked="hasFilter('keywords',key)"></span>
-                    <span>{{:: key | translate}} <i>{{:: value }}</i></span>
+                    <span>{{ key | translate}} <i>{{ value }}</i></span>
                 </li>
             </ul>
         </div>
@@ -104,7 +95,7 @@
             <ul class="filter-box">
                 <li ng-repeat="(key,value) in aggregations.genre" ng-click="toggleFilter('genre', key)">
                     <span class="sd-checkbox" ng-checked="hasFilter('genre',key)"></span>
-                    <span>{{:: key | translate}} <i>{{:: value }}</i></span>
+                    <span>{{ key | translate}} <i>{{ value }}</i></span>
                 </li>
             </ul>
         </div>
@@ -113,7 +104,7 @@
             <ul class="filter-box">
                 <li ng-repeat="(key,value) in aggregations.urgency" ng-click="toggleFilter('urgency', key)">
                     <span class="sd-checkbox" ng-checked="hasFilter('urgency',key)"></span>
-                    <span>{{:: key | translate}} <i>{{:: value }}</i></span>
+                    <span>{{ key | translate}} <i>{{ value }}</i></span>
                 </li>
             </ul>
         </div>
@@ -122,7 +113,7 @@
             <ul class="filter-box">
                 <li ng-repeat="(key,value) in aggregations.priority" ng-click="toggleFilter('priority', key)">
                     <span class="sd-checkbox" ng-checked="hasFilter('priority',key)"></span>
-                    <span>{{:: key | translate}} <i>{{:: value }}</i></span>
+                    <span>{{ key | translate}} <i>{{ value }}</i></span>
                 </li>
             </ul>
         </div>
@@ -131,11 +122,11 @@
             <ul class="filter-box">
                 <li ng-click="toggleFilter('legal', 'true')" ng-hide="isEmpty('legal')">
                     <span class="sd-checkbox" ng-checked="hasFilter('legal', 'true')"></span>
-                    <span>{{:: 'Legal' | translate}} <i>{{:: aggregations.legal.count }}</i></span>
+                    <span>{{:: 'Legal' | translate}} <i>{{ aggregations.legal.count }}</i></span>
                 </li>
                 <li ng-click="toggleFilter('sms', 'true')" ng-hide="isEmpty('sms')">
                     <span class="sd-checkbox" ng-checked="hasFilter('sms', 'true')"></span>
-                    <span>{{:: 'Sms' | translate}} <i>{{:: aggregations.sms.count }}</i></span>
+                    <span>{{:: 'Sms' | translate}} <i>{{ aggregations.sms.count }}</i></span>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
Fixes Following issues:
- Aggregations on  global search never updates.
Current aggregations don't change count at all i.e. aggregations count is same even if the user   switches between repos. For example, if user select only ingest repo then the user sees the aggregates of desk which imo is incorrect. If you search on aap multimedia repo then the user see aggregates of multimedia + superdesk.

- Remove `Keywords` from aggregates and allow to be search as text filter.
- Date range filter was not displayed when aggregates tab is open. It only displays when parameters  toggle is used.

This PR is dependent on [#349](https://github.com/superdesk/superdesk-core/pull/349)