### PR TITLE
Let me specify "devtool" and "progress" options for "grunt build"

### DIFF
--- a/tasks/options/webpack.js
+++ b/tasks/options/webpack.js
@@ -3,6 +3,9 @@ var webpack = require('webpack');
 module.exports = function(grunt) {
     var config = require('../../webpack.config.js')(grunt);
 
+    config.progress = !grunt.option('webpack-no-progress');
+    config.devtool = grunt.option('webpack-devtool') || 'cheap-source-map';
+
     return {
         options: config,
         build: {


### PR DESCRIPTION
Useful in CI
`$ grunt build --webpack-no-progress`

Play with different devtool (also for CI)
`$ grunt build --webpack-devtool=eval`