### PR TITLE
Fix protractor version, because error: "Jasmine spec timed out..."

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "karma-ng-html2js-preprocessor": "^0.1.2",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
-    "protractor": "^4.0.9",
+    "protractor": "4.0.11",
     "react-addons-test-utils": "^15.3.2",
     "sinon": "^2.0.0-pre.2"
   },


### PR DESCRIPTION
Builds are failing now on new infrastructure and Travis.

A lot of such errors:
```
FA Jasmine spec timed out. Resetting the WebDriver Control Flow.
at subscribers: list subscriber
FA Jasmine spec timed out. Resetting the WebDriver Control Flow.
at subscribers: save button is disabled when subscriber type is changed
FA Jasmine spec timed out. Resetting the WebDriver Control Flow.
at workspace: can switch views by keyboard
FA Jasmine spec timed out. Resetting the WebDriver Control Flow.
at spike: can spike item
```
It's started with `protractor@4.0.12`