### PR TITLE
feat(sass): Webpack configuration for sass preprocessor

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,9 +107,11 @@
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
     "lodash": "^4.14.1",
+    "node-sass": "^3.10.1",
     "phantomjs-prebuilt": "^2.1.7",
     "protractor": "2.2.0",
     "protractor-flake": "1.0.1",
+    "sass-loader": "^4.0.2",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.1",
     "webpack-dev-server": "1.14.1"
@@ -142,7 +144,8 @@
     "karma-junit-reporter": "^0.3.3",
     "karma-ng-html2js-preprocessor": "^0.1.2",
     "karma-phantomjs-launcher": "^1.0.0",
-    "phantomjs-prebuilt": "^2.1.7"
+    "phantomjs-prebuilt": "^2.1.7",
+    "node-sass": "^3.10.1"
   },
   "scripts": {
     "test": "grunt ci:travis"

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -3,6 +3,7 @@ const appConfig = __SUPERDESK_CONFIG__;
 
 // styles
 import 'bootstrap.less';
+import 'app.scss';
 
 // vendor
 import 'jquery-ui/jquery-ui';

--- a/styles/sass/app.scss
+++ b/styles/sass/app.scss
@@ -1,0 +1,1 @@
+@import "test.scss";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,8 @@ module.exports = function makeConfig(grunt) {
             root: [
                 __dirname,
                 path.join(__dirname, '/scripts'),
-                path.join(__dirname, '/styles/less')
+                path.join(__dirname, '/styles/less'),
+                path.join(__dirname, '/styles/sass')
             ],
             alias: {
                 'moment-timezone': 'moment-timezone/builds/moment-timezone-with-data-2010-2020',
@@ -54,6 +55,7 @@ module.exports = function makeConfig(grunt) {
             },
             extensions: ['', '.js']
         },
+        devtool: 'source-map',
         module: {
             loaders: [
                 {
@@ -78,6 +80,10 @@ module.exports = function makeConfig(grunt) {
                 {
                     test: /\.less$/,
                     loader: 'style!css!less'
+                },
+                {
+                    test: /\.scss$/,
+                    loaders: ['style', 'css?sourceMap', 'sass?sourceMap']
                 },
                 {
                     test: /\.(png|gif|jpeg|jpg|woff|woff2|eot|ttf|svg)(\?.*$|$)/,


### PR DESCRIPTION
We want to migrate from less to sass. I created a feature branch for it, and @fritzSF and @darconny will work on this migration and refactoring in next few days.

I includeed `node-sass` and `sass-loader` and configure it in webpack. Also, added support for sourcemaps in sass.

@gbbr please check this configuration and let me know if everything is ok.

We want to refactor and clean over stylesheets.

After refactoring is done, we will remove `less` files, together with `less` compilers.