### PR TITLE
[SD-5001] - Separation of parameters, filters and saved panels in global search

### DIFF
--- a/scripts/superdesk-authoring/metadata/metadata.js
+++ b/scripts/superdesk-authoring/metadata/metadata.js
@@ -927,10 +927,10 @@ function MetadataService(api, $q, subscribersService, config) {
     var service = {
         values: {},
         cvs: [],
-        search_cvs: config.search_cvs || [{'id': 'subject', 'name': 'Subject',
-            'field': 'subject', 'list': 'subjectcodes'}],
+        search_cvs: config.search_cvs || [{'id': 'subject', 'name': 'Subject', 'field': 'subject', 'list': 'subjectcodes'}, 
+                     {'id': 'companycodes', 'name': 'Company Codes', 'field': 'company_codes', 'list': 'company_codes'}],
         search_config: config.search || {'slugline': 1, 'headline': 1, 'unique_name': 1, 'story_text': 1,
-            'byline': 1, 'keywords': 1, 'creator': 1, 'from_desk': 1, 'to_desk': 1, 'spike': 1, 'scheduled': 1},
+            'byline': 1, 'keywords': 1, 'creator': 1, 'from_desk': 1, 'to_desk': 1, 'spike': 1, 'scheduled': 1, 'company_codes': 1},
         subjectScope: null,
         loaded: null,
         _urgencyByValue: {},

--- a/scripts/superdesk-items-common/styles/archive-filtering.less
+++ b/scripts/superdesk-items-common/styles/archive-filtering.less
@@ -472,8 +472,9 @@
 
 .save-search__link {
     display: inline-block;
-    margin-right: 10px;
+    margin-right: 32px;
     cursor: pointer;
+    font-size: 14px;
     &:hover {
         text-decoration: underline;
     }

--- a/scripts/superdesk-publish/styles/publish.less
+++ b/scripts/superdesk-publish/styles/publish.less
@@ -125,11 +125,14 @@ div {
     }
 }
 
-.dropdown.dropdown-bigger {
-    .dropdown-menu {
-        min-width: 500px;
+.subscriber-products {
+    .dropdown.dropdown-bigger {
+        .dropdown-menu {
+            min-width: 500px;
+        }
     }
 }
+
 
 .publish-queue {
     top: @subnav-height;

--- a/scripts/superdesk-publish/views/subscribers.html
+++ b/scripts/superdesk-publish/views/subscribers.html
@@ -86,7 +86,7 @@
                         <div class="field">
                             <label translate>Products</label>
                             <div sd-meta-terms
-                                class="data"
+                                class="subscriber-products"
                                 data-reload-list="true"
                                 data-item="subscriber"
                                 data-field="products"

--- a/scripts/superdesk-search/views/item-search.html
+++ b/scripts/superdesk-search/views/item-search.html
@@ -18,35 +18,28 @@
         </div>
     </fieldset>
     <fieldset class="search-parameters" ng-show="repo.search === 'local'">
-        <div class="field" ng-if="search_config.slugline">
-            <label for="search-slugline">
-                {{:: 'Slugline' | translate}}
-            </label>
-            <div class="control">
+        <div class="multiple">
+            <div class="field" ng-if="search_config.slugline">
+                <label for="search-slugline">
+                    {{:: 'Slugline' | translate}}
+                </label>
                 <input type="text" id="search-slugline" ng-model="meta.slugline">
             </div>
-        </div>
-        <div class="field" ng-repeat="cv in cvs track by cv.id">
-            <label for="search-subject">
-                {{cv.name | translate}}
-            </label>
-            <div id="search-subject">
-                <div id="subjects" sd-meta-terms
-                    data-item="selecteditems"
-                    data-field="{{cv.id}}"
-                    data-unique="qcode"
-                    data-list="metadata[cv.list]"
-                    data-reload-list="true"
-                    data-header="true"
-                    data-change="subjectSearch(selecteditems)"></div>
+            
+            <div class="field" ng-if="search_config.headline">
+                <label for="search-headline">
+                    {{:: 'Headline' | translate}}
+                </label>
+                <input type="text" id="search-headline" ng-model="meta.headline">
             </div>
         </div>
-        <div class="field" ng-if="search_config.headline">
-            <label for="search-headline">
-                {{:: 'Headline' | translate}}
+
+        <div class="field" ng-if="search_config.story_text">
+            <label for="search-storytext">
+                {{:: 'Story Text' | translate}}
             </label>
             <div class="control">
-                <input type="text" id="search-headline" ng-model="meta.headline">
+                <input type="text" id="search-storytext" ng-model="meta.body_html">
             </div>
         </div>
 
@@ -57,19 +50,28 @@
                 </label>
                 <input type="text" id="search-storyname" ng-model="fields.unique_name">
             </div>
-            <div class="field" ng-if="search_config.story_text">
-                <label for="search-storytext">
-                    {{:: 'Story Text' | translate}}
+            <div class="field" ng-if="search_config.byline">
+                <label for="search-byline">
+                    {{:: 'Byline' | translate}}
                 </label>
-                <input type="text" id="search-storytext" ng-model="meta.body_html">
+                <input type="text" id="search-byline" ng-model="meta.byline">
             </div>
         </div>
 
-        <div class="field" ng-if="search_config.byline">
-            <label for="search-byline">
-                {{:: 'Byline' | translate}}
+        <div class="field" ng-repeat="cv in cvs track by cv.id">
+            <label for="search-{{cv.name}}">
+                {{cv.name | translate}}
             </label>
-            <input type="text" id="search-byline" ng-model="meta.byline">
+            <div id="search-{{cv.name}}">
+                <div id="{{cv.name}}" sd-meta-terms
+                    data-item="selecteditems"
+                    data-field="{{cv.field}}"
+                    data-unique="qcode"
+                    data-list="metadata[cv.list]"
+                    data-reload-list="true"
+                    data-header="true"
+                    data-change="itemSearch(selecteditems, cv.field)"></div>
+            </div>
         </div>
 
         <div class="field keywords" ng-if="search_config.keywords">
@@ -85,46 +87,51 @@
             ></div>
         </div>
 
-        <div class="field" ng-if="repo.archive && search_config.creator">
-            <label for="search-creator">
-                {{:: 'Creator' | translate}}
-            </label>
-            <select id="search-creator"
-                    ng-model="fields.original_creator"
-                    ng-options="user._id  as user.display_name for user in userList">
-            <option value="" label=""></option>
-            </select>
+        <div class="multiple">
+            <div class="field" ng-if="search_config.from_desk">
+                <label for="from-desk">
+                    {{:: 'From Desk' | translate}}
+                </label>
+                <select
+                    id="from-desk" name="from-desk"
+                    ng-options="d._id as d.name for d in desks._items"
+                    ng-model="fields.from_desk">
+                    <option value="" label=""></option>
+                </select>
+            </div>
+            <div class="field" ng-if="search_config.to_desk">
+                <label for="to-desk">
+                    {{:: 'To Desk' | translate}}
+                </label>
+                <select
+                    id="to-desk" name="to-desk"
+                    ng-options="d._id as d.name for d in desks._items"
+                    ng-model="fields.to_desk">
+                    <option value="" label=""></option>
+                </select>
+            </div>
         </div>
 
-        <div class="field" ng-if="search_config.from_desk">
-            <label for="from-desk">
-                {{:: 'From Desk' | translate}}
-            </label>
-            <select
-                id="from-desk" name="from-desk"
-                ng-options="d._id as d.name for d in desks._items"
-                ng-model="fields.from_desk">
+        <div class="multiple">
+            <div class="field" ng-if="repo.archive && search_config.creator">
+                <label for="search-creator">
+                    {{:: 'Creator' | translate}}
+                </label>
+                <select id="search-creator"
+                        ng-model="fields.original_creator"
+                        ng-options="user._id  as user.display_name for user in userList track by user._id">
                 <option value="" label=""></option>
-            </select>
-        </div>
+                </select>
+            </div>
 
-        <div class="field" ng-if="search_config.to_desk">
-            <label for="to-desk">
-                {{:: 'To Desk' | translate}}
-            </label>
-            <select
-                id="to-desk" name="to-desk"
-                ng-options="d._id as d.name for d in desks._items"
-                ng-model="fields.to_desk">
-                <option value="" label=""></option>
-            </select>
+            <div class="field" ng-if="search_config.spike">
+                <label for="search-spike">
+                {{:: 'In Spiked' | translate}}
+                </label>
+                <span sd-switch ng-model="fields.spike"></span>
+            </div>
         </div>
-        <div class="field" ng-if="search_config.spike">
-            <label for="search-spike">
-            {{:: 'In Spiked' | translate}}
-            </label>
-            <span sd-switch ng-model="fields.spike"></span>
-        </div>
+        
     </fieldset>
     <fieldset ng-show="repo.search === 'aapmm'">
         <div class="field">
@@ -194,6 +201,6 @@
     </fieldset>
 </form>
 <div class="actions">
-    <button class="btn btn-info pull-right" ng-click="search()" ng-disabled="!isSearchEnabled()" translate>Go</button>
+    <button class="btn btn-info pull-right" ng-click="search()" ng-disabled="!isSearchEnabled()" translate>Search</button>
 </div>
  

--- a/scripts/superdesk-search/views/search-facets.html
+++ b/scripts/superdesk-search/views/search-facets.html
@@ -4,18 +4,19 @@
         <button ng-click="cancel()" class="backlink"><span translate>Back / Cancel</span></button>
       </div>
         <ul ng-show="!editingSearch || activateSearchPane">
-            <li ng-class="{active: sTab}" ng-click="sTab = true" translate>Advanced Search</li>
+            <li ng-class="{active: sTab === 'parameters'}" ng-click="changeTab('parameters')" translate>Parameters</li>
+            <li ng-class="{active: sTab === 'filters'}" ng-click="changeTab('filters')" translate>Filters</li>
             <li id="saved_searches_tab" 
                 ng-show="privileges.saved_searches == 1" 
-                ng-class="{active: !sTab}" 
-                ng-click="sTab = false" translate>Saved
+                ng-class="{active: sTab === 'savedSearches'}" 
+                ng-click="changeTab('savedSearches')" translate>Saved
             </li>
         </ul>
-        <div class="doopen" ng-click="flags.facets = false"><i class="icon-close-small"></i></div>
+        <div class="doopen" ng-click="closeFacets()"><i class="icon-close-small"></i></div>
     </div>
-    <div class="content" ng-if="sTab" ng-class="{pull: showSaveSearch}">
+    
 
-        <!--<div sd-search-within></div>-->
+    <div class="content" ng-if="sTab==='parameters'" ng-class="{pull: showSaveSearch}">
 
         <div id="edit-search-name" class="edit-search" ng-show="editingSearch && !activateSearchPane">
           <form name="viewsForm">
@@ -34,8 +35,29 @@
           </form>
         </div>
 
-        <div id="search-parameters" sd-toggle-box data-title="{{:: 'Parameters' | translate }}" data-open="{{repo.search.indexOf('scanpix') == 0}}">
-            <div sd-item-search data-repo="repo" data-context="context"></div>
+        <div sd-item-search data-repo="repo" data-context="context"></div>
+
+    </div>
+
+
+    <div class="content" ng-if="sTab==='filters'" ng-class="{pull: showSaveSearch}">
+
+
+        <div id="edit-search-name" class="edit-search" ng-show="editingSearch && !activateSearchPane">
+          <form name="viewsForm">
+            <fieldset>
+              <div class="field">
+                <input id="search_name" type="text" class="fullwidth-input line-input" ng-model="edit.name" placeholder="{{:: 'Name' | translate}}" required>
+              </div>
+              <div class="field">
+                <textarea id="search_description" class="line-input" sd-auto-height ng-model="edit.description" placeholder="{{:: 'Description' | translate}}"></textarea>
+              </div>
+              <div class="field">
+                <span id="search_global" sd-switch ng-model="edit.is_global"></span>
+                <label class="label--inline" translate>Make global</label>
+              </div>
+            </fieldset>
+          </form>
         </div>
 
         <div sd-toggle-box data-title="{{:: 'Content types' | translate }}" ng-hide="isEmpty('type')" data-open="true">
@@ -86,6 +108,7 @@
             </ul>
         </div>
 
+
         <div sd-toggle-box data-title="{{:: 'Genres' | translate }}" ng-hide="isEmpty('genre')" data-open="true">
             <ul class="filter-box">
                 <li ng-repeat="(key,value) in aggregations.genre" ng-click="toggleFilter('genre', key)">
@@ -127,8 +150,7 @@
         </div>
 
         <div sd-toggle-box data-title="{{:: 'Dates' | translate }}" data-open="true">
-
-           <form class="date-filter">
+            <form class="date-filter">
                 <div class="predefined-dates">
                         <button ng-click="toggleFilter('date', 'Last Day')" 
                                 class="btn btn-mini" 
@@ -176,8 +198,8 @@
                 </fieldset>
            </form>
         </div>
-        <div sd-toggle-box data-title="{{:: 'Scheduled' | translate }}" data-open="false"
-                ng-show="search_config.scheduled">
+
+        <div sd-toggle-box data-title="{{:: 'Scheduled' | translate }}" data-open="true" ng-show="search_config.scheduled">
             <form class="date-filter">
                 <div class="predefined-dates">
                     <button id="search_scheduled_24h" ng-click="toggleFilter('date', 'Scheduled Last Day')" class="btn btn-mini" 
@@ -192,7 +214,7 @@
 
     <div sd-save-search ng-show="showSaveSearch && sTab"></div>
 
-    <div class="content views" ng-if="!sTab">
+    <div class="content views" ng-if="sTab==='savedSearches'">
         <div sd-saved-searches></div>
     </div>
 </div>

--- a/scripts/superdesk-search/views/search-within.html
+++ b/scripts/superdesk-search/views/search-within.html
@@ -1,6 +1,0 @@
-<div class="search-within-filter">
-    <input id="search_within" type="text" ng-model="within" placeholder="{{'Search within' | translate}}">
-    <button id="search_within_button" ng-click="searchWithin()" ng-if="within">
-        <i class="svg-icon-right"></i>
-    </button>
-</div>

--- a/styles/less/sf-additional.less
+++ b/styles/less/sf-additional.less
@@ -1818,7 +1818,7 @@ header .sortbar {
 .toggle-button {
     border-radius: 2px;
     box-sizing: border-box;
-    padding: 0 10px;
+    padding: 0 5px;
     text-decoration: none;
     font-size: 12px;
     background: #fff;


### PR DESCRIPTION
- [x] Separate parameters section to its own tab in global search
- [x] Queries with aggregations will run only when the filters panel is opened
- [x] Reduce the query timeout from 3 sec to 300 msec
- [x] Re-arrange controls in parameters tab
- [x] Add Company Codes to the parameters
- [x] Change category and company code from `q` to `params` in query
- [x] Search from parameters will run only when `Search` button is clicked
- [ ] Fix e2e tests