### PR TITLE
feat(swimlane/column view) - Swimlane view or Column view functionali…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ To configure the build, the `superdesk.config.js` file must export a function th
 - `features.alchemy`: `false` - allow alchemy widget for keywords
 - `features.elasticHighlight`: `false` - allow highlighting of search terms by elasticsearch
 - `features.noTakes`: `false` - disable takes related functionality
+- `features.swimlane`: `null` - enables switch view button in monitoring view, which allows to switch between list view or swimlane view. Example: `features: {swimlane: {columnsLimit: 4}}` will enable switch view button and displays 4 columns when turned ON, set null or keep undefined to disable
 
 ##### Workspace
 - `workspace.content`: `false` - enable content view in workspace (obsolete)

--- a/scripts/apps/monitoring/directives/MonitoringView.js
+++ b/scripts/apps/monitoring/directives/MonitoringView.js
@@ -3,8 +3,8 @@
  *
  * it's a directive so that it can be put together with authoring into some container directive
  */
-MonitoringView.$inject = ['$rootScope', 'authoringWorkspace', 'pageTitle'];
-export function MonitoringView($rootScope, authoringWorkspace, pageTitle) {
+MonitoringView.$inject = ['$rootScope', 'authoringWorkspace', 'pageTitle', '$timeout'];
+export function MonitoringView($rootScope, authoringWorkspace, pageTitle, $timeout) {
     return {
         templateUrl: 'scripts/apps/monitoring/views/monitoring-view.html',
         controller: 'Monitoring',
@@ -14,22 +14,75 @@ export function MonitoringView($rootScope, authoringWorkspace, pageTitle) {
             state: '='
         },
         link: function(scope, elem) {
+
             var containerElem = elem.find('.content-list');
             containerElem.on('scroll', handleContainerScroll);
             pageTitle.setUrl(_.capitalize(gettext(scope.type)));
 
-            function handleContainerScroll() {
+            scope.viewColumn = scope.monitoring.viewColumn;
+
+            /**
+             * Toggle viewColumn to switch views between swimlane and list
+             */
+            scope.displayColumn = function() {
+                scope.viewColumn = !scope.viewColumn;
+                scope.monitoring.switchView(scope.viewColumn);
+                scope.$broadcast('view:column', {viewColumn: scope.viewColumn});
+            };
+
+            /**
+             * @description Returns true when group's item is selected for previewing, false otherwise.
+             * @param {Object} group
+             * @returns {Boolean}
+             */
+            scope.isActiveGroup = function(group) {
+                return scope.monitoring.selectedGroup ? (scope.monitoring.selectedGroup._id === group._id) : true;
+            };
+
+            var updateTimeout;
+            function handleContainerScroll($event) {
                 if ($rootScope.itemToogle) {
                     scope.$applyAsync(function() {
                         $rootScope.itemToogle(false);
                         $rootScope.itemToogle = null;
                     });
                 }
+
+                // If scroll bar leaves top position update scope.scrollTop
+                // which is used to display refresh button on list item updates
+                if ($event.currentTarget.scrollTop >= 0 && $event.currentTarget.scrollTop < 100) {
+                    scope.$applyAsync(function() {
+                        scope.scrollTop = scope.monitoring.scrollTop = $event.currentTarget.scrollTop;
+
+                        // force refresh the group or list, if scroll bar hits the top of list.
+                        if (scope.monitoring.scrollTop === 0) {
+                            scope.$broadcast('refresh:list', scope.group);
+                        }
+                    });
+                }
+
+                $timeout.cancel(updateTimeout);
+                updateTimeout = $timeout(renderIfNeeded($event), 100, false);
+            }
+
+            function isListEnd(containerElem) {
+                return containerElem.scrollTop + containerElem.offsetHeight + 200 >= containerElem.scrollHeight;
+            }
+
+            /**
+             * Trigger render in case user scrolls to the very end of list
+             */
+            function renderIfNeeded($event) {
+                if (isListEnd($event.currentTarget)) {
+                    scope.rendering = scope.loading = true;
+                    scope.$broadcast('render:next');
+                }
             }
 
             // force refresh on refresh button click when in specific view such as single, highlights or spiked.
             scope.refreshGroup = function(group) {
-                $rootScope.$broadcast('refresh:list', group);
+                containerElem[0].scrollTop = 0;
+                scope.$broadcast('refresh:list', group);
             };
 
             scope.$on('$destroy', function() {

--- a/scripts/apps/monitoring/directives/SortGroups.js
+++ b/scripts/apps/monitoring/directives/SortGroups.js
@@ -30,8 +30,9 @@ export function SortGroups() {
                         var end = {
                             index: ui.item.parent().find('li.sort-item').index(ui.item)
                         };
+
+                        scope.reorder(start, end, ui.item);
                         ui.item.remove();
-                        scope.reorder(start, end);
                         scope.$apply();
                     }
                 },

--- a/scripts/apps/monitoring/styles/aggregate.scss
+++ b/scripts/apps/monitoring/styles/aggregate.scss
@@ -307,8 +307,6 @@ $search-widget-preview-width: 440px;
                 }
             }
             .stage-name {
-                padding: 0 8px 0 0;
-                margin: auto 0;
                 font-size: 11px;
                 line-height: 100%;
                 @include text-semibold();
@@ -323,15 +321,17 @@ $search-widget-preview-width: 440px;
         .stage-content {
             margin: 5px 0 20px;
             overflow-y: auto;
-            overflow-x: hidden;
             position: relative;
+            &.swimlane {
+                overflow-y: hidden !important;
+            }
         }
     }
 }
 .label-total {
     box-sizing: border-box;
     height: 16px;
-    margin: auto 0;
+    margin: 4px 4px;
     padding: 4px 6px 3px;
     @include border-radius(8px);
     color: $white !important;
@@ -340,9 +340,13 @@ $search-widget-preview-width: 440px;
     line-height: 100%;
     letter-spacing: 0.06em;
     @include text-normal();
+    vertical-align: sub;
 }
 .refresh-box {
     display: flex;
+    &.swimlane {
+        position: relative;
+    }
     button {
         background: none;
         border: 0;
@@ -354,7 +358,16 @@ $search-widget-preview-width: 440px;
         }
         &.btnRefresh {
             border-left: 0px !important;
-            margin-right: 0px !important;
+            margin-right: 3px !important;
+            padding-left: 0px !important;
+            height: 26px;
+            position: absolute;
+            right: 12px;
+            &.swimlane {
+                right: 0;
+                top: 2px;
+                margin-right: 0px !important;
+            }
         }
     }
 }
@@ -397,6 +410,7 @@ $search-widget-preview-width: 440px;
 .aggregate-widget-config {
     .modal-body {
         padding: 0 0 50px 0;
+        overflow: scroll;
     }
     .modal-screen {
         position: relative;

--- a/scripts/apps/monitoring/styles/monitoring.scss
+++ b/scripts/apps/monitoring/styles/monitoring.scss
@@ -31,10 +31,20 @@
             text-align: center;
             border-left: 0;
         }
+
+        .navbtn {
+            &.btnRearrange {
+                width: 80px !important;
+            }
+        }
+
+        .title {
+            text-transform: uppercase;
+        }
     }
 
-    .monitoring-preview-layout{
-        margin-top:48px;
+    .monitoring-preview-layout {
+        margin-top: 48px;
     }
 
     .main-section {
@@ -47,14 +57,105 @@
             left: 0;
             right: 0;
             bottom: 0;
-            padding: 9px 18px 18px;
             overflow-y: scroll;
             @include transition(all .3s);
             @include border-box();
+            padding: 0px 18px 18px !important;
+
+            .list {
+                padding: 9px 18px 18px !important;
+            }
+
+            .swimlane {
+                margin-top: 0px !important;
+            }
+
+            .sd-columns.swimlane {
+                display: table;
+                width: 100%;
+                table-layout: fixed;
+                @media only screen and (max-width : 1430px) {
+                    right: $sidepreview-width - 40;
+                }
+            }
+            .sd-column.swimlane {
+                display: table-cell;
+                position: relative;
+                vertical-align: top;
+            }
 
             .stage {
                 padding: 0;
                 margin: 9px 0;
+                .column-header {
+                    &:not(.swimlane) {
+                        width: 100% !important;
+                    }
+                }
+                &.swimlane {
+                    width: 98% !important;
+                    margin: 0;
+                    .header-container {
+                        width: 100%;
+                    }
+                    .column-header {
+                        position: fixed;
+                        z-index: 4;
+                    }
+                    .stage-header {
+                        background-color: #f8f8f8;
+                        background: rgba(245, 245, 245, 1);
+                        height: 55px;
+                        border-radius: 3px 3px 1px 1px;
+                        margin-left: 0px !important;
+                        padding-left: 2px;
+                        overflow: hidden;
+                        box-shadow: 0px 1px 4px 0px rgba(0,0,0,0.5) !important;
+
+                        .stage-name {
+                            width: 100%;
+                            .group-header {
+                                display: block;
+                                position: absolute;
+                                left: 0; right: 0; top:0;
+                                padding-left: 2px;
+                                text-transform: uppercase;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                                font-size: 12px;
+                                color: #333;
+                                font-weight: 700;
+                                height: 26px;
+                                line-height: 26px;
+                                border-bottom: 5px solid #4d4d4d;
+                            }
+                            .group-subheader {
+                                display: block;
+                                left: 0; right: 0; top:0;
+                                padding: 30px 0px 0px 2px;
+                                height: 26px;
+                                line-height: 26px;
+                                width: 100%;
+                                font-size: 12px;
+                                color: #777;
+                                @include text-semibold();
+                                text-transform: uppercase;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                            }
+                            .link {
+                                margin-left: 10px;
+                                vertical-align: sub;
+                                i { margin-bottom: 3px; color: $grayLight; }
+                                &:hover {
+                                    i { color: $grayDark; }
+                                    cursor:pointer;
+                                }
+                            }
+
+                        }
+                    }
+                }
             }
 
             .stage-content {
@@ -79,6 +180,9 @@
                         }
                     }
                 }
+                &.swimlane {
+                    padding-top: 57px;
+                }
             }
 
             .single-group {
@@ -97,17 +201,17 @@
                 @include border-box();
                 max-height: calc(100vh - 180px) !important;
             }
+
         }
+
     }
 }
-
-
-
 
 .workspace {
   .main-section {
     .content-item-preview {
       position: absolute;
+      z-index: 4;
       top: 0;
       right: 0;
       bottom: 0;
@@ -134,7 +238,6 @@
     }
   }
 }
-
 
 .workspace.authoring {
     .main-section {
@@ -199,12 +302,42 @@
                 @media only screen and (max-width : 1430px) {
                     right: 0;
                 }
+                .sd-column.swimlane {
+                    &.inactive {
+                        display: none !important;
+                    }
+                }
+            }
+            .navbtn {
+                &.btnRearrange {
+                    width: 80px !important;
+                    @media only screen and (max-width : 1430px) {
+                        display: none !important;
+                    }
+                }
             }
         }
     }
 }
 
-.search-page-container
+.notification-container {
+    display: inline-flex !important;
+    vertical-align: sub;
+    margin-top: 2px;
+    &.swimlane {
+        position: absolute;
+        right: 0px;
+        top: 3px;
+        &.refresh {
+            right: 25px !important;
+        }
+        .monitoring-dropdown {
+            .dropdown-menu {
+                margin-top: 35px !important;
+            }
+        }
+    }
+}
 
 .notification-label {
     margin: 2px 4px;

--- a/scripts/apps/monitoring/tests/monitoring.spec.js
+++ b/scripts/apps/monitoring/tests/monitoring.spec.js
@@ -4,6 +4,37 @@ describe('monitoring', function() {
     beforeEach(window.module('superdesk.apps.monitoring'));
     beforeEach(window.module('superdesk.mocks'));
 
+    it('can switch between list and swimlane view', inject(function($controller, $rootScope, storage, config) {
+        config.features = {
+            swimlane: {columnsLimit: 4}
+        };
+
+        var scope = $rootScope.$new(),
+            ctrl = $controller('Monitoring', {$scope: scope});
+
+        expect(ctrl.hasSwimlaneView).toBe(1);
+
+        // Default will be list view
+        storage.clear();
+        expect(ctrl.viewColumn).toBe(null);       // no swimlane
+        // display all groups for list view, i.e. limitTo: null when no swimlane
+        expect(ctrl.columnsLimit).toBe(null);
+
+        // Switch to swimlane view, via switch view button or returning back to monitoring
+        // view while swimlane view was already ON
+        ctrl.switchView(true);
+        expect(storage.getItem('displaySwimlane')).toBe(true);
+        expect(ctrl.viewColumn).toBe(true);     // swimlane
+        expect(ctrl.columnsLimit).toBe(4);
+
+        // Switch back to list view
+        ctrl.switchView(false);
+        expect(storage.getItem('displaySwimlane')).toBe(false);
+        expect(ctrl.viewColumn).toBe(false);
+        expect(ctrl.columnsLimit).toBe(null);
+
+    }));
+
     it('can preview an item', inject(function($controller, $rootScope) {
         var scope = $rootScope.$new(),
             ctrl = $controller('Monitoring', {$scope: scope}),

--- a/scripts/apps/monitoring/views/aggregate-settings.html
+++ b/scripts/apps/monitoring/views/aggregate-settings.html
@@ -2,9 +2,11 @@
     <a href="" class="close" ng-click="cancel()"><i class="icon-close-small"></i></a>
     <h3 translate>Monitoring settings <span ng-if="settings.desk" translate>for "{{settings.desk.name}}" Desk</span></h3>
 </div>
-<div class="modal-body aggregate-settings" sd-wizard data-name="aggregatesettings" data-current-step="step.current" data-finish="cancel()">
 
-    <div sd-wizard-step data-title="{{ :: 'Desks' | translate }}" data-code="desks">
+<div class="modal-body aggregate-settings" sd-wizard data-name="aggregatesettings"
+     data-current-step="step.current" ng-init="setCurrentStep()" data-finish="cancel()">
+    <div sd-wizard-step data-title="{{ :: 'Desks' | translate }}" data-code="desks"
+         data-hide="shouldHideStep('desks')">
         <div class="content">
             <div ng-if="widget">
                 <span class="pull-right" sd-character-count data-item="widget.configuration.label" data-limit="30"></span>
@@ -40,7 +42,8 @@
         </div>
     </div>
 
-    <div sd-wizard-step data-title="{{ :: 'Saved Searches' | translate }}" data-code="searches">
+    <div sd-wizard-step data-title="{{ :: 'Saved Searches' | translate }}" data-code="searches"
+         data-hide="shouldHideStep('searches')">
         <div class="content">
             <div class="legend"><span translate>Select global saved searches</span>
                 <span sd-switch class="pull-right" ng-model="showGlobalSavedSearches"
@@ -77,11 +80,13 @@
         </div>
     </div>
 
-    <div sd-wizard-step data-title="{{ :: 'Reorder Sections' | translate }}" data-code="reorder">
+    <div sd-wizard-step data-title="{{ :: 'Reorder Sections' | translate }}" data-code="reorder"
+         data-hide="shouldHideStep('reorder')">
         <div class="content">
             <div class="legend" translate>Reorder stages and saved searches for view</div>
-            <ul class="groups draggable-list" sd-sort-groups>
-                <li class="sort-item clearfix" ng-repeat="item in getValues()">
+            <ul class="groups draggable-list serial-decimal" sd-sort-groups>
+                <li class="sort-item clearfix" ng-class="{'active': item.order < columnsLimit}"
+                 ng-repeat="item in getValues() track by item.order">
                     <div class="group-title" ng-if="item.type === 'stage'">
                         {{deskLookup[stageLookup[item._id].desk].name}} : <span>{{stageLookup[item._id].name}}</span>
                     </div>
@@ -100,7 +105,8 @@
         </div>
     </div>
 
-    <div sd-wizard-step data-title="{{ :: 'Items Count' | translate }}" data-code="maxitems">
+    <div sd-wizard-step data-title="{{ :: 'Items Count' | translate }}" data-code="maxitems"
+         data-hide="shouldHideStep('maxitems')">
         <div class="content">
             <div class="legend" translate>Set maximum items per stages and saved searches for view</div>
             <div class="groups">
@@ -127,7 +133,7 @@
 </div>
 
 <div class="modal-footer">
-    <button id="previousBtn" class="btn pull-left" ng-if="step.current !== 'desks'" ng-click="previous()" translate>Previous</button>
-    <button id="nextBtn" class="btn" ng-if="step.current !== 'maxitems'" ng-click="next()" translate>Next</button>
+    <button id="previousBtn" class="btn pull-left" ng-if="step.current !== 'desks' && !displayOnlyCurrentStep" ng-click="previous()" translate>Previous</button>
+    <button id="nextBtn" class="btn" ng-if="step.current !== 'maxitems' && !displayOnlyCurrentStep" ng-click="next()" translate>Next</button>
     <button class="btn btn-primary" ng-click="save()" translate>Done</button>
 </div>

--- a/scripts/apps/monitoring/views/monitoring-group-header.html
+++ b/scripts/apps/monitoring/views/monitoring-group-header.html
@@ -1,24 +1,62 @@
-<div class="refresh-box pull-right">
-    <button ng-if="showRefresh" ng-click="refreshGroup()" ng-class="{btnRefresh: viewType === 'monitoring'}"
-        tooltip="{{:: 'Refresh' | translate}}" tooltip-placement="left">
-        <i class="icon-repeat blue"></i>
-    </button>
-</div>
 <div class="stage-header clearfix">
-    <span class="stage-name" ng-if="group.header && group.subheader && viewType !== 'single_monitoring'">
-        <a href="" ng-click="viewSingleGroup(group, 'desk')">{{ :: group.header }}</a>
-        <span>/</span>
-        <a href="" ng-click="viewSingleGroup(group, 'stage')">
-            <span>{{ :: group.subheader }} </span> {{ :: group.type | translate }}
-        </a>
-    </span>
-    <span class="stage-name" ng-if="group.header && !group.subheader && viewType !== 'single_monitoring'">
-        <a href="" ng-click="viewSingleGroup(group, 'single-stage')">
-            {{ :: group.header }} {{ :: group.type|splitText | translate }}
-        </a>
-    </span>
-    <span class="label-total">{{ total || '0' }}</span>
-    <div>
+    <!-- list view -->
+    <div class="header-container" ng-if="!viewColumn || viewType === 'spiked'">
+        <span class="stage-name" ng-if="group.header && group.subheader && viewType !== 'single_monitoring'">
+            <span class="group-header">
+                <a href="" ng-click="viewSingleGroup(group, 'desk')">
+                    {{ :: group.header }}</a></span>
+            <span>/</span>
+            <span class="group-subheader">
+                <a href="" ng-click="viewSingleGroup(group, 'stage')">
+                    <span>{{ :: group.subheader }} </span> {{ :: group.type | translate }}
+                </a>
+                <span class="label-total">{{ total || '0' }}</span>
+            </span>
+        </span>
+        <!-- Desk output stages-->
+        <span class="stage-name" ng-if="group.header && !group.subheader && viewType !== 'single_monitoring'">
+            <span class="group-header">
+                <a href="" ng-click="viewSingleGroup(group, 'single-stage')">
+                    {{ :: group.header }} {{ :: group.type|splitText | translate }}</a>
+            </span>
+            <span class="label-total">{{ total || '0' }}</span>
+        </span>
+    </div>
+    <!-- swimlane view -->
+    <div class="header-container" ng-if="viewColumn && viewType != 'spiked'">
+        <span class="stage-name" ng-if="group.header && group.subheader && viewType !== 'single_monitoring'">
+            <span class="group-header">{{ :: group.header }}
+                <span class="link" ng-click="viewSingleGroup(group, 'desk')" title="{{ 'Open desk content' | translate}}">
+                    <i class="icon-external"></i></span>
+            </span>
+            <span class="group-subheader">{{ :: group.subheader }} {{ :: group.type | translate }}
+                <span class="link" ng-click="viewSingleGroup(group, 'stage')" title="{{ 'Open stage content' | translate}}">
+                    <i class="icon-external"></i></span>
+                <span class="label-total pull-right">{{ total || '0' }}</span>
+            </span>
+        </span>
+        <!-- Desk output stages-->
+        <span class="stage-name" ng-if="group.header && !group.subheader && viewType !== 'single_monitoring'">
+            <span class="group-header">{{ :: group.header }}
+                <span class="link" ng-click="viewSingleGroup(group, 'single-stage')" title="{{ 'Open desk content' | translate}}">
+                    <i class="icon-external"></i></span>
+            </span>
+            <span class="group-subheader">{{ :: group.type|splitText | translate }}
+                <span class="link" ng-click="viewSingleGroup(group, 'single-stage')" title="{{ 'Open desk content' | translate}}">
+                    <i class="icon-external"></i></span>
+                <span class="label-total pull-right">{{ total || '0' }}</span>
+            </span>
+        </span>
+    </div>
+    <!-- refresh button -->
+    <div class="refresh-box pull-right" ng-class="{swimlane: viewColumn}">
+        <button ng-if="showRefresh" ng-click="refreshGroup(group)" ng-class="{btnRefresh: viewType === 'monitoring' || viewColumn, swimlane: viewColumn}"
+            tooltip="{{:: 'Refresh' | translate}}" tooltip-placement="left">
+            <i class="icon-repeat blue"></i>
+        </button>
+    </div>
+    <!-- desk notification section -->
+    <div class="notification-container" ng-class="{'swimlane pull-right': viewColumn, 'refresh': showRefresh}">
         <div ng-if="group.type === 'stage'" class="dropdown dropright dropdown-hover monitoring-dropdown"
              dropdown-append-to-body dropdown sd-desk-notifications data-stage="group._id">
         </div>

--- a/scripts/apps/monitoring/views/monitoring-group.html
+++ b/scripts/apps/monitoring/views/monitoring-group.html
@@ -1,9 +1,12 @@
-<div class="stage">
-    <div sd-monitoring-group-header 
-    	ng-if="group.header && viewType !== 'single_monitoring'">
+<div class="stage"
+	ng-class="{swimlane: (viewColumn && (viewType === 'monitoring' || viewType === 'deskOutput' || viewType === 'scheduledDeskOutput'))}">
+
+    <div sd-monitoring-group-header class="column-header" ng-class="{swimlane: viewColumn}" ng-if="group.header && viewType !== 'single_monitoring'">
     </div>
+
     <div class="stage-content group"
-        ng-class="{limited: limited, refresh: showRefresh}"
+        ng-class="{limited: limited, refresh: showRefresh, 
+         swimlane: (viewColumn && (viewType === 'monitoring' || viewType === 'deskOutput' || viewType === 'scheduledDeskOutput'))}"
         ng-style="style"
         sd-items-list>
     </div>

--- a/scripts/apps/monitoring/views/monitoring-view.html
+++ b/scripts/apps/monitoring/views/monitoring-view.html
@@ -54,6 +54,13 @@
                 <i class="icon-settings"></i>
             </button>
 
+            <button id="switch-view-btn" ng-if="!monitoring.singleGroup && type === 'monitoring' && monitoring.hasSwimlaneView"
+             class="navbtn strict" ng-click="displayColumn()" ng-class="{active: viewColumn}"
+                 tooltip="{{ viewColumn ? 'Switch to List View' : 'Switch to Swimlane View'  | translate }}"
+                 tooltip-placement="left">
+                <i class="big-icon-view"></i>
+            </button>
+
             <div class="dropdown navbtn strict" ng-if="!state.opened" title="{{ :: 'Create' | translate }}" dropdown>
                 <button class="dropdown-toggle sd-create-btn" dropdown-toggle></button>
                 <ul class="dropdown-menu scrollable pull-right" sd-content-create></ul>
@@ -73,6 +80,10 @@
                     <i ng-if="fileType=='highlightsPackage'" class="toggle-button__icon filetype-icon-highlight-pack" title="{{ :: 'Highlight Package' | translate }}"></i>
                 </a>
             </div>
+            <button class="navbtn navbtn--btn-rearrange pull-left" tooltip="{{:: 'Re-Arrange Groups' | translate}}" tooltip-placement="right" ng-if="type === 'monitoring' && monitoring.singleGroup.singleViewType == null && viewColumn"
+                 ng-click="aggregate.edit('reorder', true)">
+                <i class="icon-move"></i> <span class="title" translate>Rearrange groups</span>
+            </button>
 
             <div class="subnav__stretch-bar"></div>
 
@@ -97,36 +108,52 @@
                     </ul>
                 </div>
             </div>
-
         </div>
+
         <div class="preview-layout monitoring-preview-layout">
             <div class="content-list" ng-show="!aggregate.loading">
-                <div ng-if="(!monitoring.singleGroup || monitoring.isDeskChanged()) && type === 'monitoring'">
-                    <div ng-repeat="group in aggregate.groups track by group._id"
-                         sd-monitoring-group data-group="group"  data-num-items="group.max_items"
-                         data-view-type="aggregate.isOutputType(group.type) ? group.type: 'monitoring'"></div>
+                <!-- list view -->
+                <div ng-if="!viewColumn" class="list">
+                    <div ng-if="(!monitoring.singleGroup || monitoring.isDeskChanged()) && type === 'monitoring'">
+                        <div ng-repeat="group in aggregate.groups track by group._id"
+                             sd-monitoring-group data-group="group"  data-num-items="group.max_items"
+                             data-view-type="aggregate.isOutputType(group.type) ? group.type: 'monitoring'"></div>
+                    </div>
                 </div>
-                <div ng-if="type === 'spike'">
+                <!-- swimlane view -->
+                <div ng-if="viewColumn" class="swimlane">
+                    <div class="sd-columns swimlane"
+                         ng-if="(!monitoring.singleGroup || monitoring.isDeskChanged()) && type === 'monitoring'">
+                        <div class="sd-column swimlane" ng-class="{active: isActiveGroup(group), inactive: !isActiveGroup(group)}"
+                             ng-repeat="group in aggregate.groups | limitTo:monitoring.columnsLimit track by group._id"
+                             sd-monitoring-group data-group="group" data-num-items="group.max_items"
+                             data-view-type="aggregate.isOutputType(group.type) ? group.type: 'monitoring'"
+                             sd-header-resize>
+                        </div>
+                    </div>
+                </div>
+                <div ng-if="type === 'spike'" class="list">
                     <div ng-repeat="group in aggregate.spikeGroups track by group._id | orderBy: name"
-                        sd-monitoring-group
-                        class="{singleGroup: aggregate.spikeGroups.length === 1}"
-                        data-group="group"
-                        data-view-type="'spiked'"
-                        data-force-limited="{{ aggregate.spikeGroups.length > 1 }}"
-                        ></div>
+                    sd-monitoring-group
+                    class="{singleGroup: aggregate.spikeGroups.length === 1}"
+                    data-group="group"
+                    data-view-type="'spiked'"
+                    data-force-limited="{{ aggregate.spikeGroups.length > 1 }}"
+                    ></div>
                 </div>
-                <div ng-if="monitoring.singleGroup && !monitoring.isDeskChanged()">
-                    <div sd-monitoring-group class="single-group" data-group="monitoring.singleGroup" data-num-items="10" data-view-type="'single_monitoring'"></div>
+                <div ng-if="monitoring.singleGroup && !monitoring.isDeskChanged()" class="list">
+                    <div sd-monitoring-group class="single-group" data-group="monitoring.singleGroup" data-num-items="10" data-view-type="'single_monitoring'">
+                    </div>
                 </div>
-                <div ng-if="type === 'personal'">
-                    <div sd-monitoring-group data-group="{'type': 'personal', 'query': query, 'fileType': aggregate.getSelectedFileTypes()}"></div>
+                <div ng-if="type === 'personal'" class="list">
+                    <div sd-monitoring-group data-group="{'type': 'personal', 'query': query, 'fileType': aggregate.getSelectedFileTypes()}">
+                    </div>
                 </div>
-                <div ng-if="type === 'highlights' && !monitoring.highlightsDeskChanged()">
+                <div ng-if="type === 'highlights' && !monitoring.highlightsDeskChanged()" class="list">
                     <div sd-monitoring-group class="single-group"
                     data-group="{'type': 'highlights', 'query': query, 'fileType': aggregate.getSelectedFileTypes()}"
                     data-view-type="'highlights'"></div>
                 </div>
-
             </div>
 
             <div sd-item-preview
@@ -150,7 +177,10 @@
              data-groups="aggregate.groups"
              data-edit-groups="aggregate.editGroups"
              data-settings="aggregate.settings"
-             data-onclose="aggregate.refreshGroups()">
+             data-onclose="aggregate.refreshGroups()"
+             data-current-step="aggregate.currentStep"
+             data-display-only-current-step="aggregate.displayOnlyCurrentStep"
+             data-columns-limit="monitoring.columnsLimit">
         </div>
     </section>
     <div sd-archived-item-kill ng-if="archived_kill" data-item="archived_kill"></div>

--- a/scripts/apps/search/directives/ItemList.js
+++ b/scripts/apps/search/directives/ItemList.js
@@ -57,7 +57,8 @@ ItemList.$inject = [
     '$rootScope',
     'config',
     '$interpolate',
-    'metadata'
+    'metadata',
+    'storage'
 ];
 
 export function ItemList(
@@ -85,7 +86,8 @@ export function ItemList(
     $rootScope,
     config,
     $interpolate,
-    metadata
+    metadata,
+    storage
 ) {
     var listConfig = config.list || DEFAULT_LIST_CONFIG;
 
@@ -452,7 +454,7 @@ export function ItemList(
             var GridTypeIcon = function(props) {
                 return React.createElement(
                     'span',
-                    {className: 'type-icon'},
+                    {className: classNames('type-icon', {swimlane: props.swimlane})},
                     React.createElement(TypeIcon, {type: props.item.type})
                 );
             };
@@ -476,7 +478,7 @@ export function ItemList(
                     var showSelect = this.state.hover || this.props.item.selected;
                     return React.createElement(
                         'div',
-                        {className: 'list-field type-icon', onMouseEnter: this.setHover, onMouseLeave: this.unsetHover},
+                        {className: classNames('list-field type-icon'), onMouseEnter: this.setHover, onMouseLeave: this.unsetHover},
                         showSelect ?
                             React.createElement(SelectBox, {item: this.props.item, onMultiSelect: this.props.onMultiSelect}) :
                             React.createElement(
@@ -1300,7 +1302,7 @@ export function ItemList(
              */
             var Item = React.createClass({
                 shouldComponentUpdate: function(nextProps, nextState) {
-                    return nextProps.item !== this.props.item ||
+                    return nextProps.swimlane !== this.props.swimlane || nextProps.item !== this.props.item ||
                         nextProps.view !== this.props.view ||
                         nextProps.flags.selected !== this.props.flags.selected ||
                         nextState !== this.state;
@@ -1377,7 +1379,8 @@ export function ItemList(
                             React.createElement(MediaPreview, {
                                 item: item,
                                 desk: this.props.desk,
-                                onMultiSelect: this.props.onMultiSelect
+                                onMultiSelect: this.props.onMultiSelect,
+                                swimlane: this.props.swimlane
                             }),
                             React.createElement(MediaInfo, {item: item, ingestProvider: this.props.ingestProvider}),
                             React.createElement(GridTypeIcon, {item: item}),
@@ -1391,7 +1394,8 @@ export function ItemList(
                             React.createElement('span', {className: 'state-border'}),
                             React.createElement(ListTypeIcon, {
                                 item: item,
-                                onMultiSelect: this.props.onMultiSelect
+                                onMultiSelect: this.props.onMultiSelect,
+                                swimlane: this.props.swimlane
                             }),
                             (item.priority || item.urgency) ? React.createElement(ListPriority, {item: item}) : null,
                             React.createElement(ListItemInfo, {
@@ -1401,7 +1405,8 @@ export function ItemList(
                                 desk: this.props.desk,
                                 ingestProvider: this.props.ingestProvider,
                                 highlightsById: this.props.highlightsById,
-                                profilesById: this.props.profilesById
+                                profilesById: this.props.profilesById,
+                                swimlane: this.props.swimlane
                             }),
                             this.state.hover && !item.gone ? React.createElement(ActionsMenu, {item: item}) : null
                         );
@@ -1652,6 +1657,7 @@ export function ItemList(
                             key: itemId,
                             item: item,
                             view: this.state.view,
+                            swimlane: this.state.swimlane || storage.getItem('displaySwimlane'),
                             flags: {selected: this.state.selected === itemId},
                             onEdit: this.edit,
                             onDbClick: this.dbClick,
@@ -1802,6 +1808,15 @@ export function ItemList(
                 scope.$watch('view', function(newValue, oldValue) {
                     if (newValue !== oldValue) {
                         listComponent.setState({view: newValue});
+                    }
+                });
+
+                scope.$watch('viewColumn', function(newValue, oldValue) {
+                    if (newValue !== oldValue) {
+                        scope.$applyAsync(function() {
+                            listComponent.setState({swimlane: newValue});
+                            scope.refreshGroup();
+                        });
                     }
                 });
 

--- a/scripts/apps/search/views/item-preview.html
+++ b/scripts/apps/search/views/item-preview.html
@@ -1,5 +1,5 @@
 <div id="item-preview" class="preview-pane content-item-preview" ng-if="item" ng-class="{shift: toggleLeft}">
-    <button class="shift-preview__toggle" ng-class="{shift: toggleLeft}" ng-click="shiftPreview()">
+    <button class="shift-preview__toggle" ng-class="{shift: toggleLeft, swimlane: viewColumn}" ng-click="shiftPreview()">
         <i class="icon-chevron-left-thin"></i>
     </button>
     <header>

--- a/scripts/core/ui/views/wizard.html
+++ b/scripts/core/ui/views/wizard.html
@@ -1,6 +1,6 @@
 <ul class="nav nav-tabs">
     <li ng-repeat="step in steps" ng-class="{active: step.selected}">
-        <button ng-click="goTo(step)" ng-disabled="step.disabled">{{ step.title | translate}}</button>
+        <button ng-click="goTo(step)" ng-disabled="step.disabled" ng-hide="step.hide">{{ step.title | translate}}</button>
     </li>
 </ul>
 <div class="steps" ng-transclude></div>

--- a/spec/authoring_spec.js
+++ b/spec/authoring_spec.js
@@ -365,6 +365,7 @@ describe('authoring', function() {
         authoring.save();
         authoring.close();
         monitoring.actionOnItem('Edit', 2, 1);
+        browser.sleep(50);
         expect(authoring.missing_link.getText()).toBe('MISSING LINK');
         authoring.openRelatedItem();
         expect(authoring.getRelatedItems().count()).toBe(1);

--- a/spec/saved_search_spec.js
+++ b/spec/saved_search_spec.js
@@ -22,6 +22,7 @@ describe('saved_search', function() {
         expect(globalSearch.getPriorityElements().count()).toBe(3);
         var priority = globalSearch.getPriorityElementByIndex(0);
         priority.click();
+        browser.sleep(100);
         expect(globalSearch.getItems().count()).toBe(1);
         element(by.id('save_search_init')).click();
         var searchPanel = element(by.className('save-search-panel'));

--- a/styles/sass/buttons.scss
+++ b/styles/sass/buttons.scss
@@ -316,6 +316,10 @@ input[type="submit"].btn {
         background-color: darken($sd-highlight, 10%);
       }
     }
+    &--btn-rearrange {
+        width: auto;
+        border-right: solid thin #eee;
+    }
 }
 .navbtn--highlighted {
   &.active,

--- a/styles/sass/layouts.scss
+++ b/styles/sass/layouts.scss
@@ -62,7 +62,7 @@ a:hover {
             box-shadow: 2px 0 10px 0 rgba(0,0,0,0.3);
             right: 44%;
             z-index:100;
-                        border-right: 3px solid #666;
+            border-right: 3px solid #666;
             @include transition(all .5s);
             @media only screen and (max-width : 1430px) {
                 right: 54%;

--- a/styles/sass/media-archive.scss
+++ b/styles/sass/media-archive.scss
@@ -616,6 +616,10 @@ $rightfield-width:60px;
             opacity: 0.5;
         }
 
+        &.swimlane {
+            padding-left: 0px !important;
+        }
+
         .list-field {
             border-right: 1px solid rgba(0,0,0,0.06);
             float: left;
@@ -623,6 +627,10 @@ $rightfield-width:60px;
 
             &.no-border {
                 border:0;
+            }
+
+            &.swimlane {
+                width: 25px !important;
             }
         }
 

--- a/styles/sass/sf-additional.scss
+++ b/styles/sass/sf-additional.scss
@@ -1874,6 +1874,21 @@ header .sortbar {
             border: 2px dashed #ebebeb;
         }
     }
+
+}
+.draggable-list.serial-decimal {
+    list-style-type: decimal !important;
+    padding-top: 0px;
+    margin-left: 5px;
+    > li {
+        word-spacing: 2px;
+        line-height: 10px;
+    }
+    .sort-item {
+        &.active {
+            background-color: #eee;
+        }
+    }
 }
 
 // HANDLE FOR SPLITTER


### PR DESCRIPTION
…ty for monitoring view

- Swimlane view available via switch view button (next to + button) in monitoring view, enabled when configured via config.features with defined columnsLimit.
- Swimlane view stuff is controlled via sd-columns.swimlane, sd-column.swimlane and swimlane css classes 
- Number of columns (i-e groups) displayed is limitTo columnsLimit.
- When "authoring is opened" and an item is selected for preview then only selected item's column would be visible with its preview, on close of preview, all defined number of columns displayed back.
- Columns order can be Re-Arraged via another available button "Re-Arrange Groups" in monitoring, which opens existing monitoring settings modal with only Re-Order tab visible,
all viewable columns are highlighted/greyed in reorder screen.
- Re-Arranged columns/groups (in order) are stored in user preferences, which allows users to have their own prefered display order of columns/groups in monitoring view. 
- when changes like stage activated/deactivated in desk monitoring settings, then column order in monitoring view will reset back to what is defined in desk monitoring setting, until the user Re-Arrange it in monitoring view.