### PR TITLE
SDPA-502 If a subservice is required then the parent service should automatically be set

### DIFF
--- a/scripts/superdesk-authoring/authoring.js
+++ b/scripts/superdesk-authoring/authoring.js
@@ -3066,8 +3066,9 @@
     }
 
     AuthoringHeaderDirective.$inject = ['api', 'authoringWidgets', '$rootScope', 'archiveService', 'metadata',
-                'content', 'lodash', 'authoring'];
-    function AuthoringHeaderDirective(api, authoringWidgets, $rootScope, archiveService, metadata, content, lodash, authoring) {
+                'content', 'lodash', 'authoring', 'vocabularies'];
+    function AuthoringHeaderDirective(api, authoringWidgets, $rootScope, archiveService, metadata, content,
+        lodash, authoring, vocabularies) {
         return {
             templateUrl: 'scripts/superdesk-authoring/views/authoring-header.html',
             require: '?^sdAuthoringWidgets',
@@ -3152,6 +3153,7 @@
                                     scope.contentType = type;
                                     scope.editor = authoring.editor = content.editor(type);
                                     scope.schema = authoring.schema = content.schema(type);
+                                    initAnpaCategories();
                                 });
                         } else {
                             scope.editor = authoring.editor = content.editor();
@@ -3182,6 +3184,38 @@
                         };
                     }
                 });
+
+                /**
+                 * Sets the anpa category corresponding to the required subservice: if a subservice
+                 * field (defined in vocabularies) was declared as required in a content profile
+                 * then make sure that the corresponding anpa category was added to the anpa_category
+                 * field in the newly created item. Without this value the anpa category field is not
+                 * displayed.
+                 */
+                function initAnpaCategories() {
+                    if (scope.schema.subject !== null && scope.schema.subject.mandatory_in_list !== null) {
+                        _.forEach(scope.schema.subject.mandatory_in_list.scheme, function(subjectName) {
+                            if (!_.startsWith(subjectName, 'subservice_')) {
+                                return;
+                            }
+                            vocabularies.getVocabularies().then(function(vocabulariesColl) {
+                                var vocabulary = _.find(vocabulariesColl._items, {'_id': subjectName});
+                                if (vocabulary) {
+                                    var qcode = _.keys(vocabulary.service).pop();
+                                    var categoriesVocabulary = _.find(vocabulariesColl._items, {'_id': 'categories'});
+                                    var category = _.find(categoriesVocabulary.items, {'qcode': qcode});
+                                    if (category && _.findIndex(scope.item.anpa_category, {'name': category.name}) === -1) {
+                                        if (!scope.item.anpa_category) {
+                                            scope.item.anpa_category = [];
+                                        }
+                                        scope.item.anpa_category.splice(-1, 0,
+                                            {'name': category.name, 'qcode': category.qcode, 'scheme': category.scheme});
+                                    }
+                                }
+                            });
+                        });
+                    }
+                }
 
                 metadata.initialize().then(function() {
                     scope.$watch('item.anpa_category', function(services) {

--- a/scripts/superdesk-authoring/authoring.spec.js
+++ b/scripts/superdesk-authoring/authoring.spec.js
@@ -1,0 +1,51 @@
+fdescribe('authoring', function() {
+    'use strict';
+
+    beforeEach(module('superdesk.vocabularies'));
+    beforeEach(module('superdesk.archive'));
+
+    it('set anpa category value for required subservice',
+            inject(function($httpBackend, $q, $rootScope, $compile, vocabularies, archiveService, content) {
+        $httpBackend.expectGET("scripts/superdesk-authoring/views/authoring-header.html");
+        $httpBackend.whenGET("scripts/superdesk-authoring/views/authoring-header.html").respond('');
+
+        var vocabulariesData = [
+            {
+                "_id": "categories",
+                "display_name": "Categories",
+                "type": "manageable",
+                "items": [{"is_active": true, "name": "Motoring", "qcode": "paservice:motoring"}]
+            },
+            {
+                "_id": "subservice_motoring",
+                "display_name": "Motoring sub-service",
+                "type": "manageable",
+                "service": {"paservice:motoring": 1},
+                "priority": 2,
+                "items": [{"is_active": true, "name": "News", "qcode": "paservice:motoring:news"}]
+            }
+        ];
+        var schema = {
+            "subject": {
+                "mandatory_in_list": {
+                    "scheme": {
+                        "subservice_motoring": "subservice_motoring",
+                    }
+                }
+            }
+        };
+
+        spyOn(archiveService, 'isLegal').and.returnValue(false);
+        spyOn(content, 'getType').and.returnValue('motoring');
+        spyOn(content, 'editor').and.returnValue({});
+        spyOn(content, 'schema').and.returnValue(schema);
+        spyOn(vocabularies, 'getVocabularies').and.returnValue($q.when({_items: vocabulariesData}));
+
+        var scope = $rootScope.$new();
+        var element = $compile('<sd-authoring-header></sd-authoring-header>')(scope);
+        scope.item = {"profile": "motoring"};
+        element.scope().$apply();
+
+        expect(scope.item.anpa_category).toBe({'name': 'Motoring', 'qcode': 'paservice:motoring', scheme: null});
+    }));
+});


### PR DESCRIPTION
Sets the anpa category corresponding to the required subservice:
if a subservice field (defined in vocabularies) was declared as
required in a content profilebthen make sure that the corresponding
anpa category was added to the anpa_category field in the newly
created item. Without this value the anpa category field is not
displayed.