### PR TITLE
editor3: Find & Replace [SDESK-136]

### DIFF
--- a/scripts/apps/authoring/editor/find-replace.js
+++ b/scripts/apps/authoring/editor/find-replace.js
@@ -7,13 +7,17 @@
  * AUTHORS and LICENSE files distributed with this source code, or
  * at https://www.sourcefabric.org/apps/license
  */
-FindReplaceDirective.$inject = ['editor', 'macros'];
+FindReplaceDirective.$inject = ['editor', 'editor3', 'macros', 'authoring'];
 /**
  * using directive here so that it can return focus
  */
-function FindReplaceDirective(editor, macros) {
+function FindReplaceDirective(editor2, editor3, macros, authoring) {
     return {
         link: function(scope, elem) {
+            // use the editor service of editor3, if it's active
+            const isEditor3 = authoring.editor.body_html.editor3;
+            const editor = isEditor3 ? editor3 : editor2;
+
             scope.to = '';
             scope.from = '';
             scope.caseSensitive = true;

--- a/scripts/core/editor3/actions/find-replace.jsx
+++ b/scripts/core/editor3/actions/find-replace.jsx
@@ -1,0 +1,68 @@
+/**
+ * @ngdoc method
+ * @name findNext
+ * @param {String} txt Text to find
+ * @description Creates the action to find the next occurence of txt.
+ */
+export function findNext() {
+    return {type: 'HIGHLIGHTS_FIND_NEXT'};
+}
+
+/**
+ * @ngdoc method
+ * @name findPrev
+ * @param {String} txt Text to find
+ * @description Creates the action to find the previous occurence of txt.
+ */
+export function findPrev() {
+    return {type: 'HIGHLIGHTS_FIND_PREV'};
+}
+
+/**
+ * @ngdoc method
+ * @name replace
+ * @param {String} from Text to replace from
+ * @param {String} to Text to replace to
+ * @description Creates the action to replace the current highlight from from to to.
+ */
+export function replace(withTxt) {
+    return {
+        type: 'HIGHLIGHTS_REPLACE',
+        payload: withTxt
+    };
+}
+
+/**
+ * @ngdoc method
+ * @name replaceAll
+ * @param {String} from Text to replace from
+ * @param {String} to Text to replace to
+ * @description Creates the action to replace all occurences of from to to.
+ */
+export function replaceAll(withTxt) {
+    return {
+        type: 'HIGHLIGHTS_REPLACE_ALL',
+        payload: withTxt
+    };
+}
+
+/**
+ * @ngdoc method
+ * @name renderHighlights
+ * @description Creates the action to re-render all the highlights.
+ */
+export function renderHighlights() {
+    return {type: 'HIGHLIGHTS_RENDER'};
+}
+
+/**
+ * @ngdoc method
+ * @name setSearchSettings
+ * @description Creates the action to set new search settings
+ */
+export function setHighlightCriteria(opts) {
+    return {
+        type: 'HIGHLIGHTS_CRITERIA',
+        payload: opts
+    };
+}

--- a/scripts/core/editor3/actions/index.jsx
+++ b/scripts/core/editor3/actions/index.jsx
@@ -1,3 +1,4 @@
 export * from './spellchecker';
 export * from './editor3';
 export * from './toolbar';
+export * from './find-replace';

--- a/scripts/core/editor3/components/Editor3.jsx
+++ b/scripts/core/editor3/components/Editor3.jsx
@@ -7,6 +7,7 @@ import * as actions from '../actions';
 import {SpellcheckerError} from './spellchecker/SpellcheckerError';
 import LinkControl from './toolbar/links/LinkControl';
 import {blockRenderer} from './blockRenderer';
+import {customStyleMap} from './customStyleMap';
 
 /**
  * @ngdoc React
@@ -108,6 +109,7 @@ export class Editor3Component extends React.Component {
                         editorState={editorState}
                         handleKeyCommand={handleKeyCommand}
                         blockRendererFn={blockRenderer}
+                        customStyleMap={customStyleMap}
                         onChange={onChange}
                         onTab={onTab}
                         readOnly={readOnly}

--- a/scripts/core/editor3/components/customStyleMap.jsx
+++ b/scripts/core/editor3/components/customStyleMap.jsx
@@ -1,0 +1,13 @@
+export const customStyleMap = {
+    HIGHLIGHT: {
+        display: 'inline-block',
+        padding: '1px 3px',
+        backgroundColor: 'rgba(255, 235, 59, 0.2)'
+    },
+
+    HIGHLIGHT_STRONG: {
+        display: 'inline-block',
+        padding: '1px 3px',
+        backgroundColor: 'rgba(255, 235, 59, 0.8)'
+    }
+};

--- a/scripts/core/editor3/directive.js
+++ b/scripts/core/editor3/directive.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {Provider} from 'react-redux';
+import {Editor3} from './components';
+import createStore from './store';
+
+/**
+ * @ngdoc directive
+ * @module superdesk.core.editor3
+ * @name sdEditor3
+ * @param {Array} editorFormat the formating settings available for editor
+ * @param {String} value the model for editor value
+ * @param {Boolean} readOnly true if the editor is read only
+ * @param {Function} onChange the callback executed when the editor value is changed
+ * @param {String} language the current language used for spellchecker
+ * @description sdEditor3 integrates react Editor3 component with superdesk app.
+ */
+export const sdEditor3 = () => new Editor3Directive();
+
+class Editor3Directive {
+    constructor() {
+        this.scope = {};
+        this.controllerAs = 'vm';
+        this.controller = ['$element', 'editor3', '$scope', this.initialize];
+
+        this.bindToController = {
+            config: '=',
+            editorFormat: '=',
+            language: '=',
+            onChange: '&',
+            value: '=',
+            editorState: '=',
+            readOnly: '='
+        };
+    }
+
+    initialize($element, editor3, $scope) {
+        const store = createStore(this);
+
+        editor3.setStore(store);
+
+        ReactDOM.render(
+            <Provider store={store}>
+                <Editor3 />
+            </Provider>, $element.get(0)
+        );
+    }
+}

--- a/scripts/core/editor3/index.js
+++ b/scripts/core/editor3/index.js
@@ -1,9 +1,7 @@
 import './styles.scss';
-import React from 'react';
-import ReactDOM from 'react-dom';
-import {Provider} from 'react-redux';
-import {Editor3} from './components';
-import createStore from './store';
+
+import {EditorService} from './service';
+import {sdEditor3} from './directive';
 
 /**
  * @ngdoc module
@@ -12,38 +10,6 @@ import createStore from './store';
  * @packageName superdesk.core
  * @description Superdesk core editor version 3.
  */
-
-/**
- * @ngdoc directive
- * @module superdesk.core.editor3
- * @name sdEditor3
- * @param {Array} editorFormat the formating settings available for editor
- * @param {String} value the model for editor value
- * @param {Boolean} readOnly true if the editor is read only
- * @param {Function} onChange the callback executed when the editor value is changed
- * @param {String} language the current language used for spellchecker
- * @description sdEditor3 integrates react Editor3 component with superdesk app.
- */
 export default angular.module('superdesk.core.editor3', ['superdesk.apps.spellcheck'])
-    .directive('sdEditor3',
-        () => ({
-            scope: {},
-            bindToController: {
-                config: '=',
-                editorFormat: '=',
-                language: '=',
-                onChange: '&',
-                value: '=',
-                editorState: '=',
-                readOnly: '='
-            },
-            controllerAs: 'vm',
-            controller: ['$element', function($element) {
-                ReactDOM.render(
-                    <Provider store={createStore(this)}>
-                        <Editor3 />
-                    </Provider>, $element.get(0)
-                );
-            }]
-        })
-    );
+    .service('editor3', EditorService)
+    .directive('sdEditor3', sdEditor3);

--- a/scripts/core/editor3/reducers/find-replace.jsx
+++ b/scripts/core/editor3/reducers/find-replace.jsx
@@ -1,0 +1,279 @@
+import {SelectionState, Modifier, EditorState} from 'draft-js';
+
+const findReplace = (state = {}, action) => {
+    switch (action.type) {
+    case 'HIGHLIGHTS_FIND_NEXT':
+        return findNext(state, action.payload);
+    case 'HIGHLIGHTS_FIND_PREV':
+        return findPrev(state, action.payload);
+    case 'HIGHLIGHTS_REPLACE':
+        return replaceHighlight(state, action.payload);
+    case 'HIGHLIGHTS_REPLACE_ALL':
+        return replaceHighlight(state, action.payload, true);
+    case 'HIGHLIGHTS_RENDER':
+        return render(state, action.payload);
+    case 'HIGHLIGHTS_CRITERIA':
+        return setCriteria(state, action.payload);
+    default:
+        return state;
+    }
+};
+
+/**
+ * @name replaceHighlight
+ * @param {Object} state
+ * @param {string} txt The text to replace the highlight with
+ * @param {boolean=} all If set to true, it replaces all occurences, otherwise it replaces
+ * only the current one.
+ * @description Replaces highlights with the given text.
+ */
+const replaceHighlight = (state, txt, all = false) => {
+    const {index, pattern, caseSensitive} = state.searchTerm;
+    const es = state.editorState;
+
+    let contentChanged = false;
+    let {content, editorState} = clearHighlights(es.getCurrentContent(), es);
+
+    // tries to replace the occurrence at position pos and returns true if successful.
+    let replaceAt = (pos) =>
+        forEachMatch(content, pattern, caseSensitive, (i, selection, block) => {
+            if (i === pos) {
+                // let's preserve styling and entities (such as links) on replacing
+                const styleAt = block.getInlineStyleAt(selection.anchorOffset) || null;
+                const entityAt = block.getEntityAt(selection.anchorOffset) || null;
+
+                content = Modifier.replaceText(content, selection, txt, styleAt, entityAt);
+                contentChanged = true;
+            }
+        });
+
+    if (all) {
+        // each replace alters the content and changes text offsets, so we need to call this method repeatedly
+        while (replaceAt(0)) { /* no-op */ }
+    } else {
+        replaceAt(index);
+    }
+
+    if (contentChanged) {
+        editorState = EditorState.push(editorState, content, 'replace-text');
+    }
+
+    return {
+        ...state,
+        editorState: editorState,
+        searchTerm: {
+            ...state.searchTerm,
+            // if we replaced the occurrence, index decreases
+            index: contentChanged && !all ? index - 1 : index
+        }
+    };
+};
+
+/**
+ * @name findNext
+ * @param {Object} state
+ * @description Increases the highlighted ocurrence index.
+ */
+const findNext = (state) => {
+    const i = state.searchTerm.index + 1;
+    const total = countOccurrences(state);
+    const index = i === total ? 0 : i;
+
+    return render({
+        ...state,
+        searchTerm: {...state.searchTerm, index}
+    });
+};
+
+/**
+ * @name findNext
+ * @param {Object} state
+ * @description Decreases the highlighted ocurrence index.
+ */
+const findPrev = (state) => {
+    const i = state.searchTerm.index - 1;
+    const total = countOccurrences(state);
+    const index = i < 0 ? total - 1 : i;
+
+    return render({
+        ...state,
+        searchTerm: {...state.searchTerm, index}
+    });
+};
+
+/**
+ * @name setCriteria
+ * @param {Object} state
+ * @param {string} pattern
+ * @param {boolean} caseSensitive
+ * @description Sets the highlight criteria pattern and case sensitivity.
+ */
+const setCriteria = (state, {pattern, caseSensitive}) => {
+    // If a new pattern is entered, the FindReplaceDirective calls selectNext, so the
+    // index needs to become -1. See apps/authoring/editor/find-replace.js
+    const index = pattern !== state.searchTerm.pattern ? -1 : 0;
+
+    return render({
+        ...state,
+        searchTerm: {pattern, caseSensitive, index}
+    });
+};
+
+/**
+ * @name render
+ * @param {Object} state
+ * @description Renders the search criteria in the state.
+ */
+const render = (state) => {
+    const {pattern, index, caseSensitive} = state.searchTerm;
+    const es = state.editorState;
+
+    let {content, editorState} = clearHighlights(es.getCurrentContent(), es);
+
+    if (!pattern) {
+        return {...state, editorState};
+    }
+
+    const changedContent = forEachMatch(content, pattern, caseSensitive, (i, selection) => {
+        content = Modifier.applyInlineStyle(
+            content,
+            selection,
+            i === index ? 'HIGHLIGHT_STRONG' : 'HIGHLIGHT'
+        );
+    });
+
+    if (changedContent) {
+        editorState = quietPush(editorState, content);
+    }
+
+    return {...state, editorState};
+};
+
+export default findReplace;
+
+/**
+ * @name countOccurences
+ * @param {Object} state
+ * @description Returns the number of occurences of the search criteria inside the current editor content.
+ */
+const countOccurrences = (state) => {
+    const content = state.editorState.getCurrentContent();
+    const {pattern, caseSensitive} = state.searchTerm;
+    const re = new RegExp(pattern, 'g' + (caseSensitive ? '' : 'i'));
+
+    let matches = 0;
+
+    content.getBlocksAsArray().forEach((block) => {
+        matches += (block.getText().match(re) || []).length;
+    });
+
+    return matches;
+};
+
+/**
+ * @name clearHighlights
+ * @param {ContentState} c The content to clear the highlights in.
+ * @param {EditorState=} es If provided, the new content state is pushed into this editor state.
+ * @returns {Object} Returns an object that contains two keys, the cleared content state and
+ * the new editor state (if it was provided).
+ * @description Clears all the highlights in the given content. If an editor state is provided,
+ * it also returns it updated.
+ */
+export const clearHighlights = (c, es = null) => {
+    let content = c;
+    let editorState = es;
+    let changedContent = false;
+
+    const filterFn = (c) => c.hasStyle('HIGHLIGHT') || c.hasStyle('HIGHLIGHT_STRONG');
+
+    content.getBlocksAsArray().forEach((block) => {
+        block.findStyleRanges(filterFn,
+            (start, end) => {
+                const selection = createSelection(block.getKey(), start, end);
+
+                content = Modifier.removeInlineStyle(content, selection, 'HIGHLIGHT');
+                content = Modifier.removeInlineStyle(content, selection, 'HIGHLIGHT_STRONG');
+
+                changedContent = true;
+            }
+        );
+    });
+
+    if (changedContent && editorState) {
+        editorState = quietPush(editorState, content);
+    }
+
+    return {content, editorState};
+};
+
+
+/**
+ * @name createSelection
+ * @param {string} key Block key
+ * @param {number} anchor Anchor offset
+ * @param {number} focus Focus offset
+ * @returns {SelectionState}
+ * @description Creates a new selection state, based on the given block key, having the specified
+ * anchor and offset.
+ */
+const createSelection = (key, start, end) =>
+    SelectionState.createEmpty(key).merge({
+        anchorOffset: start,
+        focusOffset: end
+    });
+
+/**
+ * @name forEachMatch
+ * @param {ContentState} content The content to search in.
+ * @param {string} pattern The pattern to search by.
+ * @param {boolean} caseSensitive Whether the search should be case sensitive or not.
+ * @param {function} cb The callback to call for each occurrence. Receives index, selection and block.
+ * @returns {boolean} True if the callback was called.
+ * @description Searches the content for the given pattern and calls the given callback
+ * for each occurrence, passing it the index of the match and its SelectionState.
+ */
+const forEachMatch = (content, pattern, caseSensitive, cb) => {
+    if (!pattern) {
+        return false;
+    }
+
+    let match;
+    let matchIndex = -1;
+
+    const re = new RegExp(pattern, 'g' + (caseSensitive ? '' : 'i'));
+
+    content.getBlocksAsArray().forEach((block) => {
+        const key = block.getKey();
+        const text = block.getText();
+
+        // eslint-disable-next-line no-cond-assign
+        while (match = re.exec(text)) {
+            cb(
+                ++matchIndex,
+                createSelection(key, match.index, match.index + pattern.length),
+                block
+            );
+        }
+    });
+
+    return matchIndex > -1;
+};
+
+/**
+ * @name quietPush
+ * @param {EditorState} editorState
+ * @param {ContentState} content
+ * @description Silently pushes the new content state into the given editor state, without
+ * affecting the undo/redo stack.
+ */
+const quietPush = (editorState, content) => {
+    const {allowUndo} = EditorState;
+
+    EditorState.allowUndo = false;
+
+    const newState = EditorState.push(editorState, content, 'insert-characters');
+
+    EditorState.allowUndo = allowUndo;
+
+    return newState;
+};

--- a/scripts/core/editor3/reducers/index.jsx
+++ b/scripts/core/editor3/reducers/index.jsx
@@ -1,6 +1,7 @@
 import spellchecker from './spellchecker';
 import editor3 from './editor3';
 import toolbar from './toolbar';
+import findReplace from './find-replace';
 
 // Returns a new reducer which chains the state and action throught the given
 // list of reducers.
@@ -11,7 +12,8 @@ const chainReduce = (...reducers) =>
 const editorReducers = chainReduce(
     spellchecker,
     toolbar,
-    editor3
+    editor3,
+    findReplace
 );
 
 export default editorReducers;

--- a/scripts/core/editor3/reducers/spellchecker.jsx
+++ b/scripts/core/editor3/reducers/spellchecker.jsx
@@ -30,7 +30,7 @@ const replaceWord = (state, {word, newWord}) => {
 
     var newState = Modifier.replaceText(editorState.getCurrentContent(), wordSelection, newWord);
 
-    newState = EditorState.push(editorState, newState, 'spellchecker');
+    newState = EditorState.push(editorState, newState, 'spellcheck-change');
 
     return {...state, editorState: newState};
 };

--- a/scripts/core/editor3/service.js
+++ b/scripts/core/editor3/service.js
@@ -1,0 +1,97 @@
+import * as action from './actions/find-replace';
+
+/**
+ * @type {Object} Redux store
+ * @description Holds the store of the currently active body editor of the open article.
+ * @private
+ */
+let store = null;
+
+/**
+ * @ngdoc service
+ * @module superdesk.core.editor3
+ * @name editor3
+ * @description editor3 is the service that allows interacting with the editor from
+ * the outside. It uses the same interface as the editor service of core/editor2/editor.js
+ * to allow plugging one or the other based on the editor of the item being edited.
+ */
+export class EditorService {
+    /**
+     * @ngdoc method
+     * @name editor3#setStore
+     * @param {Object} redux store
+     * @description Registers the passed redux store with the service.
+     */
+    setStore(s) {
+        store = s;
+    }
+
+    /**
+     * @ngdoc method
+     * @name editor3#selectNext
+     * @description Triggers the action to select the next occurence of the search
+     * criteria in the editor.
+     */
+    selectNext() {
+        store.dispatch(action.findNext());
+    }
+
+    /**
+     * @ngdoc method
+     * @name editor3#selectPrev
+     * @description Triggers the action to select the previous occurence of the search
+     * criteria in the editor.
+     */
+    selectPrev() {
+        store.dispatch(action.findPrev());
+    }
+
+    /**
+     * @ngdoc method
+     * @name editor3#replace
+     * @param {string} txt
+     * @description Replaces the currently highlighted search criteria with the given text.
+     */
+    replace(txt) {
+        store.dispatch(action.replace(txt));
+    }
+
+    /**
+     * @ngdoc method
+     * @name editor3#replace
+     * @param {string} txt
+     * @description Replaces all the search criteria with the given text.
+     */
+    replaceAll(txt) {
+        store.dispatch(action.replaceAll(txt));
+    }
+
+    /**
+     * @ngdoc method
+     * @name editor3#setSettings
+     * @param {Object} findReplace The new search criteria. An object containing the keys
+     * caseSensitive (boolean) and diff (object having one key that is the pattern).
+     * @description Updates the search criteria.
+     */
+    setSettings({findreplace}) {
+        if (findreplace === null) {
+            store.dispatch(action.setHighlightCriteria({pattern: ''}));
+
+            return;
+        }
+
+        const {diff, caseSensitive} = findreplace;
+        const pattern = Object.keys(diff || {})[0] || '';
+
+        store.dispatch(action.setHighlightCriteria({pattern, caseSensitive}));
+    }
+
+    /**
+     * @ngdoc method
+     * @name editor3#render
+     * @description Highlights the current search criteria in the editor.
+     */
+    render() {
+        store.dispatch(action.renderHighlights());
+    }
+}

--- a/scripts/core/editor3/store/index.js
+++ b/scripts/core/editor3/store/index.js
@@ -7,6 +7,7 @@ import {Editor3} from '../components/Editor3';
 import {EditorState, convertFromRaw, convertToRaw, ContentState} from 'draft-js';
 import {stateToHTML} from 'draft-js-export-html';
 import {stateFromHTML} from 'draft-js-import-html';
+import {clearHighlights} from '../reducers/find-replace';
 
 /**
  * @name createEditorStore
@@ -26,6 +27,7 @@ export default function createEditorStore(ctrl) {
 
     const store = createStore(reducers, {
         editorState: EditorState.createWithContent(content, decorators),
+        searchTerm: {pattern: '', index: -1, caseSensitive: false},
         readOnly: ctrl.readOnly,
         showToolbar: showToolbar,
         singleLine: singleLine,
@@ -48,8 +50,11 @@ export default function createEditorStore(ctrl) {
  * is bound to the controller, so 'this' points to controller attributes.
  */
 function onChange(content) {
-    this.editorState = convertToRaw(content);
-    this.value = stateToHTML(content);
+    // clear find & replace highlights
+    const cleanedContent = clearHighlights(content).content;
+
+    this.editorState = convertToRaw(cleanedContent);
+    this.value = stateToHTML(cleanedContent);
     this.onChange();
 }
 


### PR DESCRIPTION
Adds new Find & Replace functionality. Works just like with editor2. No new changes or behaviours. Entities such as links and styling are preserved on replacing.

TODO:

- [x] ~~Exclude highlight state from content state (we don't want the DB to store this).~~
- [x] ~~Find a way to not register search actions in history.~~
- [x] ~~Documentation.~~
- [x] ~~Find a way to not destroy already existing entities, such as links by replacing (see [getEntityForSelection](https://github.com/facebook/draft-js/blob/0.9-stable/src/model/entity/getEntityKeyForSelection.js#L26)).~~
- [x] ~~Clean up.~~