### PR TITLE
[SDESK-1056] - Correct and Kill buttons missing when workqueue item opened

### DIFF
--- a/scripts/apps/authoring/authoring/services/AuthoringService.js
+++ b/scripts/apps/authoring/authoring/services/AuthoringService.js
@@ -50,8 +50,9 @@ export function AuthoringService($q, $location, api, lock, autosave, confirm, pr
      * @param {string} _id Item _id.
      * @param {boolean} readOnly
      * @param {string} repo - repository where an item whose identifier is _id can be found.
+     * @param {string} action - action performed to open the story: edit, correct or kill
      */
-    this.open = function openAuthoring(_id, readOnly, repo) {
+    this.open = function openAuthoring(_id, readOnly, repo, action) {
         if ($location.$$path !== '/multiedit') {
             superdeskFlags.flags.authoring = true;
         }
@@ -79,7 +80,7 @@ export function AuthoringService($q, $location, api, lock, autosave, confirm, pr
                 }
 
                 item._editable = true; // not locked at all, try to lock
-                return lock.lock(item);
+                return lock.lock(item, false, action);
             })
             .then((item) => autosave.open(item).then(null, (err) => item));
     };

--- a/scripts/apps/authoring/authoring/services/AuthoringWorkspaceService.js
+++ b/scripts/apps/authoring/authoring/services/AuthoringWorkspaceService.js
@@ -202,7 +202,7 @@ export function AuthoringWorkspaceService($location, superdeskFlags, authoring, 
      * Fetch item by id and start editing it
      */
     function authoringOpen(itemId, action, repo) {
-        return authoring.open(itemId, action === 'view', repo)
+        return authoring.open(itemId, action === 'view', repo, action)
             .then((item) => {
                 self.item = item;
                 self.action = action !== 'view' && item._editable ? action : 'view';

--- a/scripts/apps/authoring/authoring/services/LockService.js
+++ b/scripts/apps/authoring/authoring/services/LockService.js
@@ -3,13 +3,14 @@ export function LockService($q, api, session, privileges, notify) {
     /**
      * Lock an item
      */
-    this.lock = function lock(item, force) {
+    this.lock = function lock(item, force, action) {
         if (!item.lock_user && item._editable || force) {
-            return api.save('archive_lock', {}, {}, item).then((lock) => {
+            return api.save('archive_lock', {}, {lock_action: action}, item).then((lock) => {
                 _.extend(item, lock);
                 item._locked = true;
                 item.lock_user = session.identity._id;
                 item.lock_session = session.sessionId;
+                item.lock_action = action || 'edit';
                 return item;
             }, (err) => {
                 notify.error(gettext('Failed to get a lock on the item!'));

--- a/scripts/apps/authoring/tests/authoring.spec.js
+++ b/scripts/apps/authoring/tests/authoring.spec.js
@@ -58,7 +58,7 @@ describe('authoring', () => {
         $rootScope.$digest();
 
         expect(api.find).toHaveBeenCalledWith('archive', GUID, jasmine.any(Object));
-        expect(lock.lock).toHaveBeenCalledWith(ITEM);
+        expect(lock.lock).toHaveBeenCalledWith(ITEM, false, undefined);
         expect(autosave.open).toHaveBeenCalledWith(lockedItem);
         expect(_item.guid).toBe(GUID);
     }));
@@ -2048,11 +2048,11 @@ describe('authoring workspace', () => {
     it('can open an item for edit or readonly', inject((authoringWorkspace, authoring, send, $q, $rootScope) => {
         item.state = 'draft';
         authoringWorkspace.open(item);
-        expect(authoring.open).toHaveBeenCalledWith(item._id, false, null);
+        expect(authoring.open).toHaveBeenCalledWith(item._id, false, null, 'edit');
 
         item.state = 'published';
         authoringWorkspace.open(item);
-        expect(authoring.open).toHaveBeenCalledWith(item._id, true, null);
+        expect(authoring.open).toHaveBeenCalledWith(item._id, true, null, 'view');
 
         var archived = {_id: 'bar'};
 
@@ -2061,7 +2061,7 @@ describe('authoring workspace', () => {
         authoringWorkspace.open(item);
         expect(send.one).toHaveBeenCalledWith(item);
         $rootScope.$digest();
-        expect(authoring.open).toHaveBeenCalledWith(archived._id, false, null);
+        expect(authoring.open).toHaveBeenCalledWith(archived._id, false, null, 'edit');
     }));
 
     describe('init', () => {

--- a/scripts/apps/authoring/workqueue/workqueue.js
+++ b/scripts/apps/authoring/workqueue/workqueue.js
@@ -207,7 +207,7 @@ function WorkqueueCtrl($scope, $rootScope, $route, workqueue, authoringWorkspace
     $scope.edit = function(item, event) {
         if (!event.ctrlKey) {
             $scope.active = item;
-            authoringWorkspace.edit(item);
+            authoringWorkspace.edit(item, item.lock_action);
             $scope.redirectOnCloseMulti();
             $scope.dashboardActive = false;
 

--- a/spec/authoring_spec.js
+++ b/spec/authoring_spec.js
@@ -723,4 +723,25 @@ describe('authoring', () => {
         workspace.selectDesk('Sports Desk');
         expect(monitoring.getGroupItems(5).count()).toBe(2);
     }, 600000);
+
+    it('can minimize story while a correction and kill is being written', () => {
+        workspace.selectDesk('Politic Desk');
+        expect(monitoring.getTextItem(3, 2)).toBe('item6');
+        monitoring.actionOnItem('Edit', 3, 2);
+        authoring.publish();
+        monitoring.filterAction('text');
+        monitoring.actionOnItem('Correct item', 5, 0); // Edit for correction
+        authoring.minimize(); // minimize before publishing the correction
+        expect(monitoring.getTextItem(2, 1)).toBe('item9');
+        monitoring.actionOnItem('Edit', 2, 1);
+        authoring.publish();
+        monitoring.actionOnItem('Kill item', 5, 0); // Edit for kill
+        authoring.minimize(); // minimize before publishing the kill
+        authoring.maximize('item6');
+        authoring.sendToButton.click();
+        expect(monitoring.getPublishButtonText()).toBe('CORRECT');
+        authoring.maximize('item9');
+        authoring.sendToButton.click();
+        expect(monitoring.getPublishButtonText()).toBe('KILL');
+    });
 });

--- a/spec/helpers/authoring.js
+++ b/spec/helpers/authoring.js
@@ -330,6 +330,14 @@ function Authoring() {
         return element(by.id('Info')).click();
     };
 
+    this.minimize = () => element(by.css('[ng-click="minimize()"]')).click();
+
+    this.maximize = (name) => {
+        let href = `#/authoring/${name}`;
+
+        element(by.css('[ng-href="' + href + '"]')).click();
+    };
+
     this.toggleNotForPublication = function() {
         element(by.model('item.flags.marked_for_not_publication')).click();
     };

--- a/spec/helpers/monitoring.js
+++ b/spec/helpers/monitoring.js
@@ -536,6 +536,8 @@ function Monitoring() {
         element(by.css('[ng-click="_publish()"]')).click();
     };
 
+    this.getPublishButtonText = () => element(by.css('[ng-click="publish()"]')).getText();
+
     this.startUpload = function() {
         element(by.id('start-upload-btn')).click();
     };

--- a/test-server/requirements.txt
+++ b/test-server/requirements.txt
@@ -2,4 +2,4 @@ gunicorn==19.6.0
 honcho==0.6.6
 newrelic>=2.66,<2.67
 
-git+git://github.com/superdesk/superdesk-core.git@1248041#egg=Superdesk-Core
+git+git://github.com/superdesk/superdesk-core.git@dec9172#egg=Superdesk-Core


### PR DESCRIPTION
During a correction or kill if the story is minimized (or another story is opened) it loses the context and the correct publish button disappears. To solve the issue now we're:

- Saving the `action` when locking the story
- Using the `action` when story is opened from workqueue