### PR TITLE
feat(monitoring): add edit in new window action

### DIFF
--- a/scripts/apps/authoring/authoring/authoring.spec.js
+++ b/scripts/apps/authoring/authoring/authoring.spec.js
@@ -54,4 +54,16 @@ describe('authoring', () => {
         expect(scope.item.anpa_category[0].qcode).toBe('paservice:motoring');
         expect(scope.item.anpa_category[0].scheme).toBeUndefined();
     }));
+
+    describe('authoring workspace', () => {
+        it('can open an item in new window', inject(($window, authoringWorkspace) => {
+            spyOn($window, 'open');
+            authoringWorkspace.popup({_id: 'foo'}, 'edit');
+            expect($window.open)
+                .toHaveBeenCalledWith(
+                    'http://server/#/workspace/monitoring?item=foo&action=edit&popup',
+                    'foo'
+                );
+        }));
+    });
 });

--- a/scripts/apps/authoring/authoring/index.js
+++ b/scripts/apps/authoring/authoring/index.js
@@ -105,6 +105,19 @@ angular.module('superdesk.apps.authoring', [
                     return authoring.itemActions(item).edit;
                 }]
             })
+            .activity('edit.item.popup', {
+                label: gettext('Edit in new Window'),
+                priority: 5,
+                icon: 'pencil',
+                keyboardShortcut: 'ctrl+alt+n',
+                controller: ['data', 'authoringWorkspace', (data, authoringWorkspace) => {
+                    authoringWorkspace.popup(data.item, 'edit');
+                }],
+                filters: [{action: 'list', type: 'archive'}],
+                additionalCondition: ['authoring', 'item', function(authoring, item) {
+                    return authoring.itemActions(item).edit;
+                }]
+            })
             .activity('kill.text', {
                 label: gettext('Kill item'),
                 priority: 100,
@@ -156,6 +169,23 @@ angular.module('superdesk.apps.authoring', [
                     {action: 'list', type: 'archived'},
                     {action: 'list', type: 'legal_archive'},
                     {action: 'view', type: 'item'}
+                ],
+                additionalCondition: ['authoring', 'item', function(authoring, item) {
+                    return authoring.itemActions(item).view;
+                }]
+            })
+            .activity('view.item.popup', {
+                label: gettext('Open in new Window'),
+                priority: 1990,
+                icon: 'external',
+                keyboardShortcut: 'ctrl+alt+n',
+                controller: ['data', 'authoringWorkspace', (data, authoringWorkspace) => {
+                    authoringWorkspace.popup(data.item, 'view');
+                }],
+                filters: [
+                    {action: 'list', type: 'archive'},
+                    {action: 'list', type: 'archived'},
+                    {action: 'list', type: 'legal_archive'}
                 ],
                 additionalCondition: ['authoring', 'item', function(authoring, item) {
                     return authoring.itemActions(item).view;

--- a/scripts/apps/authoring/authoring/services/AuthoringWorkspaceService.js
+++ b/scripts/apps/authoring/authoring/services/AuthoringWorkspaceService.js
@@ -16,9 +16,9 @@
  * @description Authoring Workspace Service is responsible for the actions done on the authoring workspace container
  */
 AuthoringWorkspaceService.$inject = ['$location', 'superdeskFlags', 'authoring', 'lock', 'send', 'config', 'suggest',
-    '$rootScope', 'search'];
+    '$rootScope', 'search', '$window'];
 export function AuthoringWorkspaceService($location, superdeskFlags, authoring, lock, send, config, suggest,
-    $rootScope, search) {
+    $rootScope, search, $window) {
     this.item = null;
     this.action = null;
     this.state = null;
@@ -91,6 +91,10 @@ export function AuthoringWorkspaceService($location, superdeskFlags, authoring, 
      * @param {boolean} showMonitoring when true shows the monitoring if monitoring is hidden.
      */
     this.close = function(showMonitoring) {
+        if ($rootScope.popup) {
+            window.close();
+        }
+
         suggest.setActive(false);
         self.item = null;
         self.action = null;
@@ -161,6 +165,24 @@ export function AuthoringWorkspaceService($location, superdeskFlags, authoring, 
      */
     this.update = function(item) {
         self.item = item;
+    };
+
+    /**
+     * Edit/view item in a new window
+     *
+     * @param {Object} item
+     * @param {string} action
+     */
+    this.popup = (item, action) => {
+        const host = $location.host();
+        const port = $location.port();
+        const proto = $location.protocol();
+        const baseURL = `${proto}://${host}${port !== 80 ? ':' + port : ''}`;
+
+        $window.open(
+            `${baseURL}/#/workspace/monitoring?item=${item._id}&action=${action}&popup`,
+            item._id
+        );
     };
 
     /**

--- a/scripts/apps/search/helpers.js
+++ b/scripts/apps/search/helpers.js
@@ -64,7 +64,7 @@ export function renderToBody(elem, target) {
     var width = rect.width;
     var height = rect.height;
 
-    var ACTION_MENU_FROM_TOP = 150; // 150 = top-menu + search bar
+    var ACTION_MENU_FROM_TOP = 100; // top-menu + search bar
     var MENU_MARGIN_HEIGHT = 16;
     var LEFT_BAR_WIDTH = 48;
     var BOTTOM_BAR_HEIGHT = 30;

--- a/scripts/apps/workspace/directives/WorkspaceSidenavDirective.js
+++ b/scripts/apps/workspace/directives/WorkspaceSidenavDirective.js
@@ -86,6 +86,10 @@ export function WorkspaceSidenavDirective(superdeskFlags, $location, Keys, gette
                     return false;
                 }
             });
+
+            if ($rootScope.popup) {
+                superdeskFlags.flags.hideMonitoring = true;
+            }
         }
     };
 }

--- a/scripts/core/menu/views/superdesk-view.html
+++ b/scripts/core/menu/views/superdesk-view.html
@@ -3,14 +3,19 @@
 
 <div class="loading" ng-if="loading"></div>
 
-<div id="main-container" ng-class="superdesk.flags" ng-if="superdesk.flags.workspace === true" ngf-drop="superdesk.openUpload($files)">
+<div id="main-container" ng-class="superdesk.flags" ng-if="!popup && superdesk.flags.workspace === true" ngf-drop="superdesk.openUpload($files)">
     <div id="workspace-container" ng-view sd-splitter-widget></div>
     <div id="authoring-container" ng-if="superdesk.flags.workspace" sd-authoring-container></div>
     <div id="superdesk-workqueue" ng-if="superdesk.flags.workspace" sd-workqueue></div>
     <div sd-item-preview-container></div>
 </div>
 
-<div id="main-container" ng-class="superdesk.flags" ng-if="superdesk.flags.workspace === false" ngf-drop="return;" ng-view></div>
+<div id="main-container" ng-class="superdesk.flags" ng-if="popup" ngf-drop="superdesk.openUpload($files)">
+    <div id="authoring-container" sd-authoring-container></div>
+    <div sd-item-preview-container></div>
+</div>
+
+<div id="main-container" ng-class="superdesk.flags" ng-if="!popup && superdesk.flags.workspace === false" ngf-drop="return;" ng-view></div>
 
 <div id="react-placeholder"></div>
 

--- a/scripts/core/ui/ui.js
+++ b/scripts/core/ui/ui.js
@@ -1196,6 +1196,10 @@ export default angular.module('superdesk.core.ui', [
         defaultConfig.set('ui.italicAbstract', true);
     }])
 
+    .run(['$rootScope', '$location', ($rootScope, $location) => {
+        $rootScope.popup = $location.search().popup || false;
+    }])
+
     .directive('sdShadow', ShadowDirective)
     .directive('sdToggleBox', ToggleBoxDirective)
     .filter('nl2el', NewlineToElement)

--- a/spec/legal_archive_spec.js
+++ b/spec/legal_archive_spec.js
@@ -23,7 +23,7 @@ xdescribe('legal_archive', () => {
         var menu = content.openItemMenu('item1 in legal archive');
         var menuItems = menu.all(by.repeater('activity in actions.default'));
 
-        expect(menuItems.count()).toBe(1);
+        expect(menuItems.count()).toBe(2); // open + open in new window
     });
 
     it('on open item close preview in a Legal Archive', () => {


### PR DESCRIPTION
it avoids using ng-view when `popup` param is used so it should avoid other actions but editing, but there are some menus still in place which will take you nowhere. keeping it like this for now to get more feedback
SDESK-1267