### PR TITLE
[SD-5554] - Search results are increasing exponentially after each scroll

### DIFF
--- a/scripts/apps/monitoring/directives/MonitoringGroup.js
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.js
@@ -241,13 +241,12 @@ export function MonitoringGroup(cards, api, authoringWorkspace, $timeout, superd
 
             /**
              * Schedule content reload after some delay
-             *
-             * In case it gets called multiple times it will query only once
              */
             function scheduleQuery(event, data) {
                 if (!queryTimeout) {
+                    // Run the first query immediately and block the others for 1 sec
+                    queryItems(event, data);
                     queryTimeout = $timeout(function() {
-                        queryItems(event, data);
                         scope.$applyAsync(function() {
                             // ignore any updates requested in current $digest
                             queryTimeout = null;


### PR DESCRIPTION
In search results page, every scroll  duplicated the amount of results to be fetched. After 5 scrolls user gets around 1600 results.

- A bug that left `criteria.source.size` accumulating has been fixed
- Ingest: update event has been suppressed if scroll position is not at the top
- Made changes to run the first `_queryItems` immediately but make the subsequent ones to wait for a sometime 