### PR TITLE
fix(templates): Missing items in content templates in desk settings

### DIFF
--- a/scripts/apps/templates/services/TemplatesService.js
+++ b/scripts/apps/templates/services/TemplatesService.js
@@ -116,7 +116,10 @@ export function TemplatesService(api, session, $q, gettext, preferencesService, 
     };
 
     this.fetchTemplatesByDesk = function(desk) {
-        let params = {sort: 'template_name'};
+        let params = {
+            sort: 'template_name',
+            max_results: 200
+        };
 
         let deskCriteria = [
             {is_public: true},


### PR DESCRIPTION
If there is some other way to return all data from database, please let me know. By default it is returning only 25 items.