### PR TITLE
[SD-5547] - Improve performace after scroll lock

### DIFF
--- a/scripts/apps/monitoring/directives/MonitoringGroup.js
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.js
@@ -328,6 +328,11 @@ export function MonitoringGroup(cards, api, authoringWorkspace, $timeout, superd
                     multi.reset();
                 }
 
+                if (data && data.items && scope.showRefresh && !data.force) {
+                    // if we know the ids of the items then try to fetch those only
+                    criteria.source.query = search.getItemQuery(data.items);
+                }
+
                 return apiquery().then(function(items) {
                     if (!scope.showRefresh && data && !data.force && (data.user !== session.identity._id)) {
                         var itemPreviewing = isItemPreviewing();

--- a/scripts/apps/search/directives/SearchResults.js
+++ b/scripts/apps/search/directives/SearchResults.js
@@ -162,6 +162,11 @@ export function SearchResults(
                     }
                 }
 
+                if (data && data.items && scope.showRefresh && !data.force) {
+                    // if we know the ids of the items then try to fetch those only
+                    criteria.source.query = search.getItemQuery(data.items);
+                }
+
                 criteria.source.from = 0;
                 scope.total = null;
                 criteria.aggregations = $rootScope.aggregations;

--- a/scripts/apps/search/services/SearchService.js
+++ b/scripts/apps/search/services/SearchService.js
@@ -574,6 +574,16 @@ export function SearchService($location, gettext, config, session) {
     };
 
     /**
+     * Returns a query to search items by id
+     *
+     * @param {Object} items - {_id: 1}
+     */
+    this.getItemQuery = function(items) {
+        var updatedItems = _.keys(items);
+        return {'filtered': {'filter': {'terms': {'_id': updatedItems}}}};
+    };
+
+    /**
      * Update scope items only with the matching fetched newItems
      *
      * @param {Object} newItems


### PR DESCRIPTION
- With this change when the scroll position is locked, system will query only the updated item instead of all items if the single item is provided.