### PR TITLE
ui(fixes SD-4258): show all desks in template filter settings

### DIFF
--- a/scripts/superdesk-desks/desks.js
+++ b/scripts/superdesk-desks/desks.js
@@ -617,6 +617,11 @@
                     activeDeskId: null,
                     activeStageId: null,
                     active: {desk: null, stage: null},
+
+                    /**
+                     * @description Fetches all desks in the system.
+                     * @returns {Promise}
+                     */
                     fetchDesks: function() {
                         var self = this;
 
@@ -628,8 +633,10 @@
                             _.each(items, function(item) {
                                 self.deskLookup[item._id] = item;
                             });
+                            return self.desks;
                         });
                     },
+
                     fetchUsers: function() {
                         var self = this;
                         return userList.getAll()

--- a/scripts/superdesk-templates/templates.js
+++ b/scripts/superdesk-templates/templates.js
@@ -343,7 +343,7 @@
 
                 // fetch all desks for the current user and add them to
                 // the list of filters.
-                desks.fetchCurrentUserDesks().then(function(desks) {
+                desks.fetchDesks().then(function(desks) {
                     $scope.filters = $scope.filters.concat(
                         desks._items.map(function(d) {
                             return {label: d.name, value: d._id};


### PR DESCRIPTION
This fixes an [issue](https://dev.sourcefabric.org/browse/SD-4528) where
only the user's desks were displayed in the filter dropdown. Now, all
desks should be visible.