### PR TITLE
CI: fix angular version to 1.5.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "main": "scripts/index.js",
   "dependencies": {
-    "angular": "^1.5.5",
+    "angular": "1.5.9",
     "angular-animate": "^1.5.5",
     "angular-bootstrap-npm": "jusopi/angular-bootstrap-npm#0.13.1",
     "angular-contenteditable": "0.0.2",


### PR DESCRIPTION
The new 1.6.0 is break "npm test" and "protractor"

`Angular` and `Protractor` what is wrong with you today?