### PR TITLE
[SD-303] - Desk and Fetched desk fields are separated

### DIFF
--- a/scripts/apps/search/directives/ItemList.js
+++ b/scripts/apps/search/directives/ItemList.js
@@ -28,7 +28,8 @@ const DEFAULT_LIST_CONFIG = {
         'category',
         'provider',
         'expiry',
-        'desk'
+        'desk',
+        'fetchedDesk'
     ]
 };
 
@@ -1030,10 +1031,14 @@ export function ItemList(
                 },
 
                 desk: function(props) {
+                    if (!props.item.archived) {
+                        return React.createElement(ItemContainer, {item: props.item, desk: props.desk, key: 'desk'});
+                    }
+                },
+
+                fetchedDesk: function(props) {
                     if (props.item.archived) {
                         return React.createElement(FetchedDesksInfo, {item: props.item, key: 'desk'});
-                    } else {
-                        return React.createElement(ItemContainer, {item: props.item, desk: props.desk, key: 'desk'});
                     }
                 },
 


### PR DESCRIPTION
Separated Fetched Desk and Desk in content list..
- Fetched desk information is creating a new query per item which is affecting the performance.
- Desk information is grabbed from the item so that doesn't have performance impact. Also users require that information.

NTB or master instance shouldn't get affected by this.
