### PR TITLE
fix(authoring): set scope dirty when something is dropped on featured

### DIFF
--- a/scripts/superdesk-authoring/authoring/directives/ItemAssociationDirective.spec.js
+++ b/scripts/superdesk-authoring/authoring/directives/ItemAssociationDirective.spec.js
@@ -1,0 +1,36 @@
+
+describe('item association directive', function() {
+    beforeEach(window.module('superdesk.authoring'));
+    beforeEach(window.module('superdesk.templates-cache'));
+
+    var elem, scope, item = {};
+
+    beforeEach(inject(function($compile, $rootScope) {
+        scope = $rootScope.$new();
+        scope.rel = 'featured';
+        scope.item = item;
+        elem = $compile(`<div sd-item-association
+            data-item="item"
+            data-rel="rel"
+            data-onchange="onChange()"></div>`
+        )(scope);
+        $rootScope.$digest();
+    }));
+
+    it('can trigger onchange handler on drop', inject(function($rootScope) {
+        var event = new window.$.Event('drop');
+        event.originalEvent = {dataTransfer: {
+            types: [{type: 'video'}],
+            getData: () => angular.toJson({headline: 'foo'})
+        }};
+        event.preventDefault = jasmine.createSpy('preventDefault');
+        event.stopPropagation = jasmine.createSpy('stopPropagation');
+        scope.onChange = jasmine.createSpy('onchange');
+        elem.triggerHandler(event);
+        $rootScope.$digest();
+        expect(scope.onChange).toHaveBeenCalled();
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
+        expect(scope.item.associations.featured.headline).toBe('foo');
+    }));
+});


### PR DESCRIPTION
it could trigger a new digest cycle when another was running already,
thus raising an error so onchange handler was never called.
now it will only call `$apply` when needed - on drop.

SD-5486