### PR TITLE
fix(toolbar): SD-5480 Keep toolbar visible when scrolling

### DIFF
--- a/scripts/superdesk/editor2/editor.js
+++ b/scripts/superdesk/editor2/editor.js
@@ -1061,7 +1061,7 @@ angular.module('superdesk.editor2', [
                         var toolbar = scope.medium.getExtensionByName('toolbar'),
                             elemPosition = elem.getBoundingClientRect();
                         if (toolbar) {
-                            toolbar.toolbar.hidden = elemPosition.top < TOP_OFFSET;
+                            toolbar.toolbar.hidden = elemPosition.top + elemPosition.height < TOP_OFFSET;
                         }
                     });
 


### PR DESCRIPTION
SD-5480 - The formatting toolbar for the body field doesn't stay visible when scrolling down