### PR TITLE
Attachments widget (SDESK-1586)

### DIFF
--- a/scripts/apps/archive/controllers/UploadAttachmentsController.js
+++ b/scripts/apps/archive/controllers/UploadAttachmentsController.js
@@ -1,0 +1,10 @@
+import '../styles/upload-attachments.scss';
+
+UploadAttachmentsController.$inject = ['$scope'];
+export function UploadAttachmentsController($scope) {
+    $scope.saving = false;
+    $scope.items = $scope.locals.data;
+    $scope.save = () => $scope.resolve($scope.items);
+    $scope.cancel = $scope.reject;
+    $scope.cancelItem = (index) => $scope.items.splice(index, 1);
+}

--- a/scripts/apps/archive/controllers/index.js
+++ b/scripts/apps/archive/controllers/index.js
@@ -1,4 +1,5 @@
 export {BaseListController} from './BaseListController';
 export {ArchiveListController} from './ArchiveListController';
 export {UploadController} from './UploadController';
+export {UploadAttachmentsController} from './UploadAttachmentsController';
 export {DuplicateController} from './DuplicateController';

--- a/scripts/apps/archive/index.js
+++ b/scripts/apps/archive/index.js
@@ -65,6 +65,7 @@ angular.module('superdesk.apps.archive', [
     .service('archiveService', svc.ArchiveService)
 
     .controller('UploadController', ctrl.UploadController)
+    .controller('UploadAttachmentsController', ctrl.UploadAttachmentsController)
     .controller('ArchiveListController', ctrl.ArchiveListController)
 
     .config(['superdeskProvider', function(superdesk) {
@@ -89,6 +90,17 @@ angular.module('superdesk.apps.archive', [
                 templateUrl: 'scripts/apps/archive/views/upload.html',
                 filters: [
                     {action: 'upload', type: 'media'}
+                ],
+                privileges: {archive: 1}
+            })
+            .activity('upload.attachments', {
+                label: gettext('Attach files'),
+                modal: true,
+                cssClass: 'upload-media edit-attachments modal--z-index-fix modal--fill',
+                controller: ctrl.UploadAttachmentsController,
+                templateUrl: 'scripts/apps/archive/views/upload-attachments.html',
+                filters: [
+                    {action: 'upload', type: 'attachments'}
                 ],
                 privileges: {archive: 1}
             })

--- a/scripts/apps/archive/styles/upload-attachments.scss
+++ b/scripts/apps/archive/styles/upload-attachments.scss
@@ -1,0 +1,11 @@
+@import '~variables.scss';
+
+.edit-attachments {
+	.upload-edit .upload-thumbs li .thumb .holder {
+		background-color: $grayLighter;
+	}
+
+	.upload-edit .upload-thumbs li .thumb .holder i {
+		font-size: 50px;
+	}
+}

--- a/scripts/apps/archive/views/upload-attachments.html
+++ b/scripts/apps/archive/views/upload-attachments.html
@@ -1,0 +1,52 @@
+<div class="modal__header">
+    <button type="button" class="modal__close pull-right" ng-click="cancel()" ng-hide="saving"><i class="icon-close-small"></i></button>
+    <h3 class="modal__heading">{{ activity.label|translate }}</h3>
+</div>
+
+<div class="modal__body">
+	<form name="attachmentsForm">
+		<div class="upload-edit" ng-show="items.length">
+			<ul class="upload-thumbs">
+				<li ng-repeat="item in items">
+					<div class="thumb"></div>
+
+					<div class="thumb">
+						<div class="holder"><i class="big-icon--text" /></div>
+						<span class="remove" ng-click="cancelItem($index)"><i class="icon-close-small"></i></span>
+					</div>
+
+					<div class="info">
+						<div class="other-info">
+							<div class="row">
+								<label>Title *</label>
+								<input type="text" required ng-model="item.meta.title" class="contenteditable-input contenteditable-input--side-padding" />
+							</div>
+							<div class="row">
+								<label>Description *</label>
+								<input type="text" required ng-model="item.meta.description" class="contenteditable-input contenteditable-input--side-padding" />
+							</div>
+							<div class="row">
+								<label translate>File Name</label>
+								<div class="contenteditable-input contenteditable-input--side-padding">
+									{{item.name}}
+								</div>                        
+							</div>
+							<div class="row">
+								<label translate>File Size</label>
+								<div class="contenteditable-input contenteditable-input--side-padding">
+									{{item.size}} bytes
+								</div>                        
+							</div>
+						</div>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</form>
+</div>
+
+<div class="modal__footer">
+	<span class="pull-left" translate>* fields are required</span>
+	<button class="btn btn--primary pull-right" ng-click="save()" ng-disabled="attachmentsForm.$invalid || saving" translate>Upload</button>
+	<button class="btn pull-right" ng-click="cancel()" ng-disabled="saving" translate>Cancel</button>
+</div>

--- a/scripts/apps/authoring/attachments/attachments.html
+++ b/scripts/apps/authoring/attachments/attachments.html
@@ -1,0 +1,35 @@
+<div class="attachments-pane" ng-controller="AttachmentsCtrl as ctrl">
+	<div class="attachments-list">
+		<ul ng-if="files">
+			<li ng-repeat="file in files">
+				<div class="title"><b>{{file.meta.title}}</b></div>
+				<div class="description">{{file.meta.description}}</div>
+				<a href="#"><i class="icon-attachment-large" />Download</a>
+			</li>
+		</ul>
+	</div>
+	<div class="attach-indicator" 
+		ngf-drop="ctrl.selectFiles($files)"
+		ngf-multiple="true"
+		ngf-max-files="10"
+		ngf-max-size="8MB">
+
+		<div class="round-box">
+			<i class="big-icon--upload-alt icon"></i>
+		</div>
+		<div class="subtext" translate>
+			Drag one or more files here to upload them, or just click the button below.
+		</div>
+
+		<a class="btn btn--hollow"
+			ngf-select="ctrl.selectFiles($files)"
+			ngf-drop="ctrl.selectFiles($files)"
+			ngf-multiple="true"
+			ngf-max-files="10"
+			ngf-max-size="8MB">
+			Attach files
+		</a>
+
+	</div>
+	<div class="clearfix"></div>
+</div>

--- a/scripts/apps/authoring/attachments/attachments.js
+++ b/scripts/apps/authoring/attachments/attachments.js
@@ -1,0 +1,57 @@
+import './attachments.scss';
+
+class AttachmentsController {
+    constructor(superdesk, $scope) {
+        this.superdesk = superdesk;
+        this.$scope = $scope;
+    }
+
+    selectFiles(files) {
+        if (Array.isArray(files) && files.length > 0) {
+            this.superdesk
+                .intent('upload', 'attachments', files)
+                .then(this.uploadFiles.bind(this));
+        }
+    }
+
+    uploadFiles(files) {
+        Promise.resolve(/* upload to server here */ files)
+            .then(
+                this.setAttachments(files).bind(this),
+                this.notifyError.bind(this)
+            );
+    }
+
+    setAttachments(files) {
+        console.log(files);
+        this.$scope.files = files;
+    }
+
+    notifyError() {
+        /* handle error */
+    }
+}
+
+AttachmentsController.$inject = ['superdesk', '$scope'];
+
+const config = (awp) =>
+    awp.widget('attachments', {
+        icon: 'attachment',
+        label: gettext('Attachments'),
+        template: 'scripts/apps/authoring/attachments/attachments.html',
+        order: 8,
+        side: 'right',
+        display: {
+            authoring: true,
+            packages: true,
+            killedItem: true,
+            legalArchive: false,
+            archived: false,
+            picture: true,
+            personal: true
+        }
+    });
+
+angular.module('superdesk.apps.authoring.attachments', ['superdesk.apps.authoring.widgets', 'ngFileUpload'])
+    .controller('AttachmentsCtrl', AttachmentsController)
+    .config(['authoringWidgetsProvider', config]);

--- a/scripts/apps/authoring/attachments/attachments.scss
+++ b/scripts/apps/authoring/attachments/attachments.scss
@@ -1,0 +1,42 @@
+@import '~variables.scss';
+
+.sd-widget.attachments {
+	.attachments-pane {
+		position: relative;
+
+		.attach-indicator {
+			position: absolute;
+			top: 100px;
+			left: 50%;
+			margin-left: -125px;
+			width: 250px;
+			text-align: center;
+
+			.round-box {
+				display: block;
+				box-sizing: border-box;
+				padding-top: 16px;
+				height: 90px;
+				width: 90px;
+				background-color: #fff;
+				border-radius: 50%;
+				margin: 0 auto;
+				box-shadow: 0 0 6px 1px rgba(0,0,0,0.08);
+				
+				i.icon {
+					display: block;
+					width: 56px;
+					height: 48px;
+					color: $sd-blue;
+					margin: 1.4rem auto 0 auto;
+					font-size: 5.2rem;
+				}
+			}
+
+			.subtext {
+				margin: 15px 0;
+				color: $sd-text-label;
+			}
+		}
+	}
+}

--- a/scripts/apps/authoring/authoring/index.js
+++ b/scripts/apps/authoring/authoring/index.js
@@ -29,6 +29,7 @@ angular.module('superdesk.apps.authoring', [
     'superdesk.apps.authoring.packages',
     'superdesk.apps.authoring.find-replace',
     'superdesk.apps.authoring.macros',
+    'superdesk.apps.authoring.attachments',
     'superdesk.apps.authoring.autosave',
     'superdesk.apps.authoring.suggest',
     'superdesk.apps.desks',

--- a/scripts/apps/authoring/index.js
+++ b/scripts/apps/authoring/index.js
@@ -13,6 +13,7 @@ import './widgets/widgets-article.scss';
 import './authoring';
 import './widgets/widgets';
 import './comments/comments';
+import './attachments/attachments';
 import './versioning/versioning';
 import './versioning/versions/versions';
 import './versioning/history/history';


### PR DESCRIPTION
See issue [SDESK-1586](https://dev.sourcefabric.org/browse/SDESK-1586) for specs and [this Wiki page](https://wiki.sourcefabric.org/display/NR/Attachments) for designs.

**In this PR:**
- Open item
- Click attachment widget in right sidebar
- Click 'Attach files' button
- Select some files
- Add their titles / descriptions
- Submit

**TODO**:
- [x] Add attachments widget in sidebar.
- [x] Implement upload attachment button functionality (multiple files, max 8MB, etc).
- [x] Implement upload modal that allows setting mandatory titles and descriptions.
- [ ] Implement upload to server (via a service perhaps?). _BACKEND NEEDED_
- [x] Display list of attached files. _BACKEND NEEDED_
- [ ] Implement edit attachment from list modal.
- [ ] Implement remove attachment from list.
- [ ] Fix problems with dragging files in.
- [ ] Finalise design and styling based on Wiki page.
- [ ] Documentation.
- [ ] Tests.
