### PR TITLE
ui/fix: fixes a problem where dictionary contents were not visible [fixes SD-4817]

### DIFF
--- a/scripts/superdesk-dictionaries/dictionaries.js
+++ b/scripts/superdesk-dictionaries/dictionaries.js
@@ -254,14 +254,8 @@
             $scope.loading = true;
             dictionaries.open(dictionary, function(result) {
                 $scope.origDictionary = result;
-                $scope.dictionary = _.create(result);
-
-                if (dictionaries.isAbbreviationsDictionary(result)) {
-                    $scope.dictionary.content = angular.extend({}, result.content);
-                } else {
-                    $scope.dictionary.content = _.create(result.content || {});
-                }
-
+                $scope.dictionary = _.cloneDeep(result);
+                $scope.dictionary.content = $scope.dictionary.content || {};
                 $scope.dictionary.is_active = $scope.dictionary.is_active !== 'false';
             });
         };


### PR DESCRIPTION
I believe that initially the intention here was to duplicate the response object. In that case `_.create` is not the best option and I assume `_.cloneDeep` is more appropriate and closer to what was planned.

Reverses some changes made in #484 /cc @mdhaman 