### PR TITLE
fix(editor): fix preformatted spellcheck highlights alignment

### DIFF
--- a/scripts/superdesk/editor2/styles.less
+++ b/scripts/superdesk/editor2/styles.less
@@ -20,6 +20,12 @@
     span, h3 {
         font-size: 16px; line-height: 24px;
     }
+
+    pre {
+        span, h3 {
+            font-size: 13px; line-height: 18px;
+        }
+    }
 }
 .medium-editor-toolbar {
     // disabled state for toolbar button


### PR DESCRIPTION
there was font/line size set for spans within editor to match
its defined size which avoids inserting those styles by chrome.
but size was defined on `p` tag and not on `pre` tag so then
it would be different for preformatted text and spans used
for spellcheck highlights which would have different size than the other text.

SD-5155