### PR TITLE
Removed suggest sub-module from documentation

### DIFF
--- a/scripts/apps/authoring/suggest/index.js
+++ b/scripts/apps/authoring/suggest/index.js
@@ -3,14 +3,6 @@ import './styles.scss';
 import SuggestService from './SuggestService';
 import SuggestDirective from './SuggestDirective';
 
-/**
- * @ngdoc module
- * @module apps.authoring.suggest
- * @name apps.authoring.suggest
- * @packageName apps
- * @description The suggest module enriches the authoring component with live
- * suggest functionality.
- */
 export default angular.module('superdesk.apps.authoring.suggest', [])
     .service('suggest', SuggestService)
     .directive('sdSuggest', SuggestDirective);


### PR DESCRIPTION
This module needs not be documented because it is considered part of `authoring`