### PR TITLE
ui(fix SD-4552): add sd-password-strength indicator

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -109,6 +109,7 @@
 
     <script src="scripts/superdesk/directives/sdAutofocus.js"></script>
     <script src="scripts/superdesk/directives/sdCheck.js"></script>
+    <script src="scripts/superdesk/directives/sdPasswordStrength.js"></script>
     <script src="scripts/superdesk/directives/sdConfirm.js"></script>
     <script src="scripts/superdesk/directives/sdDebounceThrottle.js"></script>
     <script src="scripts/superdesk/directives/sdDragDrop.js"></script>

--- a/scripts/superdesk-users/views/edit-form.html
+++ b/scripts/superdesk-users/views/edit-form.html
@@ -182,8 +182,7 @@
 
         <div class="field">
           <label translate>new</label>
-          <input name="new" type="password" ng-model="newPwd" required ng-minlength="5">
-          <p sd-valid-error ng-show="changePasswordForm.new.$error.minlength">please provide password at least 5 characters long.</p>
+          <input sd-password-strength name="new" type="password" ng-model="newPwd" required>
         </div>
 
         <div class="field">

--- a/scripts/superdesk/auth/reset-password.html
+++ b/scripts/superdesk/auth/reset-password.html
@@ -45,11 +45,7 @@
 
             <form name="resetForm" ng-submit="resetPassword()"  ng-show="flowStep == 3">
                 <fieldset class="inputs">
-                    <input type="password" name="password" ng-model="password" ng-minlength="5" placeholder="{{ 'Enter new password'|translate }}" class="fullwidth-input" required />
-                    <div ng-show="resetForm.password.$error.minlength" sd-valid-info>
-                        <i class="icon-info-sign-warning"></i>
-                        <span translate>password must have at least 5 characters</span>
-                    </div>
+                    <input type="password" sd-password-strength name="password" ng-model="password" placeholder="{{ 'Enter new password'|translate }}" class="fullwidth-input" required />
                 </fieldset>
                 <fieldset class="inputs">
                     <input type="password" name="passwordConfirm" ng-model="passwordConfirm" placeholder="{{ 'Confirm new password'|translate }}" class="fullwidth-input" sd-password-confirm data-password="password" required />

--- a/scripts/superdesk/directives/sdPasswordStrength.js
+++ b/scripts/superdesk/directives/sdPasswordStrength.js
@@ -1,0 +1,111 @@
+(function() {
+    'use strict';
+
+    // config holds the default configuration for the password strength calculator.
+    var config = {
+        MIN_LENGTH: 8,
+        ONE_LOWER: /^(?=.*[a-z])/g,
+        ONE_UPPER: /^(?=.*[A-Z])/g,
+        ONE_NUMBER: /^(?=.*[0-9])/g,
+        ONE_OTHER: /^(?=.*[^0-9^a-z^A-Z])/g,
+        MIN_STRENGTH: 3
+    };
+
+    /**
+     * sdPasswordStrength appends a strength indicator to the input that it is
+     * added to. Strength is computed in the following way:
+     *
+     *   - If the length of the password is less than 8, strength will be set
+     *     to 'Short'.
+     *
+     *   - Strength is increased whenever one of the following is found:
+     *        - a lower-case letter
+     *        - an upper-case letter
+     *        - a number
+     *        - another character
+     *
+     * Usage:
+     * <input type="password" sd-password-strength ng-model="pass">
+     *
+     * Params:
+     * @scope {Object} ngModel - model that the input is bound to
+     */
+    PasswordStrength.$inject = ['gettext', '$interpolate'];
+    function PasswordStrength(gettext, $interpolate) {
+        // styles holds each of the strength labels by index along with the class
+        // to be added to the indicator.
+        var styles = [
+            {txt: gettext('Short'), cls: 'red'},
+            {txt: gettext('Weak'), cls: 'red'},
+            {txt: gettext('Better'), cls: 'yellow'},
+            {txt: gettext('OK'), cls: 'green'},
+            {txt: gettext('Strong'), cls: 'green'}
+        ];
+
+        // helpText holds the text that will be shown when the user hovers over the
+        // informational icon.
+        var helpText = gettext('Must be {{ MIN_LENGTH }} characters long and ' +
+            'contain {{ MIN_STRENGTH }} out of 4 of the following:' +
+            '<ul>' +
+                '<li>a lower case letter (a-z)</li>' +
+                '<li>an upper case letter (A-Z)</li>' +
+                '<li>a number (0-9)</li>' +
+                '<li>a special character (!@#$%^&...)</li>' +
+            '</ul>');
+
+        return {
+            require: 'ngModel',
+            scope: {
+                password: '=ngModel'
+            },
+            link: function($scope, el, attr, ngModel) {
+                var indicator = angular.element(
+                    '<div class="password-strength">' +
+                        gettext('Strength') + ': <span class="label"></span>' +
+                        '<div class="icon-question-sign"></div>' +
+                    '</div>'
+                );
+
+                indicator.find('.icon-question-sign').tooltip({
+                    title: $interpolate(helpText)(config),
+                    html: true
+                });
+
+                ngModel.$error.weakPass = gettext('Password is too weak.');
+
+                /*
+                 * @description updateStrength updates the indicator's state to
+                 * reflect the strength of the given password.
+                 * @param {string} pass the password to compute the strength of
+                 */
+                var updateStrength = function updateStrength(pass) {
+                    var strength = 0;
+
+                    if (typeof pass !== 'undefined') {
+                        strength = pass.length >= config.MIN_LENGTH ?
+                        (config.ONE_LOWER.test(pass)  ? 1 : 0) +
+                        (config.ONE_UPPER.test(pass)  ? 1 : 0) +
+                        (config.ONE_NUMBER.test(pass) ? 1 : 0) +
+                        (config.ONE_OTHER.test(pass)  ? 1 : 0) : 0;
+                    }
+
+                    indicator.find('.label')
+                        .text(styles[strength].txt)
+                        .removeClass('red yellow green')
+                        .addClass(styles[strength].cls);
+
+                    ngModel.$setValidity('weakPass', strength >= config.MIN_STRENGTH);
+                };
+
+                updateStrength(ngModel.$modelValue || '');
+                $scope.$watch('password', updateStrength);
+                indicator.insertAfter(el);
+            }
+        };
+    }
+
+    return angular
+        .module('superdesk.directives.passwordStrength', [])
+        .directive('sdPasswordStrength', PasswordStrength);
+})();
+

--- a/scripts/superdesk/directives/tests/sdPasswordStrength.js
+++ b/scripts/superdesk/directives/tests/sdPasswordStrength.js
@@ -1,0 +1,94 @@
+'use strict';
+
+describe('sdPasswordStrength', function() {
+    var $compile, $rootScope, compileDirective;
+
+    beforeEach(module('gettext'));
+    beforeEach(module('superdesk.directives.passwordStrength'));
+
+    beforeEach(inject(function (_$compile_, _$rootScope_) {
+        $compile = _$compile_;
+        $rootScope = _$rootScope_;
+        compileDirective = function compileDirective(scopeValues) {
+            var html = '<input type="password" ng-model="pwd" sd-password-strength>';
+            var newScope = $rootScope.$new();
+
+            angular.extend(newScope, scopeValues);
+            var el = $compile(html)(newScope);
+            newScope.$digest();
+
+            return el;
+        };
+    }));
+
+    it('should insert strength indicator after input', function() {
+        var $el = compileDirective();
+        expect($el.next().hasClass('password-strength')).toBeTruthy();
+    });
+
+    it('should start of with strength as "Short" if empty', function() {
+        var $el = compileDirective();
+        expect($el.next().find('.label').text()).toBe('Short');
+    });
+
+    it('should start of with correct strength when model is pre-populated', function() {
+        var $el = compileDirective({'pwd': 'abcdE123'});
+        expect($el.next().find('.label').text()).toBe('OK');
+    });
+
+    it('should update strength when model changes', function() {
+        var $el = compileDirective();
+        var $scope = $el.scope();
+        var label = $el.next().find('.label');
+
+        expect(label.text()).toBe('Short');
+
+        $scope.pwd = '123456789';
+        $scope.$digest();
+
+        expect(label.text()).toBe('Weak');
+    });
+
+    it('should update strength as input progresses', function() {
+        var $el = compileDirective();
+        var label = $el.next().find('.label');
+        var $scope = $el.scope();
+
+        expect(label.text()).toBe('Short');
+
+        $scope.pwd = 'abcdefgh';
+        $scope.$digest();
+        expect(label.text()).toBe('Weak');
+
+        $scope.pwd = $scope.pwd + 'A';
+        $scope.$digest();
+        expect(label.text()).toBe('Better');
+
+        $scope.pwd = $scope.pwd + '1';
+        $scope.$digest();
+        expect(label.text()).toBe('OK');
+
+        $scope.pwd = $scope.pwd + '@';
+        $scope.$digest();
+        expect(label.text()).toBe('Strong');
+    });
+
+    it('should invalidate model when password is not good enough', function() {
+        var $el = compileDirective({'pwd': 'abcd'});
+        var ctrl = $el.controller('ngModel');
+
+        expect(ctrl.$invalid).toBeTruthy();
+    });
+
+    it('should validate model when password becomes good enough', function() {
+        var $el = compileDirective({'pwd': 'abcd'});
+        var $scope = $el.scope();
+        var ctrl = $el.controller('ngModel');
+
+        expect(ctrl.$invalid).toBeTruthy();
+
+        $scope.pwd = $scope.pwd + '@123';
+        $scope.$digest();
+        expect(ctrl.$valid).toBeTruthy();
+    });
+});

--- a/scripts/superdesk/superdesk.js
+++ b/scripts/superdesk/superdesk.js
@@ -34,6 +34,7 @@
         'superdesk.directives.autofocus',
         'superdesk.directives.throttle',
         'superdesk.directives.sort',
+        'superdesk.directives.passwordStrength',
         'superdesk.links',
         'superdesk.check.directives',
         'superdesk.confirm.directives',

--- a/styles/less/bootstrap.less
+++ b/styles/less/bootstrap.less
@@ -22,6 +22,7 @@
 
 // Components: common
 @import "sd-typeahead.less";
+@import "sd-password-strength.less";
 @import "sd-icon-font.less";
 @import "dropdowns.less";
 

--- a/styles/less/sd-password-strength.less
+++ b/styles/less/sd-password-strength.less
@@ -1,0 +1,49 @@
+div.password-strength {
+	color: #666;
+	margin: 3px 0;
+	font-size: 12px;
+
+	.label {
+		&.red { background-color: @red; }
+		&.yellow { background-color: @yellow; }
+		&.green { background-color: @green; }
+	}
+
+	.icon-question-sign {
+		margin: 0px 0 0 5px;
+		position: relative;
+		top: 3px;
+		color: @blue;
+		cursor: pointer;
+	}
+
+	.tooltip {
+		> .tooltip-arrow {
+			border-color: @grayDark transparent @grayDark transparent;
+			opacity: 0.9;
+		}
+
+		> .tooltip-inner {
+			text-align: left;
+			background-color: @grayDark;
+			border-radius: 3px;
+			opacity: 0.9;
+			line-height: 16px;
+
+			ul {
+				padding: 3px 0;
+
+				li {
+					padding: 0;
+					margin: 0;
+					line-height: 16px;
+
+					&:before {
+						content: "- ";
+						padding-left: 5px;
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Contains a new directive called `sd-password-strength` that enhances password inputs with strength validation. This directive will fail the validity of the model that is bound to the form if the minimum strength is not met (as per [requirements](https://dev.sourcefabric.org/browse/SD-4552)).

When less than 8 characters are entered, the strength indicator shows the text "_Short_":
<img width="239" alt="screen shot 2016-05-26 at 1 39 47 pm" src="https://cloud.githubusercontent.com/assets/6686356/15572140/6cbd96f6-2347-11e6-95e8-e092757c2223.png">

After more than 8 characters have been entered, strength will be computed on a scale from 1 to 4 based on how many points from below are found:
* a lower case letter (a-z)
* an upper case letter (A-Z)
* a number (0-9)
* a special characters (e.g. !@#$%^&*()_+|~-=\‘{}[]:";’<>?,./)

**Strength 1/4**:
<img width="232" alt="screen shot 2016-05-26 at 1 39 57 pm" src="https://cloud.githubusercontent.com/assets/6686356/15572163/82db26ce-2347-11e6-8d97-4f3fbce0d295.png">

**Strength 2/4**:
<img width="233" alt="screen shot 2016-05-26 at 1 40 03 pm" src="https://cloud.githubusercontent.com/assets/6686356/15572171/8ad1e19c-2347-11e6-959e-1ec200c54726.png">

**Strength 3/4 (valid password)**:
<img width="235" alt="screen shot 2016-05-26 at 1 40 09 pm" src="https://cloud.githubusercontent.com/assets/6686356/15572173/901efaa4-2347-11e6-9226-53232822746b.png">

**Strength 4/4 (strong password)**:
<img width="234" alt="screen shot 2016-05-26 at 1 40 17 pm" src="https://cloud.githubusercontent.com/assets/6686356/15572175/963ab752-2347-11e6-8b3f-06636fd3d200.png">

Additionally, hovering the question mark will display information about the password requirements:
<img width="253" alt="screen shot 2016-05-26 at 1 40 22 pm" src="https://cloud.githubusercontent.com/assets/6686356/15572186/a0a15d9a-2347-11e6-9992-2ad7a713edfc.png">
