### PR TITLE
Few UI changes to preview, labels and authoring

### DIFF
--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -3096,7 +3096,7 @@ msgid "Not For Publication"
 msgstr "Nicht zur Veröffentlichung"
 
 #: scripts/superdesk-search/react.js:968 scripts/superdesk-search/react.js:970
-msgid "Not For Publications"
+msgid "Not For Publication"
 msgstr "Nicht zur Veröffentlichung"
 
 #: scripts/superdesk-authoring/versioning/history/views/publish_queue.html:10

--- a/po/nb.po
+++ b/po/nb.po
@@ -3173,7 +3173,7 @@ msgstr "Ikke for publisering"
 
 #: scripts/superdesk-search/react.js:1051
 #: scripts/superdesk-search/react.js:1053
-msgid "Not For Publications"
+msgid "Not For Publication"
 msgstr "Ikke for publisering"
 
 #: scripts/superdesk-authoring/versioning/history/views/publish_queue.html:10

--- a/scripts/superdesk-archive/views/preview.html
+++ b/scripts/superdesk-archive/views/preview.html
@@ -28,6 +28,9 @@
             <div class="preview-header__flex-row preview-header__flex-row--single-line" ng-if="selected.preview.anpa_take_key">
               <span class="inline-label">takekey:</span><span class="takekey">{{selected.preview.anpa_take_key | translate}}</span>
             </div>
+            <div class="preview-header__flex-row preview-header__flex-row--single-line" ng-if="selected.preview.ednote">
+              <span class="inline-label">ednote:</span><span class="ednote">{{selected.preview.ednote | translate}}</span>
+            </div>
             <div class="preview-header__flex-row">
               <span sd-item-state data-state=selected.preview.state data-embargo=item.embargo></span>
               <span class="state-label not-for-publication" ng-if="item.flags.marked_for_not_publication" translate>Not For Publication</span>

--- a/scripts/superdesk-authoring/views/authoring-topbar.html
+++ b/scripts/superdesk-authoring/views/authoring-topbar.html
@@ -28,8 +28,8 @@
     </div>
 
     <div class="subnav__authoring-topbar" ng-class="{'has-highlights': item.highlights}">
-        <span class="stage" ng-show="stage" ng-if="item._type !== 'legal_archive'"><b>{{deskName}}</b> / {{ stage.name }}</span>
-        <span class="stage" ng-show="stage" ng-if="item._type === 'legal_archive'"><b>{{deskName}}</b> / {{ stage }}</span>
+        <span class="stage" tooltip="{{deskName}} / {{ stage.name }}" tooltip-placement="bottom" ng-show="stage" ng-if="item._type !== 'legal_archive'"><b>{{deskName}}</b> / {{ stage.name }}</span>
+        <span class="stage" tooltip="{{deskName}} / {{ stage }}" tooltip-placement="bottom" ng-show="stage" ng-if="item._type === 'legal_archive'"><b>{{deskName}}</b> / {{ stage }}</span>
         <div ng-if="item.more_coming === true" class="state-label state-in_progress" translate>More coming</div>
         <span ng-if="item.highlights" sd-highlights-title data-item="item"></span>
     </div>

--- a/scripts/superdesk-items-common/styles/archive-preview.less
+++ b/scripts/superdesk-items-common/styles/archive-preview.less
@@ -1195,6 +1195,13 @@
             color: #333;
             line-height: 116.6%;
         }
+
+        .ednote {
+            display: inline;
+            font-size: 12px;
+            color: #d25932;
+            line-height: 116.6%;
+        }
 }
 
 // Preview image overlay

--- a/scripts/superdesk-search/react.js
+++ b/scripts/superdesk-search/react.js
@@ -1048,9 +1048,9 @@
                                     React.createElement(
                                         'div', {
                                             className: 'state-label not-for-publication',
-                                            title: gettext('Not For Publications'),
+                                            title: gettext('Not For Publication'),
                                             key: 'not-for-publication'
-                                        }, gettext('Not For Publications'))
+                                        }, gettext('Not For Publication'))
                                     : null,
                                 flags.marked_for_legal ?
                                     React.createElement(


### PR DESCRIPTION
- [SD-4904] - Show ednote in story preview
- [SD-4905] - Remove 's' from Not For Publications label
- [SD-4955] - Display full desk/stage name in authoring