### PR TITLE
[SDESK-705] - Grouping macros

### DIFF
--- a/scripts/apps/authoring/macros/macros.js
+++ b/scripts/apps/authoring/macros/macros.js
@@ -1,3 +1,12 @@
+/**
+ * @ngdoc service
+ * @module superdesk.apps.authoring.macros
+ * @name macros
+ * @requires api
+ * @requires notify
+ * @description MacrosService provides set of methods which allows fetching of macros
+ * and triggering of macros to be apply on provided item
+ */
 MacrosService.$inject = ['api', 'notify'];
 function MacrosService(api, notify) {
     /**
@@ -74,27 +83,69 @@ function MacrosService(api, notify) {
     }
 }
 
-MacrosController.$inject = ['$scope', 'macros', 'desks', 'autosave', '$rootScope'];
-function MacrosController($scope, macros, desks, autosave, $rootScope) {
+/**
+ * @ngdoc controller
+ * @module superdesk.apps.authoring.macros
+ * @name Macros
+ * @requires https://docs.angularjs.org/api/ng/type/$rootScope.Scope $scope
+ * @requires macros
+ * @requires desks
+ * @requires autosave
+ * @requires https://docs.angularjs.org/api/ng/service/$rootScope $rootScope
+ * @requires storage
+ * @description MacrosController holds a set of convenience functions used by macros widget
+ */
+MacrosController.$inject = ['$scope', 'macros', 'desks', 'autosave', '$rootScope', 'storage'];
+function MacrosController($scope, macros, desks, autosave, $rootScope, storage) {
+    let expandedGroup = storage.getItem('expandedGroup') || [];
+
     $scope.loading = true;
 
     macros.get().then(() => {
-        var currentDeskId = desks.getCurrentDeskId();
+        let currentDeskId = desks.getCurrentDeskId();
 
         if (currentDeskId !== null) {
             macros.getByDesk(desks.getCurrentDesk().name).then((_macros) => {
-                $scope.macros = _macros;
+                displayMacros(_macros);
             });
         } else {
-            $scope.macros = macros.macros;
+            displayMacros(macros.macros);
         }
     })
     .finally(() => {
         $scope.loading = false;
     });
 
+    /**
+     * @ngdoc method
+     * @name Macros#displayMacros
+     * @private
+     * @param {Array<object>} macros - each of macro contains name, label, group, order etc.
+     * @description displays the list of fetched macros
+     */
+    function displayMacros(fetchedMacros) {
+        $scope.macros = fetchedMacros;
+        // grouped macros list
+        $scope.groupedMacros = _.groupBy(_.filter($scope.macros, 'group'), 'group');
+        // provide grouping macros list option and prepare list, if group available.
+        if (_.isEmpty($scope.groupedMacros)) {
+            $scope.groupedList = false;
+        } else {
+            $scope.groupedList = true;
+            prepareMacrosList($scope.macros);
+        }
+    }
+
+    /**
+     * @ngdoc method
+     * @name Macros#call
+     * @param {Object} macro - contains name, label, group, order etc.
+     * @returns {Promise} - If resolved then macro is applied successfully
+     * @description
+     * Triggers macros service call to apply the provided macro on opened article
+     */
     $scope.call = function(macro) {
-        var item = _.extend({}, $scope.origItem, $scope.item);
+        let item = _.extend({}, $scope.origItem, $scope.item);
 
         $scope.loading = true;
         return macros.call(macro, item).then((res) => {
@@ -110,8 +161,75 @@ function MacrosController($scope, macros, desks, autosave, $rootScope) {
            $scope.loading = false;
        });
     };
+
+    /**
+     * @ngdoc method
+     * @name Macros#prepareMacrosList
+     * @private
+     * @param {Array<object>} macros - each of macro contains name, label, group, order etc.
+     * @description Prepares sections for list of macros, which includes quick, grouped and
+     * miscellaneous set of macros for display
+     */
+    function prepareMacrosList(allMacros) {
+        // macros quick list, i.e. where order is defined
+        $scope.quickList = _.filter(allMacros, 'order');
+
+        // miscellaneous macros list, i.e, where group is not defined
+        $scope.miscMacros = _.filter(allMacros, (o) => o.group === undefined);
+
+        // sort grouped macros
+        let ordered = {};
+
+        Object.keys($scope.groupedMacros)
+        .sort()
+        .forEach((key) => {
+            ordered[key] = _.sortBy($scope.groupedMacros[key], 'label');
+        });
+
+        // sorted grouped macros
+        $scope.orderedGroupedMacros = ordered;
+    }
+
+    /**
+     * @ngdoc method
+     * @name Macros#getGroupStatus
+     * @param {String} group - key that represents macro group, like area, currency etc.
+     * @returns {Boolean}
+     * @description gets the remembered toggle status of provided group,
+     * retrieved from local storage
+     */
+    $scope.getGroupStatus = function(group) {
+        return _.includes(expandedGroup, group);
+    };
+
+    /**
+     * @ngdoc method
+     * @name Macros#setGroupStatus
+     * @param {String} group - key that represents macro group, like area, currency etc.
+     * @description sets the toggle status of provided group to be remember in local storage
+     */
+    $scope.setGroupStatus = function(group) {
+        let index = expandedGroup.indexOf(group);
+
+        if (index > -1) {
+            expandedGroup.splice(index, 1);
+        } else {
+            expandedGroup.push(group);
+        }
+
+        storage.setItem('expandedGroup', expandedGroup);
+    };
 }
 
+/**
+ * @ngdoc directive
+ * @module superdesk.apps.authoring.macros
+ * @name sdMacrosReplace
+ * @requires editor
+ * @description sd-macro-replace performs the necessary replacement on editor's item in order to
+ * apply the results of triggered macro with the use of available set of methods such that next,
+ * prev and replace
+ */
 MacrosReplaceDirective.$inject = ['editor'];
 function MacrosReplaceDirective(editor) {
     return {
@@ -174,6 +292,13 @@ function MacrosReplaceDirective(editor) {
     };
 }
 
+/**
+ * @ngdoc module
+ * @module superdesk.apps.authoring.macros
+ * @name superdesk.apps.authoring.macros
+ * @packageName superdesk.apps
+ * @description Superdesk module that allows managing and using macros
+ */
 angular.module('superdesk.apps.authoring.macros', [
     'superdesk.core.api',
     'superdesk.core.notify',

--- a/scripts/apps/authoring/macros/macros.spec.js
+++ b/scripts/apps/authoring/macros/macros.spec.js
@@ -1,6 +1,31 @@
 
 
 describe('macros', () => {
+    let allMacros = [
+        {
+            _etag: '1',
+            description: 'Converts distance values from feet and inches to metric',
+            group: 'area',
+            label: 'Length feet-inches to metric',
+            name: 'feet_inches_to_metric',
+            order: 1
+        },
+        {
+            _etag: '2',
+            description: 'Marco function to generate slugline story by desk',
+            name: 'skeds_by_desk',
+            label: 'Skeds By Desk'
+        },
+        {
+            _etag: '3',
+            description: 'Convert CNY to AUD.',
+            group: 'currency',
+            label: 'Currency CNY to AUD',
+            name: 'yuan_to_aud',
+            order: 2
+        }
+    ];
+
     beforeEach(window.module('superdesk.apps.desks'));
     beforeEach(window.module('superdesk.apps.authoring.macros'));
     beforeEach(window.module('superdesk.apps.authoring.autosave'));
@@ -39,4 +64,36 @@ describe('macros', () => {
         $scope.$digest();
         expect($rootScope.$broadcast).toHaveBeenCalledWith('macro:diff', diff);
     }));
+
+    it('can provide group list option when group is defined in of macros',
+        inject((macros, $q, autosave, $rootScope) => {
+            // when group defined in any of macros
+            let groupedMacros = _.groupBy(_.filter(allMacros, 'group'), 'group');
+
+            let $scope = $rootScope.$new();
+
+            macros.macros = allMacros;
+            $controller('Macros', {$scope: $scope});
+            $scope.$digest();
+
+            expect($scope.macros).toEqual(allMacros);
+            expect($scope.groupedMacros).toEqual(groupedMacros);
+            expect($scope.groupedList).toBe(true);
+        }));
+
+    it('can hide group list option when group undefined in any of macros',
+        inject((macros, $q, autosave, $rootScope) => {
+            // when no group defined in any macros
+            let withoutGroupMacros = _.filter(allMacros, (o) => o.group === undefined);
+
+            let $scope = $rootScope.$new();
+
+            macros.macros = withoutGroupMacros;
+            $controller('Macros', {$scope: $scope});
+            $scope.$digest();
+
+            expect($scope.macros).toEqual(withoutGroupMacros);
+            expect($scope.groupedMacros).toEqual({});
+            expect($scope.groupedList).toBe(false);
+        }));
 });

--- a/scripts/apps/authoring/macros/views/macros-widget.html
+++ b/scripts/apps/authoring/macros/views/macros-widget.html
@@ -1,7 +1,40 @@
 <div class="widget" ng-controller="Macros">
-    <ul class="link-list" sd-loading="loading">
-        <li ng-repeat="macro in macros">
-            <button class="btn" ng-click="call(macro)">{{ macro.label | translate }}</button>
-        </li>
-    </ul>
+    <div class="macro-option" ng-show="groupedMacros">
+        <span translate>Group Macros</span>
+        <span class="pull-right" sd-switch ng-model="groupedList"></span>
+    </div>
+    <div ng-show="!groupedList">
+        <ul class="link-list" sd-loading="loading">
+            <li ng-repeat="macro in macros">
+                <button class="btn" ng-click="call(macro)">{{ macro.label | translate }}</button>
+            </li>
+        </ul>
+    </div>
+    <div ng-show="groupedList">
+        <div sd-toggle-box data-title="{{:: 'quick list' | translate }}" data-open="true">
+            <ul class="link-list" sd-loading="loading">
+                <li ng-repeat="macro in quickList | orderBy:'label'">
+                    <button class="btn" ng-click="call(macro)">{{ macro.label | translate }}</button>
+                </li>
+            </ul>
+        </div>
+        <div ng-repeat="(key,value) in orderedGroupedMacros">
+            <div sd-toggle-box data-title="{{:: key | translate }}"
+                ng-click="setGroupStatus(key)" data-open="{{getGroupStatus(key)}}">
+                <ul class="link-list" sd-loading="loading">
+                    <li ng-repeat="macro in value">
+                        <button class="btn" ng-click="call(macro)">{{ macro.label | translate }}</button>
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div sd-toggle-box data-title="{{:: 'miscellaneous' | translate }}"
+            ng-click="setGroupStatus('miscellaneous')" data-open="{{getGroupStatus('miscellaneous')}}">
+            <ul class="link-list" sd-loading="loading">
+                <li ng-repeat="macro in miscMacros | orderBy:'label'">
+                    <button class="btn" ng-click="call(macro)">{{ macro.label | translate }}</button>
+                </li>
+            </ul>
+        </div>
+    </div>
 </div>

--- a/scripts/apps/authoring/styles/authoring.scss
+++ b/scripts/apps/authoring/styles/authoring.scss
@@ -409,6 +409,10 @@
         margin-bottom: 0.5em;
     }
 
+    .macro-option {
+      margin-bottom: 20px;
+    }
+
     .link-list .btn {
         display: block;
         width: 100%;


### PR DESCRIPTION
- Provides the grouping option of macros in macros widget when group property is available.
- Displays grouped macros in form of expand/collapse(able) list when turned on
- Remembers expand/collapse via local storage
- Quick list of macros always available expanded on top of list, i-e, the macros where order is defined. 