### PR TITLE
ui(fix): when slug line is too long it breaks layout in preview (SD-4775)

### DIFF
--- a/scripts/superdesk-archive/views/preview.html
+++ b/scripts/superdesk-archive/views/preview.html
@@ -23,7 +23,7 @@
           </div>
           <div class="preview-header__main-block">
             <div class="preview-header__flex-row">
-              <span ng-if="selected.preview.slugline" class="keyword">{{selected.preview.slugline}}</span>
+              <span ng-if="selected.preview.slugline" class="keyword" title="{{selected.preview.slugline}}">{{selected.preview.slugline}}</span>
             </div>
             <div class="preview-header__flex-row preview-header__flex-row--single-line" ng-if="selected.preview.anpa_take_key">
               <span class="inline-label">takekey:</span><span class="takekey">{{selected.preview.anpa_take_key}}</span>

--- a/scripts/superdesk-items-common/styles/archive-preview.less
+++ b/scripts/superdesk-items-common/styles/archive-preview.less
@@ -1138,10 +1138,12 @@
             flex-grow: 1;
             padding-right: 12px;
             text-align: left;
+            overflow: hidden;
         }
         .preview-header__flex-row {
             min-height: 18px;
             margin-bottom: 4px;
+            overflow: hidden;
             &--single-line {
                 //display:flex;
                 //flex-direction: row;
@@ -1154,6 +1156,10 @@
             display: inline-block;
             line-height: 116.6%;
             color: @sd-keyword;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            width: 100%;
+            overflow: hidden;
         }
         .word-count {
             font-size: 10px;


### PR DESCRIPTION
Additionally, when hovering over the slugline, the full text can be seen in the tooltip.