### PR TITLE
[SDESK-1048] fix: re-enable compiler pre-assign bindings

### DIFF
--- a/scripts/core/index.js
+++ b/scripts/core/index.js
@@ -77,6 +77,7 @@ core.config(['$routeProvider', ($routeProvider) => {
 // due to angular 1.6
 core.config(['$locationProvider', ($locationProvider) => $locationProvider.hashPrefix('')]);
 core.config(['$qProvider', ($qProvider) => $qProvider.errorOnUnhandledRejections(false)]);
+core.config(['$compileProvider', ($compileProvider) => $compileProvider.preAssignBindingsEnabled(true)]);
 
 core.run(['$injector', ng.register]);
 


### PR DESCRIPTION
Fixes [SDESK-1048](https://dev.sourcefabric.org/browse/SDESK-1048).

Controller bindings are not immediately available at the moment of initialization since Angular 1.6. This PR re-enables it. For more info see [this](http://stackoverflow.com/questions/41755751/why-is-binding-value-not-available-in-controller-immediately-in-angular) StackOverflow article.