### PR TITLE
Fixes a blocker on highlights

### DIFF
--- a/scripts/superdesk-desks/desks.js
+++ b/scripts/superdesk-desks/desks.js
@@ -351,7 +351,7 @@
                             }
                             if (index === -1) { // selected not in current items, select first
                                 container.scrollTop = 0;
-                                clickItem(_.first(scope.items), event);
+                                clickItem(_.head(scope.items), event);
                             }
                             var nextIndex = _.max([0, _.min([scope.items.length - 1, index + diff])]);
                             if (nextIndex < 0) {

--- a/scripts/superdesk-highlights/highlights.js
+++ b/scripts/superdesk-highlights/highlights.js
@@ -154,8 +154,8 @@ function HighlightsService(api, $q, $cacheFactory, packages, privileges) {
             } else if (highlight.auto_insert === 'now/w') {
                 return hourDifference <= 168; //24*7
             } else if (_.startsWith(highlight.auto_insert, 'now-')) {
-                var trimmedValue = _.trimLeft(highlight.auto_insert, 'now-');
-                trimmedValue = _.trimRight(highlight.auto_insert, 'h');
+                var trimmedValue = _.trimStart(highlight.auto_insert, 'now-');
+                trimmedValue = _.trimEnd(highlight.auto_insert, 'h');
                 return hourDifference <= _.parseInt(trimmedValue);
             }
         }

--- a/scripts/superdesk/activity/activity-chooser-directive.js
+++ b/scripts/superdesk/activity/activity-chooser-directive.js
@@ -20,7 +20,7 @@ function(activityChooser, keyboardManager, asset, _) {
             scope.$watch(function watchActivities() {
                 return activityChooser.activities;
             }, function(activities, prev) {
-                scope.selected = activities ? _.first(activities) : null;
+                scope.selected = activities ? _.head(activities) : null;
 
                 if (activities) {
                     keyboardManager.push('up', function() {

--- a/scripts/superdesk/filters.js
+++ b/scripts/superdesk/filters.js
@@ -74,7 +74,7 @@ export default angular.module('superdesk.filters', []).
     })
     .filter('truncateString', function() {
         return function(inputString, limit, postfix) {
-            return _.trunc(inputString, {'length': limit, 'omission': postfix || '...'});
+            return _.truncate(inputString, {'length': limit, 'omission': postfix || '...'});
         };
     })
     .filter('formatDateTimeString', [function() {

--- a/scripts/superdesk/list/list.js
+++ b/scripts/superdesk/list/list.js
@@ -58,7 +58,7 @@ mod.directive('sdListView', ['$location', 'keyboardManager', 'asset', function($
                     if (scope.items) {
                         var index = _.indexOf(scope.items, scope.selected);
                         if (index === -1) { // selected not in current items, select first
-                            return scope.clickItem(_.first(scope.items));
+                            return scope.clickItem(_.head(scope.items));
                         }
 
                         var nextIndex = _.max([0, _.min([scope.items.length - 1, index + diff])]);
@@ -152,7 +152,7 @@ mod.directive('sdUpdowns', ['$location', 'keyboardManager', '$anchorScroll', fun
                     if (scope.items) {
                         var index = _.findIndex(scope.items, {_id: $location.search()._id});
                         if (index === -1) { // selected not in current items, select first
-                            return clickItem(_.first(scope.items));
+                            return clickItem(_.head(scope.items));
                         }
                         var nextIndex = _.max([0, _.min([scope.items.length - 1, index + diff])]);
                         if (nextIndex < 0) {


### PR DESCRIPTION
This was caused due to the update to lodash 4.x. This PR should update all deprecated and renamed methods as per the [lodash changelog](https://github.com/lodash/lodash/wiki/Changelog#v400) for 4.x

Addresses [SD-5342](https://dev.sourcefabric.org/browse/SD-5342)