### PR TITLE
fix(editor3): temporarily remove embed button tooltip

### DIFF
--- a/scripts/core/editor3/components/embeds/EmbedButton.jsx
+++ b/scripts/core/editor3/components/embeds/EmbedButton.jsx
@@ -44,7 +44,7 @@ export class EmbedButton extends Component {
         const {dialogOpen} = this.state;
 
         return (
-            <div data-flow={'down'} data-sd-tooltip="Embed content" className="Editor3-styleButton">
+            <div className="Editor3-styleButton">
                 <span onClick={this.showInput}><i className="icon-code" /></span>
                 {dialogOpen ? <EmbedInput onCancel={this.hideInput} /> : null}
             </div>


### PR DESCRIPTION
The tooltip is being removed because it is breaking the input layout.
When it will be fixed in superdesk-ui-framework it should be added back.

Change-Id: I4148ed8b8e0de4c1ac53f5b1df235aa6f9a00f98