### PR TITLE
[SD-5017] Legal Archive date search label change for clarity

### DIFF
--- a/scripts/superdesk-legal-archive/directives/LegalItemSortbar.js
+++ b/scripts/superdesk-legal-archive/directives/LegalItemSortbar.js
@@ -18,10 +18,7 @@ export function LegalItemSortbar(legal, asset) {
                 legal.toggleSortDir();
             };
 
-            scope.canSort = function canSort()
-            {
-                return true;
-            };
+            scope.canSort = () => true;
 
             scope.$on('$routeUpdate', getActive);
             getActive();

--- a/scripts/superdesk-legal-archive/directives/LegalItemSortbar.js
+++ b/scripts/superdesk-legal-archive/directives/LegalItemSortbar.js
@@ -18,6 +18,11 @@ export function LegalItemSortbar(legal, asset) {
                 legal.toggleSortDir();
             };
 
+            scope.canSort = function canSort()
+            {
+                return true;
+            };
+
             scope.$on('$routeUpdate', getActive);
             getActive();
         }

--- a/scripts/superdesk-legal-archive/services/LegalArchiveService.js
+++ b/scripts/superdesk-legal-archive/services/LegalArchiveService.js
@@ -63,6 +63,8 @@ export function LegalArchiveService($q, api, notify, $location, gettext, config)
         if (params.sort) {
             var sort = params.sort.split(':');
             criteria.sort = formatSort(sort[0], sort[1]);
+        } else {
+            criteria.sort = formatSort('versioncreated', 'desc');
         }
 
         return criteria;

--- a/scripts/superdesk-legal-archive/views/legal_archive.html
+++ b/scripts/superdesk-legal-archive/views/legal_archive.html
@@ -1,9 +1,9 @@
 <div class="subnav subnav--plain">
     <header class="search-page-header">
         <div class="filter-trigger" ng-click="openAdvanceSearch = !openAdvanceSearch" ng-class="{'filter-trigger--active': openAdvanceSearch}"><i class="icon-filter-large"></i></div>
-        <div sd-legal-item-sortbar></div>
         <div sd-pagination data-items="items"></div>
         <div class="searchbar-flex-handler"></div>
+        <div sd-legal-item-sortbar></div>
 
         <div class="view-select">
             <button tooltip="{{ :: 'switch to grid view' | translate }}" tooltip-placement="left"  ng-show="view !== 'mgrid'" ng-click="setview('mgrid')"><i class="icon-th"></i></button>
@@ -58,14 +58,13 @@
                                 <input type="text" id="search-storytext" ng-model="criteria.body_html" tabindex="4">
                             </div>
                         </div>
-
-                        <div class="field" sd-date-param data-location="criteria.published_before">
-                            <label for="published_before" translate>Published before</label>
-                            <div sd-datepicker id="published_before" ng-model="criteria.published_before"></div>
-                        </div>
                         <div class="field" sd-date-param data-location="criteria.published_after">
-                            <label for="published_after" translate>Published after</label>
+                            <label for="published_after" translate>Published From</label>
                             <div sd-datepicker id="published_after" ng-model="criteria.published_after"></div>
+                        </div>
+                        <div class="field" sd-date-param data-location="criteria.published_before">
+                            <label for="published_before" translate>Published Until</label>
+                            <div sd-datepicker id="published_before" ng-model="criteria.published_before"></div>
                         </div>
                     </fieldset>
                 </form>


### PR DESCRIPTION
Date search boxes have been labeled to be more consistent with global search.

The sort selection is now visible again.

If not sort order is specified the default order is passed