### PR TITLE
[sdesk-369] Use ctrl+shift+# for spiking an item

### DIFF
--- a/scripts/apps/archive/index.js
+++ b/scripts/apps/archive/index.js
@@ -93,9 +93,10 @@ angular.module('superdesk.apps.archive', [
                 label: gettext('Spike Item'),
                 icon: 'trash',
                 monitor: true,
-                controller: ['spike', 'data', '$rootScope', 'modal', '$location', '$q',
-                    function spikeActivity(spike, data, $rootScope, modal, $location, $q) {
-                        if (!data.item || !spike.canSpike(data.item)) {
+                controller: ['spike', 'data', '$rootScope', 'modal', '$location', '$q', 'multi',
+                    function spikeActivity(spike, data, $rootScope, modal, $location, $q, multi) {
+                        // If multibar is open, let its keyboard binding handle this - so, return.
+                        if (!data.item || !spike.canSpike(data.item) || multi.count > 0) {
                             return;
                         }
 
@@ -110,7 +111,7 @@ angular.module('superdesk.apps.archive', [
                     }],
                 filters: [{action: 'list', type: 'archive'}],
                 action: 'spike',
-                keyboardShortcut: 'ctrl+k',
+                keyboardShortcut: 'ctrl+shift+#',
                 additionalCondition: ['session', 'authoring', 'item', function(session, authoring, item) {
                     return authoring.itemActions(item).spike &&
                         (item.lock_user === null || angular.isUndefined(item.lock_user) ||

--- a/scripts/apps/monitoring/directives/MonitoringGroup.js
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.js
@@ -260,7 +260,7 @@ export function MonitoringGroup(cards, api, authoringWorkspace, $timeout, superd
                 superdesk.findActivities(intent, item).forEach((activity) => {
                     if (activity.keyboardShortcut && workflowService.isActionAllowed(item, activity.action)) {
                         monitoring.bindedItems.push(
-                            scope.$on('key:' + activity.keyboardShortcut.replace('+', ':'),
+                            scope.$on('key:' + activity.keyboardShortcut.replace(/\+/g, ':'),
                             () => {
                                 if (activity._id === 'mark.item') {
                                     bindMarkItemShortcut();

--- a/scripts/apps/monitoring/index.js
+++ b/scripts/apps/monitoring/index.js
@@ -51,6 +51,10 @@ angular.module('superdesk.apps.monitoring', [
     .run(['keyboardManager', 'gettext', function(keyboardManager, gettext) {
         keyboardManager.register('Monitoring', 'ctrl + g', gettext('Switches between single/grouped stage view'));
         keyboardManager.register('Monitoring', 'ctrl + alt + g', gettext('Switches between single/grouped desk view'));
+        keyboardManager.register('Monitoring', 'ctrl + d', gettext('Duplicates an item'));
+        keyboardManager.register('Monitoring', 'ctrl + b', gettext('Creates a broadcast'));
+        keyboardManager.register('Monitoring', 'ctrl + alt + t', gettext('Creates a new take'));
+        keyboardManager.register('Monitoring', 'ctrl + shift + #', gettext('Spikes item(s)'));
     }]);
 
 angular.module('superdesk.apps.aggregate', [

--- a/scripts/apps/search/directives/MultiActionBar.js
+++ b/scripts/apps/search/directives/MultiActionBar.js
@@ -62,7 +62,7 @@ export function MultiActionBar(asset, multi, authoringWorkspace, superdesk, keyb
                 scope.activity = activities;
             }
 
-            keyboardManager.bind('ctrl+k', () => {
+            keyboardManager.bind('ctrl+shift+#', () => {
                 if (scope.activity.spike > 0) {
                     scope.action.spikeItems();
                 }

--- a/scripts/apps/workspace/index.js
+++ b/scripts/apps/workspace/index.js
@@ -28,4 +28,5 @@ angular.module('superdesk.apps.workspace', ['superdesk.apps.workspace.content'])
         keyboardManager.register('General', 'alt + x', gettext('Opens spike'));
         keyboardManager.register('General', 'alt + p', gettext('Opens personal'));
         keyboardManager.register('General', 'alt + f', gettext('Opens search'));
+        keyboardManager.register('General', 'x', gettext('Multi-selects(or deselects) an item'));
     }]);


### PR DESCRIPTION
1 - KeyEventBroadcast to emit shift characters similar to keyboardManager service (i.e. for example, ctrl+shit+# and not ctrl+shift+3).
2 - Register other common keyboard shortcuts.