### PR TITLE
fix(date param): SD-5086 Refreshing date param after route change

### DIFF
--- a/scripts/superdesk-settings/module.js
+++ b/scripts/superdesk-settings/module.js
@@ -40,6 +40,10 @@ export default angular.module('superdesk.settings', [])
                         $location.search(attrs.location, date);
                     }
                 });
+
+                scope.$on('$routeUpdate', function(event, route) {
+                    scope.date = route.params[attrs.location];
+                });
             }
         };
     }])


### PR DESCRIPTION
SD-5086 - Clear filters is not working for dates search in global search