### PR TITLE
fix(search): Keep repo filters when clearing searches

### DIFF
--- a/scripts/apps/search/directives/SaveSearch.js
+++ b/scripts/apps/search/directives/SaveSearch.js
@@ -39,7 +39,11 @@ export function SaveSearch($location, asset, api, session, notify, gettext, $roo
             scope.clear = function() {
                 scope.editingSearch = false;
                 scope.edit = null;
-                $location.url($location.path());
+                _.each($location.search(), (item, key) => {
+                    if (key !== 'repo') {
+                        $location.search(key, null);
+                    }
+                });
             };
 
             scope.search = function() {

--- a/spec/search_spec.js
+++ b/spec/search_spec.js
@@ -171,6 +171,8 @@ describe('search', () => {
 
         // can do a boolean search in the raw panel
         globalSearch.clickClearFilters();
+        globalSearch.archiveRepo.click();
+        globalSearch.archivedRepo.click();
         globalSearch.openRawSearchTab();
         var rawTextbox = element(by.id('raw-query'));
 


### PR DESCRIPTION
SDESK-286 - Clicking the "Clear filters" button switches user to standard SD search from Search provider