### PR TITLE
fix(monitoring) - schedule fetchNext to avoid multiple calls on scrol…

### DIFF
--- a/scripts/apps/monitoring/directives/MonitoringGroup.js
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.js
@@ -167,7 +167,9 @@ export function MonitoringGroup(cards, api, authoringWorkspace, $timeout, superd
 
             scope.$on('render:next', function(event) {
                 scope.$applyAsync(function() {
-                    scope.fetchNext(scope.items._items.length);
+                    if (scope.items) {
+                        scope.fetchNext(scope.items._items.length);
+                    }
                 });
             });
 
@@ -272,9 +274,8 @@ export function MonitoringGroup(cards, api, authoringWorkspace, $timeout, superd
              */
             function scheduleQuery(event, data) {
                 if (!queryTimeout) {
-                    // Run the first query immediately and block the others for 1 sec
-                    queryItems(event, data);
                     queryTimeout = $timeout(function() {
+                        queryItems(event, data);
                         scope.$applyAsync(function() {
                             // ignore any updates requested in current $digest
                             queryTimeout = null;

--- a/scripts/apps/monitoring/directives/MonitoringView.js
+++ b/scripts/apps/monitoring/directives/MonitoringView.js
@@ -73,9 +73,24 @@ export function MonitoringView($rootScope, authoringWorkspace, pageTitle, $timeo
              * Trigger render in case user scrolls to the very end of list
              */
             function renderIfNeeded($event) {
-                if (isListEnd($event.currentTarget)) {
-                    scope.rendering = scope.loading = true;
-                    scope.$broadcast('render:next');
+                if (scope.viewColumn && isListEnd($event.currentTarget)) {
+                    scheduleFetchNext();
+                }
+            }
+
+            let fetchNextTimeout;
+
+            /**
+             * Schedule content fetchNext after some delay
+             */
+            function scheduleFetchNext() {
+                if (!fetchNextTimeout) {
+                    fetchNextTimeout = $timeout(function() {
+                        scope.$broadcast('render:next');
+                        scope.$applyAsync(function() {
+                            fetchNextTimeout = null;
+                        });
+                    }, 1000, false);
                 }
             }
 

--- a/scripts/apps/search/directives/SearchResults.js
+++ b/scripts/apps/search/directives/SearchResults.js
@@ -147,9 +147,9 @@ export function SearchResults(
              */
             function queryItems(event, data) {
                 if (!nextUpdate) {
-                    // Run the first query immediately and block the others for 1 sec
-                    _queryItems(event, data);
+                    scope.loading = true;
                     nextUpdate = $timeout(function() {
+                        _queryItems(event, data);
                         scope.$applyAsync(function() {
                             nextUpdate = null; // reset for next $digest
                         });


### PR DESCRIPTION
…s revert change in schedule queryItems
- schedule fetchNext to avoid multiple calls on monitoring view scroll.
- plus revert changes related to schedule queryItems, as just duplicated item not showing immediately (requires some delay to queryItems)