### PR TITLE
fix(editor3): fixes a problem with allowing focus of toolbar inputs

### DIFF
--- a/scripts/core/editor3/components/Editor3.jsx
+++ b/scripts/core/editor3/components/Editor3.jsx
@@ -111,18 +111,20 @@ export class Editor3Component extends React.Component {
         });
 
         return (
-            <div className={cx} onClick={this.focus}>
+            <div className={cx}>
                 {showToolbar ? <Toolbar editorRect={this.editorRect} disabled={readOnly} /> : null}
-                <Editor
-                    editorState={editorState}
-                    handleKeyCommand={this.handleKeyCommand}
-                    blockRendererFn={blockRenderer}
-                    customStyleMap={customStyleMap}
-                    onChange={onChange}
-                    onTab={onTab}
-                    readOnly={readOnly}
-                    ref="editor"
-                />
+                <div className="focus-screen" onClick={this.focus}>
+                    <Editor
+                        editorState={editorState}
+                        handleKeyCommand={this.handleKeyCommand}
+                        blockRendererFn={blockRenderer}
+                        customStyleMap={customStyleMap}
+                        onChange={onChange}
+                        onTab={onTab}
+                        readOnly={readOnly}
+                        ref="editor"
+                    />
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
The `div` that was responding to onClick events for focusing the editor
was wrapping the toolbar, making it impossible to focus inputs triggered
by the toolbar (such as link input, embed input, etc). This fixes the
problem.