### PR TITLE
fix(search-results) - Single item query is made to run once

### DIFF
--- a/scripts/apps/search/directives/SearchResults.js
+++ b/scripts/apps/search/directives/SearchResults.js
@@ -163,6 +163,7 @@ export function SearchResults(
             function _queryItems(event, data) {
                 criteria = search.query($location.search()).getCriteria(true);
                 criteria.source.size = 50;
+                var originalQuery;
 
                 // when forced refresh or query then keep query size default as set 50 above.
                 if (!(data && data.force)) {
@@ -174,6 +175,7 @@ export function SearchResults(
 
                 if (data && data.items && scope.showRefresh && !data.force) {
                     // if we know the ids of the items then try to fetch those only
+                    originalQuery = angular.extend({}, criteria.source.query);
                     criteria.source.query = search.getItemQuery(data.items);
                 }
 
@@ -206,6 +208,9 @@ export function SearchResults(
                     }
                 }).finally(function() {
                     scope.loading = false;
+                    if (originalQuery) {
+                        criteria.source.query = originalQuery;
+                    }
                 });
             }
 


### PR DESCRIPTION
- After a content:update event is triggered, a singleItem query is executed but then the original query needs to be recovered for fetching next items to continue