### PR TITLE
(fix): Modifying config to show-hide media metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ You can configure what will be displayed in list views, there are 3 areas in lis
 
 - `defaultRoute` - sets the route that the app will go to upon logging in (home route).
 - `langOverride` - allows to override some labels in the UI (breaking, not recommended). It should be an object containing keys for language identifier and values as objects mapping labels to their translation. Example value: `{'en': {'Category':'Service'}}` would display _Service_ in place of _Category_ for the english (_en_) version.
-- `requiredMediaMetadata`: `array` - describes a list of fields that are required for media items (images/video)
+- `validatorMediaMetadata`: `object` - describes a fields that are required for media items (images/video). If the field is present in the object then it is displayed.

--- a/scripts/apps/archive/controllers/UploadController.js
+++ b/scripts/apps/archive/controllers/UploadController.js
@@ -9,7 +9,7 @@ export function UploadController($scope, $q, upload, api, archiveService, sessio
     $scope.enableSave = false;
     $scope.currentUser = session.identity;
     $scope.uniqueUpload = $scope.locals && $scope.locals.data && $scope.locals.data.uniqueUpload === true;
-    $scope.requiredFields = config.requiredMediaMetadata;
+    $scope.validator = config.validatorMediaMetadata;
 
     var uploadFile = function(item) {
         var handleError = function(reason) {
@@ -49,8 +49,8 @@ export function UploadController($scope, $q, upload, api, archiveService, sessio
         $scope.errorMessage = null;
         if (!_.isEmpty($scope.items)) {
             _.each($scope.items, (item) => {
-                _.each($scope.requiredFields, (key) => {
-                    if (_.isNil(item.meta[key]) || _.isEmpty(item.meta[key])) {
+                _.each(Object.keys($scope.validator), (key) => {
+                    if ($scope.validator[key].required && (_.isNil(item.meta[key]) || _.isEmpty(item.meta[key]))) {
                         $scope.errorMessage = 'Required field(s) are missing';
                         return false;
                     }

--- a/scripts/apps/archive/views/upload.html
+++ b/scripts/apps/archive/views/upload.html
@@ -37,29 +37,31 @@
                         <div class="bar" style="width:{{ item.progress }}%"></div>
                     </div>
 
-                    <div class="row">
-                        <label ng-class="{'label-asterisk':(requiredFields.indexOf('headline') > -1)}" translate>Title</label>
+                    <div ng-if="validator.headline" class="row">
+                        <label ng-class="{'label-asterisk':validator.headline.required}" translate>Title</label>
                         <div ng-model="item.meta.headline" contenteditable="true" class="contenteditable-input contenteditable-input--side-padding"></div>
                     </div>
                     <div class="other-info">
-                        <div class="row">
-                            <label ng-class="{'label-asterisk':(requiredFields.indexOf('description_text') > -1)}" translate>Description</label>
+                        <div class="row" ng-if="validator.description_text">
+                            <label ng-class="{'label-asterisk':validator.description_text.required}" translate>Description</label>
                             <div ng-model="item.meta.description_text" contenteditable="true" class="contenteditable-input contenteditable-input--side-padding"></div>
                         </div>
-                        <div class="row">
-                            <label ng-class="{'label-asterisk':(requiredFields.indexOf('alt_text') > -1)}" translate>Alt text</label>
+                        <div class="row" ng-if="validator.alt_text">
+                            <label ng-class="{'label-asterisk':validator.alt_text.required}" translate>Alt text</label>
                             <div ng-model="item.meta.alt_text" contenteditable="true" class="contenteditable-input contenteditable-input--side-padding"></div>
                         </div>
-                        <div class="row">
-                            <label ng-class="{'label-asterisk':(requiredFields.indexOf('byline') > -1)}" translate>Credit</label>
+                        <div class="row" ng-if="validator.byline">
+                            <label ng-class="{'label-asterisk':validator.byline.required}" translate>Credit</label>
                             <div ng-model="item.meta.byline" contenteditable="true" class="contenteditable-input contenteditable-input--side-padding"></div>
                         </div>
-                        <div class="row">
-                            <label ng-class="{'label-asterisk':(requiredFields.indexOf('copyrightholder') > -1)}" translate>Copyright holder</label>
+                        <div class="row" ng-if="validator.copyrightholder">
+                            <label ng-class="{'label-asterisk':validator.copyrightholder.required}" translate>Copyright holder</label>
                             <div ng-model="item.meta.copyrightholder" contenteditable="true" class="contenteditable-input contenteditable-input--side-padding"></div>
                         </div>
-                        <div class="row">
-                            <label><span translate>Assign Rights</span></label>
+                        <div class="row" ng-if="validator.usageterms">
+                            <label ng-class="{'label-asterisk':validator.usageterms.required}">
+                                <span translate>Assign Rights</span>
+                            </label>
                             <select ng-model="item.meta.usageterms">
                                 <option translate value="">--- Not selected ---</option> <!-- not selected / blank option -->
                                 <option translate value="single-usage">Single Usage</option>
@@ -67,8 +69,8 @@
                                 <option translate value="indefinite-usage">Indefinite Usage</option>
                             </select>
                         </div>
-                        <div class="row">
-                            <label ng-class="{'label-asterisk':(requiredFields.indexOf('copyrightnotice') > -1)}" translate>Copyright notice</label>
+                        <div class="row" ng-if="validator.copyrightnotice">
+                            <label ng-class="{'label-asterisk':validator.copyrightnotice.required}" translate>Copyright notice</label>
                             <div ng-model="item.meta.copyrightnotice" contenteditable="true" class="contenteditable-input contenteditable-input--side-padding"></div>
                         </div>
                         <div class="row" ng-if="item.cssType === 'image'">

--- a/scripts/apps/authoring/authoring/controllers/ChangeImageController.js
+++ b/scripts/apps/authoring/authoring/controllers/ChangeImageController.js
@@ -7,23 +7,18 @@
  * @requires gettext
  * @requires notify
  * @requires modal
- * @requires $q
  * @requires lodash
  * @requires api
  * @requires $rootScope
  * @requires config
- * @requires authoringWorkspace
- * @requires archiveService
  *
  * @description Controller is responsible for cropping pictures and setting Point of Interest for an image.
  */
-ChangeImageController.$inject = ['$scope', 'gettext', 'notify', 'modal', '$q', 'lodash', 'api', '$rootScope',
-    'config', 'authoringWorkspace', 'archiveService'];
-export function ChangeImageController($scope, gettext, notify, modal, $q, _, api, $rootScope, config,
-    authoringWorkspace, archiveService) {
+ChangeImageController.$inject = ['$scope', 'gettext', 'notify', 'modal', 'lodash', 'api', '$rootScope', 'config'];
+export function ChangeImageController($scope, gettext, notify, modal, _, api, $rootScope, config) {
     $scope.data = $scope.locals.data;
     $scope.data.cropData = {};
-    $scope.data.requiredFields = config.requiredMediaMetadata;
+    $scope.validator = config.validatorMediaMetadata;
     let sizes = {};
 
     $scope.data.renditions.forEach((rendition) => {
@@ -87,11 +82,11 @@ export function ChangeImageController($scope, gettext, notify, modal, $q, _, api
         }
         /* Throw an exception if a required metadata field is missing */
         function validateMediaFields() {
-            _.each($scope.data.requiredFields, (key) => {
+            _.each(Object.keys($scope.validator), (key) => {
                 let value = $scope.data.metadata[key];
                 let regex = new RegExp('^\<*br\/*\>*$', 'i');
 
-                if (!value || value.match(regex)) {
+                if ($scope.validator[key].required && (!value || value.match(regex))) {
                     throw gettext('Required field(s) missing');
                 }
             });

--- a/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.spec.js
+++ b/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.spec.js
@@ -47,6 +47,7 @@ describe('item association directive', () => {
     it('can trigger onsave handler on drop when content is not published', inject(($rootScope, renditions) => {
         var event = new window.$.Event('drop');
 
+        scope.item.state = 'in_progress';
         event.originalEvent = {dataTransfer: {
             types: [{type: 'video'}],
             getData: () => angular.toJson({headline: 'foo', _type: 'externalsource'})
@@ -75,6 +76,7 @@ describe('item association directive', () => {
             types: [{type: 'video'}],
             getData: () => angular.toJson({headline: 'foo', _type: 'externalsource'})
         }};
+
         event.preventDefault = jasmine.createSpy('preventDefault');
         event.stopPropagation = jasmine.createSpy('stopPropagation');
         scope.onChange = jasmine.createSpy('onchange');
@@ -89,4 +91,32 @@ describe('item association directive', () => {
         expect(event.stopPropagation).toHaveBeenCalled();
         expect(scope.item.associations.featured.headline).toBe('foo');
     }));
+
+    it('cannot trigger onchange handler on drop when feature media is not editable',
+        inject(($rootScope, renditions, config) => {
+            var event = new window.$.Event('drop');
+
+            config.features = {
+                editFeaturedImage: 0
+            };
+            scope.item.state = 'in_progress';
+            event.originalEvent = {dataTransfer: {
+                types: [{type: 'image'}],
+                getData: () => angular.toJson({headline: 'foo', _type: 'externalsource'})
+            }};
+
+            event.preventDefault = jasmine.createSpy('preventDefault');
+            event.stopPropagation = jasmine.createSpy('stopPropagation');
+            scope.onChange = jasmine.createSpy('onchange');
+            scope.save = jasmine.createSpy('save');
+            elem.triggerHandler(event);
+            $rootScope.$digest();
+            expect(renditions.ingest).not.toHaveBeenCalled();
+            expect(renditions.crop).not.toHaveBeenCalled();
+            expect(scope.onChange).not.toHaveBeenCalled();
+            expect(scope.save).toHaveBeenCalled();
+            expect(event.preventDefault).toHaveBeenCalled();
+            expect(event.stopPropagation).toHaveBeenCalled();
+            expect(scope.item.associations.featured.headline).toBe('foo');
+        }));
 });

--- a/scripts/apps/authoring/views/change-image.html
+++ b/scripts/apps/authoring/views/change-image.html
@@ -71,28 +71,30 @@
              ng-class="{'modal-body__flex--disabled': isAoISelectionModeEnabled}"
              ng-if="data.showMetadataEditor">
             <div class="header" translate>Metadata</div>
-            <div>
-                <label ng-class="{'label-asterisk':(data.requiredFields.indexOf('headline') > -1)}" translate>Title</label>
+            <div ng-if="validator.headline">
+                <label ng-class="{'label-asterisk':validator.headline.required}" translate>Title</label>
                 <div ng-model="data.metadata.headline" ng-change="data.isDirty = true" contenteditable="true" class="contenteditable-input"></div>
             </div>
-            <div>
-                <label ng-class="{'label-asterisk':(data.requiredFields.indexOf('description_text') > -1)}" translate>Description</label>
+            <div ng-if="validator.description_text">
+                <label ng-class="{'label-asterisk':validator.description_text.required}" translate>Description</label>
                 <div ng-model="data.metadata.description_text" ng-change="data.isDirty = true" contenteditable="true" class="contenteditable-input"></div>
             </div>
-            <div>
-                <label ng-class="{'label-asterisk':(data.requiredFields.indexOf('alt_text') > -1)}" translate>Alt Text</label>
+            <div ng-if="validator.alt_text">
+                <label ng-class="{'label-asterisk':validator.alt_text.required}" translate>Alt Text</label>
                 <div ng-model="data.metadata.alt_text" ng-change="data.isDirty = true" contenteditable="true" class="contenteditable-input"></div>
             </div>
-            <div>
-                <label ng-class="{'label-asterisk':(data.requiredFields.indexOf('byline') > -1)}" translate>Credit</label>
+            <div ng-if="validator.byline">
+                <label ng-class="{'label-asterisk':validator.byline.required}" translate>Credit</label>
                 <div ng-model="data.metadata.byline" ng-change="data.isDirty = true" contenteditable="true" class="contenteditable-input"></div>
             </div>
-            <div>
-                <label ng-class="{'label-asterisk':(data.requiredFields.indexOf('copyrightholder') > -1)}" translate>Copyright holder</label>
+            <div ng-if="validator.copyrightholder">
+                <label ng-class="{'label-asterisk':validator.copyrightholder.required}" translate>Copyright holder</label>
                 <div ng-model="data.metadata.copyrightholder" ng-change="data.isDirty = true" contenteditable="true" class="contenteditable-input"></div>
             </div>
-            <div>
-                <label><span translate>Assign Rights</span></label>
+            <div ng-if="validator.usageterms">
+                <label ng-class="{'label-asterisk':validator.usageterms.required}">
+                    <span translate>Assign Rights</span>
+                </label>
                 <select ng-model="data.metadata.usageterms" ng-change="data.isDirty = true">
                     <option translate value="">--- Not selected ---</option> <!-- not selected / blank option -->
                     <option translate value="single-usage">Single Usage</option>
@@ -100,8 +102,8 @@
                     <option translate value="indefinite-usage">Indefinite Usage</option>
                 </select>
             </div>
-            <div>
-                <label ng-class="{'label-asterisk':(data.requiredFields.indexOf('copyrightnotice') > -1)}" translate>Copyright notice</label>
+            <div ng-if="validator.copyrightnotice">
+                <label ng-class="{'label-asterisk':validator.copyrightnotice.required}" translate>Copyright notice</label>
                 <div ng-model="data.metadata.copyrightnotice" ng-change="data.isDirty = true" contenteditable="true" class="contenteditable-input"></div>
             </div>
         </div>

--- a/scripts/apps/authoring/views/item-association.html
+++ b/scripts/apps/authoring/views/item-association.html
@@ -1,7 +1,7 @@
 <figure class="item-association"
         ng-class="{'item-association--preview': related, 'item-association--loading': loading}"
-        ng-click="isEditable() && !related && upload()">
-    <div ng-if="related && isEditable()" class="close-overlay">
+        ng-click="editable && !related && upload()">
+    <div ng-if="related && editable" class="close-overlay">
         <button class="btn btn--mini btn--light btn--pull-right" ng-click="remove(related); $event.stopPropagation()">
             <i class="icon-close-small"></i>
         </button>
@@ -13,8 +13,8 @@
     </video>
     <img ng-if="related && (related.type === 'picture' || related.type === 'graphic')"
          ng-src="{{ related.renditions.viewImage.href }}"
-         ng-class="{'not-editable': !isEditable()}"
-         ng-click="isEditable() && edit(related); $event.stopPropagation()">
+         ng-class="{'not-editable': !(isMediaEditable() && editable)}"
+         ng-click="editable && edit(related); $event.stopPropagation()">
     <div sd-remove-tags
         type="text"
         ng-model="related.description_text"

--- a/scripts/apps/search/constants.js
+++ b/scripts/apps/search/constants.js
@@ -98,10 +98,7 @@ export const CORE_PROJECTED_FIELDS = {
         'source',
         'last_published_version',
         'archived',
-        'associations',
-        'poi',
-        'alt_text',
-        'description_text'
+        'associations'
     ]
 };
 

--- a/scripts/core/tests/mocks.js
+++ b/scripts/core/tests/mocks.js
@@ -17,7 +17,29 @@ angular.module('superdesk.mocks', [])
             dateformat: 'DD/MM/YYYY',
             timeformat: 'HH:mm:ss'
         },
-        requiredMediaMetadata: ['headline', 'description_text', 'alt_text']
+        validatorMediaMetadata: {
+            headline: {
+                required: true
+            },
+            alt_text: {
+                required: true
+            },
+            description_text: {
+                required: true
+            },
+            copyrightholder: {
+                required: false
+            },
+            byline: {
+                required: false
+            },
+            usageterms: {
+                required: false
+            },
+            copyrightnotice: {
+                required: false
+            }
+        }
     })
     .service('features', () => { /* no-op */ })
     .service('preferencesService', function($q) {

--- a/superdesk.config.js
+++ b/superdesk.config.js
@@ -8,7 +8,29 @@
 module.exports = function(grunt) {
     return {
         defaultRoute: '/workspace',
-        requiredMediaMetadata: ['headline', 'description_text', 'alt_text'],
+        validatorMediaMetadata: {
+            headline: {
+                required: true
+            },
+            alt_text: {
+                required: true
+            },
+            description_text: {
+                required: true
+            },
+            copyrightholder: {
+                required: false
+            },
+            byline: {
+                required: false
+            },
+            usageterms: {
+                required: false
+            },
+            copyrightnotice: {
+                required: false
+            }
+        },
         features: {
             swimlane: {columnsLimit: 4}
         },


### PR DESCRIPTION
- Changing config to show-hide media metadata
- Fixing the issue when a media item from monitoring is associated to an text item then metadata is not copied across to the associated item.

This would require change to the `superdesk.config.js` in the repo https://github.com/superdesk/superdesk.