### PR TITLE
feature(core/editor3): editor3 feature flag

### DIFF
--- a/scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js
+++ b/scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js
@@ -1,7 +1,7 @@
 import * as constant from '../constants';
 
-ContentProfileSchemaEditor.$inject = ['gettext', 'metadata', 'content'];
-export function ContentProfileSchemaEditor(gettext, metadata, content) {
+ContentProfileSchemaEditor.$inject = ['gettext', 'metadata', 'content', 'config'];
+export function ContentProfileSchemaEditor(gettext, metadata, content, config) {
     // labelMap maps schema entry keys to their display names.
     var labelMap = {
         headline: gettext('Headline'),
@@ -51,10 +51,15 @@ export function ContentProfileSchemaEditor(gettext, metadata, content) {
             model: '=ngModel'
         },
         link: function(scope, elem, attr, form) {
+            // schema & editor active settings
             scope.model.schema = scope.model.schema || {};
             scope.model.editor = scope.model.editor || {};
+
+            // schema & editor fields
             scope.schema = angular.extend({}, content.contentProfileSchema);
             scope.editor = angular.extend({}, content.contentProfileEditor);
+
+            scope.withEditor3 = config.features.editor3;
 
             metadata.initialize().then(() => {
                 scope.options = {subject: metadata.values.subjectcodes};

--- a/scripts/apps/workspace/content/views/schema-editor.html
+++ b/scripts/apps/workspace/content/views/schema-editor.html
@@ -19,6 +19,10 @@
             <div class="body" ng-if="model.schema[id]">
                 <form>
                     <fieldset class="fieldset-flex">
+                        <div class="field" ng-if="id == 'body_html' && withEditor3">
+                            <label translate>Editor3</label>
+                            <div sd-check ng-model="model.editor[id].editor3"></div>
+                        </div>
                         <div class="field">
                             <label translate>Required</label>
                             <div sd-check ng-model="model.schema[id].required"></div>


### PR DESCRIPTION
When adding `editor3: true` to the `features` object of
superdesk.config.js, content profiles will now display the option to
enable Editor3 for the body_html field.