### PR TITLE
fix(authoring): [SD-5552] Fixing the saving of an item after publish action fails.

### DIFF
--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.js
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.js
@@ -298,6 +298,7 @@ export function AuthoringDirective(superdesk, superdeskFlags, authoringWorkspace
 
                 return authoring.publish(orig, item, action)
                 .then(function(response) {
+                    tryPublish = false;
                     if (response) {
                         if (angular.isDefined(response.data) && angular.isDefined(response.data._issues)) {
                             if (angular.isDefined(response.data._issues['validator exception'])) {


### PR DESCRIPTION
If the publishing action fails and subsequently the user tries to make changes to the item and save the changes then the changes are not saved to the database.
