### PR TITLE
Update "grunt:build" task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -77,16 +77,32 @@ module.exports = function(grunt) {
     ]);
 
     // Production build
-    grunt.registerTask('build', [
-        'clean',
-        'copy:index',
-        'copy:assets',
-        'ngtemplates:gen-importer',
-        'ngtemplates:core',
-        'webpack:build',
-        'filerev',
-        'usemin'
-    ]);
+    grunt.registerTask('build', '', () => {
+        grunt.task.run([
+            'clean',
+            'copy:index',
+            'copy:assets',
+            'ngtemplates:gen-importer',
+            'ngtemplates:core'
+        ]);
+
+        // if we have "*.po" files in "superdesk/client"
+        // use them to generate "lang.generated.js"
+        // to support client based translations
+        var pkgName = grunt.file.readJSON('package.json').name;
+        if (grunt.file.expand("po/*.po").length && pkgName != 'superdesk-core') {
+            grunt.task.run([
+                'nggettext_extract',
+                'nggettext_compile'
+            ]);
+        }
+
+        grunt.task.run([
+            'webpack:build',
+            'filerev',
+            'usemin'
+        ]);
+    });
 
     grunt.registerTask('package', ['ci', 'build']);
     grunt.registerTask('default', ['server']);

--- a/tasks/options/nggettext_compile.js
+++ b/tasks/options/nggettext_compile.js
@@ -1,7 +1,7 @@
 module.exports = {
     all: {
         files: {
-            'scripts/core/lang/lang.generated.js': '<%= poDir %>/*.po'
+            '<%= coreDir %>/scripts/core/lang/lang.generated.js': '<%= poDir %>/*.po'
         }
     }
 };


### PR DESCRIPTION
Generate `lang.generated.js` if "*.po" files exist in customer branch/repo
- simplifying the process of updating translations for the particular customer
- generate translations for languages we only need



Ref: https://dev.sourcefabric.org/browse/SDESK-523