### PR TITLE
feat(config): allow config changes without rebuilt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,8 +64,8 @@ module.exports = function(grunt) {
     grunt.registerTask('server', [
         'clean',
         'copy:index',
+        'copy:config',
         'copy:locales',
-
         'ngtemplates:gen-apps',
         'ngtemplates:dev',
         'webpack-dev-server:start'
@@ -76,6 +76,7 @@ module.exports = function(grunt) {
         grunt.task.run([
             'clean',
             'copy:index',
+            'copy:config',
             'copy:assets',
             'copy:locales',
             'ngtemplates:gen-apps',

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ To configure the build, the `superdesk.config.js` file must export a function th
 - `shortDateFormat`: `'MM/DD'` - format for other days in item list
 - `longDateFormat`: `'LLL'` - format with full date and time
 
+##### Language
+
+- `language`: `'en'` - default language
+
 ##### Authoring
 
 - `previewSubjectFilterKey`: `null` - full preview in authoring displays only matching subjects

--- a/index.html
+++ b/index.html
@@ -11,5 +11,6 @@
   <body ng-class="config.bodyClass">
     <div sd-superdesk-view></div>
     <script src="app.bundle.js"></script>
+    <script src="config.js"></script>
   </body>
 </html>

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,0 +1,1 @@
+window.superdeskConfig = {};

--- a/scripts/core/services/translate.js
+++ b/scripts/core/services/translate.js
@@ -16,13 +16,15 @@ export default angular.module('superdesk.core.translate', [
         tmhDynamicLocaleProvider.localeLocationPattern('locales/angular-locale_{{locale}}.js');
     }])
 
-    .run(['gettextCatalog', '$location', '$rootScope', 'SESSION_EVENTS', 'tmhDynamicLocale',
-        function(gettextCatalog, $location, $rootScope, SESSION_EVENTS, tmhDynamicLocale) {
+    .run(['gettextCatalog', 'config', '$location', '$rootScope', 'SESSION_EVENTS', 'tmhDynamicLocale',
+        function(gettextCatalog, config, $location, $rootScope, SESSION_EVENTS, tmhDynamicLocale) {
             $rootScope.$on(SESSION_EVENTS.IDENTITY_LOADED, (event) => {
                 if ($rootScope.$root.currentUser
                     && gettextCatalog.strings.hasOwnProperty($rootScope.$root.currentUser.language)) {
                     // if the current logged in user has a saved language preference that is available
                     gettextCatalog.setCurrentLanguage($rootScope.$root.currentUser.language);
+                } else if (config.language) {
+                    gettextCatalog.setCurrentLanguage(config.language);
                 } else if (gettextCatalog.strings.hasOwnProperty(window.navigator.language)) {
                     // no saved preference but browser language is available
                     gettextCatalog.setCurrentLanguage(window.navigator.language);
@@ -30,6 +32,7 @@ export default angular.module('superdesk.core.translate', [
                     // no other options available go with baseLanguage
                     gettextCatalog.setCurrentLanguage(gettextCatalog.baseLanguage);
                 }
+
                 // set locale for date/time management
                 moment.locale(gettextCatalog.currentLanguage);
                 // set locale for angular-i18n

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -14,13 +14,18 @@ if (appConfig.features.useTansaProofing) {
     require('apps/tansa');
 }
 
-// non-mock app configuration must live here to allow tests to override
-// since tests do not import this file.
-angular.module('superdesk.config').constant('config', appConfig);
-
 let body = angular.element('body');
 
 body.ready(() => {
+    // update config via config.js
+    if (window.superdeskConfig) {
+        angular.merge(appConfig, window.superdeskConfig);
+    }
+
+    // non-mock app configuration must live here to allow tests to override
+    // since tests do not import this file.
+    angular.module('superdesk.config').constant('config', appConfig);
+
     /**
      * @ngdoc module
      * @name superdesk-client

--- a/tasks/options/copy.js
+++ b/tasks/options/copy.js
@@ -16,6 +16,20 @@ module.exports = {
             }
         ]
     },
+    config: {
+        files: [
+            {
+                cwd: process.cwd(),
+                src: path.join(appRoot, 'scripts', 'config.js'),
+                dest: '<%= distDir %>/config.js'
+            },
+            {
+                cwd: process.cwd(),
+                src: 'config.js',
+                dest: '<%= distDir %>/config.js'
+            },
+        ]
+    },
     assets: {
         files: [
             {

--- a/tasks/options/webpack-dev-server.js
+++ b/tasks/options/webpack-dev-server.js
@@ -75,6 +75,7 @@ function getProxy() {
 
     // on the dev server the bundle is in the dist folder
     proxy['/app.bundle.js'] = prepend('dist');
+    proxy['/config.js'] = prepend('dist');
 
     return proxy;
 }


### PR DESCRIPTION
it will load `config.js` where user can set `superdeskConfig` dict
which is used to update config before `angular.bootstrap`.

there is empty file provided in core by default, but will use
`config.js` file from `superdesk/client` if any.

SDESK-577