### PR TITLE
feat(editor3): floating toolbar [SDESK-879]

### DIFF
--- a/scripts/apps/authoring/views/article-edit.html
+++ b/scripts/apps/authoring/views/article-edit.html
@@ -204,6 +204,7 @@
     <span sd-word-count data-item="item.body_html" data-html="true"></span>
     <div id="bodyhtml"
          sd-editor3
+         data-scroll-container=".page-content-container"
          data-editor-format="editor.body_html.formatOptions"
          data-editor-state="item.editor_state"
          data-value="item.body_html"

--- a/scripts/core/editor3/components/toolbar/index.js
+++ b/scripts/core/editor3/components/toolbar/index.js
@@ -11,11 +11,8 @@ import classNames from 'classnames';
  * @ngdoc React
  * @module superdesk.core.editor3
  * @name Toolbar
- * @param {Object} editorState The state of the editor.
  * @param {Object} editorRect Position of editor on the screen (top, left).
- * @param {Function} onChange On change function to be called when the editor
- * state changes.
- * @param {Array} editorFormat options and settings for formatting
+ * @param {boolean} disabled Disables clicking on the toolbar, if true.
  * @description Holds the editor's toolbar.
  */
 export default class Toolbar extends Component {

--- a/scripts/core/editor3/directive.js
+++ b/scripts/core/editor3/directive.js
@@ -24,6 +24,7 @@ class Editor3Directive {
         this.controller = ['$element', 'editor3', '$scope', this.initialize];
 
         this.bindToController = {
+            scrollContainer: '@',
             config: '=',
             editorFormat: '=',
             language: '=',
@@ -41,7 +42,7 @@ class Editor3Directive {
 
         ReactDOM.render(
             <Provider store={store}>
-                <Editor3 />
+                <Editor3 scrollContainer={this.scrollContainer} />
             </Provider>, $element.get(0)
         );
     }

--- a/scripts/core/editor3/styles.scss
+++ b/scripts/core/editor3/styles.scss
@@ -5,8 +5,18 @@
 	border: 1px solid #ddd;
 	font-family: 'Georgia', serif;
 	font-size: 14px;
-	padding: 15px;
+	padding: 40px 15px 15px;
 	position: relative;
+
+	&.floating-toolbar .Editor3-controls {
+		position: fixed;
+		top: 132px;
+		left: auto;
+		margin-left: -15px;
+		z-index: 10;
+		border-bottom: 1px solid #dedede;
+		box-shadow: 0px 1px 5px #efefef;
+	}
 
 	&.read-only {
 		.Editor3-controls {
@@ -143,7 +153,11 @@
 	font-size: 14px;
 	margin-bottom: 5px;
 	user-select: none;
-	position: relative;
+	position: absolute;
+	top: 0;
+	left: 0;
+	padding: 15px;
+	background-color: #fff;
 
 	&.disabled {
 		* {


### PR DESCRIPTION
When content is too long and scrolling down, float toolbar at top of the page container (just like editor2 does now):

![apr-18-2017 12-29-21](https://cloud.githubusercontent.com/assets/6686356/25126451/adbff936-2432-11e7-86c0-ab12586cf4a4.gif)