### PR TITLE
Fix dgeni documentation website

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "webpack-dev-server": "1.14.1"
   },
   "devDependencies": {
-    "dgeni-alive": "gbbr/dgeni-alive",
+    "dgeni-alive": "gbbr/dgeni-alive#superdesk",
     "dgeni-packages": "^0.16.0",
     "enzyme": "^2.4.1",
     "grunt-karma": "0.12.0",


### PR DESCRIPTION
Dgeni stopped working after some new versions of its dependencies were released, so we have now stripped all dependencies inside dgeni-alive of the `~` version approximation character via [this commit](https://github.com/gbbr/dgeni-alive/commit/d83bd9dfc777a7eeeeef9931a0a0bbe663bbd86a), which fixes the problem.