### PR TITLE
ui(editor3/embed): allow adding embed codes

### DIFF
--- a/scripts/core/editor3/actions/toolbar.jsx
+++ b/scripts/core/editor3/actions/toolbar.jsx
@@ -100,7 +100,7 @@ export function cropImage(entityKey, entityData) {
 
 /**
  * @ngdoc method
- * @name embedURL
+ * @name embed
  * @return {Object} oEmbed
  * @description Dispatches the action to use the given oEmbed data for media embedding.
  */
@@ -108,5 +108,18 @@ export function embed(oEmbed) {
     return {
         type: 'TOOLBAR_APPLY_EMBED',
         payload: oEmbed
+    };
+}
+
+/**
+ * @ngdoc method
+ * @name embedCode
+ * @return {string} code
+ * @description Dispatches the action to use the given embed code for media embedding.
+ */
+export function embedCode(code) {
+    return {
+        type: 'TOOLBAR_APPLY_EMBED_CODE',
+        payload: code
     };
 }

--- a/scripts/core/editor3/components/embeds/EmbedInput.jsx
+++ b/scripts/core/editor3/components/embeds/EmbedInput.jsx
@@ -76,6 +76,12 @@ export class EmbedInputComponent extends Component {
      */
     onSubmit() {
         const {value} = this.refs.txt;
+
+        if (!value.startsWith('http://') && !value.startsWith('https://')) {
+            this.props.embedCode(value);
+            return this.onCancel();
+        }
+
         const config = ng.get('config');
         const apiKey = config.iframely.key || fallbackAPIKey;
 
@@ -101,7 +107,7 @@ export class EmbedInputComponent extends Component {
 
         return (
             <form onSubmit={this.onSubmit} className="embed-dialog" onKeyUp={this.onKeyUp}>
-                <input type="url" ref="txt" placeholder="Enter a URL to embed" />
+                <input type="url" ref="txt" placeholder={gettext('Enter URL or code to embed')} />
                 <div className="input-controls">
                     <i className="svg-icon-ok" onClick={this.onSubmit} />
                     <i className="icon-close-small" onClick={onCancel} />
@@ -114,11 +120,13 @@ export class EmbedInputComponent extends Component {
 
 EmbedInputComponent.propTypes = {
     onCancel: React.PropTypes.func.isRequired,
-    onSubmit: React.PropTypes.func.isRequired
+    onSubmit: React.PropTypes.func.isRequired,
+    embedCode: React.PropTypes.func.isRequired
 };
 
 const mapDispatchToProps = (dispatch) => ({
-    onSubmit: (oEmbed) => dispatch(actions.embed(oEmbed))
+    onSubmit: (oEmbed) => dispatch(actions.embed(oEmbed)),
+    embedCode: (html) => dispatch(actions.embedCode(html))
 });
 
 export const EmbedInput = connect(null, mapDispatchToProps)(EmbedInputComponent);

--- a/scripts/core/editor3/components/tests/embeds.spec.jsx
+++ b/scripts/core/editor3/components/tests/embeds.spec.jsx
@@ -84,13 +84,13 @@ describe('editor3.components.embed-input', () => {
     it('should display error when ajax call returns it', inject(($q, $rootScope) => {
         const {options} = mockStore();
         const noop = () => ({});
-        const wrapper = mount(<EmbedInput onCancel={noop} onSubmit={noop} />, options);
+        const wrapper = mount(<EmbedInput onCancel={noop} embedCode={noop} onSubmit={noop} />, options);
 
         spyOn($, 'ajax').and.returnValue($q.reject({
             responseJSON: {error: 'this is the error'}
         }));
 
-        wrapper.ref('txt').value = 'http://will.fail';
+        wrapper.find('input').node.value = 'http://will.fail';
         wrapper.simulate('submit');
 
         $rootScope.$apply();
@@ -108,7 +108,7 @@ describe('editor3.components.embed-input', () => {
         spyOn($, 'ajax').and.returnValue($q.resolve('resolve-value'));
 
         wrapper.setState({error: 'some error'});
-        wrapper.ref('txt').value = 'http://will.fail';
+        wrapper.find('input').node.value = 'http://will.fail';
         wrapper.simulate('submit');
 
         $rootScope.$apply();

--- a/scripts/core/editor3/components/tests/images.spec.jsx
+++ b/scripts/core/editor3/components/tests/images.spec.jsx
@@ -10,7 +10,7 @@ describe('editor3.components.image-block', () => {
             <ImageBlock
                 cropImage={() => ({})}
                 changeCaption={() => ({})}
-                setReadOnly={() => ({})}
+                setLocked={() => ({})}
                 block={block}
                 contentState={contentState} />);
 
@@ -26,7 +26,7 @@ describe('editor3.components.image-block', () => {
             <ImageBlock
                 cropImage={cropImage}
                 changeCaption={() => ({})}
-                setReadOnly={() => ({})}
+                setLocked={() => ({})}
                 block={block}
                 contentState={contentState} />);
 

--- a/scripts/core/editor3/components/tests/tables.spec.jsx
+++ b/scripts/core/editor3/components/tests/tables.spec.jsx
@@ -27,7 +27,7 @@ describe('editor3.component.table-block', () => {
                 setActiveCell={() => { /* no-op */ }}
                 editorState={{}}
                 parentOnChange={() => { /* no-op */ }}
-                parentReadOnly={false} />
+                readOnly={false} />
         );
 
         expect(wrapper.find('tr').length).toEqual(2);
@@ -43,7 +43,7 @@ describe('editor3.component.table-block', () => {
                 setActiveCell={() => { /* no-op */ }}
                 editorState={{}}
                 parentOnChange={() => { /* no-op */ }}
-                parentReadOnly={true} />
+                readOnly={true} />
         );
 
         ['a', 'b', 'c', 'd', 'e', 'f'].forEach((letter, i) => {
@@ -63,6 +63,7 @@ describe('editor3.component.table-cell', () => {
             <TableCell
                 editorState={EditorState.createWithContent(ContentState.createFromText('abc'))}
                 onChange={() => { /* no-op */ }}
+                readOnly={false}
                 onFocus={() => { /* no-op */ }} />
         );
 

--- a/scripts/core/editor3/reducers/toolbar.jsx
+++ b/scripts/core/editor3/reducers/toolbar.jsx
@@ -20,6 +20,8 @@ const toolbar = (state = {}, action) => {
         return updateImage(state, action.payload);
     case 'TOOLBAR_APPLY_EMBED':
         return applyEmbed(state, action.payload);
+    case 'TOOLBAR_APPLY_EMBED_CODE':
+        return applyEmbedCode(state, action.payload);
     default:
         return state;
     }
@@ -182,6 +184,30 @@ const applyEmbed = (state, data) => {
 
     const contentState = state.editorState.getCurrentContent();
     const contentStateWithEntity = contentState.createEntity('EMBED', 'MUTABLE', {data});
+    const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
+
+    editorState = AtomicBlockUtils.insertAtomicBlock(
+        editorState,
+        entityKey,
+        ' '
+    );
+
+    return {...state, editorState};
+};
+
+/**
+ * @ngdoc method
+ * @name applyEmbedCode
+ * @param {string} code
+ * @description Applies the embed code into the editor.
+ */
+const applyEmbedCode = (state, code) => {
+    var {editorState} = state;
+
+    const contentState = state.editorState.getCurrentContent();
+    const contentStateWithEntity = contentState.createEntity('EMBED', 'MUTABLE', {
+        data: {html: code}
+    });
     const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
 
     editorState = AtomicBlockUtils.insertAtomicBlock(

--- a/scripts/core/editor3/styles.scss
+++ b/scripts/core/editor3/styles.scss
@@ -6,6 +6,10 @@
 }
 
 .Editor3-root {
+	iframe {
+		width: 97%;
+	}
+
 	background: #fff;
 	border: 1px solid #ddd;
 	font-family: 'Georgia', serif;


### PR DESCRIPTION
This is a highly insecure implementation which allows pasting random
HTML into the embed input, which alternatively gets injected into the
editor's content.

It's a temporary solution after discussing with @karelpetrak. Assuming
this software is used only internally and that potential employee X with
malicious intentions can find worse ways to harm the company, it should
be ok for now.

The 'correct' implementation would be to sanitize the input and see if
it's a valid embed code for any of the supported providers, which would
prove a lot more work and would be harder to maintain due to the fact
that embed codes might change all the time. Alternatively, we could also
simply santitize the URLs presented in the HTML, making sure they
represent trusted sources.

Change-Id: I63fe77e32b69038a86b0e7c927cd8b9728295df5