### PR TITLE
fix(editor3): show spellchecking errors on first load

### DIFF
--- a/scripts/core/editor3/actions/editor3.jsx
+++ b/scripts/core/editor3/actions/editor3.jsx
@@ -14,6 +14,18 @@ export function changeEditorState(editorState) {
 
 /**
  * @ngdoc method
+ * @name forceUpdate
+ * @return {String} action
+ * @description Causes the editor to force update. This is used by the spellchecker
+ * to cause the editor to re-render its decorators based on new information retrieved
+ * in dictionaries. Use of this method should be avoided.
+ */
+export function forceUpdate() {
+    return {type: 'EDITOR_FORCE_UPDATE'};
+}
+
+/**
+ * @ngdoc method
  * @name handleEditorTab
  * @param {Object} e on tab event
  * @return {String} action

--- a/scripts/core/editor3/reducers/editor3.jsx
+++ b/scripts/core/editor3/reducers/editor3.jsx
@@ -1,5 +1,6 @@
 import {RichUtils} from 'draft-js';
 import {stateToHTML} from 'draft-js-export-html';
+import {EditorState} from 'draft-js';
 
 /**
  * @ngdoc React
@@ -15,9 +16,31 @@ const editor3 = (state = {}, action) => {
         return onTab(state, action.payload);
     case 'EDITOR_KEY_COMMAND':
         return handleKeyCommand(state, action.payload);
+    case 'EDITOR_FORCE_UPDATE':
+        return forceUpdate(state);
     default:
         return state;
     }
+};
+
+/**
+ * @ngdoc method
+ * @name forceUpdate
+ * @param {Object} editorState
+ * @return {Object}
+ * @description Forces an update of the editor. This is somewhat of a hack
+ * based on https://github.com/facebook/draft-js/issues/458#issuecomment-225710311
+ * until a better solution is found.
+ */
+const forceUpdate = (state) => {
+    const {editorState} = state;
+    const content = editorState.getCurrentContent();
+    const decorator = editorState.getDecorator();
+
+    return {
+        ...state,
+        editorState: EditorState.createWithContent(content, decorator)
+    };
 };
 
 /**

--- a/scripts/core/editor3/store/index.js
+++ b/scripts/core/editor3/store/index.js
@@ -3,6 +3,7 @@ import thunk from 'redux-thunk';
 import {stateFromHTML} from 'draft-js-import-html';
 import reducers from '../reducers';
 import ng from 'core/services/ng';
+import {forceUpdate} from '../actions';
 
 import {SpellcheckerError} from '../components/spellchecker/SpellcheckerError';
 import Toolbar from '../components/toolbar';
@@ -12,7 +13,7 @@ export default function createEditorStore(ctrl) {
     const spellcheck = ng.get('spellcheck');
 
     spellcheck.setLanguage(ctrl.language);
-    spellcheck.getDict();
+    const dict = spellcheck.getDict();
 
     const singleLine = !!(!ctrl.editorFormat || ctrl.readOnly);
     const showToolbar = !singleLine;
@@ -27,7 +28,7 @@ export default function createEditorStore(ctrl) {
         SpellcheckerError.getDecorators().concat(Toolbar.getDecorators())
     );
 
-    return createStore(reducers, {
+    const store = createStore(reducers, {
         editorState: EditorState.createWithContent(initialValue, decorators),
         readOnly: ctrl.readOnly,
         showToolbar: showToolbar,
@@ -35,4 +36,9 @@ export default function createEditorStore(ctrl) {
         editorFormat: ctrl.editorFormat,
         onChangeValue: onChange
     }, applyMiddleware(thunk));
+
+
+    dict.finally(() => store.dispatch(forceUpdate()));
+
+    return store;
 }


### PR DESCRIPTION
Causes the editor to update when the dictionary for spellchecking is loaded. Unfortunately there is currently no functionality in draft-js to allow forcing the editor to update so somewhat of a "_mild_" hack is used based on [this comment](https://github.com/facebook/draft-js/issues/458#issuecomment-225710311) in the original project.