### PR TITLE
fix(search-results) - Reverted the queryItems changes

### DIFF
--- a/scripts/apps/monitoring/directives/MonitoringGroup.js
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.js
@@ -243,9 +243,8 @@ export function MonitoringGroup(cards, api, authoringWorkspace, $timeout, superd
              */
             function scheduleQuery(event, data) {
                 if (!queryTimeout) {
-                    // Run the first query immediately and block the others for 1 sec
-                    queryItems(event, data);
                     queryTimeout = $timeout(function() {
+                        queryItems(event, data);
                         scope.$applyAsync(function() {
                             // ignore any updates requested in current $digest
                             queryTimeout = null;

--- a/scripts/apps/search/directives/SearchResults.js
+++ b/scripts/apps/search/directives/SearchResults.js
@@ -147,9 +147,8 @@ export function SearchResults(
              */
             function queryItems(event, data) {
                 if (!nextUpdate) {
-                    // Run the first query immediately and block the others for 1 sec
-                    _queryItems(event, data);
                     nextUpdate = $timeout(function() {
+                        _queryItems(event, data);
                         scope.$applyAsync(function() {
                             nextUpdate = null; // reset for next $digest
                         });


### PR DESCRIPTION
Reverting the change I have done to improve the query behavior. We saw few problems during UAT testing that this change affected the results reflected on the list. For instance an item duplicate action took longer than the query so the results were not visible until the next query runs.
