### PR TITLE
Auto-load external Angular modules using config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,6 +50,7 @@ module.exports = function(grunt) {
     grunt.registerTask('server', [
         'clean',
         'copy:index',
+        'ngtemplates:gen-importer',
         'ngtemplates:dev',
         'webpack-dev-server:start'
     ]);
@@ -58,6 +59,7 @@ module.exports = function(grunt) {
         'clean',
         'copy:index',
         'copy:assets',
+        'ngtemplates:gen-importer',
         'ngtemplates:core',
         'webpack:build'
     ]);

--- a/scripts/apps/authoring/tests/authoring.spec.js
+++ b/scripts/apps/authoring/tests/authoring.spec.js
@@ -1985,7 +1985,7 @@ describe('send item directive', function() {
     beforeEach(window.module('superdesk.core.preferences'));
     beforeEach(window.module('superdesk.apps.authoring'));
     beforeEach(window.module('superdesk.templates-cache'));
-    beforeEach(window.module('superdesk.api'));
+    beforeEach(window.module('superdesk.core.api'));
 
     beforeEach(inject(function($templateCache) {
         $templateCache.put('scripts/apps/authoring/views/send-item.html', '');

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -7,6 +7,10 @@ import 'apps';
 /* globals __SUPERDESK_CONFIG__: true */
 const appConfig = __SUPERDESK_CONFIG__;
 
+// external-apps is alias for dist/app-importer.generated.js, which is generated
+// by the grunt ngtemplates task 'gen-importer'
+import externalApps from 'external-apps';
+
 if (appConfig.features.useTansaProofing) {
     require('apps/tansa');
 }
@@ -21,7 +25,7 @@ body.ready(function() {
         'superdesk.config',
         'superdesk.core',
         'superdesk.apps'
-    ], {strictDi: true});
+    ].concat(externalApps), {strictDi: true});
 
     window.superdeskIsReady = true;
 });

--- a/tasks/options/ngtemplates.js
+++ b/tasks/options/ngtemplates.js
@@ -28,19 +28,47 @@ module.exports = {
         src: src,
         options: options
     },
+
     docs: {
         cwd: '<%= coreDir %>',
         dest: 'docs/dist/templates-cache-docs.generated.js',
         src: src,
         options: options
     },
+
     dev: {
         cwd: '<%= coreDir %>',
         dest: path.join(rootDir, 'templates-cache.generated.js'),
         src: [],
+        options: {bootstrap: () => ''}
+    },
+
+    // gen-importer generates a file that imports all of the external node
+    // modules defined in superdesk.config.js and returns an array of their
+    // exports.
+    'gen-importer': {
+        cwd: '<%= coreDir %>',
+        dest: 'dist/app-importer.generated.js',
+        src: __filename, // hack to make ngtemplate work
         options: {
             bootstrap: function() {
-                return '';
+                // get apps defined in config
+                var paths = require(
+                    path.join(process.cwd(), 'superdesk.config.js')
+                )().apps || [];
+
+                if (!paths.length) {
+                    return 'export default [];\r\n';
+                }
+
+                let abs = p => path.join(process.cwd(), 'node_modules', p);
+                let data = 'export default [\r\n\trequire("' + abs(paths[0]) + '").default.name';
+
+                for (var i = 1; i < paths.length; i++) {
+                    data += ',\r\n\trequire("' + abs(paths[i]) + '").default.name';
+                }
+
+                return data + '\r\n];\r\n';
             }
         }
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,8 @@ module.exports = function makeConfig(grunt) {
                 'moment-timezone': 'moment-timezone/builds/moment-timezone-with-data-2010-2020',
                 'rangy-saverestore': 'rangy/lib/rangy-selectionsaverestore',
                 'angular-embedly': 'angular-embedly/em-minified/angular-embedly.min',
-                'jquery-gridster': 'gridster/dist/jquery.gridster.min'
+                'jquery-gridster': 'gridster/dist/jquery.gridster.min',
+                'external-apps': path.join(process.cwd(), 'dist', 'app-importer.generated.js')
             },
             extensions: ['', '.js']
         },
@@ -59,11 +60,13 @@ module.exports = function makeConfig(grunt) {
                 {
                     test: /\.js$/,
                     exclude: function(p) {
-                        'use strict';
-                        // exclude parsing node modules, but allow the 'superdesk-core'
-                        // node module, because it will be used when building in the
-                        // main 'superdesk' repository.
-                        return p.indexOf('node_modules') > -1 && p.indexOf('superdesk-core') < 0;
+                        // don't exclude anything outside node_modules
+                        if (p.indexOf('node_modules') === -1) {
+                            return false;
+                        }
+                        // include only 'superdesk-core' and valid modules inside node_modules
+                        let validModules = ['superdesk-core'].concat(sdConfig.apps);
+                        return !validModules.some(app => p.indexOf(app) > -1);
                     },
                     loader: 'babel',
                     query: {


### PR DESCRIPTION
Enables telling superdesk to load external resources via configuration. In `superdesk.config.js`, adding:
```js
apps: ['superdesk-planning', 'my-app']
```
will cause the client to include `node_modules/superdesk-planning` and `node_modules/my-app` into the compilation, as well as load all exported Angular modules into superdesk. 

--
All that external apps need to do is export an Angular module that is the entry point as default. ie:

```js
export default angular.module('my.superdesk.app', []);
```
--
### TODO

- [x] Allow importing `npm` modules by config
- [x] Write documentation