### PR TITLE
[SD-4268] - Unlocking a draft of a story creates 404

### DIFF
--- a/scripts/superdesk-authoring/authoring.js
+++ b/scripts/superdesk-authoring/authoring.js
@@ -791,7 +791,7 @@
             if (this.isLockedByMe(item)) {
                 return true;
             } else {
-                return privileges.privileges.unlock;
+                return item.state === 'draft'? false : privileges.privileges.unlock;
             }
         };
     }

--- a/scripts/superdesk-authoring/tests/authoring_spec.js
+++ b/scripts/superdesk-authoring/tests/authoring_spec.js
@@ -528,6 +528,16 @@ describe('lock service', function() {
         expect(lock.can_unlock({lock_user: user._id, lock_session: 'another_session'})).toBe(true);
         expect(lock.can_unlock({lock_user: anotherUser._id, lock_session: 'another_session'})).toBe(0);
     }));
+
+    it('can unlock own draft but not other users item', inject(function(lock, privileges, $rootScope) {
+        privileges.setUserPrivileges({unlock: 1});
+        $rootScope.$digest();
+        // testing if the user can unlock its own content.
+        expect(lock.can_unlock({lock_user: user._id, state: 'draft'})).toBe(true);
+        expect(lock.can_unlock({lock_user: user._id, state: 'draft', lock_session: 'another_session'})).toBe(true);
+        var item = {lock_user: anotherUser._id, state: 'draft', lock_session: 'another_session'};
+        expect(lock.can_unlock(item)).toBe(false);
+    }));
 });
 
 describe('authoring actions', function() {


### PR DESCRIPTION
- A user can still unlock his/her draft version but it won't be accessible because it will be deleted
- It won't be possible to unlock a draft version of someone else's story