### PR TITLE
fix(multi-action) - Keep selected items in single desk view

### DIFF
--- a/scripts/apps/archive/services/MultiService.js
+++ b/scripts/apps/archive/services/MultiService.js
@@ -1,54 +1,71 @@
-import _ from 'lodash';
-
+/**
+ * @ngdoc service
+ * @module superdesk.apps.archive
+ * @name multi
+ * @requires $rootScope
+ * @description Multi Service keeps track of multiple selections
+ */
 MultiService.$inject = ['$rootScope'];
 export function MultiService($rootScope) {
     var items = [];
-
     var self = this;
+    var findItem = (item) => _.find(items, (i) => i._id === item._id && i._current_version === item._current_version);
 
     /**
-     * Test if given item is selected
-     *
-     * @param {Object} item
+     * @ngdoc method
+     * @name multi#isSelected
+     * @public
+     * @description Checks if given item is selected
+     * @param {Object} item - story
+     * @returns {Boolean}
      */
     this.isSelected = function(item) {
-        return item.selected;
+        return _.size(findItem(item)) > 0;
     };
 
     /**
-     * Toggle item selected state
-     *
-     * @param {Object} item
+     * @ngdoc method
+     * @name multi#toggle
+     * @public
+     * @description Toggles the given item selected state
+     * @param {Object} item - story
      */
     this.toggle = function(item) {
-        items = _.without(items, _.find(items, identity));
+        items = _.without(items, findItem(item));
         if (item.selected) {
             items = _.union(items, [item]);
         }
 
         this.count = items.length;
-
-        function identity(_item) {
-            return _item._id === item._id && _item._current_version === item._current_version;
-        }
     };
 
     /**
-     * Get list of selected items identifiers
+     * @ngdoc method
+     * @name multi#getIds
+     * @public
+     * @description Returns list of selected item identifiers
+     * @returns {Array} item ids
      */
     this.getIds = function() {
         return _.map(items, '_id');
     };
 
     /**
-     * Get list of selected items
+     * @ngdoc method
+     * @name multi#getItems
+     * @public
+     * @description Returns list of selected items
+     * @returns {Array} items
      */
     this.getItems = function() {
         return items;
     };
 
     /**
-     * Reset to empty
+     * @ngdoc method
+     * @name multi#reset
+     * @public
+     * @description Resets selected items
      */
     this.reset = function() {
         var ids = [];
@@ -63,8 +80,11 @@ export function MultiService($rootScope) {
     };
 
     /**
-     * update count on deselection
-     * e.g, when selected item gets published, corrected or killed
+     * @ngdoc method
+     * @name multi#remove
+     * @public
+     * @description Removes the item and updates count on deselection
+     * @param {string} item id
      */
     this.remove = function(itemId) {
         _.remove(items, {_id: itemId});

--- a/scripts/apps/archive/tests/archive.spec.js
+++ b/scripts/apps/archive/tests/archive.spec.js
@@ -165,6 +165,14 @@ describe('content', () => {
             multi.toggle(items[1]);
             expect(multi.getItems()).toEqual(items);
         }));
+
+        it('can check if item is selected', inject((multi) => {
+            var items = [{_id: 1, selected: true}];
+
+            multi.toggle(items[0]);
+            expect(multi.isSelected(items[0])).toEqual(true);
+            expect(multi.isSelected({_id: 2})).toEqual(false);
+        }));
     });
 
     describe('media-related directive', () => {

--- a/scripts/apps/monitoring/controllers/AggregateCtrl.js
+++ b/scripts/apps/monitoring/controllers/AggregateCtrl.js
@@ -371,7 +371,6 @@ export function AggregateCtrl($scope, api, desks, workspaces, preferencesService
      * param {string} fileType
      */
     this.setFileType = function(fileType) {
-        multi.reset();
         if (fileType === 'all') {
             this.selectedFileType = [];
         } else {

--- a/scripts/apps/monitoring/views/monitoring-view.html
+++ b/scripts/apps/monitoring/views/monitoring-view.html
@@ -155,7 +155,7 @@
                     ></div>
                 </div>
                 <div ng-if="monitoring.singleGroup && !monitoring.isDeskChanged()" class="list">
-                    <div sd-monitoring-group class="single-group" data-group="monitoring.singleGroup" data-num-items="10" data-view-type="'single_monitoring'">
+                    <div sd-monitoring-group class="single-group" data-group="monitoring.singleGroup" data-num-items="50" data-view-type="'single_monitoring'">
                     </div>
                 </div>
                 <div ng-if="type === 'personal'" class="list">

--- a/scripts/apps/search/directives/MultiActionBar.js
+++ b/scripts/apps/search/directives/MultiActionBar.js
@@ -7,7 +7,17 @@ export function MultiActionBar(asset, multi, authoringWorkspace, superdesk, keyb
         scope: true,
         link: function(scope) {
             scope.multi = multi;
+            scope.display = true;
             scope.$watch(multi.getItems, detectType);
+
+            scope.$watch('multi.count', () => {
+                scope.display = true;
+            });
+
+            scope.toggleDisplay = () => {
+                scope.display = !scope.display;
+            };
+
             scope.$on('item:lock', (_e, data) => {
                 if (_.includes(multi.getIds(), data.item)) {
                     // locked item is in the selections so update lock info

--- a/scripts/apps/search/services/SearchService.js
+++ b/scripts/apps/search/services/SearchService.js
@@ -17,11 +17,12 @@ import _ from 'lodash';
  * @requires gettext
  * @requires config
  * @requires session
+ * @requires multi
  *
  * @description Search Service is responsible for creation and manipulation of Query object
  */
-SearchService.$inject = ['$location', 'gettext', 'config', 'session'];
-export function SearchService($location, gettext, config, session) {
+SearchService.$inject = ['$location', 'gettext', 'config', 'session', 'multi'];
+export function SearchService($location, gettext, config, session, multi) {
     var sortOptions = [
         {field: 'versioncreated', label: gettext('Updated')},
         {field: 'firstcreated', label: gettext('Created')},
@@ -599,6 +600,10 @@ export function SearchService($location, gettext, config, session) {
         if (this.getElasticHighlight()) {
             newItems._items = _.map(newItems._items, this.mergeHighlightFields);
         }
+
+        newItems._items.forEach((item) => {
+            item.selected = multi.isSelected(item);
+        });
 
         if (force || !scopeItems) {
             return newItems;

--- a/scripts/apps/search/styles/search.scss
+++ b/scripts/apps/search/styles/search.scss
@@ -121,6 +121,23 @@
     #multi-select-count {
         margin-left: 15px;
     }
+
+    .toggle {
+      width: 23px;
+      height: 23px;
+      border: 0;
+      padding: 0;
+      margin-right: 10px;
+      z-index: 3;
+      line-height: 0;
+      @include border-radius(23px);
+      box-shadow: 0 0 7px 0 rgba(0,0,0,0.3);
+      @include transition(transform 0.5s);
+      i { height: 15px; }
+      &.active {
+        @include rotate(180deg);
+      }
+    }
 }
 
 .item-searchbar {

--- a/scripts/apps/search/views/multi-action-bar.html
+++ b/scripts/apps/search/views/multi-action-bar.html
@@ -1,5 +1,6 @@
 
-<div class="multi-action-bar" ng-if="multi.count">
+<div class="multi-action-bar" ng-if="multi.count && display">
+    <button class="toggle" ng-click="toggleDisplay()"><i class="icon-chevron-up-thin"></i></button>
     <button class="btn" ng-click="multi.reset()">cancel</button>
     <span id="multi-select-count"
         translate


### PR DESCRIPTION
This PR addresses few minor issues with multi selections:
- Keeps the selected items if user moves to single desk or single stage view and back
- Added a hide button for multi select header panel so user can do a search or go back to monitoring
- Changed the initial number of items in single group from 10 to 50