### PR TITLE
fix(desks): reload saved searches in monitoring config on update

### DIFF
--- a/scripts/superdesk-monitoring/controllers/AggregateCtrl.js
+++ b/scripts/superdesk-monitoring/controllers/AggregateCtrl.js
@@ -54,8 +54,6 @@ export function AggregateCtrl($scope, api, desks, workspaces, preferencesService
             }));
     }));
 
-    $scope.$on('savedsearch:update', angular.bind(savedSearch, savedSearch.resetSavedSearches));
-
     /**
      * If view showed as widget set the current widget
      *

--- a/scripts/superdesk-search/services/SavedSearchService.js
+++ b/scripts/superdesk-search/services/SavedSearchService.js
@@ -1,14 +1,13 @@
-SavedSearchService.$inject = ['api', '$filter', '$q'];
+SavedSearchService.$inject = ['api', '$filter', '$q', '$rootScope'];
 
-export function SavedSearchService(api, $filter, $q){
+export function SavedSearchService(api, $filter, $q, $rootScope) {
 
     var _getAll = function(endPoint, page, items, params) {
         page = page || 1;
         items = items || [];
-        params = params || {};
+        params = params || null;
 
-        return api(endPoint, params)
-        .query({max_results: 200, page: page})
+        return api.query(endPoint, {max_results: 200, page: page}, params)
         .then(function(result) {
             items = items.concat(result._items);
             if (result._links.next) {
@@ -48,4 +47,7 @@ export function SavedSearchService(api, $filter, $q){
         this.savedSearches = null;
         this.savedSearchLookup = null;
     };
+
+    // reset cache on update
+    $rootScope.$on('savedsearch:update', angular.bind(this, this.resetSavedSearches));
 }

--- a/scripts/superdesk-search/services/SavedSearchService.spec.js
+++ b/scripts/superdesk-search/services/SavedSearchService.spec.js
@@ -1,0 +1,25 @@
+describe('saved search service', () => {
+
+    beforeEach(window.module('superdesk.search'));
+
+    it('can reset searches on event', inject((savedSearch, $rootScope, $q, api) => {
+        spyOn(api, 'query').and.returnValue($q.when({_items: [{_id: 'foo', name: 'Foo'}], _links: {}}));
+
+        savedSearch.getAllSavedSearches();
+        $rootScope.$digest();
+
+        savedSearch.getAllSavedSearches();
+        $rootScope.$digest();
+
+        expect(api.query.calls.count()).toBe(1);
+        expect(savedSearch.savedSearches.length).toBe(1);
+
+        $rootScope.$broadcast('savedsearch:update');
+        $rootScope.$digest();
+
+        savedSearch.getAllSavedSearches();
+        $rootScope.$digest();
+
+        expect(api.query.calls.count()).toBe(2);
+    }));
+});


### PR DESCRIPTION
it was only reseting when config modal was opened, so moved that
listener into service so that it can reset any time.

SDESK-145