### PR TITLE
[SDNTB-215] Change "subscriptions" in Scanpix search provider

### DIFF
--- a/scripts/superdesk-search/search.js
+++ b/scripts/superdesk-search/search.js
@@ -1587,6 +1587,14 @@
                             scope.searchProviderTypes = searchProviderService.getProviderTypes();
                             scope.cvs = metadata.search_cvs;
                             scope.search_config = metadata.search_config;
+                            scope.scanpix_subscriptions = [{
+                                name: 'subscription',
+                                label: 'inside subscription',
+                            }, {
+                                name: 'all',
+                                label: 'all photos',
+                            }];
+                            scope.meta.scanpix_subscription = scope.scanpix_subscriptions[0].name;
                             scope.lookupCvs = {};
                             angular.forEach(scope.cvs, function(cv) {
                                 scope.lookupCvs[cv.id] = cv;
@@ -1789,6 +1797,9 @@
                                     metas.push(val.join(' '));
                                 } else {
                                     if (val) {
+                                        if (key.startsWith('scanpix_')) {
+                                            key = key.substring(8);
+                                        }
                                         if (typeof(val) === 'string'){
                                             if (val) {
                                                 metas.push(key + ':(' + val + ')');

--- a/scripts/superdesk-search/views/item-search.html
+++ b/scripts/superdesk-search/views/item-search.html
@@ -184,10 +184,8 @@
                 </label>
                 <select
                     id="subscription" name="subscription"
-                    ng-options="o for o in ['subscription', 'punchcard']"
-                    ng-init="meta.subscription='subscription'"
-                    ng-model="meta.subscription">
-                    <option value="" label=""></option>
+                    ng-options="s.name as s.label for s in scanpix_subscriptions"
+                    ng-model="meta.scanpix_subscription">
                 </select>
             </div>
         </div>


### PR DESCRIPTION
moved subscriptions options to search.js. Scanpix options are put
directly here for now as it was done in a similar way for PA, but
search providers handling should be refactored and providers
list/params should be updated by backend.