### PR TITLE
Remove duplication of index.html and index.less (fixes SD-5119)

### DIFF
--- a/tasks/options/template.js
+++ b/tasks/options/template.js
@@ -1,3 +1,4 @@
+var path = require('path');
 
 module.exports = function(grunt) {
 
@@ -66,7 +67,8 @@ module.exports = function(grunt) {
         }};
     }
 
-    var files = {'<%= distDir %>/index.html': '<%= appDir %>/index.html'};
+    var indexSrc = path.join('<%= coreDir %>', '<%= appDir %>/index.html');
+    var files = {'<%= distDir %>/index.html': indexSrc};
 
     return {
         mock: {
@@ -75,7 +77,7 @@ module.exports = function(grunt) {
         },
         dev: {
             options: data('http://localhost:5000/api'),
-            files: {'index.html': '<%= appDir %>/index.html'}
+            files: {'index.html': indexSrc}
         },
         travis: {
             options: data('http://localhost:5000/api'),

--- a/tasks/options/useminPrepare.js
+++ b/tasks/options/useminPrepare.js
@@ -1,5 +1,9 @@
+var path = require('path');
 
 module.exports = {
-    html: ['<%= appDir %>/index.html', '<%= appDir %>/docs.html'],
+    html: [
+        path.join('<%= coreDir %>', '<%= appDir %>/index.html'),
+        '<%= appDir %>/docs.html'
+    ],
     options: {root: process.cwd()}
 };


### PR DESCRIPTION
This will cause the client-core to always use its own `index.html` file, even when embedded into the main `superdesk` repo, allowing the removal of `index.html` and `index.less` in the main repo.

Corresponds to https://github.com/superdesk/superdesk/pull/2189