### PR TITLE
[publishing] added keys to pick when publishing an item

### DIFF
--- a/scripts/superdesk-publish/publish.js
+++ b/scripts/superdesk-publish/publish.js
@@ -282,7 +282,7 @@ function PublishQueueController($scope, subscribersService, api, $q, notify, $lo
 
     $scope.buildNewSchedule = function (item) {
         var pick_fields = ['item_id', 'item_version', 'publishing_action', 'formatted_item', 'headline',
-            'content_type', 'subscriber_id', 'unique_name', 'destination', 'ingest_provider'];
+            'content_type', 'subscriber_id', 'unique_name', 'destination', 'ingest_provider', 'item_encoding', 'encoded_item_id'];
 
         var newItem = _.pick(item, pick_fields);
         return newItem;


### PR DESCRIPTION
"item_encoding" and "encoded_item_id" are needed by backend to produce binary data.

needed for SDNTB-253