### PR TITLE
[SD-4565] - Filtering subscribers as 'targetable by users'

### DIFF
--- a/scripts/superdesk-archive/directives.js
+++ b/scripts/superdesk-archive/directives.js
@@ -681,7 +681,7 @@
                             scope.selectedSubscribers = {items: []};
 
                             if (item && !scope.customSubscribers) {
-                                subscribersService.fetchActiveSubscribers().then(function(items) {
+                                subscribersService.fetchTargetableSubscribers().then(function(items) {
                                     scope.customSubscribers = [];
                                     scope.subscribers = items._items;
                                     _.each(items, function(item) {

--- a/scripts/superdesk-authoring/metadata/metadata.js
+++ b/scripts/superdesk-authoring/metadata/metadata.js
@@ -892,7 +892,7 @@ function MetadataService(api, $q, subscribersService, config) {
         fetchSubscribers: function() {
             var self = this;
             self.values.customSubscribers = [];
-            return subscribersService.fetchActiveSubscribers().then(function(items) {
+            return subscribersService.fetchTargetableSubscribers().then(function(items) {
                 _.each(items, function(item) {
                     self.values.customSubscribers.push({'_id': item._id, 'name': item.name});
                 });

--- a/scripts/superdesk-ingest/tests/subscribers_spec.js
+++ b/scripts/superdesk-ingest/tests/subscribers_spec.js
@@ -8,7 +8,10 @@ describe('subscribers service', function() {
     beforeEach(inject(function(subscribersService, $q, api) {
         spyOn(api, 'query').and.returnValue($q.when({
             _items: [{'name': 'sub-1', 'is_active': false},
-            {'name': 'sub-2', 'is_active': true}, {'name': 'sub-3', 'is_active': false}],
+            {'name': 'sub-2', 'is_active': true, 'is_targetable': true},
+            {'name': 'sub-3', 'is_active': false},
+            {'name': 'sub-4', 'is_active': true, 'is_targetable': false},
+            {'name': 'sub-5', 'is_active': true}],
             _links: {}
         }));
     }));
@@ -20,7 +23,7 @@ describe('subscribers service', function() {
         });
 
         $rootScope.$digest();
-        expect(allSubscribers.length).toBe(3);
+        expect(allSubscribers.length).toBe(5);
     }));
 
     it('can get all subscribers with criteria', inject(function(subscribersService, api, $q, $rootScope) {
@@ -36,7 +39,17 @@ describe('subscribers service', function() {
         });
 
         $rootScope.$digest();
-        expect(allSubscribers.length).toBe(1);
+        expect(allSubscribers.length).toBe(3);
+    }));
+
+    it('can get all targetable subscribers', inject(function(subscribersService, api, $q, $rootScope) {
+        var allSubscribers;
+        subscribersService.fetchTargetableSubscribers().then(function(subs) {
+            allSubscribers = subs;
+        });
+
+        $rootScope.$digest();
+        expect(allSubscribers.length).toBe(2);
     }));
 
 });

--- a/scripts/superdesk-publish/publish.js
+++ b/scripts/superdesk-publish/publish.js
@@ -81,6 +81,14 @@
                 });
             },
 
+            fetchTargetableSubscribers: function(criteria) {
+                return _getAllSubscribers(criteria).then(function(result) {
+                    return _.filter(result, function(r) {
+                        return (!('is_targetable' in r) || r.is_targetable) && r.is_active;
+                    });
+                });
+            },
+
             fetchSubscribersByKeyword: function(keyword) {
                 return this.fetchSubscribers({'$or': [{name: {'$regex': keyword, '$options': '-i'}}]});
             },
@@ -583,6 +591,10 @@
                         $scope.subscriber = _.create($scope.origSubscriber);
                         $scope.subscriber.critical_errors = $scope.origSubscriber.critical_errors;
                         $scope.subscriber.sequence_num_settings = $scope.origSubscriber.sequence_num_settings;
+
+                        if (!('is_targetable' in $scope.origSubscriber)) {
+                            $scope.subscriber.is_targetable = true;
+                        }
 
                         $scope.subscriber.products = [];
                         if ($scope.origSubscriber.products) {

--- a/scripts/superdesk-publish/views/subscribers.html
+++ b/scripts/superdesk-publish/views/subscribers.html
@@ -66,11 +66,18 @@
                             </select>
                         </div>
 
-                        
-
                         <div class="field">
                             <label translate>Subscriber codes</label><i class="field-info" translate>*comma separated values</i>
                             <textarea class="fullwidth-input" ng-model="subscriber.codes"></textarea>
+                        </div>
+
+                        <div class="field">
+                            <label class="left">
+                                {{:: 'Targetable by users' | translate }}
+                                <span title="{{ subscriber.is_targetable ? 'Deactivate' : 'Activate'  | translate }}">
+                                    <span sd-switch ng-model="subscriber.is_targetable"></span>
+                                </span>
+                            </label>
                         </div>
 
                         <div class="field">


### PR DESCRIPTION
Too many subscribers (as we have in pre-production) make it difficult to use resend or target subscriber collections:

- Subscribers `is_targetable` field set as `false` won't be listed in the target subscribers and resend selections.
- If the field is not set or true then the subscriber will be listed.
