### PR TITLE
fix(schedule): fix time picker time when utc time is missing

### DIFF
--- a/scripts/superdesk-authoring/metadata/metadata.js
+++ b/scripts/superdesk-authoring/metadata/metadata.js
@@ -186,7 +186,9 @@ function MetadataCtrl(
      */
     function resolvePublishScheduleAndEmbargoTS() {
         var info;
-        var embargo = $scope.item.embargo, publish_schedule = $scope.item.publish_schedule;
+        var embargo = datetimeHelper.removeTZ($scope.item.embargo);
+        var publish_schedule = datetimeHelper.removeTZ($scope.item.publish_schedule);
+
         if ($scope.item.schedule_settings) {
             $scope.item.time_zone = $scope.item.schedule_settings.time_zone;
             if ($scope.item.schedule_settings.utc_embargo) {

--- a/scripts/superdesk-authoring/metadata/tests/MetadataWidgetCtrl_spec.js
+++ b/scripts/superdesk-authoring/metadata/tests/MetadataWidgetCtrl_spec.js
@@ -39,7 +39,10 @@ describe('MetadataWidgetCtrl controller', function () {
         spyOn(preferencesService, 'get').and.returnValue(prefsGet.promise);
 
         scope = $rootScope.$new();
-        scope.item = {publish_schedule: '2015-08-01T15:12:34+00:00'};
+        scope.item = {
+            publish_schedule: '2015-08-01T15:12:34+0000',
+            schedule_settings: {time_zone: 'Europe/Prague'}
+        };
         $controller('MetadataWidgetCtrl', {$scope: scope});
     }));
 

--- a/scripts/superdesk/datetime/datetime.js
+++ b/scripts/superdesk/datetime/datetime.js
@@ -115,6 +115,20 @@
         this.greaterThanUTC = function(timestring) {
             return moment(timestring, 'YYYY-MM-DDTHH:mm:ssZZ') > moment.utc();
         };
+
+        /**
+         * Remove tz info from given datetime
+         *
+         * it's added automatically on server for every datetime like values
+         *
+         * @param {String} datetime
+         * @return {String}
+         */
+        this.removeTZ = function(datetime) {
+            if (datetime) {
+                return datetime.replace('+0000', '').replace('+00:00', '');
+            }
+        };
     }
 
     return angular.module('superdesk.datetime', [


### PR DESCRIPTION
after descheduling there is no utc schedule value, so it's using
`publish_schedule` field which has timezone info added by server (+0000)
which is wrong and should be ignored

SD-4759