### PR TITLE
fix(indent): Remove indentation for paragraph after headline

### DIFF
--- a/scripts/apps/authoring/styles/authoring.scss
+++ b/scripts/apps/authoring/styles/authoring.scss
@@ -1196,11 +1196,14 @@ feature-image {
 
 .indent-article {
     #bodyhtml, .text.body-text {
-        :header {
-            text-indent: 0;
-        }
         p:first-of-type, p+p {
             text-indent: 25px;
+        }
+        h2+p:first-of-type, 
+        h3+p:first-of-type, 
+        h4+p:first-of-type, 
+        h5+p:first-of-type {
+            text-indent: 0;
         }
     }
 }


### PR DESCRIPTION
SDESK-221 - NTB: text after subheading on the first line is (incorrectly) indented