### PR TITLE
Added a method to set default value on init and search provider change

### DIFF
--- a/scripts/superdesk-search/search.js
+++ b/scripts/superdesk-search/search.js
@@ -1594,6 +1594,15 @@
                         });
 
                         /*
+                         * function to initialize default values on init or search provider change
+                         */
+                        scope.setDefaultValues = function() {
+                            if (scope.repo && scope.repo.search && scope.repo.search === 'scanpix') {
+                                scope.meta.scanpix_subscription = scope.scanpix_subscriptions[0].name;
+                            }
+                        };
+
+                        /*
                          * init function to setup the directive initial state and called by $locationChangeSuccess event
                          * @param {boolean} load_data.
                          */
@@ -1637,9 +1646,7 @@
                                 }
                             }
 
-                            if (scope.repo && scope.repo.search && scope.repo.search === 'scanpix') {
-                                scope.meta.scanpix_subscription = scope.scanpix_subscriptions[0].name;
-                            }
+                            scope.setDefaultValues();
 
                             if ($location.search().unique_name) {
                                 scope.fields.unique_name = $location.search().unique_name;

--- a/scripts/superdesk-search/views/item-search.html
+++ b/scripts/superdesk-search/views/item-search.html
@@ -12,7 +12,7 @@
         </div>
         <div ng-repeat="provider in providers">
             <label>
-                <input type="radio" ng-value="provider.search_provider" ng-model="repo.search" ng-checked="isDefault(provider)">
+                <input type="radio" ng-value="provider.search_provider" ng-model="repo.search" ng-checked="isDefault(provider)" ng-change="setDefaultValues()">
                 {{:: provider.source}}
             </label>
         </div>


### PR DESCRIPTION
Default value (only used for Scanpix so far) was only set on init, so
it was not working when opening advanced search with default to
inside superdesk, and then clicking on Scanpix.
This commit add setDefaultValues function which is called both on init
and search provider change making initial values consistant.

SDNTB-215