### PR TITLE
[SDESK-924] - Removing paranthesis from search bar keywords

### DIFF
--- a/scripts/apps/search/directives/ItemSearchbar.js
+++ b/scripts/apps/search/directives/ItemSearchbar.js
@@ -20,20 +20,12 @@ export function ItemSearchbar($location, $document, asset) {
             };
 
             scope.search = function() {
-                var output = '';
-
                 if (scope.query) {
-                    var newQuery = _.uniq(scope.query.split(/[\s,]+/));
-
-                    _.each(newQuery, (item, key) => {
-                        if (item) {
-                            output += key !== 0 ? ' (' + item + ')' : '(' + item + ')';
-                        }
-                    });
+                    let newQuery = _.uniq(scope.query.split(/[\s,]+/));
 
                     scope.query = newQuery.join(' ');
                 }
-                $location.search('q', output || null);
+                $location.search('q', scope.query || null);
             };
 
             scope.cancel = function() {

--- a/scripts/apps/search/directives/ItemSearchbar.js
+++ b/scripts/apps/search/directives/ItemSearchbar.js
@@ -35,14 +35,19 @@ export function ItemSearchbar($location, $document, asset) {
                 // to be implemented
             };
 
-            // initial query
-            var srch = $location.search();
+            const init = () => {
+                let srch = $location.search();
 
-            if (srch.q && srch.q !== '') {
-                scope.query = srch.q.replace(/[()]/g, '');
-            } else {
-                scope.query = null;
-            }
+                if (srch.q && srch.q !== '') {
+                    scope.query = srch.q.replace(/[()]/g, '');
+                } else {
+                    scope.query = null;
+                }
+            };
+
+            init();
+
+            scope.$on('tag:removed', init);
 
             function closeOnClick() {
                 scope.$applyAsync(() => {

--- a/scripts/apps/search/directives/SaveSearch.js
+++ b/scripts/apps/search/directives/SaveSearch.js
@@ -44,6 +44,7 @@ export function SaveSearch($location, asset, api, session, notify, gettext, $roo
                         $location.search(key, null);
                     }
                 });
+                $rootScope.$broadcast('tag:removed');
             };
 
             scope.search = function() {

--- a/scripts/apps/search/directives/SearchResults.js
+++ b/scripts/apps/search/directives/SearchResults.js
@@ -11,7 +11,8 @@ SearchResults.$inject = [
     'session',
     '$rootScope',
     'config',
-    'superdeskFlags'
+    'superdeskFlags',
+    'notify'
 ];
 
 const HEX_REG_EXP = /[a-f0-9]{24}/;
@@ -49,7 +50,8 @@ export function SearchResults(
         session,
         $rootScope,
         config,
-        superdeskFlags
+        superdeskFlags,
+        notify
 ) { // uff - should it use injector instead?
     var preferencesUpdate = {
         'archive:view': {
@@ -243,6 +245,8 @@ export function SearchResults(
                         // update scope items only with the matching fetched items
                         scope.items = search.updateItems(items, scope.items);
                     }
+                }, (error) => {
+                    notify.error(gettext('Failed to run the query!'));
                 })
                 .finally(() => {
                     scope.loading = false;

--- a/scripts/apps/search/directives/SearchTags.js
+++ b/scripts/apps/search/directives/SearchTags.js
@@ -48,8 +48,12 @@ export function SearchTags($location, tags, asset, metadata, desks) {
                 var searchParameters = $location.search();
 
                 if (searchParameters.q && searchParameters.q.indexOf(param) >= 0) {
-                    searchParameters.q = searchParameters.q.replace(param, '').trim();
+                    let newQuery = _.uniq(searchParameters.q.replace(param, '').trim()
+                        .split(/[\s,]+/));
+
+                    searchParameters.q = newQuery.join(' ');
                     $location.search('q', searchParameters.q || null);
+
                     return;
                 }
 

--- a/scripts/apps/search/directives/SearchTags.js
+++ b/scripts/apps/search/directives/SearchTags.js
@@ -1,7 +1,7 @@
 import {PARAMETERS} from 'apps/search/constants';
 
-SearchTags.$inject = ['$location', 'tags', 'asset', 'metadata', 'desks'];
-export function SearchTags($location, tags, asset, metadata, desks) {
+SearchTags.$inject = ['$location', 'tags', 'asset', 'metadata', 'desks', '$rootScope'];
+export function SearchTags($location, tags, asset, metadata, desks, $rootScope) {
     return {
         scope: {},
         templateUrl: asset.templateUrl('apps/search/views/search-tags.html'),
@@ -53,6 +53,7 @@ export function SearchTags($location, tags, asset, metadata, desks) {
 
                     searchParameters.q = newQuery.join(' ');
                     $location.search('q', searchParameters.q || null);
+                    $rootScope.$broadcast('tag:removed');
 
                     return;
                 }

--- a/scripts/apps/search/services/TagService.js
+++ b/scripts/apps/search/services/TagService.js
@@ -87,28 +87,8 @@ export function TagService($location, desks, userList, metadata, search, ingestS
     /*
      * function to parse search input from the search bar.
      */
-    function initSelectedKeywords(kwds) {
-        let keywords = kwds;
-
-        tags.selectedKeywords = [];
-        while (keywords.indexOf('(') >= 0 && keywords.indexOf(')') > 0) {
-            var closeIndex = keywords.indexOf('(');
-            var counter = 1;
-
-            while (counter > 0 && closeIndex < keywords.length) {
-                var c = keywords[++closeIndex];
-
-                if (c === '(') {
-                    counter++;
-                } else if (c === ')') {
-                    counter--;
-                }
-            }
-            var keyword = keywords.substring(keywords.indexOf('('), closeIndex + 1);
-
-            tags.selectedKeywords.push(keyword);
-            keywords = keywords.replace(keyword, '');
-        }
+    function initSelectedKeywords(keywords) {
+        tags.selectedKeywords = keywords ? keywords.split(' ') : [];
     }
 
     function processFromToDesk(index, value) {

--- a/scripts/apps/search/tests/tags.spec.js
+++ b/scripts/apps/search/tests/tags.spec.js
@@ -121,7 +121,7 @@ describe('Tag Service', () => {
 
         $rootScope.$digest();
         expect(members.selectedFacets.type.length).toBe(2);
-        expect(members.selectedKeywords.length).toBe(2);
+        expect(members.selectedKeywords.length).toBe(3);
         expect(members.selectedParameters.length).toBe(1);
     }));
 


### PR DESCRIPTION
- AND, OR was creating HTTP 500 from elastic search due to unnecessary paranthesis for keywords
- Users were not notified about failed search
- Now updating the search bar keywords along with clean filters button and tags