### PR TITLE
[SD-4681] ui(fix/content-profiles): reject server requests that return errors.

### DIFF
--- a/scripts/superdesk-workspace/content/content.js
+++ b/scripts/superdesk-workspace/content/content.js
@@ -402,8 +402,8 @@
         };
     }
 
-    ContentProfilesController.$inject = ['$scope', 'notify', 'content', 'modal'];
-    function ContentProfilesController($scope, notify, content, modal) {
+    ContentProfilesController.$inject = ['$scope', 'notify', 'content', 'modal', '$q'];
+    function ContentProfilesController($scope, notify, content, modal, $q) {
         var that = this;
 
         // creating will be true while the modal for creating a new content
@@ -433,6 +433,7 @@
         function reportError(resp) {
             notify.error('Operation failed (check console for response).');
             console.error(resp);
+            return $q.reject(resp);
         }
 
         /**
@@ -450,7 +451,7 @@
                     angular.isObject(resp.data._issues.label) &&
                     resp.data._issues.label.unique) {
                     notify.error(that.duplicateErrorTxt);
-                    return resp;
+                    return $q.reject(resp);
                 }
                 return next(resp);
             };


### PR DESCRIPTION
This was causing a bug when creating a content profile with a name that already exists. The "Edit" modal was being brought up, even though a content profile wasn't created.