### PR TITLE
SD-5075: Unable to follow up the warning message in Edit crops and save changes in image item

### DIFF
--- a/scripts/superdesk-authoring/authoring.js
+++ b/scripts/superdesk-authoring/authoring.js
@@ -967,8 +967,14 @@ function ChangeImageController($scope, gettext, notify, modal, $q, _, api, $root
     var sizes = {};
 
     $scope.data.renditions.forEach(function(rendition) {
-        sizes[rendition.name] = {width: rendition.width, height: rendition.height};
-        $scope.data.cropData[rendition.name] = angular.extend({}, $scope.data.item.renditions[rendition.name]);
+        var original = $scope.data.item.renditions.original;
+        // only extend the item renditions if the original image can fit the rendition dimensions
+        // otherwise we will get an error saving
+        if ((original.height >= rendition.height) &&
+            (original.width >= rendition.width)) {
+            sizes[rendition.name] = {width: rendition.width, height: rendition.height};
+            $scope.data.cropData[rendition.name] = angular.extend({}, $scope.data.item.renditions[rendition.name]);
+        }
     });
     var poiOrig = angular.extend({}, $scope.data.poi);
     $scope.data.isDirty = false;
@@ -1079,7 +1085,6 @@ function ChangeImageController($scope, gettext, notify, modal, $q, _, api, $root
             if (angular.isDefined(renditionName)) {
                 $scope.data.cropData[renditionName] = angular.extend({}, cropData, sizes[renditionName]);
             }
-            $scope.data.isDirty = true;
         });
     };
 }
@@ -2908,10 +2913,13 @@ function ArticleEditDirective(
                     })
                     .then(function(result) {
                         var renditions = _.create(scope.item.renditions || {});
+                        // always mark dirty as poi could have changed with no
+                        // cropData changes
+                        mainEditScope.dirty = true;
                         angular.forEach(result.cropData, function(crop, rendition) {
-                            mainEditScope.dirty = true;
                             renditions[rendition] = angular.extend({}, renditions[rendition] || {}, crop);
                         });
+
                         scope.item.renditions = renditions;
                     });
             };

--- a/scripts/superdesk/upload/image-crop-directive.js
+++ b/scripts/superdesk/upload/image-crop-directive.js
@@ -145,7 +145,7 @@
                 });
 
                 scope.$watch('cropData', function() {
-                    cropData = scope.cropData;
+                    cropData = scope.cropData || {};
                     if (cropData && cropData.CropBottom) {
                         refreshImage(img.src, [
                             cropData.CropLeft,


### PR DESCRIPTION
updated authoring to not extend renditions if the original image size is too small for the rendition.
also fixed an issue with incorrectly setting isDirty flag on Edit/Apply crop area