### PR TITLE
html-loader added to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "grunt-template": "0.2.3",
     "grunt-usemin": "3.1.1",
     "grunt-webpack": "^1.0.11",
+    "html-loader": "^0.4.4",
     "jasmine-core": "^2.4.1",
     "jquery": "^2.2.3",
     "jquery-jcrop": "^0.9.13",


### PR DESCRIPTION
this lib is used with webpack but missing from deps