### PR TITLE
fix(monitoring): stop preview on doubleclick

### DIFF
--- a/scripts/superdesk-search/react.js
+++ b/scripts/superdesk-search/react.js
@@ -1453,7 +1453,7 @@
                                         scope.preview(item);
                                     });
                                 }
-                            }, 200, false);
+                            }, 500, false);
                         },
 
                         edit: function(item) {


### PR DESCRIPTION
it was only waiting for 200ms for second click, now it will
wait for 500ms before starting the preview so it will match
windows defaults

SD-4694