### PR TITLE
(fix)[SD-4768] Queue items should only refresh if there change in the items.

### DIFF
--- a/scripts/superdesk-authoring/views/dashboard-articles.html
+++ b/scripts/superdesk-authoring/views/dashboard-articles.html
@@ -1,4 +1,4 @@
-<div sd-modal data-model="dashboardActive" class="modal--fullscreen">
+<div sd-modal data-model="active" class="modal--fullscreen">
     <div class="modal-header">
         <h3 class="pull-left" translate>Currently working on</h3>
         <div class="btn-group pull-right">
@@ -8,7 +8,7 @@
 
     <div class="modal-body">
         <div class="flex-grid box wrap-items small-2 medium-4 large-6">
-            <div class="flex-item card-box card-box--with-click card-box--flex" ng-repeat="article in workqueue.items track by article._id"  ng-class="{active: article === active}">
+            <div class="flex-item card-box card-box--with-click card-box--flex" ng-repeat="article in items track by article._id"  ng-class="{active: article === active}">
                 <a class="card-box__full-click" ng-click="edit(article, $event)" ng-href="{{ :: link(article)}}"></a>
                 <span class="close cardbox__close" ng-click="closeItem(article)"><i class="icon-close-small white"></i></span>
                 <div class="card-box__header card-box__header--padded-flex">

--- a/scripts/superdesk-authoring/views/opened-articles.html
+++ b/scripts/superdesk-authoring/views/opened-articles.html
@@ -22,4 +22,11 @@
     </ul>
 </div>
 
-<div sd-dashboard-articles data-active="dashboardActive"></div>
+<div sd-dashboard-articles
+     data-active="dashboardActive"
+     data-close-dashboard="closeDashboard()"
+     data-close-item="closeItem(item)"
+     data-edit="edit(item, event)"
+     data-link="link(item)"
+     data-items="workqueue.items"
+></div>


### PR DESCRIPTION
Problems Fixed:
- Workqueue items were fetched on every `item:lock`,  `item:unlock`, `locationChangeSuccess` and `content:update` event.
- All queries were fired twice.

I have removed `locationChangeSuccess`. imo, 'content:update', 'item:lock' and 'item:unlock' are sufficient.