### PR TITLE
Added main argument in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "Tolga Akin",
     "Yauhen 'actionless' Kirylau"
   ],
+  "main": "scripts/index.js",
   "dependencies": {
     "angular-history": "git+https://github.com/decipherinc/angular-history.git#v0.8.0",
     "btoa": "1.1.2",


### PR DESCRIPTION
This line is required by Liveblog to be able to properly require superdesk as a npm package