### PR TITLE
ui(hotfix): fixes a problem with a regression in webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "protractor-flake": "1.0.1",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.1",
-    "webpack-dev-server": "^1.14.1"
+    "webpack-dev-server": "1.14.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
There was a regression in the webpack-dev-server that introduced a lot of problems with the proxy, making it impossible for some people to run the app locally. This freezes the version to avoid these issues in the future.