### PR TITLE
[SD-4512] - Associate as a take

### DIFF
--- a/scripts/superdesk-archive/related-item-widget/relatedItem.js
+++ b/scripts/superdesk-archive/related-item-widget/relatedItem.js
@@ -63,7 +63,34 @@
                     'class': 'open',
                     icon: 'icon-expand',
                     condition: function(item) {
-                        return true;
+                        return item.type !== 'composite';
+                    }
+                },
+                addTake: {
+                    title: 'Associate as take',
+                    method: function(item) {
+                        var target = {_id: item.package_type === 'takes' ? item.last_take : item._id};
+                        var originalItem = $scope.item;
+                        authoring.linkItem(target, $scope.item._id).then(function(_item) {
+                            notify.success(gettext('item is associated as a take.'));
+                            authoringWorkspace.close(false);
+                            authoringWorkspace.edit(originalItem);
+                        }, function(err) {
+                            if (angular.isDefined(err.data._message)) {
+                                notify.error(gettext('Failed to associated as take: ' + err.data._message));
+                            } else {
+                                notify.error(gettext('There is an error. Failed to associated as take.'));
+                            }
+                        });
+                    },
+                    'class': 'open',
+                    icon: 'icon-expand',
+                    condition: function(item) {
+                        var canHaveNewTake = authoring.itemActions(item).new_take;
+                        return (item.package_type === 'takes' || canHaveNewTake) &&
+                                $scope.item.type === 'text' &&
+                                !$scope.item.takes &&
+                                $scope.item._current_version >= 1;
                     }
                 },
                 update: {

--- a/scripts/superdesk/itemList/views/relatedItem-list-widget.html
+++ b/scripts/superdesk/itemList/views/relatedItem-list-widget.html
@@ -17,7 +17,7 @@
     <div class="ingest-list-holder" ng-class="{'mode-detailed': options.mode === 'detailed'}">
         <div sd-shadow>
             <ul class="ingest-list list-view">
-                <li ng-repeat="item in processedItems track by $index" class="list-item-view">
+                <li ng-repeat="item in processedItems track by $index" class="list-item-view" ng-if="options.item._id !== item._id">
                     <div class="dropdown more-actions" dropdown>
                         <button class="dropdown-toggle" dropdown-toggle><i class="icon-dots-vertical"></i></button>
                         <div class="dropdown-menu pull-right">
@@ -34,6 +34,7 @@
                             <span class="keyword" ng-if="item.slugline">{{ item.slugline }}</span>
                             <span class="headline">{{item.headline || item.type}}</span>
                             <span class="takekey">{{item.anpa_take_key}}</span>
+                            <span ng-if="item.package_type" class="state-label takes" translate>Takes</span>
                             <span ng-if="item.flags.marked_for_legal" class="state-label legal" translate>Legal</span>
                             <span ng-if="item.flags.marked_for_sms" class="state-label sms" translate>Sms</span>
                             <span ng-if="item.rewritten_by" class="state-label updated" translate>Updated</span>

--- a/spec/authoring_spec.js
+++ b/spec/authoring_spec.js
@@ -264,7 +264,7 @@ describe('authoring', function() {
     it('related item widget', function() {
         monitoring.actionOnItem('Edit', 2, 1);
         authoring.openRelatedItem();
-        expect(authoring.getRelatedItems().count()).toBe(8);
+        expect(authoring.getRelatedItems().count()).toBe(7);
         authoring.searchRelatedItems('item3');
         expect(authoring.getRelatedItems().count()).toBe(1);
     });


### PR DESCRIPTION
Users can associate the opened story in the editor as a next take by selecting: 
- a non-take story (This then will become the first take)
- a take package (If there are few takes already in place)