### PR TITLE
SDESK-233: Date fields in search filters do not reset when value is cleared

### DIFF
--- a/scripts/apps/settings/directives/DateParam.js
+++ b/scripts/apps/settings/directives/DateParam.js
@@ -11,9 +11,8 @@ export function DateParam($location) {
             }
 
             scope.$watch('date', function(date) {
-                if (date != null) {
-                    $location.search(attrs.location, date);
-                }
+                // NOTE: null values should be allowed to reset
+                $location.search(attrs.location, date);
             });
 
             scope.$on('$routeUpdate', function(event, route) {

--- a/scripts/apps/settings/directives/DateParam.js
+++ b/scripts/apps/settings/directives/DateParam.js
@@ -11,7 +11,6 @@ export function DateParam($location) {
             }
 
             scope.$watch('date', function(date) {
-                // NOTE: null values should be allowed to reset
                 $location.search(attrs.location, date);
             });
 


### PR DESCRIPTION
allow null values in watch to update the field so values can be reset.