### PR TITLE
[SDESK-550] Added keepinput functionality to typeahead feature

### DIFF
--- a/scripts/apps/authoring/metadata/metadata.js
+++ b/scripts/apps/authoring/metadata/metadata.js
@@ -828,7 +828,8 @@ function MetaLocatorsDirective() {
             change: '&',
             postprocessing: '&',
             header: '@',
-            tabindex: '='
+            tabindex: '=',
+            keepinput: '='
         },
 
         templateUrl: 'scripts/apps/authoring/metadata/views/metadata-locators.html',

--- a/scripts/apps/authoring/metadata/views/metadata-locators.html
+++ b/scripts/apps/authoring/metadata/views/metadata-locators.html
@@ -1,5 +1,5 @@
 <div class="term-editor data visible locators" ng-show="!header">
-    <div sd-typeahead items="locators" data-tabindex="tabindex" term="selectedTerm" search="searchLocator(term)" select="selectLocator(item)" data-blur="selectLocator(item)" data-disabled="disabled">
+    <div sd-typeahead items="locators" data-tabindex="tabindex" term="selectedTerm" search="searchLocator(term)" select="selectLocator(item)" data-blur="selectLocator(item)" data-disabled="disabled" data-keepinput="keepinput">
 	  <li typeahead-item="t" ng-repeat="t in locators">
 		 {{ :: t.city }}
 		 <div class="country_state_info">{{:: t.state}}, {{:: t.country}}</div>

--- a/scripts/apps/authoring/views/article-edit.html
+++ b/scripts/apps/authoring/views/article-edit.html
@@ -145,7 +145,8 @@
              sd-focus-element
              data-element="input"
              data-append-element=".field"
-             data-append-class="active">
+             data-append-class="active"
+             data-keepinput="true">
         </div>
 
         <div ng-show="!editor.dateline.hideDate" class="dateline-date">

--- a/scripts/core/directives/TypeaheadDirective.js
+++ b/scripts/core/directives/TypeaheadDirective.js
@@ -13,6 +13,7 @@ export default angular.module('superdesk.core.directives.typeahead', [])
      * @param {Boolen} alwaysVisible List of posible choices always stay visible.
      * @param {Function} search Callback for filtering choice action.
      * @param {Function} select Callback for select item aciton.
+     * @param {Boolean} keepinput if true, the input text after selecting an item-selection will not be deleted/nulled
      *
      * @description Typeahead directive.
      *
@@ -41,7 +42,8 @@ export default angular.module('superdesk.core.directives.typeahead', [])
                 blur: '&',
                 placeholder: '@',
                 tabindex: '=',
-                style: '='
+                style: '=',
+                keepinput: '='
             },
             controller: ['$scope', function($scope) {
                 $scope.hide = true;
@@ -80,7 +82,11 @@ export default angular.module('superdesk.core.directives.typeahead', [])
                         // triggers closing of dropdown when adding item on search by pressing enter
                         if (item) {
                             $document.triggerHandler('click');
-                            $scope.term = null;
+
+                            // Clear text input
+                            if (!$scope.keepinput) {
+                                $scope.term = null;
+                            }
                         }
                     }
                 };


### PR DESCRIPTION
This is to signal the tyepahead directive not to delete the input text - currently useful for Dateline usage.