### PR TITLE
SD-5071 Editor history shortcut

### DIFF
--- a/scripts/superdesk-authoring/services.js
+++ b/scripts/superdesk-authoring/services.js
@@ -31,13 +31,16 @@ function HistoryFactory(History, $window, $timeout) {
             var onHistoryKeydown = function(event) {
                 onHistoryKey(event, function() {
                     event.preventDefault();
+                    // action is on keydown becuase command key (event.metakey) on OSX is not detected on keyup events
+                    // for some reason.
+                    scope.$apply(function() {
+                        KeyOperations[event.keyCode].bind(History)(expression, scope);
+                    });
                 });
             };
             var onHistoryKeyup = function(event) {
                 onHistoryKey(event, function() {
-                    scope.$apply(function() {
-                        KeyOperations[event.keyCode].bind(History)(expression, scope);
-                    });
+                    event.preventDefault();
                 });
             };
             angular.element($window).on('keydown', onHistoryKeydown);

--- a/scripts/superdesk-authoring/services.js
+++ b/scripts/superdesk-authoring/services.js
@@ -22,17 +22,23 @@ function HistoryFactory(History, $window, $timeout) {
                 History.watch(expression, scope);
                 lastArchive = new Date();
             }, 0, false);
-            var onHistoryKeydown = function(event) {
-                if (event.ctrlKey && KeyOperations[event.keyCode]) {
-                    event.preventDefault();
+            var onHistoryKey = function(event, cb) {
+                var modifier = event.ctrlKey || event.metaKey;
+                if (modifier && KeyOperations[event.keyCode]) {
+                    cb();
                 }
             };
+            var onHistoryKeydown = function(event) {
+                onHistoryKey(event, function() {
+                    event.preventDefault();
+                });
+            };
             var onHistoryKeyup = function(event) {
-                if (event.ctrlKey && KeyOperations[event.keyCode]) {
+                onHistoryKey(event, function() {
                     scope.$apply(function() {
                         KeyOperations[event.keyCode].bind(History)(expression, scope);
                     });
-                }
+                });
             };
             angular.element($window).on('keydown', onHistoryKeydown);
             angular.element($window).on('keyup', onHistoryKeyup);

--- a/spec/authoring_spec.js
+++ b/spec/authoring_spec.js
@@ -3,6 +3,7 @@
 var monitoring = require('./helpers/monitoring'),
     authoring = require('./helpers/authoring'),
     ctrlKey = require('./helpers/utils').ctrlKey,
+    commandKey = require('./helpers/utils').commandKey,
     ctrlShiftKey = require('./helpers/utils').ctrlShiftKey,
     assertToastMsg = require('./helpers/utils').assertToastMsg,
     openUrl = require('./helpers/utils').open,
@@ -62,9 +63,9 @@ describe('authoring', function() {
         authoring.addEmbed('Embed');
         authoring.blockContains(1, 'Embed');
         authoring.blockContains(2, 'to be undone');
-        ctrlKey('z');
+        commandKey('z');
         authoring.blockContains(0, 'to be undone');
-        ctrlKey('y');
+        commandKey('y');
         authoring.blockContains(1, 'Embed');
         authoring.blockContains(2, 'to be undone');
         authoring.cutBlock(1);

--- a/spec/helpers/utils.js
+++ b/spec/helpers/utils.js
@@ -9,6 +9,7 @@ module.exports.waitForSuperdesk = waitForSuperdesk;
 module.exports.nav = nav;
 module.exports.getListOption = getListOption;
 module.exports.ctrlKey = ctrlKey;
+module.exports.commandKey = commandKey;
 module.exports.ctrlShiftKey = ctrlShiftKey;
 module.exports.altKey = altKey;
 module.exports.assertToastMsg = assertToastMsg;
@@ -182,6 +183,16 @@ function getListOption(dropdown, n) {
 function ctrlKey(key) {
     var Key = protractor.Key;
     browser.actions().sendKeys(Key.chord(Key.CONTROL, key)).perform();
+}
+
+/**
+ * Performs COMMAND + key action
+ *
+ * @param {char} key
+ */
+function commandKey(key) {
+    var Key = protractor.Key;
+    browser.actions().sendKeys(Key.chord(Key.COMMAND, key)).perform();
 }
 
 /**


### PR DESCRIPTION
Adds `cmd`+[`z`|`y`] to let mac users to use their favorite key

I replaced in the e2e tests a `ctrl`+`z` by a `cmd`+`z`. Is that fine with every kind of environment ?
It works on my setup (ubuntu + chrome) and travis.