### PR TITLE
[SD-4580]: show timezone typeahead in authoring on top

### DIFF
--- a/scripts/superdesk-authoring/styles/authoring.less
+++ b/scripts/superdesk-authoring/styles/authoring.less
@@ -1208,7 +1208,7 @@ feature-image {
 
 	ul.item-list {
 		right: auto;
-		top: 37px;
+		top: -170px;
 		width: 100%;
 	}
 


### PR DESCRIPTION
![screen shot 2016-06-23 at 10 49 52 am](https://cloud.githubusercontent.com/assets/6686356/16299066/3def8d1c-3930-11e6-9fd4-cc51bad078ae.png)
