### PR TITLE
fix(editor3): fixes problem with spellchecker context menu

### DIFF
--- a/scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.jsx
+++ b/scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.jsx
@@ -74,15 +74,15 @@ class SpellcheckerContextMenuComponent extends Component {
                     {suggestions.length === 0 ? <li><button>SORRY, NO SUGGESTIONS.</button></li>
                         : suggestions.map((suggestion, index) =>
                             <li key={index}>
-                                <button onClick={this.replaceWord(suggestion.key)}>
+                                <button onMouseDown={this.replaceWord(suggestion.key)}>
                                     {suggestion.value}
                                 </button>
                             </li>
                         )
                     }
                     <li className="divider"/>
-                    <li><button onClick={this.addWord}>Add to dictionary</button></li>
-                    <li><button onClick={this.ignoreWord}>Ignore word</button></li>
+                    <li><button onMouseDown={this.addWord}>Add to dictionary</button></li>
+                    <li><button onMouseDown={this.ignoreWord}>Ignore word</button></li>
                 </ul>
             </div>
         );

--- a/scripts/core/editor3/components/spellchecker/SpellcheckerError.jsx
+++ b/scripts/core/editor3/components/spellchecker/SpellcheckerError.jsx
@@ -63,7 +63,11 @@ export class SpellcheckerError extends Component {
 
         const fn = menuShowing ? 'on' : 'off';
 
-        $(window)[fn]('click', this.closeContextMenu);
+        $(window)[fn]('mousedown', this.closeContextMenu);
+    }
+
+    componentWillUnmount() {
+        $(window).off('mousedown', this.closeContextMenu);
     }
 
     render() {


### PR DESCRIPTION
This fixes a problem where it was possible to display multiple spellchecker menus by continuously right-clicking words with typos.