### PR TITLE
[SDESK-212] Live suggestions

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -17,7 +17,6 @@
     "requireLineFeedAtFileEnd": true,
     "requireCommaBeforeLineBreak": true,
     "validateJSDoc": {
-        "checkParamNames": true,
         "requireParamTypes": true
     },
     "requireSpaceBeforeBinaryOperators": ["=", "+", "-", "*", "/", "==", "===", "!=", "!=="],

--- a/scripts/apps/authoring/authoring/directives/ArticleEditDirective.js
+++ b/scripts/apps/authoring/authoring/directives/ArticleEditDirective.js
@@ -10,7 +10,8 @@ ArticleEditDirective.$inject = [
     'session',
     'gettext',
     'history',
-    '$interpolate'
+    '$interpolate',
+    'suggest'
 ];
 export function ArticleEditDirective(
     autosave,
@@ -24,7 +25,8 @@ export function ArticleEditDirective(
     session,
     gettext,
     history,
-    $interpolate
+    $interpolate,
+    suggest
 ) {
     return {
         templateUrl: 'scripts/apps/authoring/views/article-edit.html',
@@ -266,6 +268,8 @@ export function ArticleEditDirective(
                     ddlHelpline[0].options[0].selected = true;
                 });
             };
+
+            scope.$watch('item.body_html', () => suggest.trigger(scope.item, scope.origItem));
 
             scope.$watch('item.flags.marked_for_sms', function(isMarked) {
                 if (isMarked) {

--- a/scripts/apps/authoring/authoring/directives/AuthoringContainerDirective.js
+++ b/scripts/apps/authoring/authoring/directives/AuthoringContainerDirective.js
@@ -5,6 +5,7 @@ export function AuthoringContainerDirective(authoring, authoringWorkspace) {
         var self = this;
 
         this.state = {};
+        this.showingSuggestions = false;
 
         /**
          * Start editing item using given action mode

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.js
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.js
@@ -24,11 +24,12 @@ AuthoringDirective.$inject = [
     'reloadService',
     '$rootScope',
     '$interpolate',
-    'metadata'
+    'metadata',
+    'suggest'
 ];
 export function AuthoringDirective(superdesk, superdeskFlags, authoringWorkspace, notify, gettext, desks, authoring, api, session, lock,
     privileges, content, $location, referrer, macros, $timeout, $q, modal, archiveService, confirm, reloadService, $rootScope,
-    $interpolate, metadata) {
+    $interpolate, metadata, suggest) {
     return {
         link: function($scope, elem, attrs) {
             var _closing;
@@ -47,6 +48,7 @@ export function AuthoringDirective(superdesk, superdeskFlags, authoringWorkspace
             $scope.itemActions = authoring.itemActions($scope.origItem);
             $scope.highlight = !!$scope.origItem.highlight;
             $scope.showExportButton = $scope.highlight && $scope.origItem.type === 'composite';
+            $scope.openSuggestions = () => suggest.setActive();
 
             $scope.$watch('origItem', function(new_value, old_value) {
                 $scope.itemActions = null;

--- a/scripts/apps/authoring/authoring/index.js
+++ b/scripts/apps/authoring/authoring/index.js
@@ -5,6 +5,8 @@ import * as directive from './directives';
 import * as ctrl from './controllers';
 import * as filter from './filters';
 
+import 'apps/authoring/suggest';
+
 angular.module('superdesk.apps.authoring.autosave', []).service('autosave', svc.AutosaveService);
 
 angular.module('superdesk.apps.authoring', [
@@ -21,6 +23,7 @@ angular.module('superdesk.apps.authoring', [
         'superdesk.apps.authoring.find-replace',
         'superdesk.apps.authoring.macros',
         'superdesk.apps.authoring.autosave',
+        'superdesk.apps.authoring.suggest',
         'superdesk.apps.desks',
         'superdesk.apps.notification',
         'contenteditable',

--- a/scripts/apps/authoring/authoring/services/AuthoringWorkspaceService.js
+++ b/scripts/apps/authoring/authoring/services/AuthoringWorkspaceService.js
@@ -1,5 +1,5 @@
-AuthoringWorkspaceService.$inject = ['$location', 'superdeskFlags', 'authoring', 'lock', 'send', 'config'];
-export function AuthoringWorkspaceService($location, superdeskFlags, authoring, lock, send, config) {
+AuthoringWorkspaceService.$inject = ['$location', 'superdeskFlags', 'authoring', 'lock', 'send', 'config', 'suggest'];
+export function AuthoringWorkspaceService($location, superdeskFlags, authoring, lock, send, config, suggest) {
     this.item = null;
     this.action = null;
     this.state = null;
@@ -66,6 +66,7 @@ export function AuthoringWorkspaceService($location, superdeskFlags, authoring, 
      * @param {boolean} showMonitoring when true shows the monitoring if monitoring is hidden.
      */
     this.close = function(showMonitoring) {
+        suggest.setActive(false);
         self.item = null;
         self.action = null;
         if (showMonitoring && superdeskFlags.flags.hideMonitoring) {

--- a/scripts/apps/authoring/suggest/SuggestController.js
+++ b/scripts/apps/authoring/suggest/SuggestController.js
@@ -5,8 +5,8 @@
  * @requires desks
  * @requires https://docs.angularjs.org/api/ng/type/$rootScope.Scope $scope
  * @description SuggestController holds a set of convenience functions used by
- * the SuggestDirective.
- * @see SuggestDirective
+ * sd-suggest.
+ * @see sd-suggest
  */
 export default class SuggestController {
     constructor(desks, scope) {

--- a/scripts/apps/authoring/suggest/SuggestController.js
+++ b/scripts/apps/authoring/suggest/SuggestController.js
@@ -1,0 +1,61 @@
+/**
+ * @ngdoc controller
+ * @module apps.authoring.suggest
+ * @name SuggestController
+ * @requires desks
+ * @requires https://docs.angularjs.org/api/ng/type/$rootScope.Scope $scope
+ * @description SuggestController holds a set of convenience functions used by
+ * the SuggestDirective.
+ * @see SuggestDirective
+ */
+export default class SuggestController {
+    constructor(desks, scope) {
+        this.desks = desks;
+        this.scope = scope;
+    }
+
+    /**
+     * @ngdoc method
+     * @name SuggestController#displayName
+     * @param {String} userId The ID of the user to look up.
+     * @returns {String} The resolved user.
+     * @description Gets the display name for the given user ID, otherwise returns
+     * the string "-".
+     */
+    displayName(userId) {
+        let usr = this.desks.userLookup[userId];
+        return usr ? usr.display_name || '-' : '-';
+    }
+
+    /**
+     * @ngdoc method
+     * @name SuggestController#close
+     * @description Closes the panel and resets it.
+     */
+    close() {
+        this.scope.showItem = null;
+        this.scope.ngShow = false;
+    }
+
+    /**
+     * @ngdoc method
+     * @name SuggestController#showItem
+     * @param {Object} item The item to show.
+     * @description Shows the passed item in the live suggestions panel.
+     */
+    showItem(item) {
+        this.scope.showItem = item;
+    }
+
+    /**
+     * @ngdoc method
+     * @name SuggestController#hideItem
+     * @description Resets the panel to the list view. This is used when a user
+     * wants to go back from the item view to the list view.
+     */
+    hideItem() {
+        this.scope.showItem = null;
+    }
+}
+
+SuggestController.$inject = ['desks', '$scope'];

--- a/scripts/apps/authoring/suggest/SuggestController.js
+++ b/scripts/apps/authoring/suggest/SuggestController.js
@@ -1,12 +1,12 @@
 /**
  * @ngdoc controller
- * @module apps.authoring.suggest
+ * @module superdesk.apps.authoring
  * @name SuggestController
  * @requires desks
  * @requires https://docs.angularjs.org/api/ng/type/$rootScope.Scope $scope
  * @description SuggestController holds a set of convenience functions used by
- * sd-suggest.
- * @see sd-suggest
+ * sdSuggest.
+ * @see sdSuggest
  */
 export default class SuggestController {
     constructor(desks, scope) {

--- a/scripts/apps/authoring/suggest/SuggestDirective.js
+++ b/scripts/apps/authoring/suggest/SuggestDirective.js
@@ -11,7 +11,7 @@ class LinkFunction {
 
     /**
      * @ngdoc method
-     * @name sd-suggest#init
+     * @name sdSuggest#init
      * @private
      * @description Initializes the directive with default values for the scope
      * and with necessary watchers.
@@ -26,7 +26,7 @@ class LinkFunction {
 
     /**
      * @ngdoc method
-     * @name sd-suggest#onUpdate
+     * @name sdSuggest#onUpdate
      * @param {Object} resp The list of items received after the update.
      * @private
      * @description onUpdate is the callback that will be triggered whenever the
@@ -39,7 +39,7 @@ class LinkFunction {
 
     /**
      * @ngdoc method
-     * @name sd-suggest#toggleActive
+     * @name sdSuggest#toggleActive
      * @param {Boolean} v The new value for the active state.
      * @private
      * @description Toggles the active state of the service.
@@ -50,7 +50,7 @@ class LinkFunction {
 
     /**
      * @ngdoc method
-     * @name sd-suggest#toggleVisible
+     * @name sdSuggest#toggleVisible
      * @param {Boolean} v The new value for the visible state.
      * @private
      * @description Toggles the visible state of the panel.
@@ -62,8 +62,8 @@ class LinkFunction {
 
 /**
  * @ngdoc directive
- * @module apps.authoring.suggest
- * @name sd-suggest
+ * @module superdesk.apps.authoring
+ * @name sdSuggest
  * @requires suggest
  * @param {Boolean} ngShow ngShow determines the visibility of the directive.
  * @description sd-suggest operates the live suggestions panel that appears

--- a/scripts/apps/authoring/suggest/SuggestDirective.js
+++ b/scripts/apps/authoring/suggest/SuggestDirective.js
@@ -11,7 +11,7 @@ class LinkFunction {
 
     /**
      * @ngdoc method
-     * @name SuggestDirective#init
+     * @name sd-suggest#init
      * @private
      * @description Initializes the directive with default values for the scope
      * and with necessary watchers.
@@ -26,7 +26,7 @@ class LinkFunction {
 
     /**
      * @ngdoc method
-     * @name SuggestDirective#onUpdate
+     * @name sd-suggest#onUpdate
      * @param {Object} resp The list of items received after the update.
      * @private
      * @description onUpdate is the callback that will be triggered whenever the
@@ -39,7 +39,7 @@ class LinkFunction {
 
     /**
      * @ngdoc method
-     * @name SuggestDirective#toggleActive
+     * @name sd-suggest#toggleActive
      * @param {Boolean} v The new value for the active state.
      * @private
      * @description Toggles the active state of the service.
@@ -50,7 +50,7 @@ class LinkFunction {
 
     /**
      * @ngdoc method
-     * @name SuggestDirective#toggleVisible
+     * @name sd-suggest#toggleVisible
      * @param {Boolean} v The new value for the visible state.
      * @private
      * @description Toggles the visible state of the panel.
@@ -66,7 +66,7 @@ class LinkFunction {
  * @name sd-suggest
  * @requires suggest
  * @param {Boolean} ngShow ngShow determines the visibility of the directive.
- * @description SuggestDirective operates the live suggestions panel that appears
+ * @description sd-suggest operates the live suggestions panel that appears
  * to the left of the authoring component.
  */
 export default function SuggestDirective(suggest) {

--- a/scripts/apps/authoring/suggest/SuggestDirective.js
+++ b/scripts/apps/authoring/suggest/SuggestDirective.js
@@ -1,0 +1,82 @@
+import SuggestController from './SuggestController';
+
+class LinkFunction {
+    constructor(suggest, scope, elem) {
+        this.suggest = suggest;
+        this.scope = scope;
+        this.elem = elem;
+
+        this.init();
+    }
+
+    /**
+     * @ngdoc method
+     * @name SuggestDirective#init
+     * @private
+     * @description Initializes the directive with default values for the scope
+     * and with necessary watchers.
+     */
+    init() {
+        this.scope.showItem = null;
+        this.scope.$watch('ngShow', this.toggleActive.bind(this));
+        this.scope.$watch(() => this.suggest.active, this.toggleVisible.bind(this));
+
+        this.suggest.onUpdate(this.onUpdate.bind(this));
+    }
+
+    /**
+     * @ngdoc method
+     * @name SuggestDirective#onUpdate
+     * @param {Object} resp The list of items received after the update.
+     * @private
+     * @description onUpdate is the callback that will be triggered whenever the
+     * suggest service updates with new items.
+     */
+    onUpdate(resp) {
+        this.scope.items = resp._items;
+        this.scope.$apply();
+    }
+
+    /**
+     * @ngdoc method
+     * @name SuggestDirective#toggleActive
+     * @param {Boolean} v The new value for the active state.
+     * @private
+     * @description Toggles the active state of the service.
+     */
+    toggleActive(v) {
+        this.suggest.setActive.call(this.suggest, v);
+    }
+
+    /**
+     * @ngdoc method
+     * @name SuggestDirective#toggleVisible
+     * @param {Boolean} v The new value for the visible state.
+     * @private
+     * @description Toggles the visible state of the panel.
+     */
+    toggleVisible(v) {
+        this.scope.ngShow = v;
+    }
+}
+
+/**
+ * @ngdoc directive
+ * @module apps.authoring.suggest
+ * @name sd-suggest
+ * @requires suggest
+ * @param {Boolean} ngShow ngShow determines the visibility of the directive.
+ * @description SuggestDirective operates the live suggestions panel that appears
+ * to the left of the authoring component.
+ */
+export default function SuggestDirective(suggest) {
+    return {
+        scope: {ngShow: '='},
+        template: require('./SuggestView.html'),
+        controller: SuggestController,
+        controllerAs: 'ctrl',
+        link: (scope, elem) => new LinkFunction(suggest, scope, elem)
+    };
+}
+
+SuggestDirective.$inject = ['suggest'];

--- a/scripts/apps/authoring/suggest/SuggestService.js
+++ b/scripts/apps/authoring/suggest/SuggestService.js
@@ -1,7 +1,7 @@
 /**
  * @ngdoc service
  * @module apps.authoring.suggest
- * @name SuggestService
+ * @name suggest
  * @requires api
  * @requires autosave
  * @description SuggestService handles the retrieval and synchronisation of live
@@ -15,19 +15,19 @@ export default class SuggestService {
 
         /**
          * @ngdoc property
-         * @name SuggestService#active
+         * @name suggest#active
          * @type {Boolean}
          * @private
          * @description Active reflects whether the service and panel are active
          * (visible) if true. Should not be set directly, instead, use
-         * SuggestService#setActive method.
-         * @see SuggestService#setActive
+         * suggest#setActive method.
+         * @see suggest#setActive
          */
         this.active = false;
 
         /**
          * @ngdoc property
-         * @name SuggestService#_listener
+         * @name suggest#_listener
          * @type {Function}
          * @private
          * @description Holds the function that will be called when new suggestions
@@ -38,7 +38,7 @@ export default class SuggestService {
 
      /**
       * @ngdoc method
-      * @name SuggestService#_get
+      * @name suggest#_get
       * @param {(Array|Object)} item Array of items or item.
       * @returns {Promise} If resolved, suggestions were obtained successfully,
       * and all listeners were triggered.
@@ -63,7 +63,7 @@ export default class SuggestService {
 
     /**
      * @ngdoc method
-     * @name SuggestService#_triggerListeners
+     * @name suggest#_triggerListeners
      * @param {Array} list List of items received from server.
      * @private
      * @description Triggers registered listeners.
@@ -74,7 +74,7 @@ export default class SuggestService {
 
     /**
      * @ngdoc method
-     * @name SuggestService#onUpdate
+     * @name suggest#onUpdate
      * @param {Function} func The function to trigger on update.
      * @description Registers the function to be called when new suggestions are
      * received. The current implementation will only use one function. On subsequent
@@ -86,7 +86,7 @@ export default class SuggestService {
 
     /**
      * @ngdoc method
-     * @name SuggestService#setActive
+     * @name suggest#setActive
      * @param {Boolean} active When set to true, the service is set to active.
      * @description setActive sets the active state of the service.
      */
@@ -96,9 +96,11 @@ export default class SuggestService {
 
     /**
      * @ngdoc method
-     * @name SuggestService#trigger
+     * @name suggest#trigger
      * @param {Object} item The item to trigger live suggestions for.
      * @param {Object} orig The original, unmodified item.
+     * @description Triggers the auto-suggest functionality. It will cause an autosave,
+     * followed by a request for suggestions.
      */
     trigger(item, orig) {
         if (!angular.isObject(item) || !this.active) {

--- a/scripts/apps/authoring/suggest/SuggestService.js
+++ b/scripts/apps/authoring/suggest/SuggestService.js
@@ -1,6 +1,6 @@
 /**
  * @ngdoc service
- * @module apps.authoring.suggest
+ * @module superdesk.apps.authoring
  * @name suggest
  * @requires api
  * @requires autosave

--- a/scripts/apps/authoring/suggest/SuggestService.js
+++ b/scripts/apps/authoring/suggest/SuggestService.js
@@ -1,0 +1,111 @@
+/**
+ * @ngdoc service
+ * @module apps.authoring.suggest
+ * @name SuggestService
+ * @requires api
+ * @requires autosave
+ * @description SuggestService handles the retrieval and synchronisation of live
+ * suggest data. Users may use this service to trigger refreshes within the live
+ * suggestions panel, as well as set it as active or inactive.
+ */
+export default class SuggestService {
+    constructor(api, autosave) {
+        this.autosave = autosave;
+        this.api = api;
+
+        /**
+         * @ngdoc property
+         * @name SuggestService#active
+         * @type {Boolean}
+         * @private
+         * @description Active reflects whether the service and panel are active
+         * (visible) if true. Should not be set directly, instead, use
+         * SuggestService#setActive method.
+         * @see SuggestService#setActive
+         */
+        this.active = false;
+
+        /**
+         * @ngdoc property
+         * @name SuggestService#_listener
+         * @type {Function}
+         * @private
+         * @description Holds the function that will be called when new suggestions
+         * have been received.
+         */
+        this._listener = data => {};
+    }
+
+     /**
+      * @ngdoc method
+      * @name SuggestService#_get
+      * @param {(Array|Object)} item Array of items or item.
+      * @returns {Promise} If resolved, suggestions were obtained successfully,
+      * and all listeners were triggered.
+      * @private
+      * @description Requests a list of suggestions from the server and triggers
+      * all listeners on success.
+      */
+    _get(item) {
+        let isArray = Array.isArray(item) && item.length > 0;
+        let isObject = angular.isObject(item) && item.hasOwnProperty('_id');
+
+        if (!isArray && !isObject) {
+            return;
+        }
+
+        let id = isArray ? item[0]._id : item._id;
+
+        return this.api
+            .get(`suggestions/${id}`)
+            .then(this._triggerListeners.bind(this));
+    }
+
+    /**
+     * @ngdoc method
+     * @name SuggestService#_triggerListeners
+     * @param {Array} list List of items received from server.
+     * @private
+     * @description Triggers registered listeners.
+     */
+    _triggerListeners(list) {
+        this._listener(list);
+    }
+
+    /**
+     * @ngdoc method
+     * @name SuggestService#onUpdate
+     * @param {Function} func The function to trigger on update.
+     * @description Registers the function to be called when new suggestions are
+     * received. The current implementation will only use one function. On subsequent
+     * calls, it will be overwritten.
+     */
+    onUpdate(func) {
+        this._listener = func;
+    }
+
+    /**
+     * @ngdoc method
+     * @name SuggestService#setActive
+     * @param {Boolean} active When set to true, the service is set to active.
+     * @description setActive sets the active state of the service.
+     */
+    setActive(active = true) {
+        this.active = !!active; // force bool
+    }
+
+    /**
+     * @ngdoc method
+     * @name SuggestService#trigger
+     * @param {Object} item The item to trigger live suggestions for.
+     * @param {Object} orig The original, unmodified item.
+     */
+    trigger(item, orig) {
+        if (!angular.isObject(item) || !this.active) {
+            return;
+        }
+        this.autosave.save(item, orig, 0).then(this._get.bind(this));
+    }
+}
+
+SuggestService.$inject = ['api', 'autosave'];

--- a/scripts/apps/authoring/suggest/SuggestView.html
+++ b/scripts/apps/authoring/suggest/SuggestView.html
@@ -1,0 +1,80 @@
+<div class="live-suggest">
+	<div ng-show="showItem === null" class="item-list">
+		<div class="live-suggest__header subnav">
+			<h3 class="subnav__page-title">Live Suggestions</h3>
+			<a class="close" ng-click="ctrl.close()"><i class="icon-close-small"></i></a>
+		</div>
+		<div class="live-suggest__body">
+			<h6 class="no-suggestions" ng-hide="items">Suggestions will appear here once the article's body starts changing...</h6>
+			<ul sd-list-view class="list-view compact-view" data-items="items" ng-show="items">
+				<li class="media-box" ng-click="ctrl.showItem(item)">
+					<div class="line item-info">
+						<i sd-filetype-icon data-item="item"></i>
+						<span class="keyword">{{ item.slugline || '-' }}</span>
+						<span class="word-count">
+							<b>{{ item.word_count || 0 }}</b>
+							<span translate translate-n="item.word_count" translate-plural="WORDS">
+								WORD
+							</span>
+						</span>
+						<div class="item-info__right">
+							<label translate>Created</label>&nbsp;
+							<span class="date" sd-datetime data="item.firstcreated"></span>&nbsp;
+							<label translate>by</label>
+							&nbsp;{{ctrl.displayName(item.original_creator)}}
+						</div>
+					</div>
+					<div class="info">
+						<b>{{ item.headline }}</b>
+						<span ng-show="item.duedate">
+							<i class="icon-desk-time"></i>{{item.duedate}}
+						</span>
+						<span ng-show="item.tasks">
+							<i class="icon-desk-task"></i>{{item.tasks}}
+						</span>
+						<span ng-show="item.attachments">
+							<i class="icon-desk-attach"></i>{{item.attachments}}
+						</span>
+						<span ng-show="item.links">
+							<i class="icon-desk-link"></i>{{item.links}}
+						</span>
+						<span ng-show="item.comments">
+							<i class="icon-desk-comments"></i>{{item.comments}}
+						</span>
+						<div sd-html-preview="item.body_html"></div>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</div>
+
+	<div ng-show="showItem !== null" class="item-details">
+		<div class="live-suggest__header subnav">
+			<h3 class="subnav__page-title" ng-click="ctrl.hideItem()">
+				<i class="backlink black">Back</i>
+			</h3>
+			<a class="close" ng-click="ngShow = false"><i class="icon-close-small"></i></a>
+		</div>
+		<div class="item-details__body">
+			<div class="line item-info">
+				<i sd-filetype-icon data-item="showItem"></i>
+				<span class="keyword">{{ showItem.slugline || '-' }}</span>
+				<span class="word-count">
+					<b>{{ showItem.word_count || 0 }}</b>
+					<span translate translate-n="showItem.word_count" translate-plural="WORDS">
+						WORD
+					</span>
+				</span>
+				<div class="item-info__right">
+					<label translate>Created</label>
+					<span class="date" sd-datetime data="showItem.firstcreated"></span>
+					<label translate>by</label>
+					{{ctrl.displayName(showItem.original_creator)}}
+				</div>
+			</div>
+			<h3 class="headline">{{ showItem.headline }}</h3>
+			<div class="abstract" sd-html-preview="showItem.abstract"></div>
+			<div class="body" sd-html-preview="showItem.body_html"></div>
+		</div>
+	</div>
+</div>

--- a/scripts/apps/authoring/suggest/index.js
+++ b/scripts/apps/authoring/suggest/index.js
@@ -1,0 +1,16 @@
+import './styles.scss';
+
+import SuggestService from './SuggestService';
+import SuggestDirective from './SuggestDirective';
+
+/**
+ * @ngdoc module
+ * @module apps.authoring.suggest
+ * @name apps.authoring.suggest
+ * @packageName apps
+ * @description The suggest module enriches the authoring component with live
+ * suggest functionality.
+ */
+export default angular.module('superdesk.apps.authoring.suggest', [])
+    .service('suggest', SuggestService)
+    .directive('sdSuggest', SuggestDirective);

--- a/scripts/apps/authoring/suggest/styles.scss
+++ b/scripts/apps/authoring/suggest/styles.scss
@@ -1,0 +1,131 @@
+@import '~variables.scss';
+@import '~mixins.scss';
+
+$panel-width: 600px;
+
+sd-suggest {
+	box-sizing: border-box;
+	max-width: $panel-width;
+	width: 100%;
+	border: 1px solid rgba(0,0,0,0.25);
+	z-index: 100;
+	background: #fff;
+	position: absolute;
+	top: 47px;
+	left: -$panel-width;
+	height: 100%;
+	padding: 48px 0 0;
+	overflow-x: scroll;
+	@include box-shadow(-2px -7px 5px 0 rgba(0,0,0,0.25));
+
+	h6.no-suggestions {
+		padding: 15px 18px;
+	}
+
+	label {
+		display: inline-block;
+	}
+
+	.live-suggest {
+		&__header {
+			top:0;
+			background: #fff;
+
+			h3 {color: $sd-text-label;}
+
+			.close i:before {
+				cursor: pointer;
+				font-weight: bold;
+				color: #000;
+				position: relative;
+				top: 13px;
+				right: 18px;
+			}
+		}
+
+		&__body {
+			.list-view {
+				height: 65%;
+				padding: 0;
+				overflow-x: scroll;
+				box-shadow: none;
+
+				.list-item-view.active .media-box {
+					&:hover {
+						background-color: #f4f4f4 !important;
+					}
+					background-color: transparent !important;
+					border-right: none !important;
+				}
+
+				.media-box {
+					padding: 0 18px 10px;
+
+					.item-info {
+						padding: 10px 0 5px;
+					}
+				}
+			}
+		}
+	}
+
+	.item-info {
+		padding: 10px 0 5px;
+
+		label {
+			color: $sd-text-label;
+		}
+
+		&__right {
+			float: right;
+		}
+
+		&:hover {
+			padding: 10px 0 5px;
+		}
+	}
+
+	i[sd-filetype-icon] {
+		color: $grayLight;
+		width: 17px;
+		position: relative;
+		top: 3px;
+	}
+
+	.keyword {
+		color: $sd-keyword;
+		text-transform: uppercase;
+		font-weight: bold;
+		font-size: 12px;
+		margin-right: 10px;
+	}
+
+	.word-count span {
+		color: $sd-text-label;
+		font-size: 12px;
+		font-weight: bold;
+	}
+
+	.item-details {
+	    i.backlink {
+			cursor: pointer;
+			line-height: 28px;
+			font-size: 0.7em;
+			font-style: normal;
+			padding-left: 35px;
+			margin-top: 0px;
+	    }	    
+
+	    .headline {
+		    margin: 13px 0 0;
+	    }
+
+	    .abstract {
+		    margin: 10px 0;
+	    }
+
+	    &__body {
+		    padding: 0 18px;
+	    }
+	}
+}

--- a/scripts/apps/authoring/suggest/suggest.spec.js
+++ b/scripts/apps/authoring/suggest/suggest.spec.js
@@ -1,0 +1,116 @@
+const testItems = [
+    {
+        _id: 1,
+        slugline: 'slugline',
+        word_count: 10,
+        firstcreated: 'ddmmyy',
+        original_creator: 'john',
+        headline: 'headline',
+        duedate: 'due-ddmmyy',
+        tasks: 'tasks',
+        attachements: 'attachements',
+        links: 'links',
+        comments: ['a', 'b'],
+        body_html: 'body'
+    }, {
+        _id: 2,
+        slugline: 'slugline2',
+        word_count: 11,
+        firstcreated: 'ddmmyy2',
+        original_creator: 'jim',
+        headline: 'headline2',
+        duedate: 'due-ddmmyy2',
+        tasks: 'tasks2',
+        attachements: 'attachements2',
+        links: 'links2',
+        comments: ['a2', 'b2'],
+        body_html: 'body2'
+    }
+];
+
+describe('suggest', function() {
+    beforeEach(window.module('superdesk.core.api'));
+    beforeEach(window.module('superdesk.apps.authoring.autosave'));
+    beforeEach(window.module('superdesk.apps.authoring.suggest'));
+
+    it('should initialize as inactive', inject(suggest => {
+        expect(suggest.active).toBe(false);
+    }));
+
+    it('should correctly set active state', inject(suggest => {
+        expect(suggest.active).toBe(false);
+        suggest.setActive();
+        expect(suggest.active).toBe(true);
+    }));
+
+    it('should not autosave on trigger when inactive', inject((suggest, autosave) => {
+        spyOn(autosave, 'save');
+
+        suggest.setActive(false);
+        suggest.trigger(testItems[0], testItems[0]);
+
+        expect(autosave.save).not.toHaveBeenCalled();
+    }));
+
+    it('should autosave on trigger when active', inject((suggest, autosave, $q) => {
+        spyOn(autosave, 'save').and.returnValue($q.reject());
+
+        suggest.setActive(true);
+        suggest.trigger(testItems[0], testItems[1]);
+
+        expect(autosave.save.calls.count()).toBe(1);
+        expect(autosave.save).toHaveBeenCalledWith(testItems[0], testItems[1], 0);
+    }));
+
+    it('should get suggestions when triggered', inject((suggest, autosave, $q, api, $rootScope) => {
+        let item = testItems[0];
+
+        spyOn(autosave, 'save').and.returnValue($q.when(item));
+        spyOn(api, 'get').and.returnValue($q.reject());
+
+        suggest.setActive();
+        suggest.trigger(item, item);
+
+        $rootScope.$digest();
+
+        expect(api.get.calls.count()).toBe(1);
+        expect(api.get).toHaveBeenCalledWith(`suggestions/${item._id}`);
+    }));
+
+    it('should get suggestion of first item in array when triggered',
+        inject((suggest, autosave, $q, api, $rootScope) => {
+            let item = testItems[0];
+
+            spyOn(autosave, 'save').and.returnValue($q.when(testItems));
+            spyOn(api, 'get').and.returnValue($q.reject());
+
+            suggest.setActive();
+            suggest.trigger(item, item);
+
+            $rootScope.$digest();
+
+            expect(api.get.calls.count()).toBe(1);
+            expect(api.get).toHaveBeenCalledWith(`suggestions/${item._id}`);
+        })
+    );
+
+    it('should trigger listeners on success', inject((suggest, autosave, $q, api, $rootScope) => {
+        let item = testItems[0];
+        let response = null;
+
+        spyOn(autosave, 'save').and.returnValue($q.when(testItems));
+        spyOn(api, 'get').and.returnValue($q.when('return value'));
+        spyOn(suggest, 'onUpdate').and.callThrough();
+
+        suggest.setActive();
+        suggest.onUpdate(v => {
+            response = v;
+        });
+        suggest.trigger(item, item);
+
+        $rootScope.$digest();
+
+        expect(suggest.onUpdate.calls.count()).toBe(1);
+        expect(response).toBe('return value');
+    }));
+});

--- a/scripts/apps/authoring/views/authoring-container.html
+++ b/scripts/apps/authoring/views/authoring-container.html
@@ -1,4 +1,5 @@
 <div class="authoring-embedded" ng-class="authoring.state">
+    <sd-suggest ng-show="authoring.showingSuggestions" />
     <div class="embedded-auth-view" ng-if="authoring.item">
         <div sd-authoring-embedded data-item="authoring.item" data-action="authoring.action"></div>
     </div>

--- a/scripts/apps/authoring/views/authoring-container.html
+++ b/scripts/apps/authoring/views/authoring-container.html
@@ -1,5 +1,5 @@
 <div class="authoring-embedded" ng-class="authoring.state">
-    <sd-suggest ng-show="authoring.showingSuggestions" />
+    <sd-suggest ng-show="authoring.showingSuggestions"></sd-suggest>
     <div class="embedded-auth-view" ng-if="authoring.item">
         <div sd-authoring-embedded data-item="authoring.item" data-action="authoring.action"></div>
     </div>

--- a/scripts/apps/authoring/views/authoring-topbar.html
+++ b/scripts/apps/authoring/views/authoring-topbar.html
@@ -138,7 +138,13 @@
                   </li>
                 </ul>
 
-                <ul><li><button type="button" ng-click="openSuggestions()" translate>Live suggestions</button></li></ul>
+                <ul>
+                  <li>
+                    <button type="button" ng-click="openSuggestions()" class="live-suggest-menu-item" translate>
+                      Live suggestions
+                    </button>
+                  </li>
+                </ul>
 
                 <ul id="multiedit" ng-if="item.task.desk && itemActions.multi_edit && !isLocked()" ng-show="action !== 'kill'">
                     <li>

--- a/scripts/apps/authoring/views/authoring-topbar.html
+++ b/scripts/apps/authoring/views/authoring-topbar.html
@@ -138,6 +138,8 @@
                   </li>
                 </ul>
 
+                <ul><li><button type="button" ng-click="openSuggestions()" translate>Live suggestions</button></li></ul>
+
                 <ul id="multiedit" ng-if="item.task.desk && itemActions.multi_edit && !isLocked()" ng-show="action !== 'kill'">
                     <li>
                     <div class="dropdown multiedit-toggle" dropdown>

--- a/spec/authoring_spec.js
+++ b/spec/authoring_spec.js
@@ -303,7 +303,7 @@ describe('authoring', function() {
         ctrlShiftKey('e');
         browser.sleep(300);
 
-        expect(element(by.className('authoring-embedded')).isDisplayed()).toBe(false);
+        expect(element.all(by.css('.authoring-embedded .embedded-auth-view')).count()).toBe(0);
     });
 
     it('can display monitoring after publishing an item using full view of authoring', function () {

--- a/spec/helpers/authoring.js
+++ b/spec/helpers/authoring.js
@@ -441,27 +441,30 @@ function Authoring() {
         });
     };
 
-    this.markForHighlights = function() {
+    function openAuthoringDropdown() {
         var toggle = element(by.id('authoring-extra-dropdown')).element(by.className('icon-dots-vertical'));
-
-        browser.wait(function() {
-            return toggle.isDisplayed();
-        });
-
+        browser.wait(toggle.isDisplayed);
         toggle.click();
+    }
+
+    this.markForHighlights = function() {
+        openAuthoringDropdown();
         browser.actions().mouseMove(element(by.css('.highlights-toggle .dropdown-toggle'))).perform();
     };
 
     this.toggleAutoSpellCheck = function() {
-        var toggle = element(by.id('authoring-extra-dropdown')).element(by.className('icon-dots-vertical'));
-
-        browser.wait(function() {
-            return toggle.isDisplayed();
-        });
-
-        toggle.click();
+        openAuthoringDropdown();
         element(by.model('spellcheckMenu.isAuto')).click();
     };
+
+    this.openLiveSuggest = function() {
+        openAuthoringDropdown();
+        element(by.css('.live-suggest-menu-item')).click();
+    };
+
+    this.getSuggestedItems = function() {
+        return element.all(by.css('sd-suggest ul[sd-list-view] > li.list-item-view'));
+    }
 
     this.getSubnav = function() {
         return element(by.id('subnav'));

--- a/spec/helpers/authoring.js
+++ b/spec/helpers/authoring.js
@@ -443,7 +443,9 @@ function Authoring() {
 
     function openAuthoringDropdown() {
         var toggle = element(by.id('authoring-extra-dropdown')).element(by.className('icon-dots-vertical'));
-        browser.wait(toggle.isDisplayed);
+        browser.wait(function() {
+            return toggle.isDisplayed();
+        });
         toggle.click();
     }
 
@@ -464,7 +466,7 @@ function Authoring() {
 
     this.getSuggestedItems = function() {
         return element.all(by.css('sd-suggest ul[sd-list-view] > li.list-item-view'));
-    }
+    };
 
     this.getSubnav = function() {
         return element(by.id('subnav'));

--- a/spec/suggest_spec.js
+++ b/spec/suggest_spec.js
@@ -1,0 +1,15 @@
+var authoring = require('./helpers/authoring'),
+    monitoring = require('./helpers/monitoring');
+
+// Live Suggest feature spec
+describe('suggest', function() {
+    beforeEach(function() {
+        monitoring.openMonitoring();
+    });
+
+    it('should open with 0 items', function() {
+        authoring.createTextItem();
+        authoring.openLiveSuggest();
+        expect(authoring.getSuggestedItems().count()).toBe(0);
+    });
+});

--- a/tasks/options/clean.js
+++ b/tasks/options/clean.js
@@ -13,13 +13,5 @@ module.exports = {
     },
     server: {
         files: '<%= tmpDir %>'
-    },
-    bower: {
-        files: [{
-            src: [
-                '<%= bowerDir %>/scripts/templates-cache.js',
-                '<%= bowerDir %>/scripts/superdesk.js'
-            ]
-        }]
     }
 };


### PR DESCRIPTION
Based on [design](https://wiki.sourcefabric.org/display/NR/Live+Suggestions) from Wiki. The button that enables the feature is found in the _triple-dot_ menu at the top right of any open authoring item.

In this PR:
- new module `apps.authoring.suggest`
- new directive `sd-suggest`
- new service `suggest` for controlling and interacting with live suggestions.
- unit tests
- e2e helper functions and initial test

Backend in progress at https://github.com/superdesk/superdesk-core/pull/609
