### PR TITLE
[SD-4745]: fix timezone behavior

### DIFF
--- a/scripts/superdesk/ui/ui.js
+++ b/scripts/superdesk/ui/ui.js
@@ -857,15 +857,15 @@
         };
     }
 
-    TimezoneDirective.$inject = ['tzdata', 'config'];
-    function TimezoneDirective(tzdata, config) {
+    TimezoneDirective.$inject = ['tzdata', 'config', '$timeout'];
+    function TimezoneDirective(tzdata, config, $timeout) {
         return {
             templateUrl: 'scripts/superdesk/ui/views/sd-timezone.html',
             scope: {
                 timezone: '=',
                 style: '@'
             },
-            link: function(scope) {
+            link: function(scope, el) {
                 scope.timeZones = [];     // all time zones to choose from
                 scope.tzSearchTerm = '';  // the current time zone search term
 
@@ -926,6 +926,9 @@
                  * @method clearSelectedTimeZone
                  */
                 scope.clearSelectedTimeZone = function () {
+                    $timeout(function() {
+                        el.find('input')[0].focus();
+                    }, 0, false);
                     delete scope.timezone;
                 };
 

--- a/scripts/superdesk/ui/views/sd-timezone.html
+++ b/scripts/superdesk/ui/views/sd-timezone.html
@@ -7,7 +7,7 @@
         search="searchTimeZones(term)"
         select="selectTimeZone(item)"
         always-visible="tzSearchTerm"
-        placeholder="Europe/London">
+        placeholder="ie. Europe/London">
         <li typeahead-item="tz" ng-repeat="tz in matchingTimeZones track by tz">{{ ::tz}}</li>
         <li ng-show="tzSearchTerm && matchingTimeZones.length === 0"
             class="no-match"
@@ -24,7 +24,7 @@
         <div id="timezone" class="name right-pad">{{timezone}}</div>
         <div class="actions">
             <button title="{{:: 'Clear' | translate }}" ng-click="clearSelectedTimeZone()">
-                <i class="icon-pencil"></i>
+                <i class="icon-remove-sign"></i>
             </button>
         </div>
     </li>

--- a/spec/helpers/pages.js
+++ b/spec/helpers/pages.js
@@ -201,7 +201,7 @@ function IngestSettings() {
         },
 
         timezoneLabel: element(by.id('timezone')),
-        timezoneDeleteBtn: $$('.icon-pencil').get(0),
+        timezoneDeleteBtn: $$('.icon-remove-sign').get(0),
         timezoneInput: $('[term="tzSearchTerm"]').element(by.model('term')),
         timezoneList: $('.item-list').all(by.tagName('li'))
     };


### PR DESCRIPTION
- Replaced pencil icon with remove (x) icon to correctly reflect the
  action that happens when it is clicked.

- Focus the timezone input once the field is cleared to encourage the
  user to type a new value.

Also fixes [SD-4791](https://dev.sourcefabric.org/browse/SD-4791).