### PR TITLE
ui/fix: changes abbreviation keys to case-sensitive in the UI to avoid confusion (fixes SD-4816)

### DIFF
--- a/scripts/superdesk-dictionaries/styles/dictionaries.less
+++ b/scripts/superdesk-dictionaries/styles/dictionaries.less
@@ -34,6 +34,7 @@
         width: 100px;
         display: inline-block;
         padding-left: 6px;
+        &.case-sensitive { text-transform: none; }
     }
     input {
         width: 250px;

--- a/scripts/superdesk-dictionaries/views/dictionary-config-modal.html
+++ b/scripts/superdesk-dictionaries/views/dictionary-config-modal.html
@@ -101,7 +101,7 @@
                 </div>
                 <div ng-repeat="key in abbreviationKeys track by key">
                     <div class="field abbreviations-field">
-                        <label>{{key}}</label>
+                        <label class="case-sensitive">{{key}}</label>
                     </div>
                     <div class="field abbreviations-field">
                         <input type="text" ng-model="dictionary.content[key]" >


### PR DESCRIPTION
Abbreviations are case sensitive, yet in the settings UI they are always capitalized, this was creating confusion.