### PR TITLE
fix(archive): remove exif-js from index imports

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -28,7 +28,6 @@ import 'angular-embed';
 import 'angular-contenteditable';
 import 'angular-vs-repeat';
 import 'ng-file-upload';
-import 'exif-js';
 import 'raven-js';
 import 'medium-editor';
 import 'rangy';

--- a/scripts/superdesk-archive/module.js
+++ b/scripts/superdesk-archive/module.js
@@ -1,4 +1,5 @@
 import BaseListController from './controllers/baseList';
+import EXIF from 'exif-js';
 
 (function() {
     'use strict';


### PR DESCRIPTION
This change fixes an issue that prevents media uploads.  wanted to add e2e test for upload, but looks to be not possible for now.