### PR TITLE
hack(editor3): allow inserting foreign script tags into embed codes [SDESK-1407]

### DIFF
--- a/scripts/apps/authoring/compare-versions/directives/CompareVersionsArticleDirective.js
+++ b/scripts/apps/authoring/compare-versions/directives/CompareVersionsArticleDirective.js
@@ -53,6 +53,7 @@ class LinkFunction {
 
         this.scope.origItem = item;
         this.scope.item = _.cloneDeep(item);
+        this.scope.compareView = true;
         this.scope._editable = false;
         this.scope.isMediaType = _.includes(['audio', 'video', 'picture', 'graphic'], this.scope.item.type);
 

--- a/scripts/apps/authoring/views/article-edit.html
+++ b/scripts/apps/authoring/views/article-edit.html
@@ -207,6 +207,7 @@
     <div id="bodyhtml"
          sd-editor3
          data-find-replace-target
+         data-bind-to-value="compareView"
          data-scroll-container=".page-content-container"
          data-editor-format="editor.body_html.formatOptions"
          data-editor-state="item.editor_state"

--- a/scripts/core/editor3/components/embeds/EmbedBlock.jsx
+++ b/scripts/core/editor3/components/embeds/EmbedBlock.jsx
@@ -9,15 +9,60 @@ import React, {Component} from 'react';
  * retrieved from iframe.ly
  */
 export class EmbedBlock extends Component {
-    render() {
+    /**
+     * @name EmbedBlock#runScripts
+     * @param {string} html
+     * @description Runs and imports all the scripts in the given HTML.
+     */
+    runScripts(html) {
+        const tree = $('<div />').html(html);
+
+        tree.find('script').each((i, s) => {
+            if (s.hasAttribute('src')) {
+                let url = s.getAttribute('src');
+                let async = s.hasAttribute('async');
+
+                if (url.startsWith('http')) {
+                    url = url.substring(url.indexOf(':') + 1);
+                }
+
+                return $.ajax({url: url, async: async, dataType: 'script'});
+            }
+
+            try {
+                // eslint-disable-next-line no-eval
+                eval(s.innerHTML);
+            } catch (e) {
+                /* carry on */
+            }
+        });
+    }
+
+    data() {
         const {block, contentState} = this.props;
         const entityKey = block.getEntityAt(0);
         const entity = contentState.getEntity(entityKey);
         const {data} = entity.getData();
 
-        return (
-            <div className="embed-block" dangerouslySetInnerHTML={{__html: data.html}} />
-        );
+        return data;
+    }
+
+    shouldComponentUpdate(nextProps) {
+        const {block, contentState} = nextProps;
+        const entityKey = block.getEntityAt(0);
+        const entity = contentState.getEntity(entityKey);
+        const {data} = entity.getData();
+        const oldData = this.data();
+
+        return data.html !== oldData.html;
+    }
+
+    render() {
+        const {html} = this.data();
+
+        this.runScripts(html);
+
+        return <div className="embed-block" dangerouslySetInnerHTML={{__html: html}} />;
     }
 }
 

--- a/scripts/core/editor3/directive.js
+++ b/scripts/core/editor3/directive.js
@@ -72,6 +72,14 @@ class Editor3Directive {
             readOnly: '=?',
 
             /**
+             * @type {Boolean}
+             * @description If true, the value prop is being watched for changes,
+             * and the changes are applied to the editor. Experimental feature used
+             * in compare versions.
+             */
+            bindToValue: '=?',
+
+            /**
              * @type {Function}
              * @description Function that gets called on every content change.
              */
@@ -112,10 +120,11 @@ class Editor3Directive {
         this.singleLine = typeof this.singleLine !== 'undefined';
         this.debounce = parseInt(this.debounce || '100', 10);
         this.disableSpellchecker = this.disableSpellchecker || false;
+        this.bindToValue = this.bindToValue || false;
 
         const store = createStore(this);
 
-        $scope.$watch('vm.value', (newValue, oldValue) => {
+        this.bindToValue && $scope.$watch('vm.value', (newValue, oldValue) => {
             const text = (newValue || '')
                 .replace(/<ins/g, '<code')
                 .replace(/<\/ins>/g, '</code>');


### PR DESCRIPTION
Besides the title of the commit, it additionally changes the compare versions functionality so that the `value` attribute of the directive is only bound two-way within this view. When editing an item in authoring, having `value` bound two-way breaks the editor because of HTML conversion inconsistencies.