### PR TITLE
fix(workspace): fix uploaded images are not visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix undo/redo changes not being saved or autosaved
+- Fix images uploaded into private space are not visible
 
 ## [1.0.0-beta1] 2016-04-26
 

--- a/scripts/superdesk-search/search.js
+++ b/scripts/superdesk-search/search.js
@@ -344,7 +344,7 @@
 
             // remove other users drafts.
             this.filter({or:[{and: [{term: {state: 'draft'}},
-                                   {term: {'task.user': session.identity._id}}]},
+                                   {term: {'original_creator': session.identity._id}}]},
                              {not: {terms: {state: ['draft']}}}]});
 
             //remove the digital package from production view.


### PR DESCRIPTION
use `original_creator` field for filtering items in draft
state instead of `task.user` which is only set on next save

SD-5217