### PR TITLE
ui/fix: hide headline if disabled in profile (fixes SD-4865)

### DIFF
--- a/scripts/superdesk-authoring/views/article-edit.html
+++ b/scripts/superdesk-authoring/views/article-edit.html
@@ -1,4 +1,4 @@
-<div class="field" ng-class="{'limit-error': item.headline.length > schema.headline.maxlength}" order="{{editor.headline.order}}" sd-validation-error="error.headline" data-required="schema.headline.required">
+<div class="field" ng-if="schema.headline" ng-class="{'limit-error': item.headline.length > schema.headline.maxlength}" order="{{editor.headline.order}}" sd-validation-error="error.headline" data-required="schema.headline.required">
   <label translate>Headline</label>
     <span ng-if="schema.headline.maxlength" sd-character-count data-item="item.headline" data-html="true" data-limit="schema.headline.maxlength"></span>
     <div id="title" class="headline"


### PR DESCRIPTION
This is a requirement from SD-4865 but as it seems in the code the headline was never be meant to be disabled. 