### PR TITLE
Added a local .vimrc

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,0 +1,10 @@
+filetype plugin indent on
+" show existing tab with 4 spaces width
+set tabstop=4
+" when indenting with '>', use 4 spaces width
+set shiftwidth=4
+" On pressing tab, insert 4 spaces
+set expandtab
+
+" Otherwise webpack doesn't detect your changes
+set backupcopy=yes


### PR DESCRIPTION
For whoever is using vim, it's possible to create a project specific vimrc.
To enable this functionality, you need to add `set exrc` in your vim config.

This current .vimrc is doing two things:

* Forcing a 4 spaces indentation
* Changing the file saving strategy and thus greatly improving the webpack hot reloading.