### PR TITLE
[SDESK-410]: When publishing/sending an item, initialize default date to current date

### DIFF
--- a/scripts/core/ui/ui.js
+++ b/scripts/core/ui/ui.js
@@ -679,7 +679,7 @@ function DatepickerInnerDirective($compile, $document, popupService, datetimeHel
 
             ctrl.$render = function() {
                 element.val(ctrl.$viewValue.viewdate);  // set the view
-                scope.date = ctrl.$viewValue.dpdate;    // set datepicker model
+                scope.date = ctrl.$viewValue.dpdate || moment().tz(config.defaultTimezone);    // set datepicker model
             };
 
             // handle model changes


### PR DESCRIPTION
This is to stop the red error border (invalid date)  around the date picker from coming up.