### PR TITLE
[SD-4988]- When a user has them scrolled, views should not change the…

### DIFF
--- a/scripts/superdesk-items-common/styles/media-archive.less
+++ b/scripts/superdesk-items-common/styles/media-archive.less
@@ -928,7 +928,6 @@
     }
 }
 
-
 /*modal window*/
 @modalMaxImageWidth : 379px;
 @modalMaxImageHeight : 250px;

--- a/scripts/superdesk-monitoring/monitoring.js
+++ b/scripts/superdesk-monitoring/monitoring.js
@@ -278,6 +278,7 @@
         this.editItem = null;
 
         this.totalItems = '';
+        this.showRefresh = false;
 
         this.isDeskChanged = function () {
             return desks.changeDesk;
@@ -344,6 +345,11 @@
                     }
                 }
 
+                // force refresh on refresh button click when in specific view such as single, highlights or spiked.
+                scope.refreshGroup = function(group) {
+                    $rootScope.$broadcast('refresh:list', group);
+                };
+
                 scope.$on('$destroy', function() {
                     containerElem.off('scroll');
                 });
@@ -365,9 +371,9 @@
         };
     }
 
-    MonitoringGroupDirective.$inject = ['cards', 'api', 'authoringWorkspace', '$timeout', 'superdesk',
+    MonitoringGroupDirective.$inject = ['cards', 'api', 'authoringWorkspace', '$timeout', 'superdesk', 'session',
         'activityService', 'workflowService', 'keyboardManager', 'desks', 'search', 'multi', 'archiveService', '$rootScope'];
-    function MonitoringGroupDirective(cards, api, authoringWorkspace, $timeout, superdesk, activityService,
+    function MonitoringGroupDirective(cards, api, authoringWorkspace, $timeout, superdesk, session, activityService,
             workflowService, keyboardManager, desks, search, multi, archiveService, $rootScope) {
 
         var ITEM_HEIGHT = 57;
@@ -412,7 +418,7 @@
                 });
 
                 scope.$on('task:stage', scheduleQuery);
-                scope.$on('item:spike', scheduleQuery);
+                scope.$on('item:spike', scheduleIfShouldUpdate);
                 scope.$on('item:copy', scheduleQuery);
                 scope.$on('item:duplicate', scheduleQuery);
                 scope.$on('broadcast:created', function(event, args) {
@@ -420,9 +426,13 @@
                     queryItems();
                     preview(args.item);
                 });
-                scope.$on('item:unspike', scheduleQuery);
-                scope.$on('item:move', scheduleQuery);
-                scope.$on('$routeUpdate', scheduleQuery);
+                scope.$on('item:unspike', scheduleIfShouldUpdate);
+                scope.$on('$routeUpdate', function(event, data) {
+                    scope.scrollTop = 0;
+                    data.force = true;
+                    scope.showRefresh = false;
+                    scheduleQuery(event, data);
+                });
                 scope.$on('broadcast:preview', function(event, args) {
                     scope.previewingBroadcast = true;
                     if (args.item != null) {
@@ -440,17 +450,25 @@
                 }
 
                 function scheduleIfShouldUpdate(event, data) {
-                    if (data.from_stage && data.from_stage === scope.group._id) {
+                    if (data && data.from_stage && data.from_stage === scope.group._id) {
                         // item was moved from current stage
                         extendItem(data.item, {
                             gone: true,
                             _etag: data.from_stage // this must change to make it re-render
                         });
-                    } else if (data.to_stage && data.to_stage === scope.group._id) {
+                        scheduleQuery(event, data);
+                    } else if (data && data.item && _.includes(['item:spike', 'item:unspike'], event.name)) {
+                        // item was spiked/unspiked from the list
+                        extendItem(data.item, {
+                            gone: true,
+                            _etag: data.item
+                        });
+                        scheduleQuery(event, data);
+                    } else if (data && data.to_stage && data.to_stage === scope.group._id) {
                         // new item in current stage
-                        scheduleQuery();
+                        scheduleQuery(event, data);
                     } else if (data && cards.shouldUpdate(scope.group, data)) {
-                        scheduleQuery();
+                        scheduleQuery(event, data);
                     }
                 }
 
@@ -493,6 +511,16 @@
                     }
                 });
 
+                // refreshes the list for matching group or view type only
+                scope.$on('refresh:list', function(event, group) {
+                    var _viewType = event.currentScope.viewType || '';
+
+                    if (group && group._id === scope.group._id ||
+                            _.includes(['highlights', 'spiked'], _viewType)) {
+                        scope.refreshGroup();
+                    }
+                });
+
                 /*
                  * Change between single desk view and grouped view by keyboard
                  * Keyboard shortcut: Ctrl + g
@@ -506,6 +534,15 @@
                         }
                     }
                 });
+
+                // forced refresh on refresh button click or on refresh:list
+                scope.refreshGroup = function() {
+                    scope.$applyAsync(function () {
+                        scope.scrollTop = 0;
+                    });
+                    monitoring.showRefresh = scope.showRefresh = false;
+                    scheduleQuery(null, {force: true});
+                };
 
                 function updateGroupStyle() {
                     scope.style.maxHeight = scope.group.max_items ? scope.group.max_items * ITEM_HEIGHT : null;
@@ -576,10 +613,10 @@
                  *
                  * In case it gets called multiple times it will query only once
                  */
-                function scheduleQuery() {
+                function scheduleQuery(event, data) {
                     if (!queryTimeout) {
                         queryTimeout = $timeout(function() {
-                            queryItems();
+                            queryItems(event, data);
                             scope.$applyAsync(function() {
                                 // ignore any updates requested in current $digest
                                 queryTimeout = null;
@@ -629,10 +666,15 @@
                     return items;
                 }
 
-                function queryItems() {
+                function queryItems(event, data) {
                     criteria = cards.criteria(scope.group, null, monitoring.queryParam);
                     criteria.source.from = 0;
                     criteria.source.size = 25;
+
+                    // To compare current scope of items, consider fetching same number of items.
+                    if (scope.items && scope.items._items.length > 25) {
+                        criteria.source.size = scope.items._items.length;
+                    }
 
                     if (desks.changeDesk) {
                         desks.changeDesk = false;
@@ -641,10 +683,27 @@
                     }
 
                     return apiquery().then(function(items) {
-                        scope.total = items._meta.total;
-                        items = scope.group.type === 'highlights' ? getOnlyHighlightsItems(items) : items;
-                        monitoring.totalItems = items._meta.total;
-                        scope.items = merge(items);
+                        if (!scope.showRefresh && data && !data.force && (data.user !== session.identity._id)) {
+                            var isItemPreviewing = (monitoring.previewItem && monitoring.previewItem.task.stage === scope.group._id);
+                            var _data = {
+                                newItems: items,
+                                scopeItems: scope.items,
+                                scrollTop: scope.scrollTop,
+                                isItemPreviewing: isItemPreviewing
+                            };
+
+                            monitoring.showRefresh = scope.showRefresh = search.canShowRefresh(_data);
+                        }
+
+                        if (!scope.showRefresh || (data && data.force)) {
+                            scope.total = items._meta.total;
+                            items = scope.group.type === 'highlights' ? getOnlyHighlightsItems(items) : items;
+                            monitoring.totalItems = items._meta.total;
+                            scope.items = search.mergeItems(items, scope.items, null, (data && data.force));
+                        } else {
+                            // update scope items only with the matching fetched items
+                            scope.items = search.updateItems(items, scope.items);
+                        }
                     });
                 }
 
@@ -655,7 +714,7 @@
                                 scope.total = items._meta.total;
                             }
                             items = scope.group.type === 'highlights' ? getOnlyHighlightsItems(items) : items;
-                            scope.items = merge(items, next);
+                            scope.items = search.mergeItems(items, scope.items, next);
                         });
                     });
                 }
@@ -695,9 +754,6 @@
                     monitoring.viewSingleGroup(group, type);
                 }
 
-                function merge(items, next) {
-                    return search.mergeItems(items, scope.items, next);
-                }
             }
         };
     }

--- a/scripts/superdesk-monitoring/styles/aggregate.less
+++ b/scripts/superdesk-monitoring/styles/aggregate.less
@@ -341,6 +341,20 @@
     letter-spacing: 0.06em;
     .text-normal();
 }
+.refresh-box {
+    display: flex;
+    button {
+        background: none;
+        border: 0;
+        border-left: 1px solid #dfdfdf;
+        margin-right: 10px;
+        padding-left: 15px;
+        &:hover {
+            .opacity(80);
+        }
+    }
+}
+
 .content-list-holder {
     position: absolute;
     top: 38px;

--- a/scripts/superdesk-monitoring/styles/monitoring.less
+++ b/scripts/superdesk-monitoring/styles/monitoring.less
@@ -64,6 +64,10 @@
                 .compact-view, .mlist-view {
                     box-shadow: none;
                 }
+                &.refresh {
+                    border: solid thin @blue;
+                    .box-shadow(0px 0px 10px 0px rgba(93,155,192,1));
+                }
                 .list-view {
                     margin-bottom: 0;
                     &.list-without-items {

--- a/scripts/superdesk-monitoring/views/monitoring-group-header.html
+++ b/scripts/superdesk-monitoring/views/monitoring-group-header.html
@@ -1,12 +1,18 @@
+<div class="refresh-box pull-right">
+    <button ng-if="showRefresh" ng-click="refreshGroup()"
+        tooltip="{{:: 'Refresh' | translate}}" tooltip-placement="left">
+        <i class="icon-repeat blue"></i>
+    </button>
+</div>
 <div class="stage-header clearfix">
-    <span class="stage-name" ng-if="group.header && group.subheader && group.singleViewType == null">
+    <span class="stage-name" ng-if="group.header && group.subheader && viewType !== 'single_monitoring'">
         <a href="" ng-click="viewSingleGroup(group, 'desk')">{{ :: group.header }}</a>
         <span>/</span>
         <a href="" ng-click="viewSingleGroup(group, 'stage')">
             <span>{{ :: group.subheader }} </span> {{ :: group.type | translate }}
         </a>
     </span>
-    <span class="stage-name" ng-if="group.header && !group.subheader && group.singleViewType == null">
+    <span class="stage-name" ng-if="group.header && !group.subheader && viewType !== 'single_monitoring'">
         <a href="" ng-click="viewSingleGroup(group, 'single-stage')">
             {{ :: group.header }} {{ :: group.type|splitText | translate }}
         </a>

--- a/scripts/superdesk-monitoring/views/monitoring-group.html
+++ b/scripts/superdesk-monitoring/views/monitoring-group.html
@@ -1,7 +1,9 @@
 <div class="stage">
-    <div sd-monitoring-group-header ng-if="group.header && group.singleViewType == null"></div>
+    <div sd-monitoring-group-header 
+    	ng-if="group.header && viewType !== 'single_monitoring'">
+    </div>
     <div class="stage-content group"
-        ng-class="{limited: limited}"
+        ng-class="{limited: limited, refresh: showRefresh}"
         ng-style="style"
         sd-items-list>
     </div>

--- a/scripts/superdesk-monitoring/views/monitoring-view.html
+++ b/scripts/superdesk-monitoring/views/monitoring-view.html
@@ -39,10 +39,16 @@
                 <span class="label-total">{{ monitoring.totalItems }}</span>
             </span>
         </h3>
-
         <div sd-multi-action-bar></div>
-
         <div class="subnav__button-stack--square-buttons">
+             <div class="refresh-box pull-right">                
+                <button ng-if="monitoring.showRefresh &&
+                    (monitoring.singleGroup || type === 'spike' || type === 'highlights')"
+                ng-click="refreshGroup(monitoring.singleGroup)"
+                    tooltip="{{:: 'Refresh' | translate}}" tooltip-placement="left">
+                    <i class="icon-repeat blue"></i>
+                </button>
+            </div>
             <div class="pull-left-10x" ng-if="type === 'highlights'" sd-create-highlights-button data-highlight="monitoring.queryParam.highlight"></div>
             <button class="navbtn strict" ng-if="type === 'monitoring' && aggregate.settings.type === 'workspace'" ng-click="aggregate.edit()">
                 <i class="icon-settings"></i>
@@ -104,7 +110,7 @@
                 </div>
                 <div ng-if="type === 'spike'">
                     <div ng-repeat="group in aggregate.spikeGroups track by group._id | orderBy: name"
-                        sd-monitoring-group data-group="group" data-view-type="'spiked'"></div>
+                        sd-monitoring-group class="single-group" data-group="group" data-view-type="'spiked'"></div>
                 </div>
                 <div ng-if="monitoring.singleGroup && !monitoring.isDeskChanged()">
                     <div sd-monitoring-group class="single-group" data-group="monitoring.singleGroup" data-num-items="10" data-view-type="'single_monitoring'"></div>
@@ -113,7 +119,8 @@
                     <div sd-monitoring-group data-group="{'type': 'personal', 'query': query, 'fileType': aggregate.getSelectedFileTypes()}"></div>
                 </div>
                 <div ng-if="type === 'highlights' && !monitoring.highlightsDeskChanged()">
-                    <div sd-monitoring-group data-group="{'type': 'highlights', 'query': query, 'fileType': aggregate.getSelectedFileTypes()}"
+                    <div sd-monitoring-group class="single-group" 
+                    data-group="{'type': 'highlights', 'query': query, 'fileType': aggregate.getSelectedFileTypes()}"
                     data-view-type="'highlights'"></div>
                 </div>
 

--- a/scripts/superdesk-search/react.js
+++ b/scripts/superdesk-search/react.js
@@ -1840,16 +1840,10 @@ import classNames from 'classnames';
                                 itemsById: itemsById,
                                 view: scope.view
                             }, function() {
-                                if (selected) {
-                                    // maintain selected items position
-                                    try {
-                                        var selectedNode = ReactDOM.findDOMNode(selected);
-                                        elem[0].scrollTop += selectedNode.offsetTop - offsetTop;
-                                    } catch (err) {
-                                        // pass - selected item is not in list anymore
-                                    }
+                                // updates scroll position to top, such as when forced refresh
+                                if (scope.scrollTop === 0) {
+                                    elem[0].scrollTop = scope.scrollTop;
                                 }
-
                                 scope.rendering = scope.loading = false;
                             });
                         }, true);
@@ -1934,6 +1928,18 @@ import classNames from 'classnames';
                          * before activating render function
                          */
                         function handleScroll($event) {
+                            // If scroll bar leaves top position update scope.scrollTop
+                            // which is used to display refresh button on list item updates
+                            if (elem[0].scrollTop >= 0 && elem[0].scrollTop < 100) {
+                                scope.$applyAsync(function() {
+                                    scope.scrollTop = elem[0].scrollTop;
+                                    // force refresh the group or list, if scroll bar hits the top of list.
+                                    if (scope.scrollTop === 0) {
+                                        $rootScope.$broadcast('refresh:list', scope.group);
+                                    }
+                                });
+                            }
+
                             if (scope.rendering) { // ignore
                                 $event.preventDefault();
                                 return;

--- a/scripts/superdesk-search/styles/search.less
+++ b/scripts/superdesk-search/styles/search.less
@@ -22,6 +22,19 @@
         //flex: 1 0 auto;
         flex-grow: 1;
     }
+
+    .refresh-box {
+        button {
+            background: none;
+            border: 0;
+            padding-left: 15px;
+            border-left: 1px solid #dfdfdf;
+            &:hover {
+                .opacity(80);
+            }
+        }
+    }
+
 }
 
 .ui-responsive-medium {

--- a/scripts/superdesk-search/tests/search.spec.js
+++ b/scripts/superdesk-search/tests/search.spec.js
@@ -104,7 +104,57 @@ describe('search service', function() {
         expect(nextItems._items.length).toBe(2);
         expect(nextItems._items[0]._id).toBe('bar');
         expect(nextItems._items[1]._id).toBe('foo');
+
+        // return newItems when forced
+        nextItems = search.mergeItems({_items: [{_id: 'foo'}]}, {_items: [{_id: 'bar'}]}, null, true);
+        expect(nextItems._items.length).toBe(1);
+        expect(nextItems._items[0]._id).toBe('foo');
+
+        // can merge content updates from matching newItem
+        nextItems = search.mergeItems({_items: [{_id: 'foo', _current_version: 2, slugline: 'slugline updated'}]},
+            {_items: [{_id: 'foo', _current_version: 1, slugline: 'slugline'}]}, null, false);
+        expect(nextItems._items.length).toBe(1);
+        expect(nextItems._items[0].slugline).toBe('slugline updated');
+
     }));
+
+    it('can evalute canShowRefresh for refresh button display', inject(function(search) {
+        var newItems, scopeItems, scrollTop, isItemPreviewing, _data;
+        newItems = {_items: [{_id: 'foo', _current_version: 1}]};
+        scopeItems = {_items: [{_id: 'bar', _current_version: 1}]};
+        // consider item is not currently previewing but scroll is not on top.
+        scrollTop = 50;
+
+        _data = prepareData(newItems, scopeItems, scrollTop, isItemPreviewing);
+        expect(search.canShowRefresh(_data)).toBe(true);
+
+        // consider published item ids are same, but version is different as in case of take/update.
+        newItems = {_items: [{_id: 'foo', _current_version: 1, _type: 'published'}]};
+        scopeItems = {_items: [{_id: 'foo', _current_version: 2, _type: 'published'}]};
+        // consider scroll on Top but item is currently previewing.
+        scrollTop = 0;
+        isItemPreviewing = true;
+
+        _data = prepareData(newItems, scopeItems, scrollTop, isItemPreviewing);
+        expect(search.canShowRefresh(_data)).toBe(true);
+
+        // consider newItems and scopeItems are same and scroll is on top and no item is currently previewing.
+        newItems = {_items: [{_id: 'foo', _current_version: 1}]};
+        scopeItems = {_items: [{_id: 'foo', _current_version: 1}]};
+
+        _data = prepareData(newItems, scopeItems, scrollTop, isItemPreviewing);
+        expect(search.canShowRefresh(_data)).toBe(undefined);
+
+    }));
+
+    function prepareData(newItems, scopeItems, scrollTop, isItemPreviewing) {
+        return {
+            newItems: newItems,
+            scopeItems: scopeItems,
+            scrollTop: scrollTop,
+            isItemPreviewing: isItemPreviewing
+        };
+    }
 
     describe('multi action bar directive', function() {
 

--- a/scripts/superdesk-search/views/search.html
+++ b/scripts/superdesk-search/views/search.html
@@ -4,7 +4,12 @@
 
       <div sd-item-searchbar data-repo="repo" data-context="context" class="searchbar-flex-handler"></div>
       <div sd-item-sortbar data-total="total_records" class="sortbar-flex-handler"></div>
-
+      <div class="refresh-box">
+          <button ng-if="showRefresh" class="pull-right" ng-click="refreshList()"
+              tooltip="{{:: 'Refresh' | translate}}" tooltip-placement="left">
+              <i class="icon-repeat blue"></i>
+          </button>
+      </div>
       <div class="view-select">
           <button title="{{ :: 'Switch to grid view' | translate }}" ng-show="view !== 'mgrid'" ng-click="setview('mgrid')"><i class="icon-th"></i></button>
           <button title="{{ :: 'Switch to list view' | translate }}" ng-show="view !== 'compact'" ng-click="setview('compact')"><i class="icon-th-list"></i></button>

--- a/spec/search_spec.js
+++ b/spec/search_spec.js
@@ -230,8 +230,8 @@ describe('search', function() {
         authoring.sendToButton.click();
         authoring.save();
         authoring.close();
-        expect(globalSearch.getItem(0).element(by.className('state_embargo')).isDisplayed()).toBe(true);
-        expect(globalSearch.getItem(0).element(by.className('state_embargo')).getText()).toEqual('EMBARGO');
+        expect(globalSearch.getItem(4).element(by.className('state_embargo')).isDisplayed()).toBe(true);
+        expect(globalSearch.getItem(4).element(by.className('state_embargo')).getText()).toEqual('EMBARGO');
 
         //can search scheduled
         expect(globalSearch.getItems().count()).toBe(14);


### PR DESCRIPTION
…ir scroll position on update events

- This change is about maintaining the user view, in case of items added/removed in the current scope of items, and provides the refresh button instead when more  updates comes in, i-e, when items added or removed from list as a result of any action/activity; provided that if scroll position is not on top of list or user is currently previewing any item.
- Content updates, locking/ unlocking remain unaffected, and reflects the change on item in current view.
- Hitting refresh button or manually scroll to top of list forces the list to refresh and scroll position initialized to its top positions.
- Applies to monitoring (groups & single view), highlights, spiked and search view
- covers SD-5253