### PR TITLE
Check ESLint errors on the fly with eslint-loader (SDESK-414)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+*.generated.js
+missing-translations-strings.js
+language-mapping-list.js

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "draft-js": "^0.9.1",
     "draft-js-export-html": "^0.5.1",
     "draft-js-import-html": "^0.3.2",
+    "eslint-loader": "^1.6.1",
     "eslint-plugin-react": "^6.7.1",
     "exif-js": "^2.1.1",
     "file-loader": "^0.9.0",

--- a/tasks/options/eslint.js
+++ b/tasks/options/eslint.js
@@ -1,21 +1,20 @@
-
 var path = require('path');
 var root = path.dirname(path.dirname(__dirname));
 
 module.exports = {
     options: {
-        configFile: path.join(root, '.eslintrc.json')
+        configFile: path.join(root, '.eslintrc.json'),
+        quiet: true
     },
+
     app: {
         src: [
             path.join(root, 'scripts/**/*.js'),
-            '!' + path.join(root, 'scripts/**/*.generated.js'),
-            '!' + path.join(root, 'scripts/core/lang/missing-translations-strings.js'),
-            '!' + path.join(root, 'scripts/core/lang/language-mapping-list.js'),
             path.join(root, 'scripts/**/*.jsx')
         ],
         envs: ['browser', 'amd']
     },
+
     specs: {
         src: [
             path.join(root, 'spec/**/*.js'),
@@ -23,6 +22,7 @@ module.exports = {
         ],
         envs: ['node', 'jasmine']
     },
+
     tasks: {
         src: path.join(root, 'tasks/**/*.js'),
         envs: ['node']


### PR DESCRIPTION
Added `eslint-loader` for webpack to report errors on the fly. Works both in `superdesk-client-core` and `superdesk`.

Shows errors immediately in both terminal and console. 