### PR TITLE
SD-5113: "Alt text is mandatory..." warning message is unclear and blocks image publishing

### DIFF
--- a/scripts/superdesk-authoring/authoring/directives/AuthoringDirective.js
+++ b/scripts/superdesk-authoring/authoring/directives/AuthoringDirective.js
@@ -379,12 +379,16 @@ export function AuthoringDirective(superdesk, superdeskFlags, authoringWorkspace
             }
 
             function validateForPublish(item) {
+                var requiredFields = config.requiredMediaMetadata;
                 if (item.type === 'picture') {
-                    if (item.alt_text === null || _.trim(item.alt_text) === '') {
-                        notify.error(gettext('Alt text is mandatory for image publishing! ' +
-                            'Edit crops to fill in the alt text.'));
-                        return false;
-                    }
+                    // required media metadata fields are defined in superdesk.config.js
+                    _.each(requiredFields, function (key) {
+                        if (item[key] == null || _.isEmpty(item[key])) {
+                            notify.error(gettext('Required field ' + key + ' is missing. ' +
+                                'Edit crops to fill in the ' + key + '.'));
+                            return false;
+                        }
+                    });
                 }
                 return true;
             }

--- a/scripts/superdesk-authoring/authoring/directives/AuthoringDirective.js
+++ b/scripts/superdesk-authoring/authoring/directives/AuthoringDirective.js
@@ -379,13 +379,13 @@ export function AuthoringDirective(superdesk, superdeskFlags, authoringWorkspace
             }
 
             function validateForPublish(item) {
-                var requiredFields = config.requiredMediaMetadata;
+                var requiredFields = $rootScope.config.requiredMediaMetadata;
                 if (item.type === 'picture') {
                     // required media metadata fields are defined in superdesk.config.js
                     _.each(requiredFields, function (key) {
                         if (item[key] == null || _.isEmpty(item[key])) {
-                            notify.error(gettext('Required field ' + key + ' is missing. ' +
-                                'Edit crops to fill in the ' + key + '.'));
+                            notify.error($interpolate(gettext(
+                                'Required field {{ key }} is missing. ...'))({key: key}));
                             return false;
                         }
                     });


### PR DESCRIPTION
updated validateForPublish function to use fields defined in superdesk.config.js for validation instead of hard coded 'alt text' field.