### PR TITLE
fix(editor3): make image captions text only [SDESK-1458]

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "react": "15.5.4",
     "react-dom": "15.5.4",
     "react-redux": "4.4.8",
+    "react-textarea-autosize": "^5.0.7",
     "redux": "3.6.0",
     "redux-thunk": "2.2.0",
     "request": "2.61.0",

--- a/scripts/core/editor3/components/images/ImageBlock.jsx
+++ b/scripts/core/editor3/components/images/ImageBlock.jsx
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import * as actions from '../../actions';
+import Textarea from 'react-textarea-autosize';
 
 /**
  * @ngdoc React
@@ -53,11 +54,11 @@ export class ImageBlockComponent extends Component {
      * @name ImageBlockComponent#onChange
      * @description Triggered (debounced) when the image caption input is edited.
      */
-    onChange() {
+    onChange({target}) {
         const {block, changeCaption} = this.props;
         const entityKey = block.getEntityAt(0);
 
-        changeCaption(entityKey, this.captionInput.innerText);
+        changeCaption(entityKey, target.value);
     }
 
     render() {
@@ -70,13 +71,13 @@ export class ImageBlockComponent extends Component {
             <div className="image-block" onClick={(e) => e.stopPropagation()}>
                 <div className="image-block__wrapper">
                     <img src={rendition.href} alt={alt} onClick={this.onClick} />
-                    <div contentEditable={true} placeholder="Description"
-                        ref={(el) => {
-                            this.captionInput = el;
-                        }}
+                    <Textarea
+                        placeholder={gettext('Description')}
                         onFocus={setLocked}
                         className="image-block__description"
-                        onInput={_.debounce(this.onChange, 500)}>{data.description_text}</div>
+                        defaultValue={data.description_text}
+                        onChange={this.onChange}
+                    />
                 </div>
             </div>
         );

--- a/scripts/core/editor3/components/tests/embeds.spec.jsx
+++ b/scripts/core/editor3/components/tests/embeds.spec.jsx
@@ -41,7 +41,7 @@ describe('editor3.components.embed-input', () => {
     it('should render', () => {
         const {options} = mockStore();
         const noop = () => ({});
-        const wrapper = shallow(<EmbedInput onCancel={noop} onSubmit={noop} />, options);
+        const wrapper = shallow(<EmbedInput embedCode={noop} onCancel={noop} onSubmit={noop} />, options);
 
         expect(wrapper.find('.svg-icon-ok').length).toBe(1);
         expect(wrapper.find('.icon-close-small').length).toBe(1);
@@ -52,7 +52,7 @@ describe('editor3.components.embed-input', () => {
         const {options} = mockStore();
         const noop = () => ({});
         const onCancel = jasmine.createSpy();
-        const wrapper = mount(<EmbedInput onCancel={onCancel} onSubmit={noop} />, options);
+        const wrapper = mount(<EmbedInput embedCode={noop} onCancel={onCancel} onSubmit={noop} />, options);
 
         wrapper.find('.icon-close-small').simulate('click');
 
@@ -63,7 +63,7 @@ describe('editor3.components.embed-input', () => {
         const {options} = mockStore();
         const noop = () => ({});
         const onCancel = jasmine.createSpy();
-        const wrapper = mount(<EmbedInput onCancel={onCancel} onSubmit={noop} />, options);
+        const wrapper = mount(<EmbedInput embedCode={noop} onCancel={onCancel} onSubmit={noop} />, options);
 
         wrapper.simulate('keyup', {key: 'Escape'});
 
@@ -74,7 +74,7 @@ describe('editor3.components.embed-input', () => {
         const {options} = mockStore();
         const noop = () => ({});
         const onCancel = jasmine.createSpy();
-        const wrapper = mount(<EmbedInput onCancel={onCancel} onSubmit={noop} />, options);
+        const wrapper = mount(<EmbedInput embedCode={noop} onCancel={onCancel} onSubmit={noop} />, options);
 
         wrapper.simulate('keyup', {key: '.'});
 
@@ -84,7 +84,14 @@ describe('editor3.components.embed-input', () => {
     it('should display error when ajax call returns it', inject(($q, $rootScope) => {
         const {options} = mockStore();
         const noop = () => ({});
-        const wrapper = mount(<EmbedInput onCancel={noop} embedCode={noop} onSubmit={noop} />, options);
+        const wrapper = mount(
+            <EmbedInput
+                embedCode={noop}
+                onCancel={noop}
+                embedCode={noop}
+                onSubmit={noop}
+            />, options
+        );
 
         spyOn($, 'ajax').and.returnValue($q.reject({
             responseJSON: {error: 'this is the error'}
@@ -103,7 +110,8 @@ describe('editor3.components.embed-input', () => {
         const {options} = mockStore();
         const onCancel = jasmine.createSpy();
         const onSubmit = jasmine.createSpy();
-        const wrapper = mount(<EmbedInput onCancel={onCancel} onSubmit={onSubmit} />, options);
+        const noop = () => ({});
+        const wrapper = mount(<EmbedInput embedCode={noop} onCancel={onCancel} onSubmit={onSubmit} />, options);
 
         spyOn($, 'ajax').and.returnValue($q.resolve('resolve-value'));
 

--- a/scripts/core/editor3/components/tests/images.spec.jsx
+++ b/scripts/core/editor3/components/tests/images.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {shallow, mount} from 'enzyme';
 import {ImageBlockComponent as ImageBlock} from '../images/ImageBlock';
 import {imageBlockAndContent} from './utils';
+import Textarea from 'react-textarea-autosize';
 
 describe('editor3.components.image-block', () => {
     it('should render', () => {
@@ -16,7 +17,7 @@ describe('editor3.components.image-block', () => {
 
         expect(wrapper.find('img').props().src).toBe('image_href');
         expect(wrapper.find('img').props().alt).toBe('image_alt_text');
-        expect(wrapper.find('.image-block__description').text()).toBe('image_description');
+        expect(wrapper.find(Textarea).prop('defaultValue')).toBe('image_description');
     });
 
     it('should trigger cropImage prop when clicked', () => {

--- a/scripts/core/editor3/styles.scss
+++ b/scripts/core/editor3/styles.scss
@@ -165,14 +165,15 @@
 			display: inline-block;
 		}
 
-                &__description {
-                    text-align: left;
-                    font-family: Arial;
-                    font-size: 14px;
-                    padding: 5px;
-                    min-height: 28px;
-                    background-color: #efefef;
-                }
+		&__description {
+			resize: none;
+			text-align: left;
+			font-family: Arial;
+			font-size: 14px;
+			padding: 5px;
+			min-height: 28px;
+			background-color: #efefef;
+		}
 
 		img {
 			display: inline-block;


### PR DESCRIPTION
Adds a dependency on [react-textarea-autosize](https://github.com/andreypopp/react-textarea-autosize) which is similar to what we have as [`sd-autoheight`](https://github.com/superdesk/superdesk-client-core/blob/master/scripts/core/ui/autoheight-directive.js).

Additionally fixes some errors in unit tests about missing props on the EmbedInput component.