### PR TITLE
fix(desk rules): SD-4930 Changed display name for desk rules

### DIFF
--- a/scripts/superdesk-authoring/metadata/views/metadata-terms.html
+++ b/scripts/superdesk-authoring/metadata/views/metadata-terms.html
@@ -7,7 +7,7 @@
 </div>
 
 <div class="dropdown dropright dropdown-bigger dropdown-terms" dropdown sd-dropdown-focus sd-dropdown-position
-    tooltip="{{ allSelected ? 'All items selected' : ''  | translate }}" tooltip-placement="left">
+    title="{{ allSelected ? 'All items selected' : ''  | translate }}">
     <button class="dropdown-toggle" dropdown-toggle tabindex="{{tabindex}}" ng-disabled="disabled" ng-if="header && !disabled">
         <i class="icon-white icon-plus-large"></i>
     </button>

--- a/scripts/superdesk-desks/views/desk-config-modal.html
+++ b/scripts/superdesk-desks/views/desk-config-modal.html
@@ -226,21 +226,21 @@
                                 <label>{{ :: 'Incoming Rule' | translate }}</label>
                                 <select ng-model="editStage.incoming_macro">
                                     <option value=""></option>
-                                    <option ng-repeat="macro in macros" ng-selected="editStage.incoming_macro === macro.name" value="{{macro.name}}">{{macro.name}}</option>
+                                    <option ng-repeat="macro in macros" ng-selected="editStage.incoming_macro === macro.name" value="{{macro.name}}">{{macro.label}}</option>
                                 </select>
                             </div>
                             <div class="field">
                                 <label>{{ :: 'Moved onto stage Rule' | translate }}</label>
                                 <select ng-model="editStage.onstage_macro">
                                     <option value=""></option>
-                                    <option ng-repeat="macro in macros" ng-selected="editStage.onstage_macro === macro.name" value="{{macro.name}}">{{macro.name}}</option>
+                                    <option ng-repeat="macro in macros" ng-selected="editStage.onstage_macro === macro.name" value="{{macro.name}}">{{macro.label}}</option>
                                 </select>
                             </div>
                             <div class="field">
                                 <label>{{ :: 'Outgoing Rule' | translate }}</label>
                                 <select ng-model="editStage.outgoing_macro">
                                     <option value=""></option>
-                                    <option ng-repeat="macro in macros" ng-selected="editStage.outgoing_macro === macro.name" value="{{macro.name}}">{{macro.name}}</option>
+                                    <option ng-repeat="macro in macros" ng-selected="editStage.outgoing_macro === macro.name" value="{{macro.name}}">{{macro.label}}</option>
                                 </select>
                             </div>
                         </div>


### PR DESCRIPTION
SD-4930 - Take away underscores and capitalize the first letters of the desk rules
SD-5184 - Tool tip "all items selected" is partially visible