### PR TITLE
feat(translations): Added translation functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-// Place your settings in this file to overwrite default and user settings.
-{
-    "editor.insertSpaces": false,
-    "editor.renderIndentGuides": true
-}

--- a/scripts/apps/archive/controllers/ArchiveListController.js
+++ b/scripts/apps/archive/controllers/ArchiveListController.js
@@ -120,6 +120,7 @@ export class ArchiveListController extends BaseListController {
         $scope.$on('item:copy', refreshItems);
         $scope.$on('item:take', refreshItems);
         $scope.$on('item:duplicate', refreshItems);
+        $scope.$on('item:translate', refreshItems);
         $scope.$on('content:update', refreshItems);
         $scope.$on('item:deleted', refreshItems);
         $scope.$on('item:highlight', refreshItems);

--- a/scripts/apps/authoring/authoring/directives/AuthoringTopbarDirective.js
+++ b/scripts/apps/authoring/authoring/directives/AuthoringTopbarDirective.js
@@ -1,9 +1,24 @@
-AuthoringTopbarDirective.$inject = [];
-export function AuthoringTopbarDirective() {
+/**
+ * @ngdoc directive
+ * @module superdesk.apps.authoring
+ * @name AuthoringTopbarDirective
+ *
+ * @requires TranslationService
+ *
+ * @description Generates authoring subnav bar
+ */
+
+AuthoringTopbarDirective.$inject = ['TranslationService'];
+export function AuthoringTopbarDirective(TranslationService) {
     return {
         templateUrl: 'scripts/apps/authoring/views/authoring-topbar.html',
         link: function(scope) {
             scope.saveDisabled = false;
+
+            /*
+             * Save item
+             * @return {promise}
+             */
             scope.saveTopbar = function() {
                 scope.saveDisabled = true;
                 return scope.save(scope.item)
@@ -12,12 +27,22 @@ export function AuthoringTopbarDirective() {
                 });
             };
 
+            // Activate preview formatted item
             scope.previewFormattedItem = function() {
                 scope.previewFormatted = true;
             };
 
+            // Close preview formatted item
             scope.closePreviewFormatted = function() {
                 scope.previewFormatted = false;
+            };
+
+            /*
+             * Check if item is available for translating
+             * @return {Boolean}
+             */
+            scope.isTranslationAvailable = function() {
+                return TranslationService.checkAvailability(scope.item);
             };
         }
     };

--- a/scripts/apps/authoring/views/article-edit.html
+++ b/scripts/apps/authoring/views/article-edit.html
@@ -48,7 +48,7 @@
     data-onchange="autosave(item)"></div>
 </div>
 
-<div ng-if="schema.feature_media" sd-validation-error="error.feature_media" order="{{editor.feature_media.order}}"
+<div ng-if="schema.feature_media" sd-width="{{editor.feature_image.sdWidth || 'full'}}" sd-validation-error="error.feature_media" order="{{editor.feature_media.order}}"
     data-required="schema.feature_media.required" class="field">
   <label translate>Featured Media</label>
   <div sd-item-association

--- a/scripts/apps/authoring/views/authoring-topbar.html
+++ b/scripts/apps/authoring/views/authoring-topbar.html
@@ -164,6 +164,20 @@
                   </li>
                 </ul>
 
+                <ul ng-if="isTranslationAvailable()">
+                  <li class="divider"></li>
+                  <li><span class="menu-label" translate>Translations</span></li>
+                  <li>
+                    <div class="dropdown highlights-toggle" dropdown>
+                      <button class="dropdown-toggle" dropdown-toggle>
+                        {{ :: 'Translate item to' | translate }}
+                        <i class="icon-chevron-right-thin submenu-icon"></i>
+                      </button>
+                      <ul class="dropdown-menu right-submenu" sd-translation-dropdown></ul>
+                    </div>
+                  </li>
+                </ul>
+
                 <ul ng-if="_editable" ng-controller="SpellcheckMenu as spellcheckMenu">
                     <li class="divider"></li>
                     <li><span class="menu-label" translate>Spell Checker</span></li>

--- a/scripts/apps/highlights/directives/HighlightsReactDropdown.js
+++ b/scripts/apps/highlights/directives/HighlightsReactDropdown.js
@@ -1,9 +1,30 @@
+/**
+ * @ngdoc directive
+ * @module superdesk.apps.highlights
+ * @name HighlightsReactDropdown
+ *
+ * @requires React
+ * @requires item
+ * @requires className
+ * @requires highlightsService
+ * @requires desks
+ * @requires noHighlightsLabel
+ *
+ * @param {Object} [highlights] collection of highlights
+ *
+ * @description Creates dropdown react element with list of available highlights
+ */
+
 import React from 'react';
 
-HighlightsReactDropdown.$inject = ['item', 'className', 'highlightsService', 'desks', 'gettext', 'translatedLabel'];
-export function HighlightsReactDropdown(item, className, highlightsService, desks, gettext, translatedLabel) {
+HighlightsReactDropdown.$inject = ['item', 'className', 'highlightsService', 'desks', 'noHighlightsLabel'];
+export function HighlightsReactDropdown(item, className, highlightsService, desks, noHighlightsLabel) {
     var highlights = highlightsService.getSync(desks.getCurrentDeskId()) || {_items: []};
 
+    /*
+     * Creates specific highlight button in list
+     * @return {React} Language button
+     */
     var HighlightBtn = React.createClass({
         markHighlight: function(event) {
             event.stopPropagation();
@@ -22,6 +43,10 @@ export function HighlightsReactDropdown(item, className, highlightsService, desk
         }
     });
 
+    /*
+     * Creates list element for specific highlight
+     * @return {React} Single list element
+     */
     var createHighlightItem = function(highlight) {
         return React.createElement(
             'li',
@@ -30,6 +55,10 @@ export function HighlightsReactDropdown(item, className, highlightsService, desk
         );
     };
 
+    /*
+     * If there are no highlights, print none-highlights message
+     * @return {React} List element
+     */
     var noHighlights = function() {
         return React.createElement(
             'li',
@@ -37,10 +66,14 @@ export function HighlightsReactDropdown(item, className, highlightsService, desk
             React.createElement(
                 'button',
                 {disabled: true},
-                translatedLabel)
+                noHighlightsLabel)
         );
     };
 
+    /*
+     * Creates list with highlights
+     * @return {React} List element
+     */
     return React.createElement(
         'ul',
         {className: className},

--- a/scripts/apps/index.js
+++ b/scripts/apps/index.js
@@ -13,6 +13,7 @@ import 'apps/legal-archive';
 import 'apps/stream';
 import 'apps/packaging';
 import 'apps/highlights';
+import 'apps/translations';
 import 'apps/content-filters';
 import 'apps/dictionaries';
 import 'apps/vocabularies';
@@ -40,6 +41,7 @@ export default angular.module('superdesk.apps', [
     'superdesk.apps.editor.spellcheck',
     'superdesk.apps.notification',
     'superdesk.apps.highlights',
+    'superdesk.apps.translations',
     'superdesk.apps.content_filters',
     'superdesk.apps.dictionaries',
     'superdesk.apps.vocabularies',

--- a/scripts/apps/monitoring/directives/MonitoringGroup.js
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.js
@@ -51,6 +51,7 @@ export function MonitoringGroup(cards, api, authoringWorkspace, $timeout, superd
             scope.$on('item:spike', scheduleIfShouldUpdate);
             scope.$on('item:copy', scheduleQuery);
             scope.$on('item:duplicate', scheduleQuery);
+            scope.$on('item:translate', scheduleQuery);
             scope.$on('broadcast:created', function(event, args) {
                 scope.previewingBroadcast = true;
                 queryItems();

--- a/scripts/apps/monitoring/index.js
+++ b/scripts/apps/monitoring/index.js
@@ -15,7 +15,7 @@ import './aggregate-widget/aggregate';
 import * as ctrl from './controllers';
 import * as config from './config';
 import * as directive from './directives';
-import { CardsService } from './services';
+import * as svc from './services';
 import { SplitFilter } from './filters';
 
 angular.module('superdesk.apps.monitoring', [
@@ -26,7 +26,7 @@ angular.module('superdesk.apps.monitoring', [
 ])
     .controller('Monitoring', ctrl.MonitoringController)
 
-    .service('cards', CardsService)
+    .service('cards', svc.CardsService)
 
     .directive('sdMonitoringView', directive.MonitoringView)
     .directive('sdMonitoringGroup', directive.MonitoringGroup)

--- a/scripts/apps/search/directives/ItemList.js
+++ b/scripts/apps/search/directives/ItemList.js
@@ -50,6 +50,7 @@ ItemList.$inject = [
     'Keys',
     'dragitem',
     'highlightsService',
+    'TranslationService',
     'monitoringState',
     'authoringWorkspace',
     'gettextCatalog',
@@ -77,6 +78,7 @@ export function ItemList(
     Keys,
     dragitem,
     highlightsService,
+    TranslationService,
     monitoringState,
     authoringWorkspace,
     gettextCatalog,
@@ -1261,7 +1263,8 @@ export function ItemList(
                                 this.state.open ? $injector.invoke(activity.dropdown, activity, {
                                     item: this.props.item,
                                     className: 'dropdown-menu upward ' + this.state.position,
-                                    translatedLabel: gettextCatalog.getString('No available highlights')
+                                    noHighlightsLabel: gettextCatalog.getString('No available highlights'),
+                                    noLanguagesLabel: gettextCatalog.getString('No available translations')
                                 }) : null
                             )
                         );

--- a/scripts/apps/search/directives/SearchResults.js
+++ b/scripts/apps/search/directives/SearchResults.js
@@ -79,6 +79,7 @@ export function SearchResults(
             scope.$on('item:spike', scheduleIfShouldUpdate);
             scope.$on('item:unspike', scheduleIfShouldUpdate);
             scope.$on('item:duplicate', queryItems);
+            scope.$on('item:translate', queryItems);
             scope.$on('ingest:update', queryItems);
             scope.$on('content:update', queryItems);
             scope.$on('item:move', scheduleIfShouldUpdate);

--- a/scripts/apps/search/index.js
+++ b/scripts/apps/search/index.js
@@ -6,6 +6,7 @@ import { MultiActionBarController } from './controllers';
 
 angular.module('superdesk.apps.search.react', [
     'superdesk.apps.highlights',
+    'superdesk.apps.translations',
     'superdesk.core.datetime',
     'superdesk.apps.authoring.metadata'
 ])

--- a/scripts/apps/translations/directives/TranslationDropdown.js
+++ b/scripts/apps/translations/directives/TranslationDropdown.js
@@ -1,0 +1,38 @@
+/**
+ * @ngdoc directive
+ * @module superdesk.apps.translations
+ * @name TranslationDropdown
+ *
+ * @requires TranslationService
+ *
+ * @param {Object} [langugages] collection of languages
+ *
+ * @description Creates dropdown element with list of available languages
+ */
+
+TranslationDropdown.$inject = ['TranslationService'];
+export function TranslationDropdown(TranslationService) {
+    return {
+        templateUrl: 'scripts/apps/translations/views/TranslationDropdown.html',
+        link: function (scope) {
+            scope.languages = _.filter(TranslationService.languages._items, {destination: true});
+
+            /*
+             * Check if item language and button language are same
+             * @param {Object} Language
+             * @return {Boolean}
+             */
+            scope.isCurrentLanguage = function (language) {
+                return scope.item && scope.item.language === language.language;
+            };
+
+            /*
+             * Function for translating item
+             * @param {Object} New language
+             */
+            scope.translateItem = function (language) {
+                TranslationService.set(scope.item, language);
+            };
+        }
+    };
+}

--- a/scripts/apps/translations/directives/TranslationReactDropdown.js
+++ b/scripts/apps/translations/directives/TranslationReactDropdown.js
@@ -1,0 +1,87 @@
+/**
+ * @ngdoc directive
+ * @module superdesk.apps.translations
+ * @name TranslationReactDropdown
+ *
+ * @requires React
+ * @requires item
+ * @requires className
+ * @requires TranslationService
+ * @requires noLanguagesLabel
+ *
+ * @param {Object} [langugages] collection of languages
+ *
+ * @description Creates dropdown react element with list of available languages
+ */
+
+import React from 'react';
+
+TranslationReactDropdown.$inject = ['item', 'className', 'TranslationService', 'noLanguagesLabel'];
+export function TranslationReactDropdown(item, className, TranslationService, noLanguagesLabel) {
+    var languages = TranslationService.get() || {_items: []};
+
+    /*
+     * Creates specific language button in list
+     * @return {React} Language button
+     */
+    var TranslateBtn = React.createClass({
+        markTranslate: function (event) {
+            event.stopPropagation();
+            TranslationService.set(this.props.item, this.props.language);
+        },
+        render: function () {
+            var item = this.props.item;
+            var language = this.props.language;
+            var isCurrentLang = item.language === language.language;
+
+            if (!language.destination) {
+                return false;
+            }
+
+            return React.createElement(
+                    'button', {
+                        disabled: isCurrentLang,
+                        onClick: this.markTranslate
+                    },
+                    language.label
+                    );
+        }
+    });
+
+    /*
+     * Creates list element for specific language
+     * @return {React} Single list element
+     */
+    var createTranslateItem = function (language) {
+        return React.createElement(
+                'li',
+                {key: 'language-' + language._id},
+                React.createElement(TranslateBtn, {item: item, language: language})
+                );
+    };
+
+    /*
+     * If there are no languages, print none-langugage message
+     * @return {React} List element
+     */
+    var noLanguage = function () {
+        return React.createElement(
+                'li',
+                {},
+                React.createElement(
+                        'button',
+                        {disabled: true},
+                        noLanguagesLabel)
+                );
+    };
+
+    /*
+     * Creates list with languages
+     * @return {React} List element
+     */
+    return React.createElement(
+            'ul',
+            {className: className},
+            languages._items.length ? languages._items.map(createTranslateItem) : React.createElement(noLanguage)
+            );
+}

--- a/scripts/apps/translations/directives/index.js
+++ b/scripts/apps/translations/directives/index.js
@@ -1,0 +1,2 @@
+export { TranslationReactDropdown } from './TranslationReactDropdown';
+export { TranslationDropdown } from './TranslationDropdown';

--- a/scripts/apps/translations/index.js
+++ b/scripts/apps/translations/index.js
@@ -1,0 +1,37 @@
+/**
+ * This file is part of Superdesk.
+ *
+ * Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+ *
+ * For the full copyright and license information, please see the
+ * AUTHORS and LICENSE files distributed with this source code, or
+ * at https://www.sourcefabric.org/superdesk/license
+ */
+
+import * as directive from './directives';
+import * as svc from './services';
+
+angular.module('superdesk.apps.translations', [
+    'superdesk.core.api'
+])
+
+.service('TranslationService', svc.TranslationService)
+
+.directive('sdTranslationDropdown', directive.TranslationDropdown)
+
+.config(['superdeskProvider', function (superdesk) {
+    superdesk
+        .activity('translate', {
+            label: gettext('Translate'),
+            icon: 'globe',
+            dropdown: directive.TranslationReactDropdown,
+            keyboardShortcut: 'ctrl+t',
+            templateUrl: 'scripts/apps/translations/views/TranslationDropdownTemplate.html',
+            filters: [
+                {action: 'list', type: 'archive'}
+            ],
+            additionalCondition:['TranslationService', 'item', function(TranslationService, item) {
+                return TranslationService.checkAvailability(item);
+            }]
+        });
+}]);

--- a/scripts/apps/translations/services/TranslationService.js
+++ b/scripts/apps/translations/services/TranslationService.js
@@ -1,0 +1,72 @@
+/**
+ * @ngdoc service
+ * @module superdesk.apps.translations
+ * @name TranslationService
+ *
+ * @requires api
+ * @requires notify
+ * @requires authoringWorkspace
+ * @requires https://docs.angularjs.org/api/ng/service/$rootScope $rootScope
+ *
+ * @description Provides set of methods to translate items to different languages
+ */
+
+TranslationService.$inject = ['api', '$rootScope', 'notify', 'authoringWorkspace'];
+export function TranslationService(api, $rootScope, notify, authoringWorkspace) {
+    var service = {};
+
+    /*
+     * Fetch languages from database
+     *
+     * @return {Object} Languages
+     */
+    service.fetch = function () {
+        return api.query('languages');
+    };
+
+    /*
+     * Return list of langugages
+     *
+     * @return {Object} list of items
+     */
+    service.get = function () {
+        return service.languages;
+    };
+
+    /*
+     * Create copy of item with new language set
+     *
+     * @param item {Object} item to be translated
+     * @param language {Object} translate language
+     */
+    service.set = function (item, language) {
+        var params = {
+            guid: item.guid,
+            language: language.language
+        };
+
+        api.save('translate', params).then(function (item) {
+            authoringWorkspace.open(item);
+            $rootScope.$broadcast('item:translate');
+            notify.success(gettext('Item Translated'));
+        });
+    };
+
+    /*
+     * Check if item is available for translating
+     *
+     * @return {boolean}
+     */
+    service.checkAvailability = function (item) {
+        return !service.languages ? false : _.find(service.languages._items, function (language) {
+            return language.source && language.language === item.language;
+        });
+    };
+
+    // Fetch languages from database on service initialization
+    service.fetch().then(function (languages) {
+        service.languages = languages;
+    });
+
+    return service;
+}

--- a/scripts/apps/translations/services/index.js
+++ b/scripts/apps/translations/services/index.js
@@ -1,0 +1,1 @@
+export { TranslationService } from './TranslationService';

--- a/scripts/apps/translations/views/TranslationDropdown.html
+++ b/scripts/apps/translations/views/TranslationDropdown.html
@@ -1,0 +1,10 @@
+<ul>
+    <li ng-if="languages.length" ng-repeat="language in languages track by language._id">
+        <button ng-disabled="isCurrentLanguage(language)" option="{{ language.label}}" ng-click="translateItem(language);">
+            {{ :: language.label | translate }}
+        </button>
+    </li>
+    <li ng-if="!languages.length">
+        <button ng-disabled="true">{{::'No available languages'|translate}}</button>
+    </li>
+</ul>

--- a/scripts/apps/translations/views/TranslationDropdownTemplate.html
+++ b/scripts/apps/translations/views/TranslationDropdownTemplate.html
@@ -1,0 +1,1 @@
+<div sd-translation-dropdown></div>


### PR DESCRIPTION
SDESK-67 - As a translator, I would like to start translating an item by clicking on a single “translate” button or action

SDESK-39 - As a translator I want to be able to translate both published and unpublished content (both “ingested” and “in production”)