### PR TITLE
fix(templates): fix abbreviations expantion when there is no language

### DIFF
--- a/scripts/superdesk/editor/spellcheck/spellcheck.js
+++ b/scripts/superdesk/editor/spellcheck/spellcheck.js
@@ -83,7 +83,9 @@ function SpellcheckService($q, api, dictionaries, $rootScope, $location) {
      */
     this.getAbbreviationsDict = function(force) {
         if (!lang) {
-            return $q.reject();
+            // here it shouldn't reject like in getDict, where it would stop only spellchecking
+            // if there is no dictionary, while here it would stop scope commit in editor
+            return $q.when({});
         }
 
         var baseLang = getBaseLanguage(lang);

--- a/scripts/superdesk/editor/spellcheck/spellcheck.spec.js
+++ b/scripts/superdesk/editor/spellcheck/spellcheck.spec.js
@@ -187,6 +187,14 @@ describe('spellcheck', function() {
         expect(errors.length).toBe(2);
     }));
 
+    it('can resolve abbreviations without language specified', inject(function(spellcheck, $rootScope) {
+        var spy = jasmine.createSpy('success');
+        spellcheck.setLanguage('');
+        spellcheck.getAbbreviationsDict().then(spy);
+        $rootScope.$digest();
+        expect(spy).toHaveBeenCalled();
+    }));
+
     function assignErrors(_errors) {
         errors.splice(0, errors.length);
         errors.push.apply(errors, _errors);


### PR DESCRIPTION
for empty item language `spellcheck.getAbbreviationsDict` would stop
promise chain which would stop `editor.commitScope`. thus all editor
directives wouldn't work at all.

so instead it will resolve with empty dict.

SD-4934