### PR TITLE
Fix arrow keys not working in editor.

### DIFF
--- a/scripts/core/keyboard/keyboard.js
+++ b/scripts/core/keyboard/keyboard.js
@@ -64,7 +64,7 @@ export default angular.module('superdesk.core.keyboard', ['gettext'])
     var stack = [],
         defaultOpt = {
             type: 'keydown',
-            propagate: false,
+            propagate: true,
             inputDisabled: false,
             target: $window.document,
             keyCode: false,


### PR DESCRIPTION
Event propagation of keyboard elements should not be stopped by default, especially when they are bound to `$window.document`! This can cause difficult bugs to nail down, such as for example not being able to use arrow keys in the editor. It's almost impossible to figure out where the event was stopped.

Events should instead not bind to `window.document`, but to their own nodes, and if they do wish to stop propagation they can explicitly specify this via the `options.propagate` argument of `keyboardManager.bind` and `keyboardManager.push`.

Ideally, `options.target` should be made mandatory as a function argument to make users of the `keyboardManager` API aware of the element that they are binding to and the consequences of this action.