### PR TITLE
[SD-4729] [SD-4730](fix) Adding target fields in template and routing.

### DIFF
--- a/scripts/superdesk-authoring/metadata/metadata.js
+++ b/scripts/superdesk-authoring/metadata/metadata.js
@@ -244,9 +244,22 @@ function MetaTargetedPublishingDirective() {
                 }
 
                 target = JSON.parse(target);
-                scope.targets.push({'qcode': target.qcode, 'name': target.name, 'allow': !scope.deny});
-                scope.autosave();
+
+                var existing = _.find(scope.targets,
+                    {'qcode': target.qcode, 'name': target.name, 'allow': !scope.deny});
+
+                if (!existing) {
+                    scope.targets.push({'qcode': target.qcode, 'name': target.name, 'allow': !scope.deny});
+                    scope.autosave();
+                }
+
+                reset();
             };
+
+            function reset() {
+                scope.target = '';
+                scope.deny = false;
+            }
 
             scope.canAddTarget = function() {
                 return scope.disabled || !scope.target || scope.target === '';

--- a/scripts/superdesk-ingest/views/settings/ingest-routing-action.html
+++ b/scripts/superdesk-ingest/views/settings/ingest-routing-action.html
@@ -48,6 +48,13 @@
                  data-reload-list="true"
                  ></div>
         </div>
+        <div class="field target-field" ng-show="showNewPublish">
+            <label translate>Target Types</label>
+            <div sd-meta-target
+                 data-list="target_types"
+                 data-targets="newPublish.target_types"
+                 ></div>
+        </div>
         <button ng-show="showNewPublish" class="btn" ng-click="addPublish();showNewPublish = false" ng-disabled="!newPublish.desk || !newPublish.stage" translate>Add</button>
         <button ng-show="showNewPublish" class="btn" ng-click="cancel();showNewPublish = false" translate>Cancel</button>
     </div>

--- a/scripts/superdesk-templates/styles/templates.less
+++ b/scripts/superdesk-templates/styles/templates.less
@@ -48,6 +48,7 @@
         .toggle-box__label {
             color: @black;
         }
+
     }
 
     .template-icon {
@@ -115,3 +116,50 @@
     }
 
 }
+
+.target-field {
+    select {
+        width: 200px;
+    }
+    .terms {
+        .user-select(none);
+        padding-top: 10px;
+        .clearfix();
+        li {
+            position: relative;
+            background: #e8e8e8;
+            line-height: 26px;
+            float: left;
+            height: 26px;
+            padding: 0 6px;
+            .border-radius(3px);
+            margin: 0 5px 5px 0;
+            .transition(all .5s);
+            i:not(.alt) {
+                position: absolute;
+                display: none;
+                right: 5px;
+                top: 6px;
+                .opacity(0);
+                .transition(all .5s);
+            }
+            &:hover {
+                cursor: pointer;
+                background: #e0e0e0;
+                i {
+                    .opacity(70);
+                }
+            }
+            &:hover {
+                > i:not(.alt) {
+                    display: inline-block;
+                }
+            }
+            &.selected {
+                background: #333333;
+                color: #e8e8e8;
+            }
+        }
+    }
+}
+

--- a/scripts/superdesk-templates/views/template-editor-modal.html
+++ b/scripts/superdesk-templates/views/template-editor-modal.html
@@ -100,6 +100,22 @@
                         <input class="line-input" type="text" ng-model="item.language" ng-disabled="!_editable" ng-change="autosave(item)">
                     </div>
                 </div>
+
+                <div class="field target-field">
+                    <label translate>Target Regions</label>
+                    <div sd-meta-target
+                        data-list="metadata.regions"
+                        data-targets="item.target_regions"
+                        ></div>
+                </div>
+
+                <div class="field target-field">
+                    <label translate>Target Types</label>
+                    <div sd-meta-target
+                        data-list="metadata.subscriberTypes"
+                        data-targets="item.target_types"
+                        ></div>
+                </div>
             </div>
 
             <div class="field" ng-if="showScheduling()">


### PR DESCRIPTION
*Fixes Include*
- The broken query for templates in save as templates
- Filter not working if desk is select in the template management
- Change the query so that user will see the `personal template, public template assigned to the desk and public template assigned to no desk` in the modal for `create item from template`. 

@petrjasek @mugurrus @ioanpocol 

Depends on [Core PR 437](https://github.com/superdesk/superdesk-core/pull/437)