### PR TITLE
 SD-4992 Editor: prevent chrome from adding an empty <div>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ templates-cache.js
 test-server/env
 test-server/__pycache__
 e2e-test-results
+.env

--- a/scripts/superdesk/editor2/editor.ctrl.js
+++ b/scripts/superdesk/editor2/editor.ctrl.js
@@ -8,18 +8,25 @@ function SdTextEditorController(_, EMBED_PROVIDERS, $timeout, $element, editor, 
     var vm = this;
     function Block(attrs) {
         var self = this;
-        angular.extend(self, {
-            body: attrs && attrs.body || '',
-            loading: attrs && attrs.loading || false,
-            caption: attrs && attrs.caption || undefined,
-            blockType: attrs && attrs.blockType || 'text',
-            embedType: attrs && attrs.embedType || undefined,
-            association: attrs && attrs.association || undefined,
+        if (!angular.isDefined(attrs)) {
+            attrs = {};
+        }
+        angular.extend(self, _.defaults({
+            body: attrs.body,
+            loading: attrs.loading,
+            caption: attrs.caption,
+            blockType: attrs.blockType,
+            embedType: attrs.embedType,
+            association: attrs.association,
             lowerAddEmbedIsExtended: undefined,
             showAndFocusLowerAddAnEmbedBox: function() {
                 self.lowerAddEmbedIsExtended = true;
-            },
-        });
+            }
+        }, {
+            body: '<p><br></p>',
+            loading: false,
+            blockType: 'text'
+        }));
     }
     /**
     * For the given blocks, merge text blocks when there are following each other and add empty text block arround embeds if needed
@@ -100,7 +107,7 @@ function SdTextEditorController(_, EMBED_PROVIDERS, $timeout, $element, editor, 
                 // if it's not a paragraph or an embed, we update the current block
             } else {
                 if (block === undefined) {
-                    block = new Block();
+                    block = new Block({body: ''});
                 }
                 // we want the outerHTML (ex: '<b>text</b>') or the node value for text and comment
                 block.body += (element.outerHTML || element.nodeValue || '').trim();


### PR DESCRIPTION
Prevent chrome from adding an empty `<div>` beginning of a new item.

This will fix the problem for every new created item.


This idea comes from the [medium-editor tests](https://github.com/yabwe/medium-editor/blob/98ebd576bc8d29e2382d5941f92932770da60730/spec/content.spec.js#L283)