### PR TITLE
[SD-4907] - Differentiate send and publish buttons

### DIFF
--- a/scripts/superdesk-authoring/styles/authoring.less
+++ b/scripts/superdesk-authoring/styles/authoring.less
@@ -1193,6 +1193,18 @@ feature-image {
     }
 }
 
+.panel-header {
+  margin-right: 20px;
+  cursor: pointer;
+  :hover {
+    background-color: #5ea9c8;
+  }
+}
+
+.panel-header-active {
+  color: #ea820e !important;
+}
+
 #timezoneTimestamp {
 	.timezone-input--dark > label {
 		display: none;

--- a/scripts/superdesk-authoring/views/send-item.html
+++ b/scripts/superdesk-authoring/views/send-item.html
@@ -1,13 +1,13 @@
 <div class="slide-pane slide-pane--dark content-item-preview" ng-show="isActive" ng-class="{open: isActive, 'slide-pane--inset': mode === 'authoring'}">
 
     <div class="slide-pane__header">
-        <h3 ng-show="canSendItem() && itemActions.publish" translate>Send to / Publish</h3>
-        <h3 ng-show="canSendItem() && !itemActions.publish" translate>Send to</h3>
-        <h3 ng-show="!canSendItem()" translate>Fetch To</h3>
+        <h3 class="panel-header {{userAction === 'send_to'?'panel-header-active':''}}" ng-show="canSendItem() && showSendButtonAndDestination()" ng-click="updateUserAction('send_to')" translate>Send To</h3>
+        <h3 class="panel-header {{userAction === 'publish'?'panel-header-active':''}}" ng-show="canPublishItem()" ng-click="updateUserAction('publish')" translate>Publish</h3>
+        <h3 class="panel-header {{userAction === 'send_to'?'.panel-header-active':''}}" ng-show="!canSendItem() && !canPublishItem() && showSendButtonAndDestination()" ng-click="updateUserAction('send_to')" translate>Fetch To</h3>
         <div class="close" ng-click="close()"><i class="icon-close-small icon-white"></i></div>
     </div>
 
-    <div class="slide-pane__content">
+    <div class="slide-pane__content" ng-show="userAction === 'send_to'">
         <div sd-toggle-box ng-if="showSendButtonAndDestination()" data-title="{{ :: 'Destination' | translate }}" data-open="true" data-style="dark">
             <div class="dropdown dropdown-noarrow dropdown--dark" dropdown>
                 <button class="dropdown-toggle" dropdown-toggle>
@@ -32,6 +32,9 @@
                 </li>
             </ul>
         </div>
+    </div>
+
+    <div class="slide-pane__content" ng-show="userAction === 'publish'">
         <div sd-toggle-box id="embargoTimestamp" ng-if="mode === 'authoring' && showEmbargo()" data-title="Embargo" data-open="true" data-style="dark">
             <label class="label--lite" translate>Embargo</label>
             <ul class="btn-list">
@@ -62,7 +65,7 @@
 
     </div>
 
-    <div class="slide-pane__footer" sd-loading="loading">
+    <div class="slide-pane__footer" sd-loading="loading" ng-show="userAction === 'send_to'">
         <ul class="btn-list">
             <li ng-if="mode === 'authoring' && canSendAndContinue() && itemActions.send && itemActions.new_take">
                 <button class="btn btn-info"
@@ -88,6 +91,11 @@
                     fetch and open
                 </button>
             </li>
+        </ul>
+    </div>
+
+    <div class="slide-pane__footer" sd-loading="loading" ng-show="userAction === 'publish'">
+        <ul class="btn-list">
             <li class="full-width" ng-if="canSendItem() && canPublishItem()">
                 <button type="submit"
                         class="btn btn-info"

--- a/scripts/superdesk-authoring/widgets/widgets.js
+++ b/scripts/superdesk-authoring/widgets/widgets.js
@@ -82,7 +82,7 @@ function WidgetsManagerCtrl($scope, $routeParams, authoringWidgets, archiveServi
     $scope.isWidgetLocked = function(widget) {
         if (widget) {
             var locked = lock.isLocked($scope.item) && !lock.can_unlock($scope.item);
-            var isReadOnlyStage = desks.isReadOnlyStage($scope.item.task.stage);
+            var isReadOnlyStage = $scope.item.task && $scope.item.task.stage && desks.isReadOnlyStage($scope.item.task.stage);
 
             return (widget.needUnlock && (locked || isReadOnlyStage)) ||
             (widget.needEditable && (!$scope.item._editable || isReadOnlyStage));


### PR DESCRIPTION
- Publish and Send-To panels are separated, user clicks the header to activate the panel
- Initially Send-To panel is shown then when changed it is remembered throughout the session
- Fetch, Fetch-To panels behave like Send-To so no change required for that section
- Multi-send action displays only the send to panel

@fritzSF Would you mind please pulling and playing these changes to let me know what you think?