### PR TITLE
refactor(search-providers): split 'superdesk-search-providers' module.

### DIFF
--- a/scripts/superdesk-search-providers/constants.js
+++ b/scripts/superdesk-search-providers/constants.js
@@ -1,0 +1,10 @@
+export const providerTypes = {
+    aapmm: 'AAP Multimedia',
+    paimg: 'PA Images',
+    // quick fix to have several scanpix instance (needed for SDNTB-237)
+    // FIXME: temporary fix, need to be refactored (SD-4448)
+    'scanpix(ntbtema)': 'ScanPix (ntbtema)',
+    'scanpix(ntbkultur)': 'ScanPix (ntbkultur)',
+    'scanpix(desk)': 'ScanPix (desk)',
+    'scanpix(npk)': 'ScanPix (npk)',
+};

--- a/scripts/superdesk-search-providers/directive.js
+++ b/scripts/superdesk-search-providers/directive.js
@@ -1,51 +1,4 @@
-/**
- * This file is part of Superdesk.
- *
- * Copyright 2013, 2014 Sourcefabric z.u. and contributors.
- *
- * For the full copyright and license information, please see the
- * AUTHORS and LICENSE files distributed with this source code, or
- * at https://www.sourcefabric.org/superdesk/license
- */
-
-var app = angular.module('superdesk.searchProviders', ['superdesk.activity', 'superdesk.api']);
-
-app.value('providerTypes', {
-    aapmm: 'AAP Multimedia',
-    paimg: 'PA Images',
-    // quick fix to have several scanpix instance (needed for SDNTB-237)
-    // FIXME: temporary fix, need to be refactored (SD-4448)
-    'scanpix(ntbtema)': 'ScanPix (ntbtema)',
-    'scanpix(ntbkultur)': 'ScanPix (ntbkultur)',
-    'scanpix(desk)': 'ScanPix (desk)',
-    'scanpix(npk)': 'ScanPix (npk)',
-});
-
-SearchProviderService.$inject = ['providerTypes', '$filter', 'api', 'allowed'];
-function SearchProviderService(providerTypes, $filter, api, allowed) {
-    return {
-        getAllowedProviderTypes: function() {
-            return allowed.filterKeys(providerTypes, 'search_providers', 'search_provider');
-        },
-        getSearchProviders: function() {
-            return api.search_providers.query({}).then(
-                function(result) {
-                    return $filter('sortByName')(result._items, 'search_provider');
-                }
-            );
-        }
-    };
-}
-
-SearchProviderSettingsController.$inject = ['$scope', 'privileges'];
-/**
- * Controller for the Search Provider Settings.
- */
-function SearchProviderSettingsController($scope, privileges) {
-}
-
-SearchProviderConfigDirective.$inject = ['searchProviderService', 'gettext', 'notify', 'api', 'modal'];
-function SearchProviderConfigDirective(searchProviderService, gettext, notify, api, modal) {
+export default function SearchProviderConfigDirective(searchProviderService, gettext, notify, api, modal) {
     return {
         templateUrl: 'scripts/superdesk-search-providers/views/search-provider-config.html',
         link: function ($scope) {
@@ -142,27 +95,4 @@ function SearchProviderConfigDirective(searchProviderService, gettext, notify, a
     };
 }
 
-app
-    .directive('sdSearchProviderConfig', SearchProviderConfigDirective)
-    .service('searchProviderService', SearchProviderService)
-    .config(['superdeskProvider', function(superdesk) {
-        superdesk
-            .activity('/settings/searchProviders', {
-                label: gettext('Search Providers'),
-                templateUrl: 'scripts/superdesk-search-providers/views/settings.html',
-                controller: SearchProviderSettingsController,
-                category: superdesk.MENU_SETTINGS,
-                privileges: {search_providers: 1},
-                priority: 2000
-            });
-    }])
-    .config(['apiProvider', function(apiProvider) {
-        apiProvider.api('search_providers', {
-            type: 'http',
-            backend: {
-                rel: 'search_providers'
-            }
-        });
-    }]);
-
-export default app;
+SearchProviderConfigDirective.$inject = ['searchProviderService', 'gettext', 'notify', 'api', 'modal'];

--- a/scripts/superdesk-search-providers/index.js
+++ b/scripts/superdesk-search-providers/index.js
@@ -1,1 +1,42 @@
-import './module';
+/**
+ * This file is part of Superdesk.
+ *
+ * Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code, or
+ * at https://www.sourcefabric.org/superdesk/license
+ */
+import { providerTypes } from './constants';
+import SearchProviderService from './service';
+import SearchProviderConfigDirective from './directive';
+
+SearchProviderSettingsController.$inject = ['$scope', 'privileges'];
+function SearchProviderSettingsController($scope, privileges) {}
+
+export default angular.module('superdesk.searchProviders', [
+    'superdesk.activity',
+    'superdesk.api'
+])
+    .value('providerTypes', providerTypes)
+    .directive('sdSearchProviderConfig', SearchProviderConfigDirective)
+    .service('searchProviderService', SearchProviderService)
+
+    .config(['superdeskProvider', function(superdesk) {
+        superdesk
+            .activity('/settings/searchProviders', {
+                label: gettext('Search Providers'),
+                templateUrl: 'scripts/superdesk-search-providers/views/settings.html',
+                controller: SearchProviderSettingsController,
+                category: superdesk.MENU_SETTINGS,
+                privileges: {search_providers: 1},
+                priority: 2000
+            });
+    }])
+
+    .config(['apiProvider', function(apiProvider) {
+        apiProvider.api('search_providers', {
+            type: 'http',
+            backend: {rel: 'search_providers'}
+        });
+    }]);

--- a/scripts/superdesk-search-providers/service.js
+++ b/scripts/superdesk-search-providers/service.js
@@ -1,0 +1,16 @@
+export default function SearchProviderService(providerTypes, $filter, api, allowed) {
+    return {
+        getAllowedProviderTypes: function() {
+            return allowed.filterKeys(providerTypes, 'search_providers', 'search_provider');
+        },
+        getSearchProviders: function() {
+            return api.search_providers.query({}).then(
+                function(result) {
+                    return $filter('sortByName')(result._items, 'search_provider');
+                }
+            );
+        }
+    };
+}
+
+SearchProviderService.$inject = ['providerTypes', '$filter', 'api', 'allowed'];


### PR DESCRIPTION
This could be another way to split smaller modules (didn't create
folders).

`superdesk-search-providers` becomes:
```
.
├── views
│   ├── search-provider-config.html
│   └── settings.html
├── constants.js
├── directive.js
├── index.js
└── service.js

1 directory, 6 files
```