### PR TITLE
(fix):Reverting changes for search providers.

### DIFF
--- a/scripts/apps/search/views/item-repo.html
+++ b/scripts/apps/search/views/item-repo.html
@@ -11,7 +11,7 @@
     </div>
     <div ng-repeat="provider in providers track by provider._id">
         <label class="sd-radio">
-            <input type="radio" ng-value="{{ provider.search_provider }}" ng-model="repo.search" ng-checked="isDefault(provider)" ng-change="toggleRepo(provider.search_provider)">
+            <input type="radio" ng-value="provider.search_provider" ng-model="repo.search" ng-checked="isDefault(provider)" ng-change="toggleRepo(provider.search_provider)">
             {{:: providerLabels[provider.source]}}<span class="check"></span>
         </label>
     </div>


### PR DESCRIPTION
Reverting the change done in PR #1585  
This change is not required for version 1.7 as the `sd-check` directive is not used. 

@petrjasek can we have this merged today. We want to do another release monday morning.
