### PR TITLE
Optional test environment indicator on header

### DIFF
--- a/scripts/superdesk/menu/menu.js
+++ b/scripts/superdesk/menu/menu.js
@@ -43,8 +43,9 @@
             'userNotifications',
             'asset',
             'privileges',
+            'config',
             'lodash',
-            function ($route, superdesk, betaService, userNotifications, asset, privileges, _) {
+            function ($route, superdesk, betaService, userNotifications, asset, privileges, config, _) {
                 return {
                     require: '^sdSuperdeskView',
                     templateUrl: asset.templateUrl('superdesk/menu/views/menu.html'),
@@ -53,6 +54,8 @@
                         scope.currentRoute = null;
                         scope.flags = ctrl.flags;
                         scope.menu = [];
+                        scope.isTestEnvironment = config.isTestEnvironment;
+                        scope.environmentName = config.environmentName;
 
                         superdesk.getMenu(superdesk.MENU_MAIN)
                                 .then(filterSettingsIfEmpty)

--- a/scripts/superdesk/menu/styles/menu.less
+++ b/scripts/superdesk/menu/styles/menu.less
@@ -48,6 +48,18 @@
         right: 0 !important;
     }
 
+    &.test-environment {
+        background: #ff0000;
+        &:after {
+            content: attr(data-text);
+            color: black;
+            font-size: 47px;
+            color: black;
+            top: 13px;
+            position: absolute;
+        }
+    }
+
     a, button {
         height: @nav-height;
         display: inline-block;

--- a/scripts/superdesk/menu/views/menu.html
+++ b/scripts/superdesk/menu/views/menu.html
@@ -1,5 +1,5 @@
 <div>
-  <div id="top-menu" ng-class="{'menu-open': flags.menu}">
+  <div id="top-menu" ng-class="{'menu-open': flags.menu, 'test-environment': isTestEnvironment}" data-text="{{environmentName}}">
       <div class="nav pull-left">
         <button class="collapse-nav pull-left" ng-click="toggleMenu()">
           <i class="icon-collapse icon-white"></i>

--- a/tasks/options/template.js
+++ b/tasks/options/template.js
@@ -19,6 +19,10 @@ module.exports = function(grunt) {
         var disableEditorToolbar = grunt.option('disableEditorToolbar');
         var defaultTimezone = grunt.option('defaultTimezone') || 'Europe/London';
 
+        //environment parameter is used to indicate a non-prod environment
+        var isTestEnvironment = !!grunt.option('environmentName');
+        var environmentName = grunt.option('environmentName');
+
         if (forceUrl) {
             server = url;
         }
@@ -50,7 +54,9 @@ module.exports = function(grunt) {
             view: {
                 dateformat: process.env.VIEW_DATE_FORMAT || 'MM/DD/YYYY',
                 timeformat: process.env.VIEW_TIME_FORMAT || 'HH:mm'
-            }
+            },
+            isTestEnvironment: isTestEnvironment,
+            environmentName: environmentName
         };
 
         return {data: {


### PR DESCRIPTION
We have Test, UAT and PROD environments deployed locally. Especially the UAT and PROD has identical data so without a visual indicator it is easy to confuse PROD as UAT which happened few times.

So an optional boolean parameter `isTestEnvironment` is created to indicate a deployment is a "Test" instance in the top banner. If the parameter is not used then there'll be no change in UI.