### PR TITLE
fix(authoring): fix reverting to an empty item after save

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
       export CHROME_BIN=`pwd`/chrome-linux/chrome && $CHROME_BIN --version ;
 
 install:
-    - npm install --python=python2.7
+    - npm install
     - bower install --quiet
     - cd test-server && pip install -q -r requirements.txt && cd ..
     - ./node_modules/.bin/webdriver-manager update

--- a/scripts/superdesk-authoring/authoring.js
+++ b/scripts/superdesk-authoring/authoring.js
@@ -6,21 +6,20 @@ import 'angular-history/history.js';
     var CONTENT_FIELDS_DEFAULTS = Object.freeze({
         headline: '',
         slugline: '',
-        body_html: null,
-        'abstract': null,
+        body_html: '',
+        'abstract': '',
         anpa_take_key: null,
-        byline: null,
+        byline: '',
         urgency: null,
         priority: null,
         subject: [],
         'anpa_category': [],
-        genre: [],
-        groups: [],
+        genre: null,
+        groups: null,
         usageterms: null,
         ednote: null,
         place: [],
-        located: null,
-        dateline: null,
+        dateline: {},
         language: null,
         unique_name: '',
         keywords: [],
@@ -34,9 +33,9 @@ import 'angular-history/history.js';
         target_types: [],
         target_subscribers: [],
         embargo: null,
-        renditions: null,
-        associations: null,
-        body_footer: null,
+        renditions: {},
+        associations: {},
+        body_footer: '',
         company_codes: [],
         schedule_settings: null,
         sms_message: null,
@@ -76,6 +75,20 @@ import 'angular-history/history.js';
      */
     function extendItem(dest, src) {
         return angular.extend(dest, _.pick(src, _.keys(CONTENT_FIELDS_DEFAULTS)));
+    }
+
+    /**
+     * Filter out default values from diff
+     *
+     * @param {Object} diff
+     * @param {Object} orig
+     */
+    function filterDefaultValues(diff, orig) {
+        Object.keys(CONTENT_FIELDS_DEFAULTS).forEach(function(key) {
+            if (diff.hasOwnProperty(key) && angular.equals(diff[key], CONTENT_FIELDS_DEFAULTS[key]) && !orig.hasOwnProperty(key)) {
+                delete diff[key];
+            }
+        });
     }
 
     function stripHtmlRaw(content) {
@@ -161,6 +174,7 @@ import 'angular-history/history.js';
                 this.stop(item);
                 timeouts[item._id] = $timeout(function() {
                     var diff = extendItem({_id: item._id}, item);
+                    filterDefaultValues(diff, orig);
                     return api.save(RESOURCE, {}, diff).then(function(_autosave) {
                         orig._autosave = _autosave;
                     });
@@ -378,9 +392,8 @@ import 'angular-history/history.js';
         this.publish = function publish(orig, diff, action) {
             action = action || 'publish';
             diff = extendItem({}, diff);
-
             this.cleanUpdatesBeforePublishing(orig, diff);
-
+            filterDefaultValues(diff, orig);
             var endpoint = 'archive_' + action;
             return api.update(endpoint, orig, diff)
             .then(function(result) {
@@ -443,18 +456,14 @@ import 'angular-history/history.js';
                 delete diff._etag;
             }
 
+            filterDefaultValues(diff, origItem);
+
             if (_.size(diff) > 0) {
-                // workaround for undo/redo:
-                // it needs to keep origItem without content changes,
-                // otherwise due to inheritance those new changes could be seen after undo
-                var _orig = angular.copy(origItem);
-                return api.save('archive', _orig, diff).then(function(_item) {
+                return api.save('archive', origItem, diff).then(function(_item) {
                     origItem._autosave = null;
                     origItem._autosaved = false;
                     origItem._locked = lock.isLockedInCurrentSession(item);
-                    origItem._etag = _item._etag;
-                    origItem._current_version = _item._current_version;
-                    $injector.get('authoringWorkspace').update(item);
+                    $injector.get('authoringWorkspace').update(origItem);
                     return origItem;
                 });
             } else {
@@ -1635,8 +1644,14 @@ import 'angular-history/history.js';
                  */
                 $scope.closePreview = function() {
                     $scope.item = _.create($scope.origItem);
-                    extendItem($scope.item, $scope.item._autosave || {});
                     $scope._editable = $scope.action !== 'view' && authoring.isEditable($scope.origItem);
+
+                    // populate content fields so that it can undo to initial (empty) version later
+                    var autosave = $scope.origItem._autosave || {};
+                    Object.keys(CONTENT_FIELDS_DEFAULTS).forEach(function(key) {
+                        var value = autosave[key] || $scope.origItem[key] || CONTENT_FIELDS_DEFAULTS[key];
+                        $scope.item[key] = angular.copy(value);
+                    });
                 };
 
                 /**

--- a/scripts/superdesk-authoring/tests/authoring.spec.js
+++ b/scripts/superdesk-authoring/tests/authoring.spec.js
@@ -156,6 +156,20 @@ describe('authoring', function() {
         expect(reloadService.forceReload).toHaveBeenCalled();
     }));
 
+    it('can populate content metadata for undo', inject(function($rootScope) {
+        var orig = {headline: 'foo'};
+        var scope = startAuthoring(orig, 'edit');
+        expect(scope.origItem.headline).toBe('foo');
+        expect(scope.item.headline).toBe('foo');
+        expect(scope.item.slugline).toBe('');
+        scope.$apply(function() {
+            scope.origItem.headline = 'bar';
+            scope.origItem.slugline = 'slug';
+        });
+        expect(scope.item.headline).toBe('foo');
+        expect(scope.item.slugline).toBe('');
+    }));
+
     /**
      * Start authoring ctrl for given item.
      *
@@ -369,7 +383,7 @@ describe('authoring', function() {
             )).toBeFalsy();
         }));
 
-        it('can keep origItem etag updated without content changes',
+        it('updates orig item on save',
         inject(function(authoring, $rootScope, $httpBackend, api, $q, urls) {
             var item = {headline: 'foo'};
             var orig = {_links: {self: {href: 'archive/foo'}}};
@@ -381,7 +395,6 @@ describe('authoring', function() {
             $httpBackend.flush();
             expect(orig._etag).toBe('new');
             expect(orig._current_version).toBe(2);
-            expect(orig.headline).toBe(undefined);
         }));
     });
 });

--- a/scripts/superdesk/datetime/reldate-directive-complex.js
+++ b/scripts/superdesk/datetime/reldate-directive-complex.js
@@ -20,24 +20,18 @@
         var DISPLAY_DAY_FORMAT = 'dddd, ';
         var DISPLAY_TODAY_FORMAT = '[Today]';
         return {
-            scope: {
-                useutc: '='
-            },
+            scope: {useutc: '='},
             require: 'ngModel',
             template: '<time datetime="{{ datetime }}">' +
                 '<span>{{ rday }}, &nbsp;{{ rdate }}</span></time>',
-            replate: true,
             link: function(scope, element, attrs, ngModel) {
-
-                if (angular.isUndefined(scope.useutc)) {
-                    scope.useutc = true;
-                }
+                var useutc = angular.isUndefined(scope.useutc) ? true : !!scope.useutc;
 
                 ngModel.$render = function() {
                     var date = moment.utc(ngModel.$viewValue);
                     scope.datetime = date.toISOString();
 
-                    if (scope.useutc) {
+                    if (useutc) {
                         date.local(); // switch to local time zone
                     }
 

--- a/test-server/requirements.txt
+++ b/test-server/requirements.txt
@@ -3,4 +3,4 @@ honcho==0.6.6
 newrelic>=2.66,<2.67
 
 
-git+git://github.com/superdesk/superdesk-core.git@885a1fc29#egg=Superdesk-Core
+git+git://github.com/superdesk/superdesk-core.git@a5fa622#egg=Superdesk-Core


### PR DESCRIPTION
populate item with default values when editing starts, so that it
can be reverted to initial state, even if origItem changed after saving.

so this is actually a workaround for js inheritance, ideally we wouldn't
use it then, but this seems to be quite some work due to those `_locked`
and `_editable` and other flags.