### PR TITLE
feat(editor3): add a control to toggle table headers (SDESK-1170)

### DIFF
--- a/scripts/core/editor3/actions/table.jsx
+++ b/scripts/core/editor3/actions/table.jsx
@@ -7,10 +7,11 @@
  */
 export function addTable(numRows, numCols) {
     const cells = [];
+    const withHeader = false;
 
     return {
         type: 'TOOLBAR_ADD_TABLE',
-        payload: {numRows, numCols, cells}
+        payload: {numRows, numCols, cells, withHeader}
     };
 }
 
@@ -48,4 +49,14 @@ export function removeRow() {
  */
 export function removeCol() {
     return {type: 'TOOLBAR_REMOVE_COL'};
+}
+
+/**
+ * @ngdoc method
+ * @name toggleTableHeader
+ * @description Toggles the tables header (enabled or disables the rendering of a header).
+ * When exporting HTML, thead/th & tbody are used, if on.
+ */
+export function toggleTableHeader() {
+    return {type: 'TOOLBAR_TABLE_HEADER'};
 }

--- a/scripts/core/editor3/components/tables/TableBlock.jsx
+++ b/scripts/core/editor3/components/tables/TableBlock.jsx
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import classNames from 'classnames';
 import * as actions from '../../actions';
 import {connect} from 'react-redux';
 import {TableCell} from '.';
@@ -93,10 +94,15 @@ export class TableBlockComponent extends Component {
     }
 
     render() {
-        const {numRows, numCols} = this.data();
+        const {numRows, numCols, withHeader} = this.data();
+
+        let cx = classNames({
+            'table-block': true,
+            'table-header': withHeader
+        });
 
         return (
-            <div className="table-block">
+            <div className={cx}>
                 <table>
                     <tbody>
                         {Array.from(new Array(numRows)).map((v, i) =>

--- a/scripts/core/editor3/components/toolbar/StyleButton.jsx
+++ b/scripts/core/editor3/components/toolbar/StyleButton.jsx
@@ -36,6 +36,7 @@ export default class StyleButton extends React.Component {
 
     render() {
         const {active, label} = this.props;
+        const iconClass = StyleIcons[label];
 
         const cx = classNames({
             'Editor3-styleButton': true,
@@ -44,7 +45,7 @@ export default class StyleButton extends React.Component {
 
         return (
             <span className={cx} onMouseDown={this.onToggle}>
-                <i className={StyleIcons[label]} />
+                {iconClass ? <i className={iconClass} /> : <b>{label}</b>}
             </span>
         );
     }

--- a/scripts/core/editor3/components/toolbar/TableControls.jsx
+++ b/scripts/core/editor3/components/toolbar/TableControls.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {connect} from 'react-redux';
+import StyleButton from './StyleButton';
 import * as actions from '../../actions';
 
 /**
@@ -12,28 +13,54 @@ import * as actions from '../../actions';
  * @param {Function} removeCol
  * @description Holds the toolbar for table operations.
  */
-const TableControlsComponent = ({addRowAfter, addColAfter, removeRow, removeCol}) =>
-    <div className="Editor3-controls table-controls">
+const TableControlsComponent = ({
+    addRowAfter,
+    addColAfter,
+    removeRow,
+    removeCol,
+    activeCell,
+    editorState,
+    toggleTableHead
+}) => {
+    const {key} = activeCell;
+    const contentState = editorState.getCurrentContent();
+    const block = contentState.getBlockForKey(key);
+    const entityKey = block.getEntityAt(0);
+    const entity = contentState.getEntity(entityKey);
+    const {withHeader} = entity.getData().data;
+
+    return <div className="Editor3-controls table-controls">
+        <StyleButton active={withHeader} label={'TH'} onToggle={toggleTableHead} />
         <span className="Editor3-styleButton short" onClick={removeRow}><i className="icon-minus-sign" /></span>
         <span className="Editor3-styleButton" onClick={addRowAfter}><i className="icon-plus-sign" /> row</span>
         <span className="Editor3-styleButton short" onClick={removeCol}><i className="icon-minus-sign" /></span>
         <span className="Editor3-styleButton" onClick={addColAfter}><i className="icon-plus-sign" /> col</span>
     </div>;
+};
 
 TableControlsComponent.propTypes = {
     addRowAfter: React.PropTypes.func,
     addColAfter: React.PropTypes.func,
     removeRow: React.PropTypes.func,
     removeCol: React.PropTypes.func,
+    activeCell: React.PropTypes.object.isRequired,
+    editorState: React.PropTypes.object,
+    toggleTableHead: React.PropTypes.func
 };
 
 const mapDispatchToProps = (dispatch) => ({
     addRowAfter: () => dispatch(actions.addRowAfter()),
     addColAfter: () => dispatch(actions.addColAfter()),
     removeRow: () => dispatch(actions.removeRow()),
-    removeCol: () => dispatch(actions.removeCol())
+    removeCol: () => dispatch(actions.removeCol()),
+    toggleTableHead: () => dispatch(actions.toggleTableHeader()),
 });
 
-const TableControls = connect(null, mapDispatchToProps)(TableControlsComponent);
+const mapStateToProps = (state) => ({
+    activeCell: state.activeCell,
+    editorState: state.editorState
+});
+
+const TableControls = connect(mapStateToProps, mapDispatchToProps)(TableControlsComponent);
 
 export default TableControls;

--- a/scripts/core/editor3/html/tests/to-html.spec.js
+++ b/scripts/core/editor3/html/tests/to-html.spec.js
@@ -128,6 +128,28 @@ describe('core.editor3.html.to-html.AtomicBlockParser', () => {
             '<tr><td><p>d</p></td><td><p>e</p></td><td><p>f</p></td></tr></tbody></table>');
     });
 
+    it('should correctly parse tables with headers', () => {
+        const cs = (txt) => convertToRaw(ContentState.createFromText(txt));
+        const {contentState, block} = testUtils.createBlockAndContent('TABLE', {
+            data: {
+                numCols: 3,
+                numRows: 3,
+                withHeader: true,
+                cells: [
+                    [cs('a'), undefined, cs('c')],
+                    [cs('d'), cs('e'), cs('f')],
+                    [cs('g'), cs('h'), cs('i')]
+                ]
+            }
+        });
+
+        const html = new AtomicBlockParser(contentState).parse(block);
+
+        expect(html).toBe('<table><thead><tr><th><p>a</p></th><th><p></p></th><th><p>c</p></th></tr></thead>' +
+            '<tbody><tr><td><p>d</p></td><td><p>e</p></td><td><p>f</p></td></tr>' +
+            '<tr><td><p>g</p></td><td><p>h</p></td><td><p>i</p></td></tr></tbody></table>');
+    });
+
     it('should correctly parse empty tables', () => {
         const {contentState, block} = testUtils.createBlockAndContent('TABLE', {
             data: {

--- a/scripts/core/editor3/html/to-html/AtomicBlockParser.js
+++ b/scripts/core/editor3/html/to-html/AtomicBlockParser.js
@@ -87,7 +87,7 @@ export class AtomicBlockParser {
             return '';
         }
 
-        const {numRows, numCols, cells} = data.data;
+        const {numRows, numCols, cells, withHeader} = data.data;
         const getCell = (i, j) => {
             const cellContentState = cells[i] && cells[i][j]
                 ? convertFromRaw(cells[i][j])
@@ -96,12 +96,36 @@ export class AtomicBlockParser {
             return new HTMLGenerator(cellContentState, ['table']).html();
         };
 
-        return '<table><tbody>' + Array.from(new Array(numRows))
-            .map((_, i) =>
-                '<tr>' + Array.from(new Array(numCols))
-                    .map((_, j) => `<td>${getCell(i, j)}</td>`)
-                    .join('') + '</tr>'
-            )
-            .join('') + '</tbody></table>';
+        let html = '<table>';
+        let startRow = 0;
+
+        if (withHeader) {
+            html += '<thead><tr>';
+
+            for (let j = 0; j < numCols; j++) {
+                html += `<th>${getCell(0, j)}</th>`;
+            }
+
+            html += '</tr></thead>';
+            startRow = 1;
+        }
+
+        if (numRows > 1) {
+            html += '<tbody>';
+
+            for (let i = startRow; i < numRows; i++) {
+                html += '<tr>';
+                for (let j = 0; j < numCols; j++) {
+                    html += `<td>${getCell(i, j)}</td>`;
+                }
+                html += '</tr>';
+            }
+
+            html += '</tbody>';
+        }
+
+        html += '</table>';
+
+        return html;
     }
 }

--- a/scripts/core/editor3/styles.scss
+++ b/scripts/core/editor3/styles.scss
@@ -67,6 +67,12 @@
 	}
 
 	.table-block {
+		&.table-header {
+			tr:first-child td {
+				background-color: #fafafa;
+			}
+		}
+
 		&__controls {
 			margin-bottom: 6px;
 
@@ -329,7 +335,7 @@
 		}
 	}
 
-	&.Editor3-activeButton [class*="icon-"] {
+	&.Editor3-activeButton, &.Editor3-activeButton [class*="icon-"] {
 		color: #5890ff;
 	}
 }


### PR DESCRIPTION
When inside a table cell, on the table controls toolbar, a new toggle-able button 'th' has been added, which enables rendering of `thead`/`th` tags in the HTML output.

In the browser, the difference is shown like this:
![apr-26-2017 10-59-21](https://cloud.githubusercontent.com/assets/6686356/25426498/a6887830-2a6f-11e7-8f1e-b27a1ae4159e.gif)
(you can observe a subtle change in the background color of the first row)

In the output HTML, proper `thead` and `th` tags are added to the result.