### PR TITLE
fix(vocabularies) Cache the vocabularies to reduce the api calls

### DIFF
--- a/scripts/apps/archive/tests/archive.spec.js
+++ b/scripts/apps/archive/tests/archive.spec.js
@@ -7,6 +7,7 @@ describe('content', function() {
     beforeEach(window.module('superdesk.mocks'));
     beforeEach(window.module('superdesk.archive'));
     beforeEach(window.module('superdesk.publish'));
+    beforeEach(window.module('superdesk.vocabularies'));
 
     beforeEach(window.module(function($provide) {
         $provide.constant('config', {

--- a/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.spec.js
+++ b/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.spec.js
@@ -2,6 +2,7 @@
 describe('item association directive', function() {
     beforeEach(window.module('superdesk.authoring'));
     beforeEach(window.module('superdesk.templates-cache'));
+    beforeEach(window.module('superdesk.vocabularies'));
 
     var elem, scope, item = {};
 

--- a/scripts/apps/authoring/metadata/metadata.js
+++ b/scripts/apps/authoring/metadata/metadata.js
@@ -931,8 +931,8 @@ function MetaLocatorsDirective() {
     };
 }
 
-MetadataService.$inject = ['api', '$q', 'subscribersService', 'config'];
-function MetadataService(api, $q, subscribersService, config) {
+MetadataService.$inject = ['api', '$q', 'subscribersService', 'config', 'vocabularies'];
+function MetadataService(api, $q, subscribersService, config, vocabularies) {
     var service = {
         values: {},
         cvs: [],
@@ -947,7 +947,7 @@ function MetadataService(api, $q, subscribersService, config) {
         _priorityByValue: {},
         fetchMetadataValues: function() {
             var self = this;
-            return api.query('vocabularies', {max_results: 50}).then(function(result) {
+            return vocabularies.getAllActiveVocabularies().then(function(result) {
                 _.each(result._items, function(vocabulary) {
                     self.values[vocabulary._id] = vocabulary.items;
                 });

--- a/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.js
+++ b/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.js
@@ -11,6 +11,7 @@ describe('MetadataWidgetCtrl controller', function () {
     beforeEach(window.module('superdesk.ui'));
     beforeEach(window.module('superdesk.filters'));
     beforeEach(window.module('superdesk.authoring.metadata'));
+    beforeEach(window.module('superdesk.vocabularies'));
 
     beforeEach(window.module(function($provide) {
         $provide.constant('config', {
@@ -131,6 +132,7 @@ describe('metadata terms directive', function() {
     beforeEach(window.module('superdesk.filters'));
     beforeEach(window.module('superdesk.publish'));
     beforeEach(window.module('superdesk.authoring.metadata'));
+    beforeEach(window.module('superdesk.vocabularies'));
 
     beforeEach(inject(function (_$rootScope_, _$compile_) {
         $rootScope = _$rootScope_;

--- a/scripts/apps/authoring/tests/authoring.spec.js
+++ b/scripts/apps/authoring/tests/authoring.spec.js
@@ -22,6 +22,7 @@ describe('authoring', function() {
     beforeEach(window.module('superdesk.privileges'));
     beforeEach(window.module('superdesk.desks'));
     beforeEach(window.module('superdesk.templates-cache'));
+    beforeEach(window.module('superdesk.vocabularies'));
 
     beforeEach(inject(function($window) {
         $window.onbeforeunload = angular.noop;
@@ -404,6 +405,7 @@ describe('cropImage', function() {
     beforeEach(window.module('superdesk.authoring'));
     beforeEach(window.module('superdesk.mocks'));
     beforeEach(window.module('superdesk.templates-cache'));
+    beforeEach(window.module('superdesk.vocabularies'));
 
     it('can change button label for apply/edit crop',
     inject(function($rootScope, $compile, $q, metadata) {
@@ -1987,6 +1989,7 @@ describe('send item directive', function() {
     beforeEach(window.module('superdesk.authoring'));
     beforeEach(window.module('superdesk.templates-cache'));
     beforeEach(window.module('superdesk.api'));
+    beforeEach(window.module('superdesk.vocabularies'));
 
     beforeEach(inject(function($templateCache) {
         $templateCache.put('scripts/apps/authoring/views/send-item.html', '');

--- a/scripts/apps/monitoring/tests/monitoring.spec.js
+++ b/scripts/apps/monitoring/tests/monitoring.spec.js
@@ -3,6 +3,7 @@ describe('monitoring', function() {
 
     beforeEach(window.module('superdesk.monitoring'));
     beforeEach(window.module('superdesk.mocks'));
+    beforeEach(window.module('superdesk.vocabularies'));
 
     it('can preview an item', inject(function($controller, $rootScope) {
         var scope = $rootScope.$new(),

--- a/scripts/apps/users/tests/sdUserPreferences.spec.js
+++ b/scripts/apps/users/tests/sdUserPreferences.spec.js
@@ -12,6 +12,7 @@ describe('sdUserPreferences directive', function() {
     beforeEach(window.module('superdesk.filters'));
     beforeEach(window.module('superdesk.templates-cache'));
     beforeEach(window.module('superdesk.publish'));
+    beforeEach(window.module('superdesk.vocabularies'));
 
     beforeEach(inject(function (
         $rootScope, $compile, $q, metadata, preferencesService, session, userList

--- a/scripts/apps/vocabularies/services/VocabularyService.js
+++ b/scripts/apps/vocabularies/services/VocabularyService.js
@@ -1,14 +1,51 @@
-VocabularyService.$inject = ['api', '$q', '$filter'];
-export function VocabularyService(api, $q, $filter) {
+/**
+ * @ngdoc service
+ * @module superdesk.apps.vocabularies
+ * @name VocabularyService
+ *
+ * @requires api
+ * @requires $q
+ * @requires $filter
+ * @requires $rootScope
+ *
+ * @description Provides a service to fetch and cache the vocabularies
+ */
+VocabularyService.$inject = ['api', '$q', '$filter', '$rootScope'];
+export function VocabularyService(api, $q, $filter, $rootScope) {
     var service = this;
+    service.AllActiveVocabularies = null;
+    service.vocabularies = null;
 
     /**
-     * Fetches and caches vocabularies or returns them from the cache.
-     *
-     * @returns {Promise}
+     * @ngdoc method
+     * @name VocabularyService#getAllVocabularies
+     * @public
+     * @description Return all of the vocabularies filtered by active items only, either from
+     * the cache or retrieved via an api request
+     * @return {Promise} {Object} vocabularies
+     */
+    this.getAllActiveVocabularies = function() {
+        if (service.AllActiveVocabularies == null) {
+            return api.query('vocabularies', {max_results: 50}).then(
+                function(result) {
+                    service.AllActiveVocabularies = result;
+                    return service.AllActiveVocabularies;
+                }
+            );
+        } else {
+            return $q.when(service.AllActiveVocabularies);
+        }
+    };
+
+    /**
+     * @ngdoc method
+     * @name VocabularyService#getVocabularies
+     * @public
+     * @description Returns the manageable vocabularies.
+     * @return {Promise} {Object} vocabularies
      */
     this.getVocabularies = function() {
-        if (typeof service.vocabularies === 'undefined') {
+        if (service.vocabularies == null) {
             return api.query('vocabularies', {where: {type: 'manageable'}}).then(
                 function(result) {
                     result._items = $filter('sortByName')(result._items, 'display_name');
@@ -20,4 +57,19 @@ export function VocabularyService(api, $q, $filter) {
             return $q.when(service.vocabularies);
         }
     };
+
+    /**
+     * @ngdoc method
+     * @name VocabularyService#_resetVocabularies
+     * @private
+     * @description Clears the cached vocabularies.
+     */
+    this._resetVocabularies = function() {
+        service.AllActiveVocabularies = null;
+        service.vocabularies = null;
+    };
+
+    // reset cache on update
+    $rootScope.$on('vocabularies:updated', angular.bind(this, this._resetVocabularies));
+
 }

--- a/scripts/apps/workspace/content/tests/content.spec.js
+++ b/scripts/apps/workspace/content/tests/content.spec.js
@@ -7,6 +7,7 @@ describe('superdesk.workspace.content', function() {
     beforeEach(window.module('superdesk.desks'));
     beforeEach(window.module('superdesk.templates-cache'));
     beforeEach(window.module('superdesk.workspace.content'));
+    beforeEach(window.module('superdesk.vocabularies'));
 
     describe('content service', function() {
         var done;

--- a/scripts/core/editor/spellcheck/spellcheck.spec.js
+++ b/scripts/core/editor/spellcheck/spellcheck.spec.js
@@ -23,6 +23,7 @@ describe('spellcheck', function() {
     beforeEach(window.module('superdesk.editor'));
     beforeEach(window.module('superdesk.editor.spellcheck'));
     beforeEach(window.module('superdesk.preferences'));
+    beforeEach(window.module('superdesk.vocabularies'));
 
     beforeEach(inject(function(dictionaries, spellcheck, $q, preferencesService) {
 

--- a/scripts/core/editor2/editor.spec.js
+++ b/scripts/core/editor2/editor.spec.js
@@ -10,6 +10,7 @@ describe('text editor', function() {
     beforeEach(window.module('superdesk.config'));
     beforeEach(window.module('superdesk.editor2'));
     beforeEach(window.module('superdesk.editor.spellcheck'));
+    beforeEach(window.module('superdesk.vocabularies'));
 
     beforeEach(function() {
         // remove all elements from body

--- a/scripts/core/editor2/embedCodeHandlers.spec.js
+++ b/scripts/core/editor2/embedCodeHandlers.spec.js
@@ -7,6 +7,7 @@ describe('Embed Code Handlers', function() {
     }));
 
     beforeEach(window.module('superdesk.editor2'));
+    beforeEach(window.module('superdesk.vocabularies'));
 
     beforeEach(inject(function($controller, $rootScope) {
         var element = angular.element('<div></div>');


### PR DESCRIPTION
Each time the metdata tab was selected in the preview pane the vocabularies would be requested, the response may be quite large. 