### PR TITLE
fix(search) - Referesh frame and button not appearing on updates

### DIFF
--- a/scripts/superdesk-search/directives/SearchResults.js
+++ b/scripts/superdesk-search/directives/SearchResults.js
@@ -160,7 +160,6 @@ export function SearchResults(
                 }
                 criteria.source.from = 0;
                 scope.total = null;
-                scope.items = null;
                 criteria.aggregations = $rootScope.aggregations;
                 criteria.es_highlight = search.getElasticHighlight();
                 return api.query(getProvider(criteria), criteria).then(function (items) {
@@ -192,7 +191,7 @@ export function SearchResults(
             }
 
             function scheduleIfShouldUpdate(event, data) {
-                if (data && data.item && _.includes(['item:spike', 'item:unspike'], event.name)) {
+                if (data && data.item && _.includes(['item:spike', 'item:unspike', 'item:deleted'], event.name)) {
                     // item was spiked/unspikes from the list
                     extendItem(data.item, {
                         gone: true,

--- a/spec/search_spec.js
+++ b/spec/search_spec.js
@@ -233,12 +233,12 @@ describe('search', function() {
         authoring.setEmbargo();
         authoring.save();
         authoring.close();
-        expect(globalSearch.getItem(0).element(by.className('state_embargo')).isDisplayed()).toBe(true);
-        expect(globalSearch.getItem(0).element(by.className('state_embargo')).getText()).toEqual('EMBARGO');
+        expect(globalSearch.getItem(4).element(by.className('state_embargo')).isDisplayed()).toBe(true);
+        expect(globalSearch.getItem(4).element(by.className('state_embargo')).getText()).toEqual('EMBARGO');
 
         //can search scheduled
         expect(globalSearch.getItems().count()).toBe(14);
-        globalSearch.actionOnItem('Edit', 4);
+        globalSearch.actionOnItem('Edit', 2);
         authoring.schedule(false);
         globalSearch.openFilterPanel();
         globalSearch.openParameters();


### PR DESCRIPTION
- fix bug introduced in recent refact(search) 2nd last changes in SearchResults.js, that was preventing to canShowRefresh() to compare and decide if refresh frame/button should appear.
- also added the removed item:deleted, work done in https://github.com/superdesk/superdesk-client-core/pull/887