### PR TITLE
refactor search providers

### DIFF
--- a/scripts/apps/ingest/controllers/ExternalSourceController.js
+++ b/scripts/apps/ingest/controllers/ExternalSourceController.js
@@ -1,15 +1,19 @@
 ExternalSourceController.$inject = ['api', 'data', 'desks'];
 export function ExternalSourceController(api, data, desks) {
-    return desks.fetchCurrentDeskId().then((deskid) => api(data.item.fetch_endpoint).save({
-        guid: data.item.guid,
-        desk: deskid
-    })
-        .then((response) => {
-            data.item = response;
-            data.item.actioning = angular.extend({}, data.item.actioning, {externalsource: false});
-            return data.item;
-        }, function errorHandler(error) {
-            data.item.error = error;
-            return data.item;
-        }));
+    return desks.fetchCurrentDeskId()
+        .then((deskid) =>
+            api(data.item.fetch_endpoint).save({
+                guid: data.item.guid,
+                desk: deskid,
+                repo: data.item.ingest_provider || null
+            })
+            .then((response) => {
+                data.item = response;
+                data.item.actioning = angular.extend({}, data.item.actioning, {externalsource: false});
+                return data.item;
+            }, (error) => {
+                data.item.error = error;
+                return data.item;
+            })
+        );
 }

--- a/scripts/apps/search-providers/directive.js
+++ b/scripts/apps/search-providers/directive.js
@@ -9,7 +9,11 @@ export default function SearchProviderConfigDirective(searchProviderService, get
 
             searchProviderService.getAllowedProviderTypes().then((providerTypes) => {
                 $scope.providerTypes = providerTypes;
-                $scope.noProvidersAllowed = !Object.keys($scope.providerTypes).length;
+                $scope.noProvidersAllowed = !$scope.providerTypes.length;
+                $scope.providerLabels = {};
+                $scope.providerTypes.forEach((type) => {
+                    $scope.providerLabels[type.search_provider] = type.label;
+                });
             });
 
             /**

--- a/scripts/apps/search-providers/service.js
+++ b/scripts/apps/search-providers/service.js
@@ -1,13 +1,8 @@
 export default function SearchProviderService(providerTypes, $filter, api, allowed) {
     return {
-        getAllowedProviderTypes: function() {
-            return allowed.filterKeys(providerTypes, 'search_providers', 'search_provider');
-        },
-        getSearchProviders: function() {
-            return api.search_providers.query({}).then(
-                (result) => $filter('sortByName')(result._items, 'search_provider')
-            );
-        }
+        getAllowedProviderTypes: () => api.get('search_providers_allowed').then((allowedTypes) => allowedTypes._items),
+        getSearchProviders: () => api.search_providers.query({})
+            .then((result) => $filter('sortByName')(result._items, 'search_provider')),
     };
 }
 

--- a/scripts/apps/search-providers/views/search-provider-config.html
+++ b/scripts/apps/search-providers/views/search-provider-config.html
@@ -10,7 +10,7 @@
         <ul class="pills-list provider-list">
             <li ng-repeat="provider in providers track by provider._id" class="clearfix">
                 <div class="header">
-                    <h6 id="providerType">{{ providerTypes[provider.search_provider] }}</h6>
+                    <h6 id="providerType">{{ providerLabels[provider.search_provider] }}</h6>
                     <span class="label offProvider" ng-if="provider.is_closed" translate>Closed</span>
                     <div class="actions">
                         <button ng-click="edit(provider)" title="{{:: 'Edit Search Provider' | translate }}"><i class="icon-pencil"></i></button>
@@ -49,8 +49,9 @@
 
                 <div class="field">
                     <label for="provider-type" translate>Provider Type</label>
-                    <select id="provider-type" ng-model="provider.search_provider" ng-options="key as val for (key, val) in providerTypes" required>
-                        <option value=""></option>
+                    <select id="provider-type"
+                        ng-model="provider.search_provider"
+                        ng-options="type.search_provider as type.label for type in providerTypes" required>
                     </select>
                 </div>
 

--- a/scripts/apps/search/directives/SearchResults.js
+++ b/scripts/apps/search/directives/SearchResults.js
@@ -13,6 +13,12 @@ SearchResults.$inject = [
     'config'
 ];
 
+const HEX_REG_EXP = /[a-f0-9]{24}/;
+
+function isObjectId(value) {
+    return value.length === 24 && HEX_REG_EXP.test(value);
+}
+
 /**
  * Item list with sidebar preview
  */
@@ -286,6 +292,12 @@ export function SearchResults(
                 if (scope.repo.search && scope.repo.search !== 'local') {
                     provider = scope.repo.search;
                 }
+
+                if (isObjectId(provider)) {
+                    criteria.repo = provider;
+                    provider = 'search_providers_proxy';
+                }
+
                 return provider;
             }
 

--- a/scripts/apps/search/views/item-repo.html
+++ b/scripts/apps/search/views/item-repo.html
@@ -11,7 +11,7 @@
     </div>
     <div ng-repeat="provider in providers track by provider._id">
         <label class="sd-radio">
-            <input type="radio" ng-value="provider.search_provider" ng-model="repo.search" ng-checked="isDefault(provider)" ng-change="toggleRepo(provider.search_provider)">
+            <input type="radio" ng-value="provider._id" ng-model="repo.search" ng-checked="isDefault(provider)" ng-change="toggleRepo(provider._id)">
             {{:: provider.source}}<span class="check"></span>
         </label>
     </div>

--- a/scripts/core/api/allowed.js
+++ b/scripts/core/api/allowed.js
@@ -16,6 +16,7 @@ function AllowedService(_, api, $q) {
                 response._items.forEach((item) => {
                     values[item._id] = item.items;
                 });
+
                 return values;
             });
     }


### PR DESCRIPTION
- read available types and labels from new api
- use search_provider id as param, thus allow multiple instances of same
  type