### PR TITLE
[SDESK-630](fix):All renditions and metadata changes should be saved in one action for not published items.

### DIFF
--- a/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.js
+++ b/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.js
@@ -7,14 +7,13 @@
  * @requires renditions
  * @requires config
  * @requires authoring
- * @requires $q
  *
  * @description
  *   This directive is responsible for rendering media associated with the item.
  */
 
-ItemAssociationDirective.$inject = ['superdesk', 'renditions', 'config', 'authoring', '$q'];
-export function ItemAssociationDirective(superdesk, renditions, config, authoring, $q) {
+ItemAssociationDirective.$inject = ['superdesk', 'renditions', 'config', 'authoring'];
+export function ItemAssociationDirective(superdesk, renditions, config, authoring) {
     return {
         scope: {
             rel: '=',
@@ -65,10 +64,6 @@ export function ItemAssociationDirective(superdesk, renditions, config, authorin
                     .then(scope.edit)
                     .finally(() => {
                         scope.loading = false;
-                    });
-                } else {
-                    scope.$apply(() => {
-                        updateItemAssociation(item);
                     });
                 }
             });

--- a/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.js
+++ b/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.js
@@ -1,12 +1,28 @@
-ItemAssociationDirective.$inject = ['superdesk', 'renditions', 'api', '$q', 'config'];
-export function ItemAssociationDirective(superdesk, renditions, api, $q, config) {
+/**
+ * @ngdoc directive
+ * @module superdesk.apps.authoring
+ * @name sdItemAssociation
+ *
+ * @requires superdesk
+ * @requires renditions
+ * @requires config
+ * @requires authoring
+ * @requires $q
+ *
+ * @description
+ *   This directive is responsible for rendering media associated with the item.
+ */
+
+ItemAssociationDirective.$inject = ['superdesk', 'renditions', 'config', 'authoring', '$q'];
+export function ItemAssociationDirective(superdesk, renditions, config, authoring, $q) {
     return {
         scope: {
             rel: '=',
             item: '=',
             editable: '=',
             allowVideo: '@',
-            onchange: '&'
+            onchange: '&',
+            save: '&'
         },
         templateUrl: 'scripts/apps/authoring/views/item-association.html',
         link: function(scope, elem) {
@@ -15,9 +31,12 @@ export function ItemAssociationDirective(superdesk, renditions, api, $q, config)
             if (scope.allowVideo === 'true') {
                 MEDIA_TYPES.push('application/superdesk.item.video');
             }
+
             /**
-             * Get superdesk item from event
-             *
+             * @ngdoc method
+             * @name sdItemAssociation#getItem
+             * @private
+             * @description Get superdesk item from event.
              * @param {Event} event
              * @param {string} dataType
              * @return {Object}
@@ -38,8 +57,7 @@ export function ItemAssociationDirective(superdesk, renditions, api, $q, config)
             elem.on('drop dragdrop', (event) => {
                 event.preventDefault();
                 event.stopPropagation();
-                var item = getItem(event, event.originalEvent.dataTransfer.types[0]);
-                // ingest picture if it comes from an external source (create renditions)
+                let item = getItem(event, event.originalEvent.dataTransfer.types[0]);
 
                 if (scope.isEditable()) {
                     scope.loading = true;
@@ -55,11 +73,23 @@ export function ItemAssociationDirective(superdesk, renditions, api, $q, config)
                 }
             });
 
+
+            /**
+             * @ngdoc method
+             * @name sdItemAssociation#updateItemAssociation
+             * @private
+             * @description If the item is not published then it saves the changes otherwise calls autosave.
+             * @param {Object} updated Item to be edited
+             */
             function updateItemAssociation(updated) {
-                var data = {};
+                let data = {};
 
                 data[scope.rel] = updated;
                 scope.item.associations = angular.extend({}, scope.item.associations, data);
+                if (!authoring.isPublished(scope.item) && updated) {
+                    return scope.save();
+                }
+
                 scope.onchange({item: scope.item, data: data});
             }
 
@@ -70,7 +100,18 @@ export function ItemAssociationDirective(superdesk, renditions, api, $q, config)
 
             renditions.get();
 
+            /**
+             * @ngdoc method
+             * @name sdItemAssociation#edit
+             * @public
+             * @description Opens the item for edit.
+             * @param {Object} item Item to be edited
+             */
             scope.edit = function(item) {
+                if (!scope.isEditable()) {
+                    return;
+                }
+
                 if (item.renditions && item.renditions.original && scope.isImage(item.renditions.original)) {
                     scope.loading = true;
                     return renditions.crop(item)
@@ -83,6 +124,13 @@ export function ItemAssociationDirective(superdesk, renditions, api, $q, config)
                 updateItemAssociation(item);
             };
 
+            /**
+             * @ngdoc method
+             * @name sdItemAssociation#isVideo
+             * @public
+             * @description Check if the rendition is video or not.
+             * @param {Object} rendition Rendition of the item.
+             */
             scope.isVideo = function(rendition) {
                 if (_.startsWith(rendition.mimetype, 'video')) {
                     return true;
@@ -91,19 +139,44 @@ export function ItemAssociationDirective(superdesk, renditions, api, $q, config)
                 return _.some(['.mp4', '.webm', '.ogv', '.ogg'], (ext) => _.endsWith(rendition.href, ext));
             };
 
+            /**
+             * @ngdoc method
+             * @name sdItemAssociation#isImage
+             * @public
+             * @description Check if the rendition is image or not.
+             * @param {Object} rendition Rendition of the item.
+             */
             scope.isImage = function(rendition) {
                 return _.startsWith(rendition.mimetype, 'image');
             };
 
+            /**
+             * @ngdoc method
+             * @name sdItemAssociation#isEditable
+             * @public
+             * @description Check if the item can be edited or not.
+             */
             scope.isEditable = function() {
                 return !(config.features && 'editFeaturedImage' in config.features
-                    && !config.features.editFeaturedImage);
+                    && !config.features.editFeaturedImage) && scope.editable;
             };
 
+            /**
+             * @ngdoc method
+             * @name sdItemAssociation#remove
+             * @public
+             * @description Remove the associations
+             */
             scope.remove = function(item) {
                 updateItemAssociation(null);
             };
 
+            /**
+             * @ngdoc method
+             * @name sdItemAssociation#upload
+             * @public
+             * @description Upload media.
+             */
             scope.upload = function() {
                 if (scope.editable) {
                     superdesk.intent('upload', 'media', {uniqueUpload: true}).then((images) => {

--- a/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.spec.js
+++ b/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.spec.js
@@ -5,7 +5,7 @@ describe('item association directive', () => {
     beforeEach(window.module('superdesk.apps.vocabularies'));
     beforeEach(window.module('superdesk.apps.searchProviders'));
 
-    var elem, scope, item = {};
+    var elem, scope, item = {associations: {}};
 
     beforeEach(inject(($compile, $rootScope) => {
         scope = $rootScope.$new();
@@ -14,24 +14,50 @@ describe('item association directive', () => {
         elem = $compile(`<div sd-item-association
             data-item="item"
             data-rel="rel"
-            data-onchange="onChange()"></div>`
+            data-onchange="onChange()"
+            data-save="save()"></div>`
         )(scope);
         $rootScope.$digest();
     }));
 
-    it('can trigger onchange handler on drop', inject(($rootScope) => {
+    it('can trigger onsave handler on drop when content is not published', inject(($rootScope) => {
         var event = new window.$.Event('drop');
 
         event.originalEvent = {dataTransfer: {
             types: [{type: 'video'}],
-            getData: () => angular.toJson({headline: 'foo'})
+            getData: () => angular.toJson({headline: 'foo', _type: 'externalsource'})
         }};
         event.preventDefault = jasmine.createSpy('preventDefault');
         event.stopPropagation = jasmine.createSpy('stopPropagation');
+        scope.editable = true;
         scope.onChange = jasmine.createSpy('onchange');
+        scope.save = jasmine.createSpy('save');
+        elem.triggerHandler(event);
+        $rootScope.$digest();
+        expect(scope.onChange).not.toHaveBeenCalled();
+        expect(scope.save).toHaveBeenCalled();
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
+        expect(scope.item.associations.featured.headline).toBe('foo');
+    }));
+
+    it('can trigger onchange handler on drop when content is published', inject(($rootScope) => {
+        var event = new window.$.Event('drop');
+
+        scope.item.state = 'published';
+        event.originalEvent = {dataTransfer: {
+            types: [{type: 'video'}],
+            getData: () => angular.toJson({headline: 'foo', _type: 'externalsource'})
+        }};
+        event.preventDefault = jasmine.createSpy('preventDefault');
+        event.stopPropagation = jasmine.createSpy('stopPropagation');
+        scope.editable = true;
+        scope.onChange = jasmine.createSpy('onchange');
+        scope.save = jasmine.createSpy('save');
         elem.triggerHandler(event);
         $rootScope.$digest();
         expect(scope.onChange).toHaveBeenCalled();
+        expect(scope.save).not.toHaveBeenCalled();
         expect(event.preventDefault).toHaveBeenCalled();
         expect(event.stopPropagation).toHaveBeenCalled();
         expect(scope.item.associations.featured.headline).toBe('foo');

--- a/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.spec.js
+++ b/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.spec.js
@@ -7,33 +7,59 @@ describe('item association directive', () => {
 
     var elem, scope, item = {associations: {}};
 
-    beforeEach(inject(($compile, $rootScope) => {
+    beforeEach(inject(($compile, $rootScope, config, renditions, $q) => {
         scope = $rootScope.$new();
         scope.rel = 'featured';
         scope.item = item;
+        scope.editable = true;
+        config.features = {
+            editFeaturedImage: 1
+        };
+
+        spyOn(renditions, 'ingest').and.returnValue($q.when({headline: 'foo',
+            _type: 'externalsource',
+            renditions: {
+                original: {
+                    mimetype: 'image/jpeg'
+                }
+            }
+        }));
+
+        spyOn(renditions, 'crop').and.returnValue($q.when({headline: 'foo',
+            _type: 'externalsource',
+            renditions: {
+                original: {
+                    mimetype: 'image/jpeg'
+                }
+            }
+        }));
+
         elem = $compile(`<div sd-item-association
             data-item="item"
             data-rel="rel"
+            data-editable="editable"
             data-onchange="onChange()"
             data-save="save()"></div>`
         )(scope);
         $rootScope.$digest();
     }));
 
-    it('can trigger onsave handler on drop when content is not published', inject(($rootScope) => {
+    it('can trigger onsave handler on drop when content is not published', inject(($rootScope, renditions) => {
         var event = new window.$.Event('drop');
 
         event.originalEvent = {dataTransfer: {
             types: [{type: 'video'}],
             getData: () => angular.toJson({headline: 'foo', _type: 'externalsource'})
         }};
+
         event.preventDefault = jasmine.createSpy('preventDefault');
         event.stopPropagation = jasmine.createSpy('stopPropagation');
-        scope.editable = true;
         scope.onChange = jasmine.createSpy('onchange');
         scope.save = jasmine.createSpy('save');
         elem.triggerHandler(event);
         $rootScope.$digest();
+        expect(renditions.ingest).toHaveBeenCalled();
+        expect(renditions.crop).toHaveBeenCalled();
         expect(scope.onChange).not.toHaveBeenCalled();
         expect(scope.save).toHaveBeenCalled();
         expect(event.preventDefault).toHaveBeenCalled();
@@ -41,7 +67,7 @@ describe('item association directive', () => {
         expect(scope.item.associations.featured.headline).toBe('foo');
     }));
 
-    it('can trigger onchange handler on drop when content is published', inject(($rootScope) => {
+    it('can trigger onchange handler on drop when content is published', inject(($rootScope, renditions) => {
         var event = new window.$.Event('drop');
 
         scope.item.state = 'published';
@@ -51,11 +77,12 @@ describe('item association directive', () => {
         }};
         event.preventDefault = jasmine.createSpy('preventDefault');
         event.stopPropagation = jasmine.createSpy('stopPropagation');
-        scope.editable = true;
         scope.onChange = jasmine.createSpy('onchange');
         scope.save = jasmine.createSpy('save');
         elem.triggerHandler(event);
         $rootScope.$digest();
+        expect(renditions.ingest).toHaveBeenCalled();
+        expect(renditions.crop).toHaveBeenCalled();
         expect(scope.onChange).toHaveBeenCalled();
         expect(scope.save).not.toHaveBeenCalled();
         expect(event.preventDefault).toHaveBeenCalled();

--- a/scripts/apps/authoring/authoring/helpers.js
+++ b/scripts/apps/authoring/authoring/helpers.js
@@ -35,7 +35,10 @@ export const CONTENT_FIELDS_DEFAULTS = Object.freeze({
     sms_message: null,
     poi: {},
     profile: null,
-    format: 'HTML'
+    format: 'HTML',
+    alt_text: null,
+    copyrightnotice: null,
+    copyrightholder: null
 });
 
 export const DEFAULT_ACTIONS = Object.freeze({

--- a/scripts/apps/authoring/styles/authoring.scss
+++ b/scripts/apps/authoring/styles/authoring.scss
@@ -1112,6 +1112,12 @@
         }
     }
 
+    .not-editable {
+       &:hover {
+         cursor: auto;
+       }
+    }
+
     .close-overlay {
         z-index:10000;
         position: absolute;
@@ -1212,5 +1218,22 @@ feature-image {
   color: $white !important;
   span {
     border-bottom: 2px solid #3299b7;
+  }
+}
+
+.media-item {
+  &--loading {
+        background-color: fade(#f7f7f7, 40%);
+        border-color: fade(#cfcfcf, 40%);
+        &:before {
+            @include spinner-big();
+            content: '';
+            top: 50%;
+            transform: translateY(-50%);
+            position: absolute;
+        }
+        img {
+            opacity: .2;
+        }
   }
 }

--- a/scripts/apps/authoring/views/article-edit.html
+++ b/scripts/apps/authoring/views/article-edit.html
@@ -58,7 +58,8 @@
     data-item="item"
     data-rel="'featureimage'"
     data-editable="_editable"
-    data-onchange="autosave(item)"></div>
+    data-onchange="autosave(item)"
+    data-save="save()"></div>
 </div>
 
 <div ng-if="schema.feature_media" sd-width="{{editor.feature_image.sdWidth || 'full'}}" sd-validation-error="error.feature_media" order="{{editor.feature_media.order}}"
@@ -69,7 +70,9 @@
     data-item="item"
     data-rel="'featuremedia'"
     data-editable="_editable"
-    data-onchange="autosave(item)"></div>
+    data-onchange="autosave(item)"
+    data-save="save()"></div>
+    <div sd-item-crops ng-if="item.associations && item.associations.featuremedia" data-item="item.associations.featuremedia"></div>
 </div>
 
 <div class="field abstract" sd-width="{{editor.abstract.sdWidth || 'full'}}" ng-class="{'limit-error': item.abstract.length > schema.abstract.maxlength}" ng-if="schema.abstract && !editor.abstract.editor3" order="{{editor.abstract.order}}" sd-validation-error="error.abstract" data-required="schema.abstract.required">
@@ -212,7 +215,11 @@
     </div>
 </div>
 
-<div class="field" ng-if="isMediaType" order="{{editor.media.order}}" sd-width="{{editor.media.sdWidth || 'full'}}">
+<div class="field media-item"
+     ng-if="isMediaType"
+     ng-class="{'media-item--loading': mediaLoading}"
+     order="{{editor.media.order}}"
+     sd-width="{{editor.media.sdWidth || 'full'}}">
 
   <div ng-if="item.type == 'picture' || item.type == 'graphic'" class="full-preview" sd-ratio-calc>
       <div>
@@ -235,7 +242,11 @@
   </div>
 </div>
 
-<div ng-if="isMediaType && !editor.description_text.editor3" class="field abstract" order="{{editor.media_description.order}}" sd-validation-error="error.description_text" sd-width="{{editor.media_description.sdWidth || 'full'}}" data-required="schema.media_description.required">
+<div ng-if="isMediaType && !editor.description_text.editor3"
+     class="field abstract"
+     order="{{editor.media_description.order}}"
+     sd-validation-error="error.description_text"
+     sd-width="{{editor.media_description.sdWidth || 'full'}}" data-required="schema.media_description.required">
   <label translate>Description</label>
   <div id="title" class="abstract"
         sd-text-editor

--- a/scripts/apps/authoring/views/change-image.html
+++ b/scripts/apps/authoring/views/change-image.html
@@ -48,7 +48,10 @@
                 </div>
                 <div ng-if="isAoISelectionModeEnabled && !loaderForAoI">
                     <button class="btn" ng-click="showAreaOfInterestView(false)" translate>Cancel</button>
-                    <button class="btn btn--primary" ng-click="saveAreaOfInterest(areaOfInterestData)" translate>Save</button>
+                    <button class="btn btn--primary"
+                            ng-click="saveAreaOfInterest(areaOfInterestData)"
+                            ng-disabled="!enableSaveAreaOfInterest()"
+                            translate>Save</button>
                 </div>
                 <button class="btn"
                         ng-click="showAreaOfInterestView()"

--- a/scripts/apps/authoring/views/item-association.html
+++ b/scripts/apps/authoring/views/item-association.html
@@ -1,13 +1,20 @@
-<figure class="item-association" ng-class="{'item-association--preview': related, 'item-association--loading': loading}" ng-click="isEditable() && !related && upload()">
-    <div ng-if="related" class="close-overlay">
+<figure class="item-association"
+        ng-class="{'item-association--preview': related, 'item-association--loading': loading}"
+        ng-click="isEditable() && !related && upload()">
+    <div ng-if="related && isEditable()" class="close-overlay">
         <button class="btn btn--mini btn--light btn--pull-right" ng-click="remove(related); $event.stopPropagation()">
             <i class="icon-close-small"></i>
         </button>
     </div>
     <video ng-if="related && related.type === 'video'" controls="controls">
-        <source vsrc="{{ rendition.href }}" ng-repeat="(key, rendition) in related.renditions" ng-if="isVideo(rendition)" html5vfix>
+        <source vsrc="{{ rendition.href }}"
+                ng-repeat="(key, rendition) in related.renditions"
+                ng-if="isVideo(rendition)" html5vfix>
     </video>
-    <img ng-if="related && (related.type === 'picture' || related.type === 'graphic')" ng-src="{{ related.renditions.viewImage.href }}" ng-click="isEditable() && edit(related); $event.stopPropagation()">
+    <img ng-if="related && (related.type === 'picture' || related.type === 'graphic')"
+         ng-src="{{ related.renditions.viewImage.href }}"
+         ng-class="{'not-editable': !isEditable()}"
+         ng-click="isEditable() && edit(related); $event.stopPropagation()">
     <div sd-remove-tags
         type="text"
         ng-model="related.description_text"

--- a/scripts/apps/ingest/controllers/ExternalSourceController.js
+++ b/scripts/apps/ingest/controllers/ExternalSourceController.js
@@ -16,7 +16,7 @@ ExternalSourceController.$inject = ['api', 'data', 'desks', 'notify', 'gettext']
 export function ExternalSourceController(api, data, desks, notify, gettext) {
     return desks.fetchCurrentDeskId()
         .then((deskid) => {
-            api(data.item.fetch_endpoint).save({
+            let fetch = api(data.item.fetch_endpoint).save({
                 guid: data.item.guid,
                 desk: deskid
             }, null, {repo: data.item.ingest_provider})
@@ -30,5 +30,7 @@ export function ExternalSourceController(api, data, desks, notify, gettext) {
                     notify.error(gettext('Failed to get item.'));
                     return data.item;
                 });
+
+            return fetch;
         });
 }

--- a/scripts/apps/packaging/views/sd-package-edit.html
+++ b/scripts/apps/packaging/views/sd-package-edit.html
@@ -28,7 +28,14 @@
 </div>
 
 <div class="field body" ng-if="item.package_type==='takes' && _isInPublishedStates">
-        <label translate>Body</label>
+    <label translate>Body</label>
     <span sd-word-count data-item="item.body_html" data-html="true"></span>
     <div class="text-editor" sd-html-preview="item.body_html"></div>
+</div>
+
+<div class="field" ng-if="item.package_type==='takes' && item.associations.featuremedia">
+    <label translate>Featured Media</label>
+    <div sd-item-rendition data-item="item.associations.featuremedia" data-rendition="viewImage"></div>
+    <p class="nav-space description-text">{{item.associations.featuremedia.description_text}}</p>
+    <div sd-item-crops ng-if="item.associations && item.associations.featuremedia" data-item="item.associations.featuremedia"></div>
 </div>

--- a/scripts/apps/search/constants.js
+++ b/scripts/apps/search/constants.js
@@ -98,7 +98,10 @@ export const CORE_PROJECTED_FIELDS = {
         'source',
         'last_published_version',
         'archived',
-        'associations'
+        'associations',
+        'poi',
+        'alt_text',
+        'description_text'
     ]
 };
 


### PR DESCRIPTION
- Picture renditions and metadata are saved to database in one action for not-published items and for published items change are in memory and need to correct the item to save changes. This applies to text where media is associated.

This PR depends on [#751](https://github.com/superdesk/superdesk-core/pull/751)