### PR TITLE
[SDESK-526] Have scroll bar always visible in swimlane view

### DIFF
--- a/scripts/apps/monitoring/styles/monitoring.scss
+++ b/scripts/apps/monitoring/styles/monitoring.scss
@@ -66,6 +66,7 @@
             .sd-columns {
                 display: table;
                 width: 100%;
+                height: 100vh;
                 table-layout: fixed;
                 @media only screen and (max-width : 1430px) {
                     right: $sidepreview-width - 40;


### PR DESCRIPTION
This is to ensure we are able to scroll down during reduced zoom size even if the contents fit the viewport so that we can trigger paging of the Monitoring stages.