### PR TITLE
[SD-5368]- Update page title with the Url and Desk/Workspace

### DIFF
--- a/scripts/apps/dashboard/controllers/DashboardController.js
+++ b/scripts/apps/dashboard/controllers/DashboardController.js
@@ -1,13 +1,14 @@
 DashboardController.$inject = ['$scope', 'desks', 'dashboardWidgets', 'api', 'session', 'workspaces',
-'modal', 'gettext', 'privileges'];
+'modal', 'gettext', 'privileges', 'pageTitle'];
 export function DashboardController($scope, desks, dashboardWidgets, api, session, workspaces,
-    modal, gettext, privileges) {
+    modal, gettext, privileges, pageTitle) {
     var vm = this;
 
     $scope.edited = null;
     $scope.workspaces = workspaces;
     $scope.$watch('workspaces.active', setupWorkspace);
     workspaces.getActive();
+    pageTitle.setPageUrl(gettext('Dashboard'));
 
     function setupWorkspace(workspace) {
         vm.current = null;

--- a/scripts/apps/dashboard/controllers/DashboardController.js
+++ b/scripts/apps/dashboard/controllers/DashboardController.js
@@ -8,7 +8,7 @@ export function DashboardController($scope, desks, dashboardWidgets, api, sessio
     $scope.workspaces = workspaces;
     $scope.$watch('workspaces.active', setupWorkspace);
     workspaces.getActive();
-    pageTitle.setPageUrl(gettext('Dashboard'));
+    pageTitle.setUrl(gettext('Dashboard'));
 
     function setupWorkspace(workspace) {
         vm.current = null;

--- a/scripts/apps/monitoring/directives/MonitoringView.js
+++ b/scripts/apps/monitoring/directives/MonitoringView.js
@@ -3,8 +3,8 @@
  *
  * it's a directive so that it can be put together with authoring into some container directive
  */
-MonitoringView.$inject = ['$rootScope', 'authoringWorkspace'];
-export function MonitoringView($rootScope, authoringWorkspace) {
+MonitoringView.$inject = ['$rootScope', 'authoringWorkspace', 'pageTitle'];
+export function MonitoringView($rootScope, authoringWorkspace, pageTitle) {
     return {
         templateUrl: 'scripts/apps/monitoring/views/monitoring-view.html',
         controller: 'Monitoring',
@@ -16,6 +16,7 @@ export function MonitoringView($rootScope, authoringWorkspace) {
         link: function(scope, elem) {
             var containerElem = elem.find('.content-list');
             containerElem.on('scroll', handleContainerScroll);
+            pageTitle.setPageUrl(_.capitalize(gettext(scope.type)));
 
             function handleContainerScroll() {
                 if ($rootScope.itemToogle) {

--- a/scripts/apps/monitoring/directives/MonitoringView.js
+++ b/scripts/apps/monitoring/directives/MonitoringView.js
@@ -16,7 +16,7 @@ export function MonitoringView($rootScope, authoringWorkspace, pageTitle) {
         link: function(scope, elem) {
             var containerElem = elem.find('.content-list');
             containerElem.on('scroll', handleContainerScroll);
-            pageTitle.setPageUrl(_.capitalize(gettext(scope.type)));
+            pageTitle.setUrl(_.capitalize(gettext(scope.type)));
 
             function handleContainerScroll() {
                 if ($rootScope.itemToogle) {

--- a/scripts/apps/monitoring/tests/monitoring.spec.js
+++ b/scripts/apps/monitoring/tests/monitoring.spec.js
@@ -161,6 +161,7 @@ describe('monitoring', function() {
 
         beforeEach(window.module('superdesk.templates-cache'));
         beforeEach(window.module('superdesk.apps.searchProviders'));
+        beforeEach(window.module('superdesk.core.services.pageTitle'));
 
         beforeEach(inject(function($templateCache) {
             // change template not to require aggregate config but rather render single group

--- a/scripts/apps/search/directives/SearchContainer.js
+++ b/scripts/apps/search/directives/SearchContainer.js
@@ -5,7 +5,7 @@ export function SearchContainer() {
             this.flags = $scope.flags || {};
             var query = _.omit($location.search(), '_id');
             this.flags.facets = !_.isEmpty(query);
-            pageTitle.setPageUrl(gettext('Search'));
+            pageTitle.setUrl(gettext('Search'));
         }]
     };
 }

--- a/scripts/apps/search/directives/SearchContainer.js
+++ b/scripts/apps/search/directives/SearchContainer.js
@@ -1,9 +1,11 @@
 export function SearchContainer() {
     return {
-        controller: ['$scope', '$location', function SearchContainerController($scope, $location) {
+        controller: ['$scope', '$location', 'gettext', 'pageTitle',
+        function SearchContainerController($scope, $location, gettext, pageTitle) {
             this.flags = $scope.flags || {};
             var query = _.omit($location.search(), '_id');
             this.flags.facets = !_.isEmpty(query);
+            pageTitle.setPageUrl(gettext('Search'));
         }]
     };
 }

--- a/scripts/apps/search/tests/search.spec.js
+++ b/scripts/apps/search/tests/search.spec.js
@@ -228,18 +228,11 @@ describe('sdSearchPanel directive', function () {
         $element;  // directive's DOM element
 
     beforeEach(window.module(
-<<<<<<< e780d4f85219cfa14f66466c66dda69adb38fede
         'superdesk.apps.authoring.metadata',
         'superdesk.apps.searchProviders',
         'superdesk.apps.search',
-=======
-        'superdesk.authoring.metadata',
-        'superdesk.searchProviders',
-        'superdesk.search',
-        'superdesk.services.pageTitle',
->>>>>>> [SD-5368]- Update page title with the Url and Desk/Workspace
-        'superdesk.templates-cache'  // needed so that directive's template is placed into
-                     // $templateCache, avoiding the "Unexpected request" error
+        'superdesk.core.services.pageTitle',
+        'superdesk.templates-cache'
     ));
 
     /**

--- a/scripts/apps/search/tests/search.spec.js
+++ b/scripts/apps/search/tests/search.spec.js
@@ -3,6 +3,7 @@
 describe('search service', function() {
     beforeEach(window.module('superdesk.templates-cache'));
     beforeEach(window.module('superdesk.apps.search'));
+    beforeEach(window.module('superdesk.core.services.pageTitle'));
 
     it('can create base query', inject(function(search, session) {
         session.identity = {_id: 'foo'};
@@ -227,9 +228,16 @@ describe('sdSearchPanel directive', function () {
         $element;  // directive's DOM element
 
     beforeEach(window.module(
+<<<<<<< e780d4f85219cfa14f66466c66dda69adb38fede
         'superdesk.apps.authoring.metadata',
         'superdesk.apps.searchProviders',
         'superdesk.apps.search',
+=======
+        'superdesk.authoring.metadata',
+        'superdesk.searchProviders',
+        'superdesk.search',
+        'superdesk.services.pageTitle',
+>>>>>>> [SD-5368]- Update page title with the Url and Desk/Workspace
         'superdesk.templates-cache'  // needed so that directive's template is placed into
                      // $templateCache, avoiding the "Unexpected request" error
     ));

--- a/scripts/apps/settings/directives/SettingsView.js
+++ b/scripts/apps/settings/directives/SettingsView.js
@@ -1,5 +1,5 @@
-SettingsView.$inject = ['$route', 'superdesk'];
-export function SettingsView($route, superdesk) {
+SettingsView.$inject = ['$route', 'superdesk', 'pageTitle'];
+export function SettingsView($route, superdesk, pageTitle) {
     return {
         scope: {},
         transclude: true,
@@ -10,6 +10,12 @@ export function SettingsView($route, superdesk) {
             });
 
             scope.currentRoute = $route.current;
+            pageTitle.setPageUrl(_.capitalize(gettext('Settings')));
+            if (scope.currentRoute.$$route.label !== 'Settings') {
+                pageTitle.setPageWorkspace(_.capitalize(gettext(scope.currentRoute.$$route.label)));
+            } else {
+                pageTitle.setPageWorkspace(null);
+            }
         }
     };
 }

--- a/scripts/apps/settings/directives/SettingsView.js
+++ b/scripts/apps/settings/directives/SettingsView.js
@@ -10,11 +10,11 @@ export function SettingsView($route, superdesk, pageTitle) {
             });
 
             scope.currentRoute = $route.current;
-            pageTitle.setPageUrl(_.capitalize(gettext('Settings')));
+            pageTitle.setUrl(_.capitalize(gettext('Settings')));
             if (scope.currentRoute.$$route.label !== 'Settings') {
-                pageTitle.setPageWorkspace(_.capitalize(gettext(scope.currentRoute.$$route.label)));
+                pageTitle.setWorkspace(_.capitalize(gettext(scope.currentRoute.$$route.label)));
             } else {
-                pageTitle.setPageWorkspace(null);
+                pageTitle.setWorkspace(null);
             }
         }
     };

--- a/scripts/apps/workspace/directives/WorkspaceDropdownDirective.js
+++ b/scripts/apps/workspace/directives/WorkspaceDropdownDirective.js
@@ -10,11 +10,11 @@ export function WorkspaceDropdownDirective(desks, workspaces, $route, preference
             scope.edited = null;
 
             scope.$watch('selected', function() {
-                pageTitle.setPageWorkspace(scope.selected ? scope.selected.name || '' : '');
+                pageTitle.setWorkspace(scope.selected ? scope.selected.name || '' : '');
             });
 
             scope.$on('$destroy', function() {
-                pageTitle.setPageWorkspace('');
+                pageTitle.setWorkspace('');
             });
 
             scope.afterSave = function(workspace) {

--- a/scripts/apps/workspace/directives/WorkspaceDropdownDirective.js
+++ b/scripts/apps/workspace/directives/WorkspaceDropdownDirective.js
@@ -1,13 +1,21 @@
 WorkspaceDropdownDirective.$inject = ['desks', 'workspaces', '$route', 'preferencesService', '$location', 'reloadService',
-    'notifyConnectionService', 'deskNotifications'];
+    'notifyConnectionService', 'deskNotifications', 'pageTitle'];
 export function WorkspaceDropdownDirective(desks, workspaces, $route, preferencesService, $location, reloadService,
-    notifyConnectionService, deskNotifications) {
+    notifyConnectionService, deskNotifications, pageTitle) {
     return {
         templateUrl: 'scripts/apps/workspace/views/workspace-dropdown.html',
         link: function(scope) {
             scope.workspaces = workspaces;
             scope.wsList = null;
             scope.edited = null;
+
+            scope.$watch('selected', function() {
+                pageTitle.setPageWorkspace(scope.selected ? scope.selected.name || '' : '');
+            });
+
+            scope.$on('$destroy', function() {
+                pageTitle.setPageWorkspace('');
+            });
 
             scope.afterSave = function(workspace) {
                 desks.setCurrentDeskId(null);

--- a/scripts/apps/workspace/tests/workspace.spec.js
+++ b/scripts/apps/workspace/tests/workspace.spec.js
@@ -6,6 +6,7 @@ describe('workspace', function() {
 
     beforeEach(window.module('superdesk.templates-cache'));
     beforeEach(window.module('superdesk.apps.dashboard'));
+    beforeEach(window.module('superdesk.core.services.pageTitle'));
 
     beforeEach(inject(function(session) {
         session.identity = {_id: 'u1'};

--- a/scripts/core/services/index.js
+++ b/scripts/core/services/index.js
@@ -10,3 +10,4 @@ import './modalService';
 import './workflowService';
 import './asset';
 import './image-factory';
+import './pageTitle';

--- a/scripts/core/services/pageTitle.js
+++ b/scripts/core/services/pageTitle.js
@@ -1,0 +1,33 @@
+/**
+ * PageTitle service
+ *
+ * PageTitle service is used to save and update the title of the page.
+ * The title will be 'Superdesk {- Url} {-Desk/Workspace}
+ * Url can be: Dashboard, Monitoring, Spike, Highlights, Search, Settings
+ * If Url is search then there won't be desk
+ *
+ */
+export default angular.module('superdesk.services.pageTitle', [])
+    .service('pageTitle', function() {
+        this.title = 'Superdesk';
+        this.url = '';
+        this.workspace = '';
+
+        this.setPageUrl = function(url) {
+            this.url = url;
+            setPageTitle(this.url, this.workspace);
+        };
+
+        this.setPageWorkspace = function(activeWorkspace) {
+            this.workspace = activeWorkspace;
+            setPageTitle(this.url, this.workspace);
+        };
+
+        function setPageTitle(url, activeWorkspace) {
+            document.title = 'Superdesk' + (url?' - ' + url:'') + (activeWorkspace?' - ' + activeWorkspace:'');
+        }
+
+        this.clearPageTitle = function() {
+            document.title = this.title ;
+        };
+    });

--- a/scripts/core/services/pageTitle.js
+++ b/scripts/core/services/pageTitle.js
@@ -7,27 +7,27 @@
  * If Url is search then there won't be desk
  *
  */
-export default angular.module('superdesk.services.pageTitle', [])
+export default angular.module('superdesk.core.services.pageTitle', [])
     .service('pageTitle', function() {
         this.title = 'Superdesk';
         this.url = '';
         this.workspace = '';
 
-        this.setPageUrl = function(url) {
+        this.setUrl = function(url) {
             this.url = url;
-            setPageTitle(this.url, this.workspace);
+            setTitle(this.url, this.workspace);
         };
 
-        this.setPageWorkspace = function(activeWorkspace) {
+        this.setWorkspace = function(activeWorkspace) {
             this.workspace = activeWorkspace;
-            setPageTitle(this.url, this.workspace);
+            setTitle(this.url, this.workspace);
         };
 
-        function setPageTitle(url, activeWorkspace) {
+        function setTitle(url, activeWorkspace) {
             document.title = 'Superdesk' + (url?' - ' + url:'') + (activeWorkspace?' - ' + activeWorkspace:'');
         }
 
-        this.clearPageTitle = function() {
+        this.clear = function() {
             document.title = this.title ;
         };
     });

--- a/scripts/core/superdesk.js
+++ b/scripts/core/superdesk.js
@@ -36,6 +36,7 @@ var modules = [
     'superdesk.core.services.entity',
     'superdesk.core.services.permissions',
     'superdesk.core.services.storage',
+    'superdesk.core.services.pageTitle',
 
     // directives/
     'superdesk.core.directives.autofocus',


### PR DESCRIPTION
The original PR was https://github.com/superdesk/superdesk-client-core/pull/886 and for some reason the changes are lost during rebase so creating the PR again...

- A new service is created to update the page title
- The title will be 'Superdesk {- Url} {-Desk/Workspace}
- Url can be:
 - Dashboard, Monitoring, Spike, Highlights, Search, Settings
- If Url is search then there won't be desk