### PR TITLE
SD-5113: "Alt text is mandatory..." warning message is unclear and blocks image publishing

### DIFF
--- a/scripts/superdesk-authoring/authoring.js
+++ b/scripts/superdesk-authoring/authoring.js
@@ -1123,11 +1123,12 @@ AuthoringDirective.$inject = [
     'reloadService',
     '$rootScope',
     '$interpolate',
-    'metadata'
+    'metadata',
+    'config'
 ];
 function AuthoringDirective(superdesk, superdeskFlags, authoringWorkspace, notify, gettext, desks, authoring, api, session, lock,
     privileges, content, $location, referrer, macros, $timeout, $q, modal, archiveService, confirm, reloadService, $rootScope,
-    $interpolate, metadata) {
+    $interpolate, metadata, config) {
     return {
         link: function($scope, elem, attrs) {
             var _closing;
@@ -1477,12 +1478,16 @@ function AuthoringDirective(superdesk, superdeskFlags, authoringWorkspace, notif
             }
 
             function validateForPublish(item) {
+                var requiredFields = config.requiredMediaMetadata;
                 if (item.type === 'picture') {
-                    if (item.alt_text === null || _.trim(item.alt_text) === '') {
-                        notify.error(gettext('Alt text is mandatory for image publishing! ' +
-                            'Edit crops to fill in the alt text.'));
-                        return false;
-                    }
+                    // required media metadata fields are defined in superdesk.config.js
+                    _.each(requiredFields, function (key) {
+                        if (item[key] == null || _.isEmpty(item[key])) {
+                            notify.error(gettext('Required field ' + key + ' is missing. ' +
+                                'Edit crops to fill in the ' + key + '.'));
+                            return false;
+                        }
+                    });
                 }
                 return true;
             }


### PR DESCRIPTION
updated AuthoringDirectives validateForPublishing function to use the required fields for media items set in superdesk.config.js instead of hard coding.