### PR TITLE
ui(fix): disable default browser behavior when dropping onto editor

### DIFF
--- a/scripts/superdesk/editor2/editor.js
+++ b/scripts/superdesk/editor2/editor.js
@@ -962,8 +962,6 @@ angular.module('superdesk.editor2', [
                         setEditorFormatOptions(editorConfig, sdTextEditor.editorformat, scope);
                         // if config.multiBlockEdition is true, add Embed and Image button to the toolbar
                         if (scope.config.multiBlockEdition) {
-                            // this dummy imageDragging stop preventing drag & drop events
-                            editorConfig.extensions = {'imageDragging': {}};
                             if (editorConfig.toolbar.buttons.indexOf('table') !== -1 && angular.isDefined(window.MediumEditorTable)) {
                                 editorConfig.extensions.table =
                                 new window.MediumEditorTable({aria:gettextCatalog.getString('insert table')});


### PR DESCRIPTION
When dragging an image onto the body field in the editor, by default,
the browser will open the image. After this change, this will no longer
happen and the user will stay with the editor.

Addresses [latest comment](https://dev.sourcefabric.org/browse/SD-4648?focusedCommentId=84964&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-84964) in [SD-4648](https://dev.sourcefabric.org/browse/SD-4648).

The line removed in the change is no longer needed because the default 
behavior has now changed via #644.