### PR TITLE
[SD-4815]: missing labels appearing as empty on content schema editor

### DIFF
--- a/scripts/superdesk-workspace/content/content.js
+++ b/scripts/superdesk-workspace/content/content.js
@@ -545,7 +545,12 @@
             'byline': gettext('By'),
             'dateline': gettext('Date'),
             'located': gettext('Located'),
-            'sign_off': gettext('Sign Off')
+            'sign_off': gettext('Sign Off'),
+            'sms': gettext('SMS'),
+            'body_footer': gettext('Body footer'),
+            'footer': gettext('Footer'),
+            'media': gettext('Media'),
+            'media_description': gettext('Media Description')
         };
 
         return {
@@ -560,7 +565,13 @@
                  * @description label returns the display name for a key.
                  */
                 scope.label = function(id) {
-                    return labelMap[id];
+                    if (labelMap.hasOwnProperty(id)) {
+                        return labelMap[id];
+                    }
+
+                    console.warn('could not find label for ' + id +
+                        '. Please add it in (superdesk-workspace/content/content.js).ContentProfileSchemaEditor/labelMap');
+                    return id;
                 };
 
                 /**


### PR DESCRIPTION
Whenever a translation is missing for an item in the schema of a content
profile, the key for the item is now displayed and a warning to check
the error console for more details.

Do note that whenever adding new items to the schema, subsequent
translations needs to be added in the front-end in
`(superdesk-workspace/content/content.js).ContentProfileSchemaEditor/labelMap`