### PR TITLE
fix(search): search provider radio button disappearing

### DIFF
--- a/scripts/superdesk-search/search.js
+++ b/scripts/superdesk-search/search.js
@@ -1580,7 +1580,6 @@
                             scope.flags = false;
                             scope.meta = {};
                             scope.fields = {};
-                            scope.providers = [];
                             scope.searchProviderTypes = searchProviderService.getProviderTypes();
                             scope.cvs = metadata.search_cvs;
                             scope.search_config = metadata.search_config;


### PR DESCRIPTION
it was reseting list of search providers without fetching it again,
now it's set only once.

SD-4496