### PR TITLE
[SDESK-794] - Display 'marked for desk' items as a separate filtered …

### DIFF
--- a/scripts/apps/monitoring/services/CardsService.js
+++ b/scripts/apps/monitoring/services/CardsService.js
@@ -72,13 +72,7 @@ export function CardsService(api, search, session, desks, config) {
 
         default:
             if (!_.isNil(card.singleViewType) && card.singleViewType === 'desk') {
-                query.filter({or: [
-                        {terms: {'marked_desks.desk_id': [card.deskId]}},
-                        {term: {'task.desk': card.deskId}}]});
-            } else if (desks.stageLookup[card._id] && desks.stageLookup[card._id].default_incoming) {
-                query.filter({or: [
-                        {terms: {'marked_desks.desk_id': [card.deskId]}},
-                        {term: {'task.stage': card._id}}]});
+                query.filter({term: {'task.desk': card.deskId}});
             } else {
                 query.filter({term: {'task.stage': card._id}});
             }

--- a/scripts/apps/monitoring/tests/monitoring.spec.js
+++ b/scripts/apps/monitoring/tests/monitoring.spec.js
@@ -139,16 +139,6 @@ describe('monitoring', () => {
             expect(criteria.source.query.filtered.query.query_string.query).toBe('test');
         }));
 
-        it('can get criteria for marked desks in incoming stage', inject((cards, session) => {
-            session.identity = {_id: 'foo'};
-            var card = {_id: '456', deskId: '1'};
-            var criteria = cards.criteria(card);
-
-            expect(criteria.source.query.filtered.filter.and[4].or).toContain(
-                {terms: {'marked_desks.desk_id': ['1']}}
-            );
-        }));
-
         it('can get criteria for personal with search', inject((cards, session) => {
             var card = {type: 'personal', query: 'test'};
 

--- a/scripts/apps/search/views/search-parameters.html
+++ b/scripts/apps/search/views/search-parameters.html
@@ -55,8 +55,7 @@
                     data-change="itemSearch(selecteditems, cv.id)"></div>
             </div>
         </div>
-
-        <div class="field">
+        <div class="field" ng-if="search_config.marked_desks">
             <label for="search-marked-desks">
                 {{:: 'Marked Desks' | translate}}
             </label>

--- a/spec/helpers/monitoring.js
+++ b/spec/helpers/monitoring.js
@@ -389,7 +389,7 @@ function Monitoring() {
 
         btn.click();
         // wait for modal to be removed
-        browser.wait(() => btn.isPresent().then((isPresent) => !isPresent), 500);
+        browser.wait(() => btn.isPresent().then((isPresent) => !isPresent), 600);
     };
 
     /**
@@ -711,7 +711,7 @@ function Monitoring() {
 
         this.openMonitoring();
 
-        return browser.wait(() => element(by.className('list-view')).isPresent(), 300);
+        return browser.wait(() => element(by.className('list-view')).isPresent(), 500);
     };
 
     this.turnOffWorkingStage = function(deskIndex, canCloseSettingsModal) {
@@ -737,7 +737,6 @@ function Monitoring() {
 
     this.turnOffDeskWorkingStage = function(deskIndex, canCloseSettingsModal) {
         this.toggleStage(deskIndex, 0);
-
         if (typeof canCloseSettingsModal !== 'boolean') {
             this.nextStages();
             this.nextSearches();

--- a/spec/helpers/search.js
+++ b/spec/helpers/search.js
@@ -14,6 +14,7 @@ function GlobalSearch() {
     this.goButton = element(by.buttonText('Search'));
     this.searchInput = element(by.id('search-input'));
     this.subject = element.all(by.css('.dropdown-terms')).first();
+    this.marked = element(by.id('marked-desks')).all(by.css('.dropdown-terms')).first();
 
     /**
      * Open dashboard for current selected desk/custom workspace.
@@ -189,6 +190,13 @@ function GlobalSearch() {
         this.subject.element(by.css('.dropdown__toggle')).click();
     };
 
+     /**
+     * Opens Marked Desks dropdown
+     */
+    this.toggleMarkedDesks = function() {
+        this.marked.element(by.css('.dropdown__toggle')).click();
+    };
+
     /**
      * Gets the term on given 'index' from the
      * filtered metadata subject list
@@ -198,6 +206,17 @@ function GlobalSearch() {
      */
     this.getSubjectFilteredTerm = function(index) {
         return this.subject.all(by.repeater('t in $vs_collection track by t[uniqueField]')).get(index).getText();
+    };
+
+    /**
+     * Gets the term on given 'index' from the
+     * filtered Marked desks list
+     *
+     * @param {number} index
+     * @return {string}
+     */
+    this.getMarkedDesksFilteredTerm = function(index) {
+        return this.marked.all(by.repeater('t in $vs_collection track by t[uniqueField]')).get(index).getText();
     };
 
     /**

--- a/spec/marked_desks_spec.js
+++ b/spec/marked_desks_spec.js
@@ -1,56 +1,82 @@
 
-var route = require('./helpers/utils').route,
-    monitoring = require('./helpers/monitoring'),
-    search = require('./helpers/search'),
+var monitoring = require('./helpers/monitoring'),
+    route = require('./helpers/utils').route,
+    globalSearch = require('./helpers/search'),
     authoring = require('./helpers/authoring'),
     workspace = require('./helpers/workspace'),
     highlights = require('./helpers/highlights'),
     desks = require('./helpers/desks');
 
 describe('marked desks', () => {
+    function setupAttentionDeskAsSavedSearch() {
+        // Create global saved search called 'Attention Sports'
+        element(by.id('save_search_init')).click();
+        let searchPanel = element(by.className('save-search-panel'));
+
+        searchPanel.all(by.id('search_name')).sendKeys('Attention Sports');
+        searchPanel.all(by.id('search_description')).sendKeys('Stories attention to sports');
+        searchPanel.all(by.id('search_global')).click();
+        searchPanel.all(by.id('search_save')).click();
+        let savedSearch = element.all(by.repeater('search in userSavedSearches')).get(0);
+
+        expect(savedSearch.element(by.css('.search-name')).getText()).toBe('Attention Sports [Global]');
+
+        // setup desk monitoring settings to turn ON Attention Sports saved search for Sports Desk
+        desks.openDesksSettings();
+        desks.showMonitoringSettings('SPORTS DESK');
+        monitoring.toggleDesk(1);
+        monitoring.nextStages();
+        monitoring.toggleGlobalSearch(0);
+        monitoring.saveSettings();
+
+        monitoring.openMonitoring();
+    }
+
     describe('marking a story for a desk:', () => {
         beforeEach(route('/workspace/monitoring'));
 
-        it('displays the story in desk output stage', () => {
-            // Setup Desk Monitoring Settings
+        it('displays the story in desk attention stage', () => {
             expect(workspace.getCurrentDesk()).toEqual('POLITIC DESK');
-            desks.openDesksSettings();
-            desks.showMonitoringSettings('POLITIC DESK');
-            monitoring.turnOffDeskWorkingStage(0);
-            monitoring.openMonitoring();
 
             // mark for desk in monitoring in list
-            monitoring.actionOnItemSubmenu('Mark for desk', 'Sports Desk', 1, 0);
-            monitoring.checkMarkedForDesk('Sports Desk', 1, 0);
+            monitoring.actionOnItemSubmenu('Mark for desk', 'Sports Desk', 2, 0);
+            monitoring.checkMarkedForDesk('Sports Desk', 2, 0);
 
             // mark for desk in monitoring in edit
-            monitoring.actionOnItem('Edit', 1, 2);
+            monitoring.actionOnItem('Edit', 2, 2);
             authoring.markForDesks();
             highlights.selectDesk(authoring.getSubnav(), 'Sports Desk');
-            monitoring.checkMarkedForDesk('Sports Desk', 1, 2);
+            monitoring.checkMarkedForDesk('Sports Desk', 2, 2);
 
-            // mark for desk in search
-            search.openGlobalSearch();
-            search.setListView();
-            search.actionOnSubmenuItem('Mark for desk', 'Sports Desk', 3);
-            search.checkMarkedForDesk('Sports Desk', 3);
+            // mark for desk in globalSearch
+            globalSearch.openGlobalSearch();
+            globalSearch.setListView();
+            globalSearch.actionOnSubmenuItem('Mark for desk', 'Sports Desk', 3);
+            globalSearch.checkMarkedForDesk('Sports Desk', 3);
 
             // search by marked desk field
-            expect(search.getItems().count()).toBe(14);
-            search.openFilterPanel();
-            search.openParameters();
-            search.selectMarkedDesk(1);
-            search.goButton.click();
-            expect(search.getItems().count()).toBe(3);
+            expect(globalSearch.getItems().count()).toBe(14);
+            globalSearch.openFilterPanel();
 
-            // check the marked items in output stage of marked desk
-            monitoring.openMonitoring();
+            // make only production and published repos selected (unselect ingest and archived)
+            globalSearch.ingestRepo.click();
+            globalSearch.archivedRepo.click();
+
+            globalSearch.openParameters();
+            globalSearch.selectMarkedDesk(1); // selects Sports Desk
+            globalSearch.goButton.click();
+            expect(globalSearch.getItems().count()).toBe(3);
+
+            // now setup attention desk of just selected Marked desk(Sports Desk) as global saved search
+            setupAttentionDeskAsSavedSearch();
+
+            // check the marked items in attention stage of marked desk
             monitoring.switchToDesk('SPORTS DESK');
-            expect(monitoring.getGroupItems(1).count()).toBe(3);
+            expect(monitoring.getGroupItems(0).count()).toBe(3);
 
             // Remove the marked desk
-            monitoring.removeFromFirstDesk(1, 1);
-            expect(monitoring.getGroupItems(1).count()).toBe(2);
+            monitoring.removeFromFirstDesk(0, 1);
+            expect(monitoring.getGroupItems(0).count()).toBe(2);
         });
     });
 });


### PR DESCRIPTION
…view in Monitoring
- Reverted https://github.com/superdesk/superdesk-client-core/pull/1311 changes, rather implementation,
- Requires setting up (say:) 'Attention Sports Desk' [Global] saved search via global search (for marked items), i.e. saving search for selected desk in 'Marked Desk' filter with only Production and Published repos selected. Then turning ON that Attention Desk saved search via 'desk monitoring settings' will display Attention Desk list (marked items) in monitoring view of the desk.
- updated e2e to simulate the process