### PR TITLE
SDESK-336: Negation is always added for target type of a routing scheme rule

### DIFF
--- a/scripts/apps/ingest/directives/IngestRoutingAction.js
+++ b/scripts/apps/ingest/directives/IngestRoutingAction.js
@@ -54,7 +54,7 @@ export function IngestRoutingAction(desks, macros, subscribersService, metadata,
                     if (action.target_types && action.target_types.length > 0) {
                         var targets = [];
                         _.forEach(action.target_types, function(targetType) {
-                            targets.push((!targetType.deny ? gettext('Not ') : '') + targetType.name);
+                            targets.push((!targetType.allow ? gettext('Not ') : '') + targetType.name);
                         });
                         actionValues.push(targets.join(','));
                     }


### PR DESCRIPTION
bug was only in display of the rule.  fixed.