### PR TITLE
fix(about): SD-5336 Added link for superdesk manual

### DIFF
--- a/scripts/superdesk/menu/views/about.html
+++ b/scripts/superdesk/menu/views/about.html
@@ -23,7 +23,8 @@
       </p>
       <p>
         Looking for help or support?<br>
-        <a href="https://forum.sourcefabric.org/categories/superdesk-dev" target="_blank">Forum</a>&nbsp;&nbsp; | &nbsp;&nbsp;<a href="#" target="_blank">User Manual</a>
+        <a href="https://forum.sourcefabric.org/categories/superdesk-dev" target="_blank">Forum</a>&nbsp;&nbsp; | &nbsp;
+        <a href="https://www.superdesk.org/attachment/13/superdeskmastermanual.pdf?g_download=1" target="_blank">User Manual</a>
       </p>
       <p>
         Get in touch with us via direct email <a href="mailto:superdesk@sourcefabric.org">superdesk@sourcefabric.org</a>... or find us in IRC Freenode at the #superdesk channel.


### PR DESCRIPTION
SD-5336 - User manual can't be opened from "About Superdesk"