### PR TITLE
fix(confirmation): Add HTML support to headline and body in confirmation

### DIFF
--- a/scripts/core/views/confirmation-modal.html
+++ b/scripts/core/views/confirmation-modal.html
@@ -1,7 +1,7 @@
 <div class="modal-header">
-    <h3>{{ headerText | translate }}</h3>
+    <h3 ng-bind-html="headerText | translate"></h3>
 </div>
-<div class="modal-body">{{ bodyText | translate }}</div>
+<div class="modal-body" ng-bind-html="bodyText | translate"></div>
 <div class="modal-footer">
     <button class="btn btn--primary" ng-click="ok()">{{ okText | translate }}</button>
     <button class="btn btn--warning" ng-click="cancel()" ng-show="cancelText">{{ cancelText | translate }}</button>


### PR DESCRIPTION
SDESK-309 - Notification message does not render html formatting, showing <tags> instead