### PR TITLE
fix(splitter): SD-4735 Fixed position of splitter after changing view

### DIFF
--- a/scripts/superdesk-packaging/packaging.less
+++ b/scripts/superdesk-packaging/packaging.less
@@ -96,6 +96,9 @@
         position: absolute;
         top: 5px;
         right: 16px;
+        .more-activity-toggle {
+            width: 16px; height: 16px;
+        }
     }
     .loading {
         width: 40px;

--- a/scripts/superdesk/ui/ui.js
+++ b/scripts/superdesk/ui/ui.js
@@ -1052,8 +1052,8 @@
      * resize monitoring and authoring screen
      *
      */
-    splitterWidget.$inject = ['superdesk', '$timeout'];
-    function splitterWidget(superdesk, $timeout) {
+    splitterWidget.$inject = ['superdesk', 'superdeskFlags', '$timeout'];
+    function splitterWidget(superdesk, superdeskFlags, $timeout) {
         return {
             link: function(scope, element) {
                 var workspace = element,
@@ -1063,8 +1063,8 @@
                  * If custom sizes are defined, preload them
                  */
                 if (superdesk.monitoringWidth && superdesk.authoringWidth) {
-                    workspace.width(superdesk.monitoringWidth);
-                    authoring.width(superdesk.authoringWidth);
+                    workspace.css({width: superdesk.monitoringWidth});
+                    authoring.css({width: superdesk.authoringWidth});
                 }
 
                 /*


### PR DESCRIPTION
SD-4735 - When authoring is expanded to the left the borders should remain unchanged if users navigate thru the left panel 

SD-4851 - Three dot menu of items of a package is not working in firefox