### PR TITLE
Automatically load external node modules via config

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   </head>
   <body ng-class="config.bodyClass">
     <div sd-superdesk-view></div>
-    <script src="app.bundle.js" /></script>
+    <script src="core.bundle.js" /></script>
+    <script src="apps.bundle.js" /></script>
   </body>
 </html>

--- a/scripts/superdesk/bootstrap.js
+++ b/scripts/superdesk/bootstrap.js
@@ -38,6 +38,9 @@ var apps = [
 
 angular.module('superdesk.config').constant('config', appConfig);
 
+var bootstrapModule = angular.module('superdesk-bootstrap', apps);
+window.RegisterSuperdeskApplication = name => { bootstrapModule.requires.push(name); };
+
 angular.module('superdesk')
     .constant('lodash', _)
     .config(['$routeProvider', function($routeProvider) {
@@ -45,6 +48,6 @@ angular.module('superdesk')
     }]);
 
 body.ready(function() {
-    angular.bootstrap(body, apps, {strictDi: true});
+    angular.bootstrap(body, ['superdesk-bootstrap'], {strictDi: true});
     window.superdeskIsReady = true;
 });

--- a/tasks/options/webpack-dev-server.js
+++ b/tasks/options/webpack-dev-server.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
                 devtool: 'eval',
                 debug: true,
                 entry: {
-                    app: ['webpack-dev-server/client?http://localhost:9000/'].concat(webpackConfig.entry.app)
+                    core: ['webpack-dev-server/client?http://localhost:9000/'].concat(webpackConfig.entry.core)
                 },
                 output: {
                     publicPath: 'dist'
@@ -71,7 +71,7 @@ function getProxy() {
     } : {};
 
     // on the dev server the bundle is in the dist folder
-    proxy['/app.bundle.js'] = prepend('dist');
+    proxy['/*.bundle.js'] = prepend('dist');
 
     return proxy;
 }


### PR DESCRIPTION
_Work in progress..._

### Proposal

Enables telling superdesk to load external resources via configuration. In `superdesk.config.js`, adding:
```js
apps: ['superdesk-planning', 'my-app']
```
will cause the client to include `node_modules/superdesk-planning` and `node_modules/my-app` into the compilation. 

External applications that want to register Angular modules into Superdesk should do so by calling:
```js
window.RegisterSuperdeskApplication('angular.module.name');
```
This will cause `angular.module.name` to be included into the main app. This is basically the entry point to your module.