### PR TITLE
Fix server core: current version with broken celery beat

### DIFF
--- a/test-server/requirements.txt
+++ b/test-server/requirements.txt
@@ -2,4 +2,4 @@ gunicorn==19.6.0
 honcho==0.6.6
 newrelic>=2.66,<2.67
 
-git+git://github.com/superdesk/superdesk-core.git@dec9172#egg=Superdesk-Core
+git+git://github.com/superdesk/superdesk-core.git@6e852ca#egg=Superdesk-Core


### PR DESCRIPTION
Celery beat is broken like this:
```
beat raised exception <class 'AttributeError'>: AttributeError("'NoneType' object has no attribute 'is_due'",) level=CRITICAL process=MainProcess
Traceback (most recent call last):
  File "/opt/superdesk/env/lib/python3.5/site-packages/celery/apps/beat.py", line 107, in start_scheduler
    service.start()
  File "/opt/superdesk/env/lib/python3.5/site-packages/celery/beat.py", line 537, in start
    interval = self.scheduler.tick()
  File "/opt/superdesk/env/lib/python3.5/site-packages/celery/beat.py", line 255, in tick
    for e in values(self.schedule)]
  File "/opt/superdesk/env/lib/python3.5/site-packages/celery/beat.py", line 255, in <listcomp>
    for e in values(self.schedule)]
  File "/opt/superdesk/env/lib/python3.5/site-packages/celery/beat.py", line 134, in is_due
    return self.schedule.is_due(self.last_run_at)
AttributeError: 'NoneType' object has no attribute 'is_due'
```