### PR TITLE
SD-4564: An item added to the highlight package is still available to be added to the highlight package

### DIFF
--- a/scripts/superdesk-packaging/packaging.js
+++ b/scripts/superdesk-packaging/packaging.js
@@ -107,7 +107,7 @@ function PackagesService(api, $q, archiveService, lock, autosave, authoring, aut
     this.isAdded = function(pkg, item) {
         var added = pkg.groups ? pkg.groups.some(function(group) {
             return group.refs.some(function(ref) {
-                return ref.guid === item._id;
+                return (ref.guid === item._id) || (ref.residRef === item._id);
             });
         }) : false;
         var addedToPkg = this.isAddedToPackage(pkg, item);


### PR DESCRIPTION
This is a small bugfix for highlight package items, that were showing "Add to current"  even if already present in the newly created item.