### PR TITLE
SD-5452: Prevent highlight package item to disappear during drag'n'drop

### DIFF
--- a/scripts/superdesk-packaging/views/sd-package-items-edit.html
+++ b/scripts/superdesk-packaging/views/sd-package-items-edit.html
@@ -14,7 +14,9 @@
                 <li class="fake clearfix"><div></div></li>
             </ul>
         </li>
-        <li ng-if="highlight">
+      </ul>
+      <ul class="package-edit package-highlight-preview" ng-if="highlight">
+        <li>
             <div class="group-info">
                 <h6>Highlight Preview</h6>
             </div>


### PR DESCRIPTION
* Prevent highlight package item to disappear while accidentally dropping it into highlight preview edit section