### PR TITLE
feature(editor3): Export to HTML [SDESK-863]

### DIFF
--- a/scripts/core/editor3/components/tables/TableBlock.jsx
+++ b/scripts/core/editor3/components/tables/TableBlock.jsx
@@ -37,7 +37,7 @@ export class TableBlockComponent extends Component {
     setCell(row, col, cellState) {
         const cellContentState = cellState.getCurrentContent();
         const data = this.data();
-        const {block, contentState} = this.props;
+        const {block, contentState, editorState, parentOnChange} = this.props;
         const entityKey = block.getEntityAt(0);
 
         if (!data.cells[row]) {
@@ -47,6 +47,7 @@ export class TableBlockComponent extends Component {
         data.cells[row][col] = convertToRaw(cellContentState);
 
         contentState.replaceEntityData(entityKey, {data});
+        parentOnChange(editorState);
     }
 
     /**
@@ -152,15 +153,19 @@ export class TableBlockComponent extends Component {
 TableBlockComponent.propTypes = {
     block: React.PropTypes.object.isRequired,
     contentState: React.PropTypes.object.isRequired,
+    editorState: React.PropTypes.object.isRequired,
     setReadOnly: React.PropTypes.func.isRequired,
+    parentOnChange: React.PropTypes.func.isRequired,
     parentReadOnly: React.PropTypes.bool.isRequired,
 };
 
 const mapDispatchToProps = (dispatch) => ({
+    parentOnChange: (editorState) => dispatch(actions.changeEditorState(editorState)),
     setReadOnly: (e) => dispatch(actions.setReadOnly())
 });
 
 const mapStateToProps = (state) => ({
+    editorState: state.editorState,
     parentReadOnly: state.readOnly
 });
 

--- a/scripts/core/editor3/components/tests/tables.spec.jsx
+++ b/scripts/core/editor3/components/tests/tables.spec.jsx
@@ -33,6 +33,8 @@ describe('editor3.component.table-block', () => {
                 contentState={contentState}
                 block={block}
                 setReadOnly={() => { /* no-op */ }}
+                editorState={{}}
+                parentOnChange={() => { /* no-op */ }}
                 parentReadOnly={false} />
         );
 
@@ -47,6 +49,8 @@ describe('editor3.component.table-block', () => {
                 contentState={contentState}
                 block={block}
                 setReadOnly={() => { /* no-op */ }}
+                editorState={{}}
+                parentOnChange={() => { /* no-op */ }}
                 parentReadOnly={true} />
         );
 
@@ -60,6 +64,8 @@ describe('editor3.component.table-block', () => {
                 contentState={contentState}
                 block={block}
                 setReadOnly={() => { /* no-op */ }}
+                editorState={{}}
+                parentOnChange={() => { /* no-op */ }}
                 parentReadOnly={false} />
         );
 
@@ -73,6 +79,8 @@ describe('editor3.component.table-block', () => {
                 contentState={contentState}
                 block={block}
                 setReadOnly={() => { /* no-op */ }}
+                editorState={{}}
+                parentOnChange={() => { /* no-op */ }}
                 parentReadOnly={true} />
         );
 
@@ -88,6 +96,8 @@ describe('editor3.component.table-block', () => {
                 contentState={contentState}
                 block={block}
                 setReadOnly={() => { /* no-op */ }}
+                editorState={{}}
+                parentOnChange={() => { /* no-op */ }}
                 parentReadOnly={true} />
         );
 
@@ -103,6 +113,8 @@ describe('editor3.component.table-block', () => {
                 contentState={contentState}
                 block={block}
                 setReadOnly={() => { /* no-op */ }}
+                editorState={{}}
+                parentOnChange={() => { /* no-op */ }}
                 parentReadOnly={true} />
         );
 

--- a/scripts/core/editor3/components/tests/utils.jsx
+++ b/scripts/core/editor3/components/tests/utils.jsx
@@ -80,7 +80,7 @@ export function imageBlockAndContent() {
  * @param {Object} data Entity data
  * @returns {Object} Keys 'block' and 'contentState'
  */
-function createBlockAndContent(type, data) {
+export function createBlockAndContent(type, data) {
     const cs = ContentState.createFromText('here is an image:');
     const contentState = cs.createEntity(type, 'MUTABLE', data);
     const entityKey = contentState.getLastCreatedEntityKey();

--- a/scripts/core/editor3/html/index.js
+++ b/scripts/core/editor3/html/index.js
@@ -1,0 +1,19 @@
+import {HTMLGenerator} from './to-html';
+
+/**
+ * @name toHTML
+ * @param {Object} contentState
+ * @description Converts DraftJS ContentState to HTML.
+ */
+export function toHTML(contentState) {
+    return new HTMLGenerator(contentState).html();
+}
+
+/**
+ * @name fromHTML
+ * @param {String} html
+ * @description Converts DraftJS ContentState to HTML.
+ */
+export function fromHTML(html) {
+    throw 'Not implemented';
+}

--- a/scripts/core/editor3/html/tests/to-html.spec.js
+++ b/scripts/core/editor3/html/tests/to-html.spec.js
@@ -1,0 +1,109 @@
+import * as testUtils from '../../components/tests/utils';
+import {AtomicBlockParser} from '../to-html';
+import {ContentState, convertToRaw} from 'draft-js';
+import {BlockInlineStyleWrapper, BlockEntityWrapper} from '../to-html';
+import {OrderedSet as OS} from 'immutable';
+
+describe('core.editor3.html.to-html.AtomicBlockParser', () => {
+    it('should correctly parse embeds', () => {
+        const {block, contentState} = testUtils.embedBlockAndContent();
+        const html = new AtomicBlockParser(contentState).parse(block);
+
+        expect(html).toBe('<div class="embed-block"><h1>Embed Title</h1></div>');
+    });
+
+    it('should correctly parse images', () => {
+        const {block, contentState} = testUtils.imageBlockAndContent();
+        const html = new AtomicBlockParser(contentState).parse(block);
+
+        expect(html).toBe('<div class="image-block"><img src="image_href" alt="image_alt_text" />' +
+            '<span class="image-block__description">image_description</span></div>');
+    });
+
+    it('should correctly parse images without alt and description', () => {
+        const {block, contentState} = testUtils.createBlockAndContent('IMAGE', {
+            img: {renditions: {original: {href: 'image_href'}}}
+        });
+
+        const html = new AtomicBlockParser(contentState).parse(block);
+
+        expect(html).toBe('<div class="image-block"><img src="image_href" alt="" /></div>');
+    });
+
+    it('should correctly parse tables', () => {
+        const cs = (txt) => convertToRaw(ContentState.createFromText(txt));
+        const {contentState, block} = testUtils.createBlockAndContent('TABLE', {
+            data: {
+                w: 3,
+                h: 2,
+                cells: [
+                    [cs('a'), undefined, cs('c')],
+                    [cs('d'), cs('e'), cs('f')]
+                ]
+            }
+        });
+
+        const html = new AtomicBlockParser(contentState).parse(block);
+
+        expect(html).toBe('<table><tbody><tr><td><p>a</p></td><td><p></p></td><td><p>c</p></td></tr>' +
+            '<tr><td><p>d</p></td><td><p>e</p></td><td><p>f</p></td></tr></tbody></table>');
+    });
+
+    it('should correctly parse empty tables', () => {
+        const {contentState, block} = testUtils.createBlockAndContent('TABLE', {
+            data: {
+                w: 3,
+                h: 2,
+                cells: []
+            }
+        });
+
+        const html = new AtomicBlockParser(contentState).parse(block);
+
+        expect(html).toBe('<table><tbody><tr><td><p></p></td><td><p></p></td><td><p></p></td></tr>' +
+            '<tr><td><p></p></td><td><p></p></td><td><p></p></td></tr></tbody></table>');
+    });
+});
+
+describe('core.editor3.html.to-html.BlockInlineStyleWrapper', () => {
+    it('should get correct tags', () => {
+        const wrapper = new BlockInlineStyleWrapper();
+
+        expect(wrapper.tags(OS([]))).toEqual('');
+        expect(wrapper.tags(OS(['BOLD', 'ITALIC']))).toEqual('<b><i>');
+        expect(wrapper.tags(OS(['BOLD', 'ITALIC']))).toEqual('');
+        expect(wrapper.tags(OS(['ITALIC']))).toEqual('</b>');
+        expect(wrapper.tags(OS(['ITALIC', 'UNDERLINE']))).toEqual('<u>');
+        expect(wrapper.tags(OS(['UNDERLINE', 'BOLD']))).toEqual('</i><b>');
+        expect(wrapper.tags(OS([]))).toEqual('</u></b>');
+        expect(wrapper.tags(OS(['ITALIC', 'UNDERLINE']))).toEqual('<i><u>');
+
+        expect(wrapper.flush()).toEqual('</u></i>');
+        expect(wrapper.flush()).toEqual('');
+    });
+});
+
+describe('core.editor3.html.to-html.BlockEntityWrapper', () => {
+    it('should get correct tags', () => {
+        const contentState = ContentState.createFromText('abcdefghijklmn');
+
+        const ek = [ // entity keys
+            contentState.createEntity('LINK', 'MUTABLE', {url: 'abc'}).getLastCreatedEntityKey(),
+            contentState.createEntity('LINK', 'MUTABLE', {url: 'def'}).getLastCreatedEntityKey(),
+            contentState.createEntity('LINK', 'MUTABLE', {url: 'jkl'}).getLastCreatedEntityKey()
+        ];
+
+        const wrapper = new BlockEntityWrapper(contentState);
+
+        expect(wrapper.tags(ek[0])).toEqual('<a href="abc">');
+        expect(wrapper.tags(ek[1])).toEqual('</a><a href="def">');
+        expect(wrapper.tags(ek[1])).toEqual('');
+        expect(wrapper.tags(ek[1])).toEqual('');
+        expect(wrapper.tags()).toEqual('</a>');
+        expect(wrapper.tags(ek[2])).toEqual('<a href="jkl">');
+        expect(wrapper.tags(ek[2])).toEqual('');
+
+        expect(wrapper.flush()).toEqual('</a>');
+        expect(wrapper.flush()).toEqual('');
+    });
+});

--- a/scripts/core/editor3/html/to-html/AtomicBlockParser.js
+++ b/scripts/core/editor3/html/to-html/AtomicBlockParser.js
@@ -1,0 +1,107 @@
+import {ContentState, convertFromRaw} from 'draft-js';
+import {HTMLGenerator} from '.';
+
+/**
+ * @ngdoc class
+ * @name AtomicBlockParser
+ * @description AtomicBlockParser is a helper class for the HTMLGenerator. It parses
+ * Editor3 atomic blocks (image, table, embed, etc.).
+ * @param {Object} contentState
+ * @param {Array=} disabled A set of disabled elements (ie. ['table'] will ignore tables.
+ */
+export class AtomicBlockParser {
+    constructor(contentState, disabled = []) {
+        this.contentState = contentState;
+        this.disabled = disabled;
+    }
+
+    /**
+     * @ngdoc method
+     * @name AtomicBlockParser#parse
+     * @param {Object} contentBlock
+     * @returns {string} HTML
+     * @description Returns the HTML representation of the passed contentBlock.
+     */
+    parse(contentBlock) {
+        const entityKey = contentBlock.getEntityAt(0);
+        const entity = this.contentState.getEntity(entityKey);
+        const data = entity.getData();
+
+        switch (entity.getType()) {
+        case 'IMAGE':
+            return this.parseImage(data);
+        case 'EMBED':
+            return this.parseEmbed(data);
+        case 'TABLE':
+            return this.parseTable(data);
+        default:
+            return '<p><b>Unimplemented or disabled atomic block</b></p>';
+        }
+    }
+
+    /**
+     * @ngdoc method
+     * @name AtomicBlockParser#parseEmbed
+     * @param {Object} data Entity data.
+     * @returns {string} HTML
+     * @description Returns the HTML representation of an atomic 'EMBED' block having
+     * the passed entity data.
+     */
+    parseEmbed(data) {
+        return `<div class="embed-block">${data.data.html}</div>`;
+    }
+
+    /**
+     * @ngdoc method
+     * @name AtomicBlockParser#parseImage
+     * @param {Object} data Entity data.
+     * @returns {string} HTML
+     * @description Returns the HTML representation of an atomic 'IMAGE' block having
+     * the passed entity data.
+     */
+    parseImage(data) {
+        const {img} = data;
+        const rendition = img.renditions.original || img.renditions.viewImage;
+        const href = rendition.href;
+        const alt = img.alt_text || '';
+
+        let html = `<div class="image-block"><img src="${href}" alt="${alt}" />`;
+
+        html += img.description_text
+            ? `<span class="image-block__description">${img.description_text}</span>`
+            : '';
+
+        return `${html}</div>`;
+    }
+
+    /**
+     * @ngdoc method
+     * @name AtomicBlockParser#parseTable
+     * @param {Object} data Entity data.
+     * @returns {string} HTML
+     * @description Returns the HTML representation of an atomic 'TABLE' block having
+     * the passed entity data.
+     */
+    parseTable(data) {
+        if (this.disabled.indexOf('table') > -1) {
+            return '';
+        }
+
+        const {w, h, cells} = data.data;
+        const getCell = (i, j) => {
+            const cellContentState = cells[i] && cells[i][j]
+                ? convertFromRaw(cells[i][j])
+                : ContentState.createFromText('');
+
+            return new HTMLGenerator(cellContentState, ['table']).html();
+        };
+
+        return '<table><tbody>' + Array.from(new Array(h))
+            .map((_, i) =>
+                '<tr>' + Array.from(new Array(w))
+                    .map((_, j) => `<td>${getCell(i, j)}</td>`)
+                    .join('') + '</tr>'
+            )
+            .join('') + '</tbody></table>';
+    }
+}

--- a/scripts/core/editor3/html/to-html/BlockEntityWrapper.js
+++ b/scripts/core/editor3/html/to-html/BlockEntityWrapper.js
@@ -1,0 +1,79 @@
+/**
+ * @ngdoc class
+ * @name BlockEntityWrapper
+ * @description This class is used as a helper for converting a DraftJS ContentBlock
+ * to HTML.
+ *
+ * BlockEntityWrapper must be instantiated for each block and the `tags` method must
+ * be called for each character in that block. The return value of this method will
+ * be a string consisting of the appropriate tags needed to preceed the next
+ * character. See the tags method for additional information.
+ */
+export class BlockEntityWrapper {
+    constructor(contentState) {
+        this.activeEntity = null;
+        this.contentState = contentState;
+    }
+
+    /**
+     * @ngdoc method
+     * @name BlockEntityWrapper#tags
+     * @param {string|undefined} entityKey
+     * @returns {string} HTML
+     * @description Returns the appropriate HTML tag(s) needed to preceed the next
+     * character which has the entity represented by entityKey. This method must be
+     * called for each character in the block if it is to work correctly.
+     */
+    tags(entityKey) {
+        if (!entityKey) {
+            return this.flush();
+        }
+
+        if (this.isActive(entityKey)) {
+            return '';
+        }
+
+        const entity = this.contentState.getEntity(entityKey);
+        const type = entity.getType();
+        const data = entity.getData();
+
+        let html = this.flush();
+
+        switch (type) {
+        case 'LINK':
+            this.activeEntity = {key: entityKey, tag: 'a'};
+
+            html += `<a href="${data.url}">`;
+        }
+
+        return html;
+    }
+
+    /**
+     * @ngdoc method
+     * @name BlockEntityWrapper#isActive
+     * @param {string} entityKey
+     * @description Checks if the active entity has been entityKey.
+     * @returns {Boolean} True if the passed entityKey has been the active one.
+     */
+    isActive(entityKey) {
+        return this.activeEntity && this.activeEntity.key === entityKey;
+    }
+
+    /**
+     * @ngdoc method
+     * @name BlockEntityWrapper#flush
+     * @description Returns the closing tag for any active entity.
+     * @returns {string} Closing tag or empty string.
+     */
+    flush() {
+        let tag = '';
+
+        if (this.activeEntity) {
+            tag = `</${this.activeEntity.tag}>`;
+            this.activeEntity = null;
+        }
+
+        return tag;
+    }
+}

--- a/scripts/core/editor3/html/to-html/BlockInlineStyleWrapper.js
+++ b/scripts/core/editor3/html/to-html/BlockInlineStyleWrapper.js
@@ -1,0 +1,104 @@
+/**
+ * @type {Object}
+ * @name InlineStyleTags
+ * @description Links DraftJS style values to tags. These are the supported inline
+ * styling options.
+ */
+const InlineStyleTags = {
+    BOLD: 'b',
+    ITALIC: 'i',
+    UNDERLINE: 'u'
+};
+
+/**
+ * @ngdoc class
+ * @name BlockInlineStyleWrapper
+ * @description This class is used as a helper for converting a DraftJS ContentBlock
+ * to HTML.
+ *
+ * BlockInlineStyleWrapper must be instantiated for each block and the `tags` method
+ * must be called for each character in that block. The return value of this method
+ * will be a string consisting of the appropriate tags needed to preceed the next
+ * character. See the tags method for additional information.
+ */
+export class BlockInlineStyleWrapper {
+    constructor() {
+        this.activeStyles = [];
+    }
+
+    /**
+     * @ngdoc method
+     * @name BlockInlineStyleWrapper#openingTags
+     * @param {OrderedSet} styles Immutable's Ordered Set (DraftInlineStyle)
+     * @description Checks the given styles set to see if any of them are new and
+     * returns the appropriate opening tags.
+     * @returns {string} HTML
+     */
+    openingTags(styles) {
+        return styles.map((style) => {
+            const tag = InlineStyleTags[style];
+            const alreadyApplied = this.activeStyles.indexOf(style) > -1;
+
+            if (tag && !alreadyApplied) {
+                this.activeStyles.push(style);
+                return `<${tag}>`;
+            }
+
+            return '';
+        }).join('');
+    }
+
+    /**
+     * @ngdoc method
+     * @name BlockInlineStyleWrapper#closingTags
+     * @param {OrderedSet} styles Immutable's Ordered Set (DraftInlineStyle)
+     * @description Checks the given styles set to see if any of them are no longer
+     * applied, returning the necessary closing tags.
+     * @returns {string} HTML
+     */
+    closingTags(styles) {
+        const noLongerApplied = this.activeStyles
+            .filter((s) => styles.toArray().indexOf(s) === -1);
+
+        return noLongerApplied.map((style) => {
+            const tag = InlineStyleTags[style];
+            const index = this.activeStyles.indexOf(style);
+
+            this.activeStyles.splice(index, 1);
+
+            return `</${tag}>`;
+        }).join('');
+    }
+
+    /**
+     * @ngdoc method
+     * @name BlockInlineStyleWrapper#flush
+     * @description Returns any remaining closing tag(s).
+     * @returns {string} HTML
+     */
+    flush() {
+        let tags = '';
+
+        while (this.activeStyles.length > 0) {
+            const style = this.activeStyles.pop();
+            const tag = InlineStyleTags[style];
+
+            tags += `</${tag}>`;
+        }
+
+        return tags;
+    }
+
+    /**
+     * @ngdoc method
+     * @name BlockInlineStyleWrapper#tags
+     * @param {OrderedSet} styles Immutable's Ordered Set (DraftInlineStyle)
+     * @returns {string} HTML
+     * @description Returns the appropriate HTML tag(s) needed to preceed the next
+     * character which has the set of passed styles. This method must be
+     * called for each character in the block if it is to work correctly.
+     */
+    tags(styles) {
+        return this.closingTags(styles) + this.openingTags(styles);
+    }
+}

--- a/scripts/core/editor3/html/to-html/HTMLGenerator.js
+++ b/scripts/core/editor3/html/to-html/HTMLGenerator.js
@@ -1,0 +1,87 @@
+import {BlockEntityWrapper} from '.';
+import {BlockInlineStyleWrapper} from '.';
+import {AtomicBlockParser} from '.';
+
+/**
+ * @type {Object}
+ * @name BlockStyleTags
+ * @description Links DraftJS block style values to their correspondent tags. These
+ * are the supported block styling options.
+ */
+const BlockStyleTags = {
+    'header-one': 'h1',
+    'header-two': 'h2',
+    'header-three': 'h3',
+    'header-four': 'h4',
+    'header-five': 'h5',
+    'header-six': 'h6',
+    blockquote: 'quote'
+};
+
+/**
+ * @ngdoc class
+ * @name HTMLGenerator
+ * @description HTMLGenerator generates HTML from a DraftJS ContentState.
+ * @param {Object} contentState
+ * @param {Array=} disabled A set of disabled elements (ie. ['table'] will ignore
+ * tables.
+ */
+export class HTMLGenerator {
+    constructor(contentState, disabled = []) {
+        this.contentState = contentState;
+        this.disabled = disabled;
+        this.atomicBlockParser = new AtomicBlockParser(contentState, disabled);
+
+        this.convertBlock = this.convertBlock.bind(this);
+    }
+
+    /**
+     * @ngdoc method
+     * @name HTMLGenerator#convertBlock
+     * @param {Object} contentBlock
+     * @returns {string} HTML
+     * @description convertBlock takes a contentBlock and converts it to HTML.
+     */
+    convertBlock(contentBlock) {
+        const type = contentBlock.getType();
+
+        if (type === 'atomic') {
+            return this.atomicBlockParser.parse(contentBlock);
+        }
+
+        const text = contentBlock.getText();
+        const styleWrapper = new BlockInlineStyleWrapper();
+        const entityWrapper = new BlockEntityWrapper(this.contentState);
+
+        let html = contentBlock.getCharacterList()
+            .map((charMeta, key) => {
+                const entityTags = entityWrapper.tags(charMeta.getEntity());
+                const styleTags = styleWrapper.tags(charMeta.getStyle());
+
+                return styleTags + entityTags + text[key];
+            })
+            .join('');
+
+        // apply left-over close tags
+        html += entityWrapper.flush();
+        html += styleWrapper.flush();
+
+        const blockTag = BlockStyleTags[type] || 'p';
+
+        return `<${blockTag}>${html}</${blockTag}>`;
+    }
+
+    /**
+     * @ngdoc method
+     * @name HTMLGenerator#html
+     * @returns {string} HTML
+     * @description Returns the HTML representation of the contentState stored by
+     * this instance.
+     */
+    html() {
+        return this.contentState
+            .getBlockMap()
+            .map(this.convertBlock)
+            .join('');
+    }
+}

--- a/scripts/core/editor3/html/to-html/index.js
+++ b/scripts/core/editor3/html/to-html/index.js
@@ -1,0 +1,4 @@
+export {HTMLGenerator} from './HTMLGenerator';
+export {BlockEntityWrapper} from './BlockEntityWrapper';
+export {BlockInlineStyleWrapper} from './BlockInlineStyleWrapper';
+export {AtomicBlockParser} from './AtomicBlockParser';

--- a/scripts/core/editor3/store/index.js
+++ b/scripts/core/editor3/store/index.js
@@ -5,9 +5,9 @@ import ng from 'core/services/ng';
 import {forceUpdate} from '../actions';
 import {Editor3} from '../components/Editor3';
 import {EditorState, convertFromRaw, convertToRaw, ContentState} from 'draft-js';
-import {stateToHTML} from 'draft-js-export-html';
 import {stateFromHTML} from 'draft-js-import-html';
 import {clearHighlights} from '../reducers/find-replace';
+import {toHTML} from 'core/editor3/html';
 
 /**
  * @name createEditorStore
@@ -52,7 +52,7 @@ export default function createEditorStore(ctrl) {
 function onChange(content) {
     // clear find & replace highlights
     const cleanedContent = clearHighlights(content).content;
-    const newValue = stateToHTML(cleanedContent);
+    const newValue = toHTML(cleanedContent);
 
     this.value = this.value || '<p><br></p>';
     if (newValue.localeCompare(this.value) === 0) {


### PR DESCRIPTION
Converts DraftJS `contentState` to HTML. Also fixes a bug where editing table cells would not trigger change events in the editor (ie. a disabled 'Save' button would stay disabled)

Addresses [SDESK-863](https://dev.sourcefabric.org/browse/SDESK-863) and [SDESK-683](https://dev.sourcefabric.org/browse/SDESK-683)