### PR TITLE
Missing moment.js from the directive dependency injection

### DIFF
--- a/scripts/core/ui/ui.js
+++ b/scripts/core/ui/ui.js
@@ -623,8 +623,8 @@ function DatepickerDirective($document) {
     };
 }
 
-DatepickerInnerDirective.$inject = ['$compile', '$document', 'popupService', 'datetimeHelper', 'config'];
-function DatepickerInnerDirective($compile, $document, popupService, datetimeHelper, config) {
+DatepickerInnerDirective.$inject = ['$compile', '$document', 'popupService', 'datetimeHelper', 'config', 'moment'];
+function DatepickerInnerDirective($compile, $document, popupService, datetimeHelper, config, moment) {
     var startingDay = config.startingDay || '0';
     var popupTpl = '<div sd-datepicker-wrapper ng-model="date">' +
         '<div datepicker format-day="d" starting-day="' + startingDay + '" show-weeks="false"></div>' +


### PR DESCRIPTION
I added a dependency to moment.js in the datepicker inner directive.
Otherwise I'm having here: https://github.com/m0g/superdesk-client-core/blob/master/scripts/core/ui/ui.js#L687
