### PR TITLE
SD-4983: Image metadata validation upon save and publish

### DIFF
--- a/scripts/superdesk-authoring/authoring/controllers/ChangeImageController.js
+++ b/scripts/superdesk-authoring/authoring/controllers/ChangeImageController.js
@@ -51,7 +51,8 @@ export function ChangeImageController($scope, gettext, notify, modal, $q, _, api
         function validateMediaFields() {
             _.each($scope.data.requiredFields, function (key) {
                 var value = $scope.data.metadata[key];
-                if (value == null || _.isEmpty(value) || value === '<br>') {
+                var regex = new RegExp('\^<*br\/*\>*$', 'i');
+                if (!!!value || value.match(regex)) {
                     throw gettext('Required field(s) missing');
                 }
             });

--- a/scripts/superdesk-authoring/authoring/controllers/ChangeImageController.js
+++ b/scripts/superdesk-authoring/authoring/controllers/ChangeImageController.js
@@ -51,7 +51,7 @@ export function ChangeImageController($scope, gettext, notify, modal, $q, _, api
         function validateMediaFields() {
             _.each($scope.data.requiredFields, function (key) {
                 var value = $scope.data.metadata[key];
-                var regex = new RegExp('\^<*br\/*\>*$', 'i');
+                var regex = new RegExp('^\<*br\/*\>*$', 'i');
                 if (!!!value || value.match(regex)) {
                     throw gettext('Required field(s) missing');
                 }

--- a/scripts/superdesk-authoring/authoring/controllers/ChangeImageController.js
+++ b/scripts/superdesk-authoring/authoring/controllers/ChangeImageController.js
@@ -50,7 +50,8 @@ export function ChangeImageController($scope, gettext, notify, modal, $q, _, api
         /* Throw an exception if a required metadata field is missing */
         function validateMediaFields() {
             _.each($scope.data.requiredFields, function (key) {
-                if ($scope.data.metadata[key] == null || _.isEmpty($scope.data.metadata[key])) {
+                var value = $scope.data.metadata[key];
+                if (value == null || _.isEmpty(value) || value === '<br>') {
                     throw gettext('Required field(s) missing');
                 }
             });


### PR DESCRIPTION
added case to check for empty <br> tags in validateMediaFields()