### PR TITLE
fix(highlights): Fixed issue with non-updating highlights on authoring

### DIFF
--- a/scripts/apps/authoring/views/authoring-topbar.html
+++ b/scripts/apps/authoring/views/authoring-topbar.html
@@ -32,7 +32,7 @@
         <span ng-if="item._type === 'archived'" class="stage" ng-style="{'overflow': 'visible'}" tooltip="{{:: 'Archived from' | translate}} {{deskName}} / {{ stage.name}}" tooltip-placement="bottom" ng-show="stage"><b>{{:: 'Archived from' | translate}} {{deskName}}</b> / {{ stage.name }}</span>
         <span ng-if="item._type !== 'archived'" class="stage" tooltip="{{deskName}} / {{ stage.name }}" tooltip-placement="bottom" ng-show="stage" ng-if="item._type !== 'legal_archive'"><b>{{deskName}}</b> / {{ stage.name }}</span>
         <span class="stage" tooltip="{{deskName}} / {{ stage }}" tooltip-placement="bottom" ng-show="stage" ng-if="item._type === 'legal_archive'"><b>{{deskName}}</b> / {{ stage }}</span>
-        <span ng-if="item.highlights" sd-marked-item-title data-item="item" data-field="highlights"></span>
+        <span sd-marked-item-title data-item="item" data-field="highlights"></span>
         <span ng-if="item.marked_desks" sd-marked-item-title data-item="item" data-field="marked_desks"></span>
         <span class="label label--warning" ng-show="item._type !== 'archived' && stage.local_readonly"
           translate>Read-only</span>


### PR DESCRIPTION
SDESK-1488 - Mark for highlight/desk does not appear in authoring

`ng-if` was killing watchers. Directive `sd-marked-item-title` already controls displaying icons, so this one here is unnecessary.