### PR TITLE
fix(search) - exclude resetting aggregation criteria on single query with refresh frame is ON

### DIFF
--- a/scripts/apps/search/directives/SearchResults.js
+++ b/scripts/apps/search/directives/SearchResults.js
@@ -205,11 +205,12 @@ export function SearchResults(
                     }
 
                     criteria.source.query = search.getItemQuery(data.items);
+                } else {
+                    criteria.aggregations = $rootScope.aggregations;
                 }
 
                 criteria.source.from = 0;
                 scope.total = null;
-                criteria.aggregations = $rootScope.aggregations;
                 criteria.es_highlight = search.getElasticHighlight();
                 criteria.projections = JSON.stringify(projections);
                 return api.query(getProvider(criteria), criteria).then((items) => {


### PR DESCRIPTION
…th refresh frame is ON
- This change fixes the issue, where user is on global search's filter tab with listed aggregations and refresh frame is ON, so even on when single updates comes in, that was causing resetting the aggregations on filters tab just for single query result, so that it is now excluded for that case only