### PR TITLE
[SDESK-1158] - Count of records vs aggregate discrepancy

### DIFF
--- a/scripts/apps/search/tests/search.spec.js
+++ b/scripts/apps/search/tests/search.spec.js
@@ -13,10 +13,20 @@ describe('search service', () => {
         var filters = criteria.query.filtered.filter.and;
 
         expect(filters).toContain({not: {term: {state: 'spiked'}}});
-        expect(filters).toContain({not: {bool: {must: [{term: {package_type: 'takes'}}, {term: {_type: 'archive'}}]}}});
         expect(filters).toContain({not: {bool: {must: [{term: {_type: 'published'}},
                 {term: {package_type: 'takes'}},
                 {term: {last_published_version: false}}]}}});
+        expect(criteria.sort).toEqual([{versioncreated: 'desc'}]);
+    }));
+
+    it('can create base query without take packages', inject((search, session) => {
+        session.identity = {_id: 'foo'};
+        var query = search.query({ignoreDigital: true});
+        var criteria = query.getCriteria();
+        var filters = criteria.query.filtered.filter.and;
+
+        expect(filters).toContain({not: {term: {state: 'spiked'}}});
+        expect(filters).toContain({not: {term: {package_type: 'takes'}}});
         expect(criteria.sort).toEqual([{versioncreated: 'desc'}]);
     }));
 

--- a/spec/authoring_spec.js
+++ b/spec/authoring_spec.js
@@ -305,6 +305,7 @@ describe('authoring', () => {
         browser.sleep(100);
         expect(authoring.getANPATakeKeyValue()).toBe('=2');
         authoring.close();
+        monitoring.filterAction('text');
         monitoring.actionOnItem('Spike', 0, 0);
         monitoring.actionOnItem('Edit', 0, 0);
         authoring.showHistory();

--- a/spec/takes_spec.js
+++ b/spec/takes_spec.js
@@ -212,6 +212,7 @@ describe('takes', () => {
         expect(monitoring.getItem(0, 0).element(by.className('takes')).isDisplayed()).toBe(true);
 
         monitoring.switchToDesk('POLITIC DESK');
+        monitoring.filterAction('text');
         expect(monitoring.getItem(0, 0).element(by.className('takes')).isDisplayed()).toBe(true);
 
         monitoring.getItem(0, 0).element(by.className('takes')).click();


### PR DESCRIPTION
When takes are disabled, aggregated figures still had the counts for the take packages whereas queries didn't return them.