### PR TITLE
[SDESK-663] Formerly thinRows config now made a user preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,7 @@ You can configure what will be displayed in list views, there are 3 areas in lis
     - `expiry` - expiry of spiked items
     - `desk` - where an item was fetched for ingested, where an item is for others
 
-- `thinRows` - optional configuration flag to have thinner rows for each line in the list.
-
-- `narrowView` - optional narrow view of 'firstLine' when authoring and preview panes are both open. This is active when the thinRows configuration is also active.
+- `narrowView` - optional narrow view of 'firstLine' when authoring and preview panes are both open. This is active when singleline:view user preference is also active.
 
 ##### Miscellaneous
 

--- a/scripts/apps/monitoring/directives/MonitoringGroup.js
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.js
@@ -18,16 +18,17 @@ import _ from 'lodash';
  * @requires multi
  * @requires archiveService
  * @requires $rootScope
+ * @requires preferencesService
  *
  * @description
  *   A directive that generates group/section on stages of a desk or saved search.
  */
 MonitoringGroup.$inject = ['cards', 'api', 'authoringWorkspace', '$timeout', 'superdesk', 'session',
     'activityService', 'workflowService', 'keyboardManager', 'desks', 'search', 'multi',
-    'archiveService', '$rootScope', 'config'];
+    'archiveService', '$rootScope', 'preferencesService'];
 export function MonitoringGroup(cards, api, authoringWorkspace, $timeout, superdesk, session, activityService,
-        workflowService, keyboardManager, desks, search, multi, archiveService, $rootScope, config) {
-    var ITEM_HEIGHT = config.list && config.list.thinRows ? 29 : 57;
+        workflowService, keyboardManager, desks, search, multi, archiveService, $rootScope, preferencesService) {
+    var ITEM_HEIGHT = 57;
 
     return {
         templateUrl: 'scripts/apps/monitoring/views/monitoring-group.html',
@@ -41,6 +42,10 @@ export function MonitoringGroup(cards, api, authoringWorkspace, $timeout, superd
         link: function(scope, elem, attrs, ctrls) {
             var monitoring = ctrls[0];
             var projections = search.getProjectedFields();
+
+            preferencesService.get('singleline:view').then((result) => {
+                ITEM_HEIGHT = result.enabled ? 29 : 57;
+            });
 
             scope.view = 'compact';
             scope.page = 1;

--- a/scripts/apps/search/components/ItemList.jsx
+++ b/scripts/apps/search/components/ItemList.jsx
@@ -63,13 +63,9 @@ export class ItemList extends React.Component {
         }
     }
 
-    // Function to make narrowView active: when both preview and authoring panes are open.
-    setNarrowView() {
-        const {superdeskFlags} = this.props.svc;
-
-        if (superdeskFlags.flags.authoring) {
-            this.setState({narrow: true});
-        }
+    // Function to make narrowView active/inactive
+    setNarrowView(setNarrow) {
+        this.setState({narrow: setNarrow});
     }
 
     select(item, event) {
@@ -170,7 +166,7 @@ export class ItemList extends React.Component {
     }
 
     deselectAll() {
-        this.setState({selected: null, narrow: false});
+        this.setState({selected: null});
     }
 
     updateAllItems(itemId, changes) {

--- a/scripts/apps/search/components/ListItemInfo.jsx
+++ b/scripts/apps/search/components/ListItemInfo.jsx
@@ -2,15 +2,11 @@ import React from 'react';
 import classNames from 'classnames';
 
 import {renderArea} from 'apps/search/helpers';
-import {DEFAULT_LIST_CONFIG} from 'apps/search/constants';
 
 export function ListItemInfo(props) {
-    const {config} = props.svc;
-    const listConfig = config.list || DEFAULT_LIST_CONFIG;
-
     return React.createElement(
         'div',
-        {className: classNames('item-info', {'item-info-reduced-rowheight': listConfig.thinRows})},
+        {className: classNames('item-info', {'item-info-reduced-rowheight': props.scope.singleLine})},
         renderArea('firstLine', angular.extend({
             svc: props.svc,
             scope: props.scope

--- a/scripts/apps/search/components/ListPriority.jsx
+++ b/scripts/apps/search/components/ListPriority.jsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
 import {renderArea} from 'apps/search/helpers';
-import {DEFAULT_LIST_CONFIG} from 'apps/search/constants';
 
 export function ListPriority(props) {
-    const {config} = props.svc;
-    var listConfig = config.list || DEFAULT_LIST_CONFIG;
     var css = {
         className: classNames('list-field urgency', {
-            'urgency-reduced-rowheight': listConfig.thinRows
+            'urgency-reduced-rowheight': props.scope.singleLine
         })
     };
 
@@ -17,4 +14,5 @@ export function ListPriority(props) {
 
 ListPriority.propTypes = {
     svc: React.PropTypes.object.isRequired,
+    scope: React.PropTypes.any.isRequired
 };

--- a/scripts/apps/search/directives/ItemList.js
+++ b/scripts/apps/search/directives/ItemList.js
@@ -33,8 +33,8 @@ ItemList.$inject = [
     '$interpolate',
     'metadata',
     'storage',
-    'superdeskFlags',
-    'keyboardManager'
+    'keyboardManager',
+    'preferencesService'
 ];
 
 export function ItemList(
@@ -64,8 +64,8 @@ export function ItemList(
     $interpolate,
     metadata,
     storage,
-    superdeskFlags,
-    keyboardManager
+    keyboardManager,
+    preferencesService
 ) {
     // contains all the injected services to be passed down to child
     // components via props
@@ -96,8 +96,8 @@ export function ItemList(
         $interpolate: $interpolate,
         metadata: metadata,
         storage: storage,
-        superdeskFlags: superdeskFlags,
-        keyboardManager: keyboardManager
+        keyboardManager: keyboardManager,
+        preferencesService: preferencesService
     };
 
     return {
@@ -329,8 +329,17 @@ export function ItemList(
                     }
                 });
 
-                scope.$on('item:previewed', listComponent.setNarrowView);
-                scope.$on('item:unselect', listComponent.deselectAll);
+                preferencesService.get('singleline:view').then((result) => {
+                    scope.singleLine = result.enabled;
+                });
+
+                scope.$on('rowview:narrow', () => {
+                    listComponent.setNarrowView(true);
+                });
+
+                scope.$on('rowview:default', () => {
+                    listComponent.setNarrowView(false);
+                });
 
                 var updateTimeout;
 

--- a/scripts/apps/search/helpers.js
+++ b/scripts/apps/search/helpers.js
@@ -104,13 +104,18 @@ export function renderToBody(elem, target) {
 }
 
 export function renderArea(area, itemProps, props) {
+    // If singleline preference is set, don't show second line
+    if (itemProps.scope.singleLine && area === 'secondLine') {
+        return;
+    }
+
     /* globals __SUPERDESK_CONFIG__: true */
     const listConfig = __SUPERDESK_CONFIG__.list || DEFAULT_LIST_CONFIG;
 
     var specs = listConfig[area] || [];
 
-    // If narrowView configuration is available and also thinRows are active
-    if (listConfig.thinRows && area === 'firstLine' && itemProps.narrow && listConfig.narrowView) {
+    // If narrowView configuration is available and also singleline are active
+    if (itemProps.scope.singleLine && area === 'firstLine' && itemProps.narrow && listConfig.narrowView) {
         specs = listConfig.narrowView;
     }
 

--- a/scripts/core/services/preferencesService.js
+++ b/scripts/core/services/preferencesService.js
@@ -30,7 +30,8 @@ export default angular.module('superdesk.core.preferences', ['superdesk.core.not
                     'categories:preferred': 1,
                     'desks:preferred': 1,
                     'destination:active': 1, // key to store last desk/stage for send to/fetch to.
-                    'spellchecker:status': 1
+                    'spellchecker:status': 1,
+                    'singleline:view': 1
                 },
                 preferences,
                 preferencesPromise;


### PR DESCRIPTION
1 - thinRows taken out of superdesk.config.js and is now a user preference.
2 - Row view changes (config.list.narrowView) events refactored and fired only when all preconditions are met.
3 - Dependent on server side PR: https://github.com/superdesk/superdesk-core/pull/778