### PR TITLE
Fix e2e tests for new naspeh-sf/deploy scripts

### DIFF
--- a/spec/monitoring_spec.js
+++ b/spec/monitoring_spec.js
@@ -468,6 +468,7 @@ describe('monitoring', () => {
 
         expect(monitoring.getGroupItems(0).count()).toBe(2);
         monitoring.actionOnItem('Spike', 0, 0);
+        browser.sleep(100);
         expect(monitoring.getGroupItems(0).count()).toBe(1);
     });
 

--- a/spec/search_spec.js
+++ b/spec/search_spec.js
@@ -114,7 +114,8 @@ describe('search', () => {
 
         // initialize for search by from desk field and company
         monitoring.openMonitoring();
-        monitoring.switchToDesk('SPORTS DESK').then(authoring.createTextItem());
+        monitoring.selectDesk('SPORTS DESK');
+        authoring.createTextItem();
         authoring.writeTextToHeadline('From-Sports-To-Politics');
         authoring.writeText('This is Body');
         authoring.writeTextToAbstract('This is Abstract');

--- a/spec/users_spec.js
+++ b/spec/users_spec.js
@@ -216,6 +216,7 @@ describe('users', () => {
            'Authoring metadata based on the user\'s preferred categories settings',
             () => {
                 userPrefs.btnCheckNone.click();  // uncheck all categories
+                browser.sleep(100);
 
                 // select the Entertainment and Finance categories
                 userPrefs.categoryCheckboxes.get(3).click();  // Entertainment


### PR DESCRIPTION
It always fails with new version of https://github.com/naspeh-sf/deploy
- https://test.superdesk.org/logs/dev/all/20170123-113248-55-sdc-naspeh/check-e2e--part2.log.htm
- https://test.superdesk.org/logs/dev/all/20170123-162048-34-sdc-naspeh/check-e2e--part2.log.htm

Because item created from "Politic Desk" instead if "Sport Desk", so `swtichToDesk` is not working somehow...

----

Also trying to get rid of some false failing like:
<details>
<summary>Log</summary>
<pre>
Failures:
1) monitoring updates personal on single item spike
  Message:
[31m    Expected 2 to be 1.[0m
  Stack:
    Error: Failed expectation
        at Object.it (/opt/superdesk/client-core/spec/monitoring_spec.js:471:53)
        at /opt/superdesk/client-core/node_modules/jasminewd2/index.js:94:23
        at new ManagedPromise (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:1082:7)
        at controlFlowExecute (/opt/superdesk/client-core/node_modules/jasminewd2/index.js:80:18)
        at TaskQueue.execute_ (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:2913:14)
        at TaskQueue.executeNext_ (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:2896:21)
        at asyncRun (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:2820:25)
        at /opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:639:7
        at process._tickCallback (internal/process/next_tick.js:103:7)

2) users editing user preferences: should filter and navigate filtered list via keyboard action in the Authoring metadata based on the user's preferred categories settings
  Message:
[31m    Expected 10 to be 2.[0m
  Stack:
    Error: Failed expectation
        at Object.it (/opt/superdesk/client-core/spec/users_spec.js:238:46)
        at /opt/superdesk/client-core/node_modules/jasminewd2/index.js:94:23
        at new ManagedPromise (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:1082:7)
        at controlFlowExecute (/opt/superdesk/client-core/node_modules/jasminewd2/index.js:80:18)
        at TaskQueue.execute_ (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:2913:14)
        at TaskQueue.executeNext_ (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:2896:21)
        at asyncRun (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:2820:25)
        at /opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:639:7
        at process._tickCallback (internal/process/next_tick.js:103:7)
  Message:
[31m    Expected 'Advisories' to equal 'Entertainment'.[0m
  Stack:
    Error: Failed expectation
        at Object.it (/opt/superdesk/client-core/spec/users_spec.js:239:55)
        at /opt/superdesk/client-core/node_modules/jasminewd2/index.js:94:23
        at new ManagedPromise (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:1082:7)
        at controlFlowExecute (/opt/superdesk/client-core/node_modules/jasminewd2/index.js:80:18)
        at TaskQueue.execute_ (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:2913:14)
        at TaskQueue.executeNext_ (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:2896:21)
        at asyncRun (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:2820:25)
        at /opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:639:7
        at process._tickCallback (internal/process/next_tick.js:103:7)
  Message:
[31m    Expected 'Australian General News' to equal 'Finance'.[0m
  Stack:
    Error: Failed expectation
        at Object.it (/opt/superdesk/client-core/spec/users_spec.js:240:55)
        at /opt/superdesk/client-core/node_modules/jasminewd2/index.js:94:23
        at new ManagedPromise (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:1082:7)
        at controlFlowExecute (/opt/superdesk/client-core/node_modules/jasminewd2/index.js:80:18)
        at TaskQueue.execute_ (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:2913:14)
        at TaskQueue.executeNext_ (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:2896:21)
        at asyncRun (/opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:2820:25)
        at /opt/superdesk/client-core/node_modules/selenium-webdriver/lib/promise.js:639:7
        at process._tickCallback (internal/process/next_tick.js:103:7)
</pre>
</details>