### PR TITLE
[SD-4705] Add search in spike to global search

### DIFF
--- a/scripts/superdesk-authoring/metadata/metadata.js
+++ b/scripts/superdesk-authoring/metadata/metadata.js
@@ -869,7 +869,7 @@ function MetadataService(api, $q, subscribersService, config) {
         search_cvs: config.search_cvs || [{'id': 'subject', 'name': 'Subject',
             'field': 'subject', 'list': 'subjectcodes'}],
         search_config: config.search || {'slugline': 1, 'headline': 1, 'unique_name': 1, 'story_text': 1,
-            'byline': 1, 'keywords': 1, 'creator': 1, 'from_desk': 1, 'to_desk': 1},
+            'byline': 1, 'keywords': 1, 'creator': 1, 'from_desk': 1, 'to_desk': 1, 'spike': 1},
         subjectScope: null,
         loaded: null,
         fetchMetadataValues: function() {

--- a/scripts/superdesk-monitoring/monitoring.js
+++ b/scripts/superdesk-monitoring/monitoring.js
@@ -88,7 +88,8 @@
                 params.q = card.query;
             }
 
-            params.spike = (card.type === 'spike' || card.type === 'spike-personal');
+            params.spike = (card.type === 'spike' || card.type === 'spike-personal' ||
+                (card.type === 'search' && params.spike === true));
 
             var query = search.query(search.setFilters(params));
 

--- a/scripts/superdesk-search/search.js
+++ b/scripts/superdesk-search/search.js
@@ -5,7 +5,8 @@
         unique_name: 'Unique Name',
         original_creator: 'Creator',
         from_desk: 'From Desk',
-        to_desk: 'To Desk'
+        to_desk: 'To Desk',
+        spike: 'In Spiked'
     });
 
     SearchService.$inject = ['$location', 'gettext', 'config'];
@@ -71,6 +72,9 @@
                                     filters.push({'exists': {'field': field}});
                                 }
                             }
+                            break;
+                        case 'spike':
+                            // Will get set in the base filters
                             break;
                         default:
                             var filter = {'term': {}};
@@ -487,6 +491,11 @@
                         case 'to_desk':
                             tags.selectedParameters.push(value + ':' +
                                 desks.deskLookup[params[key].split('-')[0]].name);
+                            break;
+                        case 'spike':
+                            if (params[key]) {
+                                tags.selectedParameters.push(value);
+                            }
                             break;
                         default:
                             tags.selectedParameters.push(value + ':' + params[key]);
@@ -1614,6 +1623,10 @@
                                 scope.fields.unique_name = $location.search().unique_name;
                             }
 
+                            if ($location.search().spike) {
+                                scope.fields.spike = true;
+                            }
+
                             if (load_data) {
                                 fetchMetadata();
                                 fetchProviders(params);
@@ -1728,7 +1741,8 @@
                                 scope.fields.from_desk !== $location.search().from_desk ||
                                 scope.fields.to_desk !== $location.search().to_desk ||
                                 scope.fields.unique_name !== $location.search().unique_name ||
-                                scope.fields.original_creator !== $location.search().original_creator) {
+                                scope.fields.original_creator !== $location.search().original_creator ||
+                                scope.fields.spike !== $location.search().spike) {
                                 init();
                             }
                         });

--- a/scripts/superdesk-search/views/item-search.html
+++ b/scripts/superdesk-search/views/item-search.html
@@ -119,7 +119,12 @@
                 <option value="" label=""></option>
             </select>
         </div>
-
+        <div class="field" ng-if="search_config.spike">
+            <label for="search-spike">
+            {{:: 'In Spiked' | translate}}
+            </label>
+            <span sd-switch ng-model="fields.spike"></span>
+        </div>
     </fieldset>
     <fieldset ng-show="repo.search === 'aapmm'">
         <div class="field">


### PR DESCRIPTION
Add the ability to search spiked content in global search, It will allow saved searches against spiked content in multiple desks.

Dependent on superdesk/superdesk-core#424