### PR TITLE
fix(editor3): when item is locked, correctly disable editing (SDESK-1400)

### DIFF
--- a/scripts/core/editor3/actions/editor3.jsx
+++ b/scripts/core/editor3/actions/editor3.jsx
@@ -59,9 +59,9 @@ export function dragDrop(e) {
  * @return {String} action
  * @description Dispatches the action to set the main editor as read-only.
  */
-export function setReadOnly(v) {
+export function setLocked(v) {
     return {
-        type: 'EDITOR_SET_READONLY',
+        type: 'EDITOR_SET_LOCKED',
         payload: v
     };
 }

--- a/scripts/core/editor3/components/Editor3.jsx
+++ b/scripts/core/editor3/components/Editor3.jsx
@@ -35,7 +35,6 @@ export class Editor3Component extends React.Component {
     constructor(props) {
         super(props);
 
-        this.readOnly = props.readOnly;
         this.scrollContainer = $(props.scrollContainer || window);
         this.state = {toolbarStyle: 'relative'};
 
@@ -52,7 +51,7 @@ export class Editor3Component extends React.Component {
      * @description Handle the editor get focus event
      */
     focus() {
-        this.props.unsetReadOnly(this.readOnly);
+        this.props.unlock();
         setTimeout(this.refs.editor.focus, 0); // after action
     }
 
@@ -170,6 +169,7 @@ export class Editor3Component extends React.Component {
         const {toolbarStyle} = this.state;
         const {
             readOnly,
+            locked,
             showToolbar,
             editorState,
             onChange,
@@ -185,7 +185,7 @@ export class Editor3Component extends React.Component {
 
         return (
             <div className={cx}>
-                {showToolbar ? <Toolbar disabled={readOnly} /> : null}
+                {showToolbar ? <Toolbar disabled={locked || readOnly} /> : null}
                 <div className="focus-screen" onMouseDown={this.focus}>
                     <Editor
                         editorState={editorState}
@@ -196,7 +196,7 @@ export class Editor3Component extends React.Component {
                         onChange={onChange}
                         onTab={onTab}
                         handlePastedText={handlePastedText.bind(this)}
-                        readOnly={readOnly}
+                        readOnly={locked || readOnly}
                         ref="editor"
                     />
                 </div>
@@ -207,10 +207,11 @@ export class Editor3Component extends React.Component {
 
 Editor3Component.propTypes = {
     readOnly: React.PropTypes.bool,
+    locked: React.PropTypes.bool,
     showToolbar: React.PropTypes.bool,
     editorState: React.PropTypes.object,
     onChange: React.PropTypes.func,
-    unsetReadOnly: React.PropTypes.func,
+    unlock: React.PropTypes.func,
     onTab: React.PropTypes.func,
     dragDrop: React.PropTypes.func,
     scrollContainer: React.PropTypes.string,
@@ -220,14 +221,15 @@ Editor3Component.propTypes = {
 const mapStateToProps = (state) => ({
     readOnly: state.readOnly,
     showToolbar: state.showToolbar,
-    editorState: state.editorState
+    editorState: state.editorState,
+    locked: state.locked
 });
 
 const mapDispatchToProps = (dispatch) => ({
     onChange: (editorState) => dispatch(actions.changeEditorState(editorState)),
     onTab: (e) => dispatch(actions.handleEditorTab(e)),
     dragDrop: (e) => dispatch(actions.dragDrop(e)),
-    unsetReadOnly: () => dispatch(actions.setReadOnly(false))
+    unlock: () => dispatch(actions.setLocked(false))
 });
 
 export const Editor3 = connect(mapStateToProps, mapDispatchToProps)(Editor3Component);

--- a/scripts/core/editor3/components/images/ImageBlock.jsx
+++ b/scripts/core/editor3/components/images/ImageBlock.jsx
@@ -61,7 +61,7 @@ export class ImageBlockComponent extends Component {
     }
 
     render() {
-        const {setReadOnly} = this.props;
+        const {setLocked} = this.props;
         const data = this.data();
         const rendition = data.renditions.viewImage || data.renditions.original;
         const alt = data.alt_text || data.description_text || data.caption;
@@ -74,7 +74,7 @@ export class ImageBlockComponent extends Component {
                         ref={(el) => {
                             this.captionInput = el;
                         }}
-                        onFocus={setReadOnly}
+                        onFocus={setLocked}
                         className="image-block__description"
                         onInput={_.debounce(this.onChange, 500)}>{data.description_text}</div>
                 </div>
@@ -86,7 +86,7 @@ export class ImageBlockComponent extends Component {
 ImageBlockComponent.propTypes = {
     cropImage: React.PropTypes.func.isRequired,
     changeCaption: React.PropTypes.func.isRequired,
-    setReadOnly: React.PropTypes.func.isRequired,
+    setLocked: React.PropTypes.func.isRequired,
     block: React.PropTypes.object.isRequired,
     contentState: React.PropTypes.object.isRequired
 };
@@ -94,7 +94,7 @@ ImageBlockComponent.propTypes = {
 const mapDispatchToProps = (dispatch) => ({
     cropImage: (entityKey, entityData) => dispatch(actions.cropImage(entityKey, entityData)),
     changeCaption: (entityKey, newCaption) => dispatch(actions.changeImageCaption(entityKey, newCaption)),
-    setReadOnly: () => dispatch(actions.setReadOnly())
+    setLocked: () => dispatch(actions.setLocked(true))
 });
 
 export const ImageBlock = connect(null, mapDispatchToProps)(ImageBlockComponent);

--- a/scripts/core/editor3/components/tables/TableBlock.jsx
+++ b/scripts/core/editor3/components/tables/TableBlock.jsx
@@ -110,6 +110,7 @@ export class TableBlockComponent extends Component {
                                 {Array.from(new Array(numCols)).map((v, j) =>
                                     <TableCell
                                         key={`cell-${i}-${j}-${numRows}-${numCols}`}
+                                        readOnly={this.props.readOnly}
                                         editorState={this.getCell(i, j)}
                                         onChange={this.setCell.bind(this, i, j)}
                                         onFocus={this.onFocus.bind(this, i, j)} />
@@ -126,6 +127,7 @@ export class TableBlockComponent extends Component {
 TableBlockComponent.propTypes = {
     block: React.PropTypes.object.isRequired,
     contentState: React.PropTypes.object.isRequired,
+    readOnly: React.PropTypes.bool.isRequired,
     editorState: React.PropTypes.object.isRequired,
     setActiveCell: React.PropTypes.func.isRequired,
     parentOnChange: React.PropTypes.func.isRequired
@@ -137,7 +139,8 @@ const mapDispatchToProps = (dispatch) => ({
 });
 
 const mapStateToProps = (state) => ({
-    editorState: state.editorState
+    editorState: state.editorState,
+    readOnly: state.readOnly
 });
 
 export const TableBlock = connect(mapStateToProps, mapDispatchToProps)(TableBlockComponent);

--- a/scripts/core/editor3/components/tables/TableCell.jsx
+++ b/scripts/core/editor3/components/tables/TableCell.jsx
@@ -124,7 +124,7 @@ export class TableCell extends Component {
 
     render() {
         const {editorState} = this.state;
-        const {onFocus} = this.props;
+        const {onFocus, readOnly} = this.props;
 
         return (
             <td onClick={(e) => e.stopPropagation()}>
@@ -132,6 +132,7 @@ export class TableCell extends Component {
                     onFocus={onFocus}
                     editorState={editorState}
                     handleKeyCommand={this.handleKeyCommand}
+                    readOnly={readOnly}
                     onChange={this.onChange}
                     keyBindingFn={this.keyBindingFn} />
             </td>
@@ -141,6 +142,7 @@ export class TableCell extends Component {
 
 TableCell.propTypes = {
     editorState: React.PropTypes.object.isRequired,
+    readOnly: React.PropTypes.bool.isRequired,
     onChange: React.PropTypes.func.isRequired,
     onFocus: React.PropTypes.func.isRequired
 };

--- a/scripts/core/editor3/reducers/editor3.jsx
+++ b/scripts/core/editor3/reducers/editor3.jsx
@@ -10,8 +10,8 @@ const editor3 = (state = {}, action) => {
     switch (action.type) {
     case 'EDITOR_CHANGE_STATE':
         return onChange(state, action.payload);
-    case 'EDITOR_SET_READONLY':
-        return setReadOnly(state, action.payload);
+    case 'EDITOR_SET_LOCKED':
+        return setLocked(state, action.payload);
     case 'EDITOR_TAB':
         return onTab(state, action.payload);
     case 'EDITOR_FORCE_UPDATE':
@@ -100,19 +100,19 @@ const dragDrop = (state, e) => {
 
 /**
  * @ngdoc method
- * @name setReadOnly
- * @param {Boolean=} readOnly If true, editor is set to read-only.
+ * @name setLocked
+ * @param {Boolean=} locked If true, editor is set to read-only.
  * @return {Object} New state
  * @description Handles setting the editor as active, or read-only.
  */
-const setReadOnly = (state, readOnly = true) => {
+const setLocked = (state, locked = true) => {
     let {activeCell} = state;
 
-    if (!readOnly) {
+    if (!locked) {
         activeCell = null;
     }
 
-    return {...state, readOnly, activeCell};
+    return {...state, locked, activeCell};
 };
 
 /**
@@ -124,7 +124,7 @@ const setReadOnly = (state, readOnly = true) => {
  */
 const setCell = (state, {i, j, key}) => ({
     ...state,
-    readOnly: true,
+    locked: true,
     activeCell: {i, j, key}
 });
 

--- a/scripts/core/editor3/store/index.js
+++ b/scripts/core/editor3/store/index.js
@@ -27,9 +27,10 @@ export default function createEditorStore(ctrl) {
         editorState: EditorState.createWithContent(content, decorators),
         searchTerm: {pattern: '', index: -1, caseSensitive: false},
         readOnly: ctrl.readOnly,
+        locked: false, // when true, main editor is disabled (ie. when editing sub-components like tables or images)
         showToolbar: showToolbar,
         singleLine: ctrl.singleLine,
-        activeCell: null,
+        activeCell: null, // currently focused table cell
         editorFormat: ctrl.editorFormat || [],
         onChangeValue: _.debounce(onChange.bind(ctrl), ctrl.debounce)
     }, applyMiddleware(thunk));

--- a/scripts/core/editor3/styles.scss
+++ b/scripts/core/editor3/styles.scss
@@ -48,6 +48,8 @@
 	}
 
 	&.read-only {
+		cursor: not-allowed;
+
 		.Editor3-controls {
 			* {
 				pointer-events: none;


### PR DESCRIPTION
Added a new 'locked' property to the redux store to indicated when the
editor is locked. This is used when a child item that contains editable
properties is being interacted with (such as images and tables).