### PR TITLE
ui(style): styling the packaging screen to add more content fields (SD-4487)

### DIFF
--- a/scripts/superdesk-packaging/packaging.js
+++ b/scripts/superdesk-packaging/packaging.js
@@ -506,8 +506,8 @@
         };
     }
 
-    PackageItemPreviewDirective.$inject = ['api', 'lock', 'superdesk', 'authoringWorkspace', '$location'];
-    function PackageItemPreviewDirective(api, lock, superdesk, authoringWorkspace, $location) {
+    PackageItemPreviewDirective.$inject = ['api', 'lock', 'superdesk', 'authoringWorkspace', '$location', '$sce', 'desks'];
+    function PackageItemPreviewDirective(api, lock, superdesk, authoringWorkspace, $location, $sce, desks) {
         return {
             scope: {
                 item: '=',
@@ -518,6 +518,7 @@
                 scope.data = null;
                 scope.error = null;
                 scope.no_open = scope.readonly || null;
+                scope.userLookup = desks.userLookup;
 
                 if (scope.item.location) {
                     var url = '';
@@ -540,6 +541,9 @@
                     api[endpoint].getByUrl(url)
                     .then(function(result) {
                         scope.data = result;
+                        if (scope.data.abstract) {
+                            scope.data.abstract = $sce.trustAsHtml(scope.data.abstract);
+                        }
                         scope.isLocked = lock.isLocked(scope.data);
                         scope.isPublished = _.contains(['published', 'corrected'], scope.data.state);
                         scope.isKilled =  scope.data.state === 'killed';

--- a/scripts/superdesk-packaging/packaging.less
+++ b/scripts/superdesk-packaging/packaging.less
@@ -16,10 +16,11 @@
     margin-bottom: 10px;
     transition: all 0.2s;
     &__icon-holder {
-        margin-right: 14px;
+        margin: 5px 0 !important;
         opacity:0.5;
         max-width: 24px;
         min-width: 24px;
+        padding-right: 10px;
     }
     &__drag-handle {
         position: absolute;
@@ -73,14 +74,24 @@
             }
         }
     }
+    &__item-text-group {
+        display: flex;
+        flex-direction: column;
+    }
     &__item-headline {
         padding-right: 40px;
         max-height: 74px;
         overflow: hidden;
         font-size: 14px;
         flex-grow: 1;
-
+        font-weight: bold;
     }
+	&__item-abstract {
+		margin-top: 5px;
+	}
+	&__item-creator {
+		color: #909090;
+	}
     .loading {
         width: 40px;
         height: 40px;

--- a/scripts/superdesk-packaging/views/sd-package-item-preview.html
+++ b/scripts/superdesk-packaging/views/sd-package-item-preview.html
@@ -13,9 +13,18 @@
     <div ng-if="data.type === 'video'"><i class="filetype-icon-large-video"></i></div>
   </div>
 
-  <div class="package-item__item-headline">
-    <div ng-show=":: data.headline || data.slugline || data.description_text">{{ :: data.headline || data.slugline || data.description_text}}</div>
-    <div ng-hide=":: data.headline || data.slugline || data.description_text" translate>Blank headline received</div>
+  <div class="package-item__item-text-group">
+    <div class="package-item__item-headline">
+      <div ng-show=":: data.headline || data.slugline || data.description_text">{{ :: data.headline || data.slugline || data.description_text}}</div>
+      <div ng-hide=":: data.headline || data.slugline || data.description_text" translate>Blank headline received</div>
+    </div>
+
+    <div class="package-item__item-creator">
+      Created <time sd-datetime data-date="item.firstcreated" data-from-now="true"></time>
+	 <span ng-if="userLookup[data.original_creator]" translate>by <b>{{userLookup[data.original_creator].display_name}}</b></span>
+    </div>
+
+    <div class="package-item__item-abstract" ng-if="data.abstract" ng-bind-html="data.abstract"></div>
   </div>
 
   <a ng-if="no_open"

--- a/scripts/superdesk/datetime/datetime.js
+++ b/scripts/superdesk/datetime/datetime.js
@@ -4,7 +4,7 @@
     DateTimeDirective.$inject = ['datetime', 'moment'];
     function DateTimeDirective(datetime, moment) {
         return {
-            scope: {date: '='},
+            scope: {date: '=', fromNow: '='},
             link: function datetimeLink(scope, elem) {
                 scope.$watch('date', renderDate);
 
@@ -15,7 +15,8 @@
                  */
                 function renderDate(date) {
                     var momentDate = moment(date);
-                    elem.text(datetime.shortFormat(momentDate));
+                    var txt = scope.fromNow ? momentDate.fromNow() : datetime.shortFormat(momentDate);
+                    elem.text(txt);
                     elem.attr('title', momentDate.format('LLLL'));
                 }
             }


### PR DESCRIPTION
New highlight packaging items list style:
<img width="641" alt="screen shot 2016-05-19 at 11 34 33 am" src="https://cloud.githubusercontent.com/assets/6686356/15387434/d2e6bf30-1db5-11e6-871c-607bd76a6a8f.png">

I've used the [wiki page](https://wiki.sourcefabric.org/display/NR/Package+creation+UPDATED) as reference.