### PR TITLE
ui/fix: add link validation option to medium-editor (fixes SD-4554)

### DIFF
--- a/scripts/superdesk/editor2/editor.js
+++ b/scripts/superdesk/editor2/editor.js
@@ -745,7 +745,8 @@ angular.module('superdesk.editor2', [
                 cleanPastedHTML: false
             },
             anchor: {
-                placeholderText: gettext('Paste or type a full link')
+                placeholderText: gettext('Paste or type a full link'),
+                linkValidation: true
             },
             anchorPreview: {
                 showWhenToolbarIsVisible: true


### PR DESCRIPTION
After this PR, whenever adding an anchor link using the `#` button in
the toolbar, the `http://` protocol will be automatically appended when
deemed necessary. The URL will also be processed using JavaScript's
`encodeURI` function. Fixes [SD-4554](https://dev.sourcefabric.org/browse/SD-4545) and [SD-4545](https://dev.sourcefabric.org/browse/SD-4545).

<details><summary>Click for details</summary>
The validation code in the `MediumEditor` plugin looks like this (source [here](https://github.com/yabwe/medium-editor/blob/c4c0dae16bbaa82da40ae4d1a8aa055c52256909/src/js/extensions/anchor.js#L234-L247)):
```js
checkLinkFormat: function (value) {
    // Matches any alphabetical characters followed by ://
    // Matches protocol relative "//"
    // Matches common external protocols "mailto:" "tel:" "maps:"
    var urlSchemeRegex = /^([a-z]+:)?\/\/|^(mailto|tel|maps):/i,
    // var te is a regex for checking if the string is a telephone number
    telRegex = /^\+?\s?\(?(?:\d\s?\-?\)?){3,20}$/;
    if (telRegex.test(value)) {
        return 'tel:' + value;
    } else {
        // Check for URL scheme and default to http:// if none found
        return (urlSchemeRegex.test(value) ? '' : 'http://') + encodeURI(value);
    }
},
```
</details>