### PR TITLE
fix(editor3): allow copy/paste of image within the same editor [SDESK-1406]

### DIFF
--- a/scripts/core/editor3/components/Editor3.jsx
+++ b/scripts/core/editor3/components/Editor3.jsx
@@ -40,6 +40,7 @@ export class Editor3Component extends React.Component {
 
         this.scrollContainer = $(props.scrollContainer || window);
         this.state = {toolbarStyle: 'relative'};
+        this.editorKey = null;
 
         this.focus = this.focus.bind(this);
         this.onScroll = this.onScroll.bind(this);
@@ -162,6 +163,9 @@ export class Editor3Component extends React.Component {
         if (this.props.showToolbar) {
             this.scrollContainer.on('scroll', this.onScroll);
         }
+
+        // the editorKey is used to identify the source of pasted blocks
+        this.editorKey = this.refs.editor._editorKey;
     }
 
     componentWillUnmount() {
@@ -198,7 +202,7 @@ export class Editor3Component extends React.Component {
                         customStyleMap={customStyleMap}
                         onChange={onChange}
                         onTab={onTab}
-                        handlePastedText={handlePastedText.bind(this)}
+                        handlePastedText={handlePastedText.bind(this, this.editorKey)}
                         readOnly={locked || readOnly}
                         ref="editor"
                     />

--- a/scripts/core/editor3/components/handlePastedText.js
+++ b/scripts/core/editor3/components/handlePastedText.js
@@ -5,14 +5,22 @@ import {fromHTML} from 'core/editor3/html';
 /**
  * @ngdoc method
  * @name handlePastedText
+ * @param {string} editorKey
  * @param {string} text Text content of paste.
  * @param {string=} html HTML content of paste.
  * @returns {Boolean} True if this method took paste into its own hands.
  * @description Handles pasting into the editor, in cases where the content contains
  * atomic blocks that need special handling in editor3.
  */
-export function handlePastedText(text, html) {
+export function handlePastedText(editorKey, text, html) {
     if (!html) {
+        return false;
+    }
+
+    // If there are blocks that have been copied from the host editor, let the editor
+    // handle the paste. The chance of having content both from the editor and from
+    // outside it as a mix in the clipboard is impossible.
+    if (HTMLComesFromEditor(html, editorKey)) {
         return false;
     }
 
@@ -54,6 +62,21 @@ export function handlePastedText(text, html) {
     onChange(EditorState.push(editorState, contentState, 'insert-characters'));
 
     return true;
+}
+
+/**
+ * @description Checks if the given html contains blocks coming from the editor with
+ * key editorKey.
+ * @param {string} html
+ * @param {string} editorKey
+ * @returns {Boolean}
+ */
+function HTMLComesFromEditor(html, editorKey) {
+    const tree = $('<div></div>');
+
+    tree.html(html);
+
+    return $(tree).find(`[data-block="true"][data-editor="${editorKey}"]`).length > 0;
 }
 
 /**


### PR DESCRIPTION
This functionality enables copy/paste of blocks within the same editor.