### PR TITLE
feat(editor3): allow setting and getting HTML in active editor

### DIFF
--- a/scripts/core/editor2/editor.js
+++ b/scripts/core/editor2/editor.js
@@ -94,6 +94,8 @@ function EditorService(spellcheck, $q, _, renditionsService, utils) {
         return $q.when(0);
     };
 
+    this.version = () => '2';
+
     this.KEY_CODES = Object.freeze({
         Y: 'Y'.charCodeAt(0),
         Z: 'Z'.charCodeAt(0),

--- a/scripts/core/editor3/actions/editor3.jsx
+++ b/scripts/core/editor3/actions/editor3.jsx
@@ -92,3 +92,18 @@ export function changeImageCaption(entityKey, newCaption) {
         payload: {entityKey, newCaption}
     };
 }
+
+/**
+ * @ngdoc method
+ * @name setHTML
+ * @param {string} html
+ * @description Replaces the current editor content with the given HTML. This is used
+ * by the Tansa spellchecker to apply a corrected text.
+ * @returns {Object}
+ */
+export function setHTML(html) {
+    return {
+        type: 'EDITOR_SET_HTML',
+        payload: html
+    };
+}

--- a/scripts/core/editor3/html/index.js
+++ b/scripts/core/editor3/html/index.js
@@ -5,6 +5,7 @@ import {HTMLParser} from './from-html';
  * @name toHTML
  * @param {Object} contentState
  * @description Converts DraftJS ContentState to HTML.
+ * @returns {string} HTML
  */
 export function toHTML(contentState) {
     return new HTMLGenerator(contentState).html();
@@ -14,6 +15,7 @@ export function toHTML(contentState) {
  * @name fromHTML
  * @param {String} html
  * @description Converts DraftJS ContentState to HTML.
+ * @returns {ContentState} DraftJS ContentState
  */
 export function fromHTML(html) {
     return new HTMLParser(html).contentState();

--- a/scripts/core/editor3/reducers/editor3.jsx
+++ b/scripts/core/editor3/reducers/editor3.jsx
@@ -1,4 +1,6 @@
+import {Editor3} from '../components/Editor3';
 import {RichUtils, EditorState} from 'draft-js';
+import {fromHTML} from 'core/editor3/html';
 import {addImage} from './toolbar';
 
 /**
@@ -20,6 +22,8 @@ const editor3 = (state = {}, action) => {
         return setCell(state, action.payload);
     case 'EDITOR_CHANGE_IMAGE_CAPTION':
         return changeImageCaption(state, action.payload);
+    case 'EDITOR_SET_HTML':
+        return setHTML(state, action.payload);
     default:
         return state;
     }
@@ -143,6 +147,22 @@ const changeImageCaption = (state, {entityKey, newCaption}) => {
     const newContentState = contentState.replaceEntityData(entityKey, {img});
 
     return onChange(state, EditorState.push(editorState, newContentState, 'update-image'));
+};
+
+/**
+ * @ngdoc method
+ * @name setHTML
+ * @param {string} html
+ * @description Replaces the current editor content with the given HTML. This is used
+ * by the Tansa spellchecker to apply a corrected text.
+ * @returns {Object}
+ */
+const setHTML = (state, html) => {
+    const decorator = Editor3.getDecorator();
+    const content = fromHTML(html);
+    const editorState = EditorState.createWithContent(content, decorator);
+
+    return {...state, editorState};
 };
 
 export default editor3;

--- a/scripts/core/editor3/service.js
+++ b/scripts/core/editor3/service.js
@@ -1,6 +1,8 @@
-import * as action from './actions/find-replace';
+import * as action from './actions';
 import ng from 'core/services/ng';
 import {countOccurrences, forEachMatch} from './reducers/find-replace';
+import {toHTML} from './html';
+import {clearHighlights} from './reducers/find-replace';
 
 /**
  * @type {Object} Redux store
@@ -30,6 +32,16 @@ export class EditorService {
         }
 
         store = s;
+    }
+
+    /**
+     * @ngdoc method
+     * @name editor3#version
+     * @description Returns the editor version (this is for when using editorResolver).
+     * @returns {string}
+     */
+    version() {
+        return '3';
     }
 
     /**
@@ -152,6 +164,34 @@ export class EditorService {
         });
 
         return txt;
+    }
+
+    /**
+     * @ngdoc method
+     * @name editor3#getHTML
+     * @description Gets the content of the editor as HTML.
+     * @returns {string} HTML
+     */
+    getHTML() {
+        if (!ok()) {
+            return '';
+        }
+
+        const state = store.getState();
+        const content = state.editorState.getCurrentContent();
+        const cleanedContent = clearHighlights(content).content;
+
+        return toHTML(cleanedContent);
+    }
+
+    /**
+     * @ngdoc method
+     * @name editor3#setHTML
+     * @param {string} html
+     * @description Replaces the content of the editor with the given HTML.
+     */
+    setHTML(html) {
+        ok() && store.dispatch(action.setHTML(html));
     }
 }
 


### PR DESCRIPTION
These methods are for allowing the tansa implementation to get and set corrected HTML in the editor.