### PR TITLE
fix(search) - Date picker triggered searches are not functioning

### DIFF
--- a/scripts/superdesk-items-common/styles/archive-filtering.less
+++ b/scripts/superdesk-items-common/styles/archive-filtering.less
@@ -70,7 +70,7 @@
 
     .content {
         position: absolute;
-        top:@nav-height; left:0px; bottom:0px; right:0px;
+        top:@nav-height; left:0px; bottom:80px; right:0px;
         padding: 20px;
         overflow: auto;
         padding-bottom: @bottom-view-padding;

--- a/scripts/superdesk-search/views/save-search.html
+++ b/scripts/superdesk-search/views/save-search.html
@@ -1,10 +1,11 @@
 <div class="save-search" ng-if="searching() || innerTab==='parameters'">
-    <div ng-if="!editingSearch">
+    <div ng-if="!editingSearch && sTab !== 'savedSearches'">
         <button class="btn btn-info btn-full search" ng-click="search()" ng-if="innerTab==='parameters'" translate>Search</button>
         <a id="clear_filters" class="save-search__link" ng-click="clear()" ng-if="searching()" translate>Clear filters</a>
         <button id="save_search_init" class="btn btn-info" ng-click="editItem()" ng-if="searching() && !editingSearch"  translate>Save Search</button>
     </div>
     <div ng-if="editingSearch">
+        <button class="btn btn-info btn-full search" ng-click="search()" ng-if="innerTab==='parameters'" translate>Search</button>
         <button id="saveas_search_init" class="btn" ng-click="saveas()" translate ng-if="editingSearch">Save As</button>
         <button id="save_search_init" class="btn btn-info" ng-click="editItem()" ng-if="!editingSearch" translate>Save Changes</button>
         <button id="save_search_init" class="btn btn-info" ng-click="save(edit)" ng-if="editingSearch" translate>Save Changes</button>

--- a/scripts/superdesk-search/views/search-filters.html
+++ b/scripts/superdesk-search/views/search-filters.html
@@ -149,7 +149,4 @@
             </div>
         </form>
     </div>
-
- <!--    <div sd-save-search></div> -->
-
 </div>

--- a/scripts/superdesk-search/views/search-panel.html
+++ b/scripts/superdesk-search/views/search-panel.html
@@ -37,8 +37,6 @@
 
     <div sd-save-search></div>
 
-    
-
     <div class="content views" ng-if="sTab==='savedSearches'">
         <div sd-saved-searches></div>
     </div>

--- a/spec/content_spec.js
+++ b/spec/content_spec.js
@@ -36,7 +36,7 @@ describe('content', function() {
         var now = new Date();
         //choose time with date not in a valid month number.
         //default view time format in config
-        var embargoDate = '09/22/' + (now.getFullYear() + 1);
+        var embargoDate = '09/09/' + (now.getFullYear() + 1);
         var embargoTime = (now.getHours() < 10 ? ('0' + now.getHours()) : now.getHours()) + ':' +
                         (now.getMinutes() < 10 ? ('0' + now.getMinutes()) : now.getMinutes());
 

--- a/styles/less/forms.less
+++ b/styles/less/forms.less
@@ -214,6 +214,7 @@ input[type="hidden"] {
 // Custom radio button
 .sd-radio {
   position: relative;
+  padding-left: 3px;
   input[type="radio"] {
     visibility: hidden;
     + .check {
@@ -226,7 +227,7 @@ input[type="hidden"] {
       .border-radius(50%);
       border: 2px solid @inputBorder;
       vertical-align: middle;
-      margin-left: 3px;
+      margin-left: 0px;
     }
     &:checked {
       + .check {

--- a/styles/less/sf-additional.less
+++ b/styles/less/sf-additional.less
@@ -1818,7 +1818,7 @@ header .sortbar {
 .toggle-button {
     border-radius: 2px;
     box-sizing: border-box;
-    padding: 0 5px;
+    padding: 0 4px;
     text-decoration: none;
     font-size: 12px;
     background: #fff;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -146,8 +146,7 @@ function getDefaults(grunt) {
 
         // view formats for datepickers/timepickers
         view: {
-            // keep defaults different from model (for testing purposes)
-            dateformat: process.env.VIEW_DATE_FORMAT || 'MM/DD/YYYY',
+            dateformat: process.env.VIEW_DATE_FORMAT || 'DD/MM/YYYY',
             timeformat: process.env.VIEW_TIME_FORMAT || 'HH:mm'
         },
 


### PR DESCRIPTION
[SD-5371] - In global search the "confirm" button does not initiate a search

This PR also addresses following tickets:
- [SD-5369] - Need further scrolling once "search" or "save search" are initiated
- [SD-5370] - Leave some space between "in Superdesk" and icon in advanced search
- [SD-5374] - Bottom buttons are not working for saved search
- [SD-5375] - Cannot save changes to parameters of a saved search