### PR TITLE
fix(authoring): avoid null value for profile not used by desk

### DIFF
--- a/scripts/apps/authoring/metadata/metadata.js
+++ b/scripts/apps/authoring/metadata/metadata.js
@@ -24,9 +24,9 @@ function MetadataCtrl(
     .then(setAvailableCompanyCodes);
 
     $scope.$watch(() => desks.active.desk, (activeDeskId) => {
-        content.getDeskProfiles(activeDeskId ? desks.getCurrentDesk() : null)
+        content.getDeskProfiles(activeDeskId ? desks.getCurrentDesk() : null, $scope.item.profile)
             .then((profiles) => {
-                $scope.content_types = profiles;
+                $scope.desk_content_types = profiles;
             });
     });
 

--- a/scripts/apps/authoring/views/authoring-header.html
+++ b/scripts/apps/authoring/views/authoring-header.html
@@ -10,7 +10,11 @@
         <div ng-if="change_profile && content_types.length">
           <label translate>PROFILE</label>
           <div class="data">
-            <select id="item-profile" ng-model="item.profile" ng-change="changeProfile(item)" ng-options="type._id as type.label for type in content_types"></select>
+            <select id="item-profile"
+              ng-model="item.profile"
+              ng-change="changeProfile(item)"
+              ng-options="type._id as type.label for type in desk_content_types">
+            </select>
           </div>
         </div>
         <div ng-if="item.type === 'text'">

--- a/scripts/apps/workspace/content/services/ContentService.js
+++ b/scripts/apps/workspace/content/services/ContentService.js
@@ -232,13 +232,14 @@ export function ContentService(api, superdesk, templates, desks, packages, archi
      * Get profiles selected for given desk
      *
      * @param {Object} desk
+     * @param {string} profileId if profileId is set add such profile to the list
      * @return {Promise}
      */
-    this.getDeskProfiles = function(desk) {
+    this.getDeskProfiles = function(desk, profileId) {
         return this.getTypes().then((profiles) => !desk || _.isEmpty(desk.content_profiles) ?
                 profiles :
-                profiles.filter((profile) => desk.content_profiles[profile._id]
-            ));
+                profiles.filter((profile) => desk.content_profiles[profile._id] || profile._id === profileId)
+            );
     };
 
     this.contentProfileSchema = angular.extend({}, constant.DEFAULT_SCHEMA, constant.EXTRA_SCHEMA_FIELDS);

--- a/scripts/apps/workspace/content/tests/content.spec.js
+++ b/scripts/apps/workspace/content/tests/content.spec.js
@@ -107,17 +107,22 @@ describe('superdesk.apps.workspace.content', () => {
         }));
 
         it('can fetch content types and filter by desk', inject((content, $rootScope, $q) => {
-            spyOn(content, 'getTypes').and.returnValue($q.when([{_id: 'foo'}, {_id: 'bar'}]));
+            spyOn(content, 'getTypes').and.returnValue($q.when([
+                {_id: 'foo'},
+                {_id: 'bar'},
+                {_id: 'baz'}
+            ]));
 
             var profiles;
 
-            content.getDeskProfiles({content_profiles: {bar: 1}}).then((_profiles) => {
+            content.getDeskProfiles({content_profiles: {bar: 1}}, 'baz').then((_profiles) => {
                 profiles = _profiles;
             });
 
             $rootScope.$digest();
-            expect(profiles.length).toBe(1);
+            expect(profiles.length).toBe(2);
             expect(profiles[0]._id).toBe('bar');
+            expect(profiles[1]._id).toBe('baz');
         }));
 
         it('can generate content types lookup dict', inject((content, $q, $rootScope) => {


### PR DESCRIPTION
when sending content to another desk where item profile was not
used it would set it to `null` and switched to default profile.

now item current profile will be always available in the dropdown
so there won't be any switch.

SDESK-1285