### PR TITLE
feat(editor3): Custom convertFromHTML [SDESK-859]

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,6 @@
     "css-loader": "^0.23.1",
     "d3": "^3.5.3",
     "draft-js": "0.10.0",
-    "draft-js-export-html": "^0.5.1",
-    "draft-js-import-html": "^0.3.2",
     "eslint-loader": "^1.6.1",
     "eslint-plugin-angular": "^1.4.1",
     "eslint-plugin-react": "^6.7.1",

--- a/scripts/core/editor3/actions/toolbar.jsx
+++ b/scripts/core/editor3/actions/toolbar.jsx
@@ -114,15 +114,15 @@ export function embed(oEmbed) {
 /**
  * @ngdoc method
  * @name addTable
- * @param {Number} w Width (columns) of the table.
- * @return {Number} h Height (rows) of the table.
+ * @param {Number} numRows
+ * @param {Number} numCols
  * @description Dispatches the action that adds a table into the content.
  */
-export function addTable(w, h) {
+export function addTable(numRows, numCols) {
     const cells = [];
 
     return {
         type: 'TOOLBAR_ADD_TABLE',
-        payload: {w, h, cells}
+        payload: {numRows, numCols, cells}
     };
 }

--- a/scripts/core/editor3/components/tables/TableBlock.jsx
+++ b/scripts/core/editor3/components/tables/TableBlock.jsx
@@ -95,7 +95,7 @@ export class TableBlockComponent extends Component {
         const {contentState} = this.props;
         const data = this.data();
 
-        data.h++;
+        data.numRows++;
         contentState.mergeEntityData(entityKey, {data});
 
         this.forceUpdate();
@@ -114,14 +114,14 @@ export class TableBlockComponent extends Component {
         const {contentState} = this.props;
         const data = this.data();
 
-        data.w++;
+        data.numCols++;
         contentState.mergeEntityData(entityKey, {data});
 
         this.forceUpdate();
     }
 
     render() {
-        const {w, h} = this.data();
+        const {numRows, numCols} = this.data();
         const {setReadOnly, parentReadOnly} = this.props;
 
         return (
@@ -132,9 +132,9 @@ export class TableBlockComponent extends Component {
                 </div> : null}
                 <table>
                     <tbody>
-                        {Array.from(new Array(h)).map((v, i) =>
+                        {Array.from(new Array(numRows)).map((v, i) =>
                             <tr key={`col-${i}`}>
-                                {Array.from(new Array(w)).map((v, j) =>
+                                {Array.from(new Array(numCols)).map((v, j) =>
                                     <TableCell
                                         key={`cell-${i}-${j}`}
                                         contentState={this.getCell(i, j)}

--- a/scripts/core/editor3/components/tables/TableButton.jsx
+++ b/scripts/core/editor3/components/tables/TableButton.jsx
@@ -26,7 +26,7 @@ TableButtonComponent.propTypes = {
 };
 
 const mapDispatchToProps = (dispatch) => ({
-    addTable: () => dispatch(actions.addTable(2, 1))
+    addTable: () => dispatch(actions.addTable(1, 2))
 });
 
 export const TableButton = connect(null, mapDispatchToProps)(TableButtonComponent);

--- a/scripts/core/editor3/components/tests/tables.spec.jsx
+++ b/scripts/core/editor3/components/tests/tables.spec.jsx
@@ -84,9 +84,9 @@ describe('editor3.component.table-block', () => {
                 parentReadOnly={true} />
         );
 
-        expect(getBlockData(block, contentState).h).toBe(2);
+        expect(getBlockData(block, contentState).numRows).toBe(2);
         wrapper.find('.add-row').simulate('click');
-        expect(getBlockData(block, contentState).h).toBe(3);
+        expect(getBlockData(block, contentState).numRows).toBe(3);
     });
 
     it('should add a column when clicking the add column button', () => {
@@ -101,9 +101,9 @@ describe('editor3.component.table-block', () => {
                 parentReadOnly={true} />
         );
 
-        expect(getBlockData(block, contentState).w).toBe(3);
+        expect(getBlockData(block, contentState).numCols).toBe(3);
         wrapper.find('.add-col').simulate('click');
-        expect(getBlockData(block, contentState).w).toBe(4);
+        expect(getBlockData(block, contentState).numCols).toBe(4);
     });
 
     it('should render correct text in each cell', () => {

--- a/scripts/core/editor3/components/tests/utils.jsx
+++ b/scripts/core/editor3/components/tests/utils.jsx
@@ -105,8 +105,8 @@ export function tableBlockAndContent(cells) {
 
     return createBlockAndContent('TABLE', {
         data: {
-            w: 3,
-            h: 2,
+            numCols: 3,
+            numRows: 2,
             cells: cells || [
                 [cs('a'), cs('b'), cs('c')],
                 [cs('d'), cs('e'), cs('f')]

--- a/scripts/core/editor3/html/from-html/index.js
+++ b/scripts/core/editor3/html/from-html/index.js
@@ -69,9 +69,10 @@ export class HTMLParser {
      */
     contentState() {
         const {contentBlocks, entityMap} = convertFromHTML(this.tree.html());
+        const processBlock = this.processBlock.bind(this);
 
         return ContentState.createFromBlockArray(
-            contentBlocks.map(this.processBlock.bind(this)),
+            contentBlocks.map(processBlock),
             entityMap
         );
     }
@@ -109,15 +110,13 @@ export class HTMLParser {
         tableNode.html(tableHTML);
 
         const rows = tableNode.find('tr');
-        const h = rows.length;
-        const w = rows.first()
-            .find('th,td')
-            .length;
+        const numRows = rows.length;
+        const numCols = rows.first().find('th,td').length;
 
         let cells = [];
 
-        for (let i = 0; i < h; i++) {
-            for (let j = 0; j < w; j++) {
+        for (let i = 0; i < numRows; i++) {
+            for (let j = 0; j < numCols; j++) {
                 const row = $(rows[i]);
                 const col = $(row.find('th,td')[j]);
                 const {contentBlocks, entityMap} = convertFromHTML(col.html());
@@ -128,7 +127,7 @@ export class HTMLParser {
             }
         }
 
-        return atomicBlock(block, 'TABLE', 'MUTABLE', {data: {w, h, cells}});
+        return atomicBlock(block, 'TABLE', 'MUTABLE', {data: {numRows, numCols, cells}});
     }
 }
 

--- a/scripts/core/editor3/html/from-html/index.js
+++ b/scripts/core/editor3/html/from-html/index.js
@@ -1,0 +1,160 @@
+import {List, OrderedSet, fromJS} from 'immutable';
+
+import {
+    ContentBlock,
+    CharacterMetadata,
+    Entity,
+    ContentState,
+    convertFromHTML,
+    convertToRaw
+} from 'draft-js';
+
+/**
+ * @ngdoc class
+ * @name HTMLParser
+ * @description HTMLParser is a class that takes HTML and returns a ContentState. At
+ * its simplest form, it uses `convertFromHTML` from draft-js to do this operation.
+ *
+ * To make it compatible with Editor3, it additionally processes Editor3 atomic blocks,
+ * such as tables, images and embeds. To process these blocks, which `convertFromHTML`
+ * doesn't do, it simply extracts the nodes from the HTML before processing it, and saves
+ * them in a separate structure, replacing the nodes with <figure> tags that contain text
+ * indicating in which structure and at which position the information was saved.
+ *
+ * Afterwards, it traverses the returned blocks, looking for atomic blocks. When an atomic
+ * block is found, it reads its text, and if it indicates one of the saved structures along
+ * with an ID, it creates the needed block.
+ *
+ * This "small hack" allows us to use a reliable HTML convertor provided by DraftJS, as
+ * well as accommodate Editor3 custom atomic blocks.
+ */
+export class HTMLParser {
+    constructor(html) {
+        this.tables = {};
+        this.tree = $('<div></div>');
+
+        this.createTree(html);
+    }
+
+    /**
+     * @name HTMLParser#createTree
+     * @param {string} html
+     * @description Takes the given HTML, extracts the atomic blocks, and creates
+     * the tree to be parsed by the DraftJS's convertor.
+     */
+    createTree(html) {
+        this.tree.html(html);
+        this.pruneNodes();
+    }
+
+    /**
+     * @name HTMLParser#pruneNodes
+     * @description Replaces the nodes that need to be converted to atomic blocks
+     * with <figure> tags containing text indicating the type of block that is needed
+     * there, along with an ID. The ID links to a structure that stores information
+     * about the HTML that was extracted.
+     */
+    pruneNodes() {
+        this.tree.find('table').each((i, node) => {
+            this.tables[i] = $(node).html();
+            $(node).replaceWith(`<figure>BLOCK_TABLE_${i}</figure>`);
+        });
+    }
+
+    /**
+     * @name HTMLParser#contentState
+     * @description Returns the full content state corresponding to the HTML that
+     * initialized the instance.
+     * @returns {ContentState} contentState
+     */
+    contentState() {
+        const {contentBlocks, entityMap} = convertFromHTML(this.tree.html());
+
+        return ContentState.createFromBlockArray(
+            contentBlocks.map(this.processBlock.bind(this)),
+            entityMap
+        );
+    }
+
+    /**
+     * @name HTMLParser#processBlock
+     * @param {ContentBlock} block
+     * @description Processes the given block. If it's an atomic block that has text
+     * indicating the ID of a pruned node, it returns the new corresponding block.
+     * @returns {ContentBlock} New block.
+     */
+    processBlock(block) {
+        const isAtomic = block.getType() === 'atomic';
+        const isTable = block.getText().indexOf('BLOCK_TABLE_') === 0;
+
+        if (isAtomic && isTable) {
+            return this.createTableBlock(block);
+        }
+
+        return block;
+    }
+
+    /**
+     * @name HTMLParser#createTableBlock
+     * @param {ContentBlock} block
+     * @description Takes an unprocessed atomic block (that is assumed to be a
+     * soon-to-be table block) and processes it.
+     * @returns {ContentBlock} The fully restored table block.
+     */
+    createTableBlock(block) {
+        const id = parseInt(block.getText().slice(12), 10);
+        const tableHTML = this.tables[id];
+        const tableNode = $('<table></table>');
+
+        tableNode.html(tableHTML);
+
+        const rows = tableNode.find('tr');
+        const h = rows.length;
+        const w = rows.first()
+            .find('th,td')
+            .length;
+
+        let cells = [];
+
+        for (let i = 0; i < h; i++) {
+            for (let j = 0; j < w; j++) {
+                const row = $(rows[i]);
+                const col = $(row.find('th,td')[j]);
+                const {contentBlocks, entityMap} = convertFromHTML(col.html());
+                const cellContentState = ContentState.createFromBlockArray(contentBlocks, entityMap);
+
+                cells[i] = cells[i] || [];
+                cells[i][j] = convertToRaw(cellContentState);
+            }
+        }
+
+        return atomicBlock(block, 'TABLE', 'MUTABLE', {data: {w, h, cells}});
+    }
+}
+
+/**
+ * @name atomicBlock
+ * @param {Object} block The block to copy
+ * @param {string} entityType
+ * @param {string} entityMutability Mutability type (MUTABLE, IMMUTABLE).
+ * @param {Object} entityData
+ * @description Returns the given block, having its text replaced by one space that
+ * has the corresponding character metadata linked to the given entity.
+ * @returns {Object} The new atomic block.
+ */
+function atomicBlock(block, entityType, entityMutability, entityData) {
+    // TODO(gbbr): Will not work with DraftJS 0.11
+    const entityKey = Entity.create(entityType, entityMutability, entityData);
+    const text = ' ';
+    const {type, key, depth} = block.toJS();
+    const data = fromJS(block.toJS().data);
+
+    const char = CharacterMetadata.create({
+        style: OrderedSet([]),
+        entity: entityKey
+    });
+
+    const characterList = List([char]);
+
+    return new ContentBlock({type, key, depth, data, text, characterList});
+}

--- a/scripts/core/editor3/html/index.js
+++ b/scripts/core/editor3/html/index.js
@@ -1,4 +1,5 @@
 import {HTMLGenerator} from './to-html';
+import {HTMLParser} from './from-html';
 
 /**
  * @name toHTML
@@ -15,5 +16,5 @@ export function toHTML(contentState) {
  * @description Converts DraftJS ContentState to HTML.
  */
 export function fromHTML(html) {
-    throw 'Not implemented';
+    return new HTMLParser(html).contentState();
 }

--- a/scripts/core/editor3/html/tests/from-html.spec.js
+++ b/scripts/core/editor3/html/tests/from-html.spec.js
@@ -1,0 +1,77 @@
+import {HTMLParser} from '../from-html';
+import {convertFromRaw} from 'draft-js';
+
+/**
+ * @param {string} html HTML to convert
+ * @returns {Array<ContentBlock>}
+ * @description Returns the set of blocks corresponding to the content state
+ * resulting from the conversion of the given HTML.
+ */
+function blocksFor(html) {
+    const contentState = new HTMLParser(html).contentState();
+    const blocks = contentState.getBlockMap().toArray();
+
+    return {contentState, blocks};
+}
+
+describe('core.editor3.html.from-html', () => {
+    it('should parse simple HTML', () => {
+        const {blocks} = blocksFor(`
+            <div>some text</div>
+            <h2>some header</h2>
+            <p>some paragraph</p>
+        `);
+
+        expect(blocks.length).toBe(3);
+
+        expect(blocks[0].getText()).toBe('some text ');
+        expect(blocks[0].getType()).toBe('unstyled');
+        expect(blocks[1].getText()).toBe('some header');
+        expect(blocks[1].getType()).toBe('header-two');
+        expect(blocks[2].getText()).toBe('some paragraph');
+        expect(blocks[2].getType()).toBe('unstyled');
+    });
+
+    it('should parse HTML with tables', () => {
+        const {blocks, contentState} = blocksFor(`
+            <h2>some header</h2>
+            <p>some paragraph</p>
+            <table>
+                <tbody>
+                    <tr><td>1</td><td>2</td><td>3</td></tr>
+                    <tr><td>4</td><td>5</td><td>6</td></tr>
+                    <tr><td>7</td><td>8</td><td>9</td></tr>
+                    <tr><td>10</td><td>11</td><td>12</td></tr>
+                </tbody>
+            </table>
+        `);
+
+        expect(blocks.length).toBe(3);
+
+        expect(blocks[0].getText()).toBe('some header');
+        expect(blocks[0].getType()).toBe('header-two');
+        expect(blocks[1].getText()).toBe('some paragraph');
+        expect(blocks[1].getType()).toBe('unstyled');
+        expect(blocks[2].getText()).toBe(' ');
+        expect(blocks[2].getType()).toBe('atomic');
+
+        const entityKey = blocks[2].getEntityAt(0);
+        const entity = contentState.getEntity(entityKey);
+        const {data} = entity.getData();
+
+        expect(data.numCols).toEqual(3);
+        expect(data.numRows).toEqual(4);
+
+        const expected = [
+            ['1', '2', '3'],
+            ['4', '5', '6'],
+            ['7', '8', '9'],
+            ['10', '11', '12']
+        ];
+
+        data.cells.forEach((row, i) =>
+            row.forEach((cell, j) =>
+                expect(convertFromRaw(data.cells[i][j]).getPlainText(''))
+                    .toEqual(expected[i][j])));
+    });
+});

--- a/scripts/core/editor3/html/tests/to-html.spec.js
+++ b/scripts/core/editor3/html/tests/to-html.spec.js
@@ -34,8 +34,8 @@ describe('core.editor3.html.to-html.AtomicBlockParser', () => {
         const cs = (txt) => convertToRaw(ContentState.createFromText(txt));
         const {contentState, block} = testUtils.createBlockAndContent('TABLE', {
             data: {
-                w: 3,
-                h: 2,
+                numCols: 3,
+                numRows: 2,
                 cells: [
                     [cs('a'), undefined, cs('c')],
                     [cs('d'), cs('e'), cs('f')]
@@ -52,8 +52,8 @@ describe('core.editor3.html.to-html.AtomicBlockParser', () => {
     it('should correctly parse empty tables', () => {
         const {contentState, block} = testUtils.createBlockAndContent('TABLE', {
             data: {
-                w: 3,
-                h: 2,
+                numCols: 3,
+                numRows: 2,
                 cells: []
             }
         });

--- a/scripts/core/editor3/html/to-html/AtomicBlockParser.js
+++ b/scripts/core/editor3/html/to-html/AtomicBlockParser.js
@@ -87,7 +87,7 @@ export class AtomicBlockParser {
             return '';
         }
 
-        const {w, h, cells} = data.data;
+        const {numRows, numCols, cells} = data.data;
         const getCell = (i, j) => {
             const cellContentState = cells[i] && cells[i][j]
                 ? convertFromRaw(cells[i][j])
@@ -96,9 +96,9 @@ export class AtomicBlockParser {
             return new HTMLGenerator(cellContentState, ['table']).html();
         };
 
-        return '<table><tbody>' + Array.from(new Array(h))
+        return '<table><tbody>' + Array.from(new Array(numRows))
             .map((_, i) =>
-                '<tr>' + Array.from(new Array(w))
+                '<tr>' + Array.from(new Array(numCols))
                     .map((_, j) => `<td>${getCell(i, j)}</td>`)
                     .join('') + '</tr>'
             )

--- a/scripts/core/editor3/reducers/toolbar.jsx
+++ b/scripts/core/editor3/reducers/toolbar.jsx
@@ -197,7 +197,7 @@ const applyEmbed = (state, data) => {
 /**
  * @ngdoc method
  * @name addTable
- * @param {Object} data Table data (w, h, ...).
+ * @param {Object} data Table data (numRows, numCols, cells).
  * @description Adds a table into the content.
  */
 const addTable = (state, data) => {

--- a/scripts/core/editor3/store/index.js
+++ b/scripts/core/editor3/store/index.js
@@ -5,9 +5,8 @@ import ng from 'core/services/ng';
 import {forceUpdate} from '../actions';
 import {Editor3} from '../components/Editor3';
 import {EditorState, convertFromRaw, convertToRaw, ContentState} from 'draft-js';
-import {stateFromHTML} from 'draft-js-import-html';
 import {clearHighlights} from '../reducers/find-replace';
-import {toHTML} from 'core/editor3/html';
+import {toHTML, fromHTML} from 'core/editor3/html';
 
 /**
  * @name createEditorStore
@@ -67,7 +66,7 @@ function onChange(content) {
 
 /**
  * @name getInitialContent
- * @params {Object} ctrl Controller hosting the editor
+ * @param {Object} ctrl Controller hosting the editor
  * @returns {ContentState} DraftJS ContentState object.
  * @description Gets the initial content state of the editor based on available information.
  * If an editor state is available as saved in the DB, we use that, otherwise we attempt to
@@ -81,7 +80,7 @@ function getInitialContent(ctrl) {
 
     // we have only HTML (possibly legacy editor2 or ingested item)
     if (ctrl.value) {
-        return stateFromHTML(ctrl.value);
+        return fromHTML(ctrl.value);
     }
 
     return ContentState.createFromText('');


### PR DESCRIPTION
* Implements a convertor that takes HTML and creates DraftJS ContentState.
* Renames some ambiguous table terminology from `w, h` to the more obvious `numCols, numRows`