### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-python: 3.4
+python: 3.5
 
 sudo: false
 
@@ -36,8 +36,8 @@ before_install:
       export CHROME_BIN=`pwd`/chrome-linux/chrome && $CHROME_BIN --version ;
 
 install:
-    - npm install --python=python2.7
-    - cd test-server && pip install -q -r requirements.txt && cd ..
+    - npm i
+    - cd test-server && pip install -r requirements.txt && cd ..
     - ./node_modules/.bin/webdriver-manager update
 
 script:


### PR DESCRIPTION
Update Python to fix `bcrypt` error that was crashing build and removed `-q` flag from `pip` for easier debugging. Also removed `npm` restriction of Python version since this is no longer causing issues.