### PR TITLE
[SDESK-966] - Hide Duplicates/Used tab in metadata if no content.

### DIFF
--- a/scripts/apps/archive/directives/MediaRelated.js
+++ b/scripts/apps/archive/directives/MediaRelated.js
@@ -1,33 +1,18 @@
-MediaRelated.$inject = ['familyService', 'superdesk'];
+MediaRelated.$inject = ['superdesk'];
 
-export function MediaRelated(familyService, superdesk) {
+export function MediaRelated(superdesk) {
     return {
         scope: {
-            item: '='
+            item: '=',
+            relatedItems: '='
         },
         templateUrl: 'scripts/apps/archive/views/related-view.html',
         link: function(scope, elem) {
-            scope.$on('item:duplicate', fetchRelatedItems);
-
-            scope.$watch('item', (newVal, oldVal) => {
-                if (newVal !== oldVal) {
-                    fetchRelatedItems();
-                }
-            });
             scope.open = function(item) {
                 superdesk.intent('view', 'item', item).then(null, () => {
                     superdesk.intent('edit', 'item', item);
                 });
             };
-
-            function fetchRelatedItems() {
-                familyService.fetchItems(scope.item.family_id || scope.item._id, scope.item)
-                .then((items) => {
-                    scope.relatedItems = items;
-                });
-            }
-
-            fetchRelatedItems();
         }
     };
 }

--- a/scripts/apps/archive/tests/archive.spec.js
+++ b/scripts/apps/archive/tests/archive.spec.js
@@ -180,8 +180,10 @@ describe('content', () => {
             var scope = $rootScope.$new();
 
             scope.item = {_id: 1, family_id: 1};
+            scope.relatedItems = {_items: [{_id: 2, family_id: 1}]};
 
-            var elem = $compile('<div sd-media-related data-item=\'item\'></div>')(scope);
+            let html = '<div sd-media-related data-item="item" data-related-items="relatedItems"></div>';
+            var elem = $compile(html)(scope);
 
             scope.$digest();
 
@@ -189,34 +191,12 @@ describe('content', () => {
 
             expect(iscope.item).toBe(scope.item);
 
-            scope.relatedItems = {_items: [{_id: 2, family_id: 1}]};
-
             spyOn(superdesk, 'intent').and.returnValue($q.when());
             iscope.open(scope.relatedItems._items[0]);
             scope.$apply();
 
             expect(superdesk.intent).toHaveBeenCalledWith('view', 'item', scope.relatedItems._items[0]);
         }));
-        it('can fetch related items when item duplicated',
-            inject((familyService, $rootScope, $compile, superdesk, $q) => {
-                var scope = $rootScope.$new();
-
-                scope.item = {_id: 1, family_id: 1};
-
-                var elem = $compile('<div sd-media-related data-item=\'item\'></div>')(scope);
-
-                scope.$digest();
-
-                var iscope = elem.isolateScope();
-
-                expect(iscope.item).toBe(scope.item);
-
-                spyOn(familyService, 'fetchItems').and.returnValue($q.when());
-                scope.$broadcast('item:duplicate');
-                scope.$apply();
-
-                expect(familyService.fetchItems).toHaveBeenCalledWith(scope.item.family_id, scope.item);
-            }));
     });
 
     describe('item preview container', () => {

--- a/scripts/apps/search/tests/sdItemPreview.spec.js
+++ b/scripts/apps/search/tests/sdItemPreview.spec.js
@@ -1,0 +1,163 @@
+
+describe('sdItemPreview directive', () => {
+    let scope, elem, iscope;
+    let archiveItem = {_id: '1', family_id: '1', _type: 'archive'};
+    let ingestItem = {_id: 'a', _type: 'ingest'};
+    let relatedItems = {_items: []};
+    let relatedItemEntries = [{_id: '2', family_id: '1'}];
+
+    beforeEach(window.module('superdesk.templates-cache'));
+    beforeEach(window.module('superdesk.mocks'));
+    beforeEach(window.module('superdesk.apps.archive'));
+    beforeEach(window.module('superdesk.apps.vocabularies'));
+
+    beforeEach(inject(($rootScope, $compile) => {
+        let html = '<div sd-item-preview data-item="item" data-close="" data-show-history-tab="true"></div>';
+
+        scope = $rootScope.$new();
+
+        elem = $compile(html)(scope);
+        scope.$digest();
+        iscope = elem.isolateScope();
+    }));
+
+    beforeEach(inject((familyService, $q) => {
+        spyOn(familyService, 'fetchItems').and.returnValue($q.when(relatedItems));
+    }));
+
+    it('defaults to `content` tab', () => {
+        expect(iscope.vm.current_tab).toBe('content');
+    });
+
+    it('can set item', () => {
+        relatedItems._items = [];
+        expect(iscope.item).not.toBeDefined();
+
+        scope.item = archiveItem;
+        scope.$apply();
+
+        expect(iscope.item).toBe(scope.item);
+    });
+
+    it('can get related items', inject((familyService) => {
+        relatedItems._items = relatedItemEntries;
+        scope.item = archiveItem;
+        scope.$apply();
+
+        expect(familyService.fetchItems).toHaveBeenCalledWith(scope.item.family_id, scope.item);
+        expect(iscope.relatedItems).toBe(relatedItems);
+    }));
+
+    it('can only get related items for archive and archived types', () => {
+        relatedItems._items = relatedItemEntries;
+        scope.item = archiveItem;
+        scope.$apply();
+        expect(iscope.relatedItems).toBe(relatedItems);
+
+        scope.item = ingestItem;
+        scope.$apply();
+        expect(iscope.relatedItems).toBeNull();
+    });
+
+    it('can hide duplicates tab when item has no related items', () => {
+        relatedItems._items = [];
+        scope.item = archiveItem;
+        scope.$apply();
+
+        expect(iscope.showRelatedTab).toBeFalsy();
+    });
+
+    it('can show duplicates tab when item has related items', () => {
+        relatedItems._items = relatedItemEntries;
+        scope.item = archiveItem;
+        scope.$apply();
+
+        expect(iscope.showRelatedTab).toBeTruthy();
+    });
+
+    it('can move to content from duplicates tab if new item has no related items', () => {
+        relatedItems._items = [];
+        scope.item = archiveItem;
+        iscope.vm.current_tab = 'related';
+        scope.$apply();
+
+        expect(iscope.vm.current_tab).toBe('content');
+    });
+
+    it('can fetch related items when item is duplicated', inject((familyService) => {
+        relatedItems._items = [];
+        scope.item = archiveItem;
+        scope.$apply();
+
+        relatedItems._items = relatedItemEntries;
+        scope.$broadcast('item:duplicate');
+        scope.$apply();
+
+        expect(familyService.fetchItems).toHaveBeenCalledWith(scope.item.family_id, scope.item);
+        expect(iscope.relatedItems).toBe(relatedItems);
+    }));
+
+    it('can re-fetch relatedItems when navigating to the duplicates tab', () => {
+        let newRelatedItemEntries = [{_id: '2', family_id: '1'}, {_id: '3', family_id: '1'}];
+
+        relatedItems._items = relatedItemEntries;
+        scope.item = archiveItem;
+        scope.$apply();
+        expect(iscope.relatedItems).toBe(relatedItems);
+
+        relatedItems._items = newRelatedItemEntries;
+        iscope.vm.current_tab = 'related';
+        scope.$apply();
+        expect(iscope.relatedItems).toBe(relatedItems);
+    });
+
+    it('can close on events when items match', () => {
+        spyOn(iscope, 'close').and.returnValue(null);
+        iscope.item = archiveItem;
+
+        scope.$broadcast('item:deleted', {item: archiveItem._id});
+        scope.$apply();
+
+        scope.$broadcast('item:unlink', {item: archiveItem._id});
+        scope.$apply();
+
+        scope.$broadcast('item:spike', {item: archiveItem._id});
+        scope.$apply();
+
+        scope.$broadcast('item:unspike', {item: archiveItem._id});
+        scope.$apply();
+
+        scope.$broadcast('item:move', {item: archiveItem._id});
+        scope.$apply();
+
+        scope.$broadcast('content:update', {items: {1: archiveItem}});
+        scope.$apply();
+
+        expect(iscope.close).toHaveBeenCalledTimes(6);
+    });
+
+    it('can not close on events when items don\'t match', () => {
+        spyOn(iscope, 'close').and.returnValue(null);
+        iscope.item = archiveItem;
+
+        scope.$broadcast('item:deleted', {item: '3'});
+        scope.$apply();
+
+        scope.$broadcast('item:unlink', {item: '3'});
+        scope.$apply();
+
+        scope.$broadcast('item:spike', {item: '3'});
+        scope.$apply();
+
+        scope.$broadcast('item:unspike', {item: '3'});
+        scope.$apply();
+
+        scope.$broadcast('item:move', {item: '3'});
+        scope.$apply();
+
+        scope.$broadcast('content:update', {items: {3: {}}});
+        scope.$apply();
+
+        expect(iscope.close).toHaveBeenCalledTimes(0);
+    });
+});

--- a/scripts/apps/search/views/item-preview.html
+++ b/scripts/apps/search/views/item-preview.html
@@ -4,20 +4,20 @@
     </button>
     <header>
         <ul class="nav nav-tabs">
-            <li ng-class="{active: tab === 'content'}">
-                <button ng-click="tab = 'content'"><span translate>Content</span></button>
+            <li ng-class="{active: vm.current_tab === 'content'}">
+                <button ng-click="vm.current_tab = 'content'"><span translate>Content</span></button>
             </li>
-            <li ng-class="{active: tab === 'metadata'}">
-                <button ng-click="tab = 'metadata'"><span translate>Metadata</span></button>
+            <li ng-class="{active: vm.current_tab === 'metadata'}">
+                <button ng-click="vm.current_tab = 'metadata'"><span translate>Metadata</span></button>
             </li>
-            <li ng-show="showHistoryTab" ng-class="{active: tab === 'related'}">
-                <button ng-click="tab = 'related'"><span translate>Duplicates</span></button>
+            <li ng-show="showRelatedTab" ng-class="{active: vm.current_tab === 'related'}">
+                <button ng-click="vm.current_tab = 'related'"><span translate>Duplicates</span></button>
             </li>
-            <li ng-show="showHistoryTab" ng-class="{active: tab === 'history'}">
-                <button ng-click="tab = 'history'" translate>Item history</button>
+            <li ng-show="showHistoryTab" ng-class="{active: vm.current_tab === 'history'}">
+                <button ng-click="vm.current_tab = 'history'" translate>Item history</button>
             </li>
-            <li ng-show="isMediaUsed" ng-class="{active: tab === 'used'}">
-                <button ng-click="tab = 'used'" translate>Used</button>
+            <li ng-show="isMediaUsed" ng-class="{active: vm.current_tab === 'used'}">
+                <button ng-click="vm.current_tab = 'used'" translate>Used</button>
             </li>
         </ul>
         <button ng-click="close()" class="close-preview">
@@ -25,10 +25,13 @@
         </button>
     </header>
     <div class="content">
-        <div ng-if="tab === 'content'" sd-media-preview data-item="item"></div>
-        <div ng-if="tab === 'metadata'" sd-media-metadata data-item="item"></div>
-        <div ng-if="tab === 'related'" sd-media-related data-item="item"></div>
-        <div ng-if="tab === 'history' && showHistoryTab" sd-versioning-history data-item="item"></div>
-        <div ng-if="tab === 'used' && isMediaUsed" sd-media-used data-item="item"></div>
+        <div ng-if="vm.current_tab === 'content'" sd-media-preview data-item="item"></div>
+        <div ng-if="vm.current_tab === 'metadata'" sd-media-metadata data-item="item"></div>
+        <div ng-if="vm.current_tab === 'related' && showRelatedTab"
+             sd-media-related data-item="item"
+             data-related-items="relatedItems">
+        </div>
+        <div ng-if="vm.current_tab === 'history' && showHistoryTab" sd-versioning-history data-item="item"></div>
+        <div ng-if="vm.current_tab === 'used' && isMediaUsed" sd-media-used data-item="item"></div>
     </div>
 </div>

--- a/spec/authoring_spec.js
+++ b/spec/authoring_spec.js
@@ -465,6 +465,7 @@ describe('authoring', () => {
         monitoring.actionOnItem('Edit', 0, 0);
 
         authoring.openRelatedItem(); // opens related item widget
+        browser.sleep(10000);
         expect(authoring.getRelatedItemBySlugline(0).getText()).toContain('item9 slugline');
         authoring.actionOpenRelatedItem(0); // Open item
         expect(authoring.getHeaderSluglineText()).toContain('item9 slugline');

--- a/spec/content_spec.js
+++ b/spec/content_spec.js
@@ -202,7 +202,7 @@ describe('content', () => {
         element(by.id('closeAuthoringBtn')).click();
 
         content.previewItem('item3');
-        element(by.css('[ng-click="tab = \'metadata\'"]')).click();
+        element(by.css('[ng-click="vm.current_tab = \'metadata\'"]')).click();
 
         expect(element(by.model('item.embargo')).isDisplayed()).toBe(true);
 

--- a/spec/helpers/monitoring.js
+++ b/spec/helpers/monitoring.js
@@ -224,7 +224,7 @@ function Monitoring() {
     };
 
     this.tabAction = function(tab) {
-        element.all(by.css('[ng-click="tab = \'' + tab + '\'"]')).click();
+        element.all(by.css('[ng-click="vm.current_tab = \'' + tab + '\'"]')).click();
     };
 
     this.openRelatedItem = function(index) {


### PR DESCRIPTION
ItemPreview Directive:
- The _**tab**_ variable is now available from within the controller, using **_controllerAs_** technique
- Fetch **_relatedItems_** upon **_scope.item_** changed, and pass this list onto the **_MediaRelated_** directive
- When changing tabs to _**Duplicate**_, reload _**scope.relatedItems**_

MediaRelated Directive:
- _**relatedItems**_ are now passed in through the scope rather than fetched in the directive