### PR TITLE
feat(translations): Added translation functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-// Place your settings in this file to overwrite default and user settings.
-{
-    "editor.insertSpaces": false,
-    "editor.renderIndentGuides": true
-}

--- a/scripts/apps/archive/controllers/ArchiveListController.js
+++ b/scripts/apps/archive/controllers/ArchiveListController.js
@@ -120,6 +120,7 @@ export class ArchiveListController extends BaseListController {
         $scope.$on('item:copy', refreshItems);
         $scope.$on('item:take', refreshItems);
         $scope.$on('item:duplicate', refreshItems);
+        $scope.$on('item:translate', refreshItems);
         $scope.$on('content:update', refreshItems);
         $scope.$on('item:deleted', refreshItems);
         $scope.$on('item:highlight', refreshItems);

--- a/scripts/apps/authoring/views/article-edit.html
+++ b/scripts/apps/authoring/views/article-edit.html
@@ -48,7 +48,7 @@
     data-onchange="autosave(item)"></div>
 </div>
 
-<div ng-if="schema.feature_media" sd-validation-error="error.feature_media" order="{{editor.feature_media.order}}"
+<div ng-if="schema.feature_media" sd-width="{{editor.feature_image.sdWidth || 'full'}}" sd-validation-error="error.feature_media" order="{{editor.feature_media.order}}"
     data-required="schema.feature_media.required" class="field">
   <label translate>Featured Media</label>
   <div sd-item-association

--- a/scripts/apps/highlights/directives/HighlightsReactDropdown.js
+++ b/scripts/apps/highlights/directives/HighlightsReactDropdown.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-HighlightsReactDropdown.$inject = ['item', 'className', 'highlightsService', 'desks', 'gettext', 'translatedLabel'];
-export function HighlightsReactDropdown(item, className, highlightsService, desks, gettext, translatedLabel) {
+HighlightsReactDropdown.$inject = ['item', 'className', 'highlightsService', 'desks', 'gettext', 'noHighlightsLabel'];
+export function HighlightsReactDropdown(item, className, highlightsService, desks, gettext, noHighlightsLabel) {
     var highlights = highlightsService.getSync(desks.getCurrentDeskId()) || {_items: []};
 
     var HighlightBtn = React.createClass({
@@ -37,7 +37,7 @@ export function HighlightsReactDropdown(item, className, highlightsService, desk
             React.createElement(
                 'button',
                 {disabled: true},
-                translatedLabel)
+                noHighlightsLabel)
         );
     };
 

--- a/scripts/apps/monitoring/directives/MonitoringGroup.js
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.js
@@ -51,6 +51,7 @@ export function MonitoringGroup(cards, api, authoringWorkspace, $timeout, superd
             scope.$on('item:spike', scheduleIfShouldUpdate);
             scope.$on('item:copy', scheduleQuery);
             scope.$on('item:duplicate', scheduleQuery);
+            scope.$on('item:translate', scheduleQuery);
             scope.$on('broadcast:created', function(event, args) {
                 scope.previewingBroadcast = true;
                 queryItems();

--- a/scripts/apps/monitoring/directives/Translations.js
+++ b/scripts/apps/monitoring/directives/Translations.js
@@ -1,0 +1,55 @@
+import React from 'react';
+
+Translations.$inject = ['item', 'className', 'TranslationService', 'noLanguagesLabel'];
+export function Translations(item, className, TranslationService, noLanguagesLabel) {
+     var languages = TranslationService.languages || {_items: []};
+
+    var TranslateBtn = React.createClass({
+        markTranslate: function(event) {
+            event.stopPropagation();
+            TranslationService.set(this.props.item, this.props.language);
+        },
+        render: function() {
+            var item = this.props.item;
+            var language = this.props.language;
+            var isCurrentLang = item.language === language.language;
+
+            if (!language.source) {
+                return false;
+            }
+
+            return React.createElement(
+                'button', {
+                    disabled: isCurrentLang,
+                    onClick: this.markTranslate
+                },
+                language.label
+            );
+        }
+    });
+
+    var createTranslateItem = function(language) {
+        return React.createElement(
+            'li',
+            {key: 'language-' + language._id},
+            React.createElement(TranslateBtn, {item: item, language: language})
+        );
+    };
+
+    var noLanguage = function() {
+        return React.createElement(
+            'li',
+            {},
+            React.createElement(
+                'button',
+                {disabled: true},
+                noLanguagesLabel)
+        );
+    };
+
+    return React.createElement(
+        'ul',
+        {className: className},
+        languages._items.length ? languages._items.map(createTranslateItem) : React.createElement(noLanguage)
+    );
+}

--- a/scripts/apps/monitoring/directives/index.js
+++ b/scripts/apps/monitoring/directives/index.js
@@ -6,3 +6,4 @@ export { ItemActionsMenu } from './ItemActionsMenu';
 
 export { AggregateSettings } from './AggregateSettings';
 export { SortGroups } from './SortGroups';
+export { Translations } from './Translations';

--- a/scripts/apps/monitoring/index.js
+++ b/scripts/apps/monitoring/index.js
@@ -15,7 +15,7 @@ import './aggregate-widget/aggregate';
 import * as ctrl from './controllers';
 import * as config from './config';
 import * as directive from './directives';
-import { CardsService } from './services';
+import * as svc from './services';
 import { SplitFilter } from './filters';
 
 angular.module('superdesk.apps.monitoring', [
@@ -26,7 +26,8 @@ angular.module('superdesk.apps.monitoring', [
 ])
     .controller('Monitoring', ctrl.MonitoringController)
 
-    .service('cards', CardsService)
+    .service('cards', svc.CardsService)
+    .service('TranslationService', svc.TranslationService)
 
     .directive('sdMonitoringView', directive.MonitoringView)
     .directive('sdMonitoringGroup', directive.MonitoringGroup)
@@ -43,6 +44,19 @@ angular.module('superdesk.apps.monitoring', [
     .run(['keyboardManager', 'gettext', function(keyboardManager, gettext) {
         keyboardManager.register('Monitoring', 'ctrl + g', gettext('Switches between single/grouped stage view'));
         keyboardManager.register('Monitoring', 'ctrl + alt + g', gettext('Switches between single/grouped desk view'));
+    }])
+
+    .config(['superdeskProvider', function (superdesk) {
+        superdesk
+            .activity('translate', {
+                label: gettext('Translate'),
+                icon: 'globe',
+                dropdown: directive.Translations,
+                keyboardShortcut: 'ctrl+t',
+                filters: [
+                    {action: 'list', type: 'archive'}
+                ]
+            });
     }]);
 
 angular.module('superdesk.apps.aggregate', [

--- a/scripts/apps/monitoring/services/TranslationService.js
+++ b/scripts/apps/monitoring/services/TranslationService.js
@@ -1,0 +1,31 @@
+TranslationService.$inject = ['api', '$rootScope', 'notify', 'authoringWorkspace'];
+export function TranslationService(api, $rootScope, notify, authoringWorkspace) {
+    var service = {};
+
+    service.fetch = function () {
+        return api.query('languages').then(function (languages) {
+            service.languages = languages;
+        });
+    };
+
+    service.get = function () {
+        return service.languages;
+    };
+
+    service.set = function (item, language) {
+        var params = {
+            guid: item.guid,
+            language: language.language
+        };
+
+        api.save('translate', params).then(function (item) {
+            authoringWorkspace.open(item);
+            $rootScope.$broadcast('item:translate');
+            notify.success(gettext('Item Translated'));
+        });
+    };
+
+    service.fetch();
+
+    return service;
+}

--- a/scripts/apps/monitoring/services/index.js
+++ b/scripts/apps/monitoring/services/index.js
@@ -1,1 +1,2 @@
 export { CardsService } from './CardsService';
+export { TranslationService } from './TranslationService';

--- a/scripts/apps/search/directives/ItemList.js
+++ b/scripts/apps/search/directives/ItemList.js
@@ -50,6 +50,7 @@ ItemList.$inject = [
     'Keys',
     'dragitem',
     'highlightsService',
+    'TranslationService',
     'monitoringState',
     'authoringWorkspace',
     'gettextCatalog',
@@ -77,6 +78,7 @@ export function ItemList(
     Keys,
     dragitem,
     highlightsService,
+    TranslationService,
     monitoringState,
     authoringWorkspace,
     gettextCatalog,
@@ -1261,7 +1263,8 @@ export function ItemList(
                                 this.state.open ? $injector.invoke(activity.dropdown, activity, {
                                     item: this.props.item,
                                     className: 'dropdown-menu upward ' + this.state.position,
-                                    translatedLabel: gettextCatalog.getString('No available highlights')
+                                    noHighlightsLabel: gettextCatalog.getString('No available highlights'),
+                                    noLanguagesLabel: gettextCatalog.getString('No available translations')
                                 }) : null
                             )
                         );

--- a/scripts/apps/search/directives/SearchResults.js
+++ b/scripts/apps/search/directives/SearchResults.js
@@ -79,6 +79,7 @@ export function SearchResults(
             scope.$on('item:spike', scheduleIfShouldUpdate);
             scope.$on('item:unspike', scheduleIfShouldUpdate);
             scope.$on('item:duplicate', queryItems);
+            scope.$on('item:translate', queryItems);
             scope.$on('ingest:update', queryItems);
             scope.$on('content:update', queryItems);
             scope.$on('item:move', scheduleIfShouldUpdate);


### PR DESCRIPTION
SDESK-67 - As  a translator, I would like to start translating an item by clicking on a single “translate” button or action

SDESK-39 - As a translator I want to be able to translate both published and unpublished content (both “ingested” and “in production”)