### PR TITLE
[AUTHORING] handle "authors" field

### DIFF
--- a/scripts/apps/authoring/authoring/helpers.js
+++ b/scripts/apps/authoring/authoring/helpers.js
@@ -14,6 +14,7 @@ export const CONTENT_FIELDS_DEFAULTS = Object.freeze({
     groups: null,
     usageterms: null,
     ednote: null,
+    authors: [],
     place: [],
     dateline: {},
     language: null,
@@ -86,8 +87,8 @@ export function extendItem(dest, src) {
  */
 export function filterDefaultValues(diff, orig) {
     Object.keys(CONTENT_FIELDS_DEFAULTS).forEach((key) => {
-        if (diff.hasOwnProperty(key) && angular.equals(diff[key], CONTENT_FIELDS_DEFAULTS[key])
-            && !orig.hasOwnProperty(key)) {
+        if (diff.hasOwnProperty(key) && angular.equals(diff[key], CONTENT_FIELDS_DEFAULTS[key]) &&
+            !orig.hasOwnProperty(key)) {
             delete diff[key];
         }
     });

--- a/scripts/apps/authoring/metadata/views/metadata-terms.html
+++ b/scripts/apps/authoring/metadata/views/metadata-terms.html
@@ -13,25 +13,36 @@
     </button>
     <ul class="dropdown__menu nested-menu pull-right">
         <li ng-show="!activeTerm && header">
-            <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="selectTerm(item)" always-visible="header" data-disabled="disabled || allSelected">
+            <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="allowEntireCat && selectTerm(item)" always-visible="header" data-disabled="disabled || allSelected">
                 <ul class="item-list" vs-repeat vs-scroll-parent=".item-list" ng-if="!activeTree.length || activeList">
-                    <li typeahead-item="t" ng-repeat="t in terms track by t[uniqueField]"><button>{{ :: t.name }}</button></li>
+                    <li typeahead-item="t" ng-repeat="t in terms track by t[uniqueField]">
+                        <button ng-click="!allowEntireCat && openTree(t, $event)">
+                            <figure ng-if="t.user" class="avatar">
+                                <img sd-user-avatar data-user="t.user" alt="{{ :: t.name}}">
+                            </figure>
+                            {{ :: t.name}}
+                        </button>
+                    </li>
                 </ul>
             </div>
         </li>
         <li class="levelup" ng-if="activeTerm">
             <i class="backlink" ng-click="openParent(activeTerm, $event)"></i>
-            <button ng-click="selectTerm(activeTerm)">
+            <button ng-click="allowEntireCat && selectTerm(activeTerm)">
                 <b class="category">{{ activeTerm.name }}</b>
-                <b class="category-hover">{{ :: "Choose entire category" | translate }}</b>
+                <b class="category-hover" ng-if="allowEntireCat">{{ :: "Choose entire category" | translate }}</b>
             </button>
         </li>
         <li class="main-list" ng-if="activeTree.length && !activeList && header" ng-class="{active: activeTerm}" ng-hide="allSelected">
             <ul vs-repeat vs-scroll-parent=".main-list">
                 <li ng-repeat="term in activeTree track by term[uniqueField]">
-                    <button ng-if="tree[term[uniqueField]]" class="nested-toggle" ng-click="openTree(term, $event)">{{ :: term.name }} 
+                    <button ng-if="tree[term[uniqueField]]" class="nested-toggle" ng-click="openTree(term, $event)">
+                        <figure ng-if="term.user" class="avatar">
+                            <img sd-user-avatar data-user="term.user" alt="{{ :: term.name}}">
+                        </figure>
+                        {{ :: term.name}}
                         <i class="icon-chevron-right-thin"></i></button>
-                    <button ng-if="!tree[term[uniqueField]]" ng-click="selectTerm(term)">{{ :: term.name }}</button>
+                    <button ng-if="!tree[term[uniqueField]]" ng-click="selectTerm(term)">{{ :: term.name}}</button>
                 </li>
             </ul>
         </li>
@@ -40,9 +51,12 @@
 
 <div class="terms-list" ng-if="selectedItems.length" title="{{helperText}}">
     <ul>
-        <li ng-if="!disabled" class="pull-left"
+        <li ng-if="!disabled && !t.sub_label" class="pull-left"
             ng-repeat="t in selectedItems track by t[uniqueField]"
             ng-click="removeTerm(t)">{{ :: t.name}}<i class="icon-close-small"></i></li>
+        <li ng-if="!disabled && t.sub_label" class="pull-left"
+            ng-repeat="t in selectedItems track by t[uniqueField]"
+            ng-click="removeTerm(t)"><label>{{ :: t.name}}:</label>{{ :: t.sub_label}}<i class="icon-close-small"></i></li>
         <li ng-if="disabled" class="pull-left disabled"
             ng-repeat="t in selectedItems track by t[uniqueField]">{{ :: t.name}}</li>
     </ul>

--- a/scripts/apps/authoring/views/authoring-header.html
+++ b/scripts/apps/authoring/views/authoring-header.html
@@ -335,7 +335,7 @@
              order="{{editor.ednote.order}}">
             <label class="authoring-header__item-label" translate>ED. NOTE</label>
             <div class="authoring-header__input-holder">
-                <textarea id="ednote" class="line-input ed-note" 
+                <textarea id="ednote" class="line-input ed-note"
                           sd-auto-height
                           tansa-scope-sync
                           tabindex="{{editor.ednote.order}}"
@@ -346,6 +346,31 @@
                 </textarea>
             </div>
 
+        </div>
+
+        <div class="authoring-header__item"
+             sd-validation-error="error.authors"
+             data-required="schema.authors.required"
+             ng-if="schema.authors && editor.authors"
+             sd-width="{{editor.authors.sdWidth}}"
+             order="{{editor.authors.order}}">
+            <label class="authoring-header__item-label" translate>AUTHORS</label>
+            <div id="authors"
+                 sd-meta-terms
+                 class="data"
+                 data-tabindex="editor.authors.order"
+                 data-item="item"
+                 data-field="authors"
+                 data-unique="_id"
+                 data-list="metadata.authors"
+                 data-label= "{{ :: 'Add author' | translate }}"
+                 ng-disabled="!_editable"
+                 data-header="true"
+                 data-change="autosave(item)"
+                 data-reload-list="true"
+                 data-select-entire-category="false"
+                 tabindex="{{editor.authors.order}}">
+            </div>
         </div>
     </div>
 </div>

--- a/spec/helpers/authoring.js
+++ b/spec/helpers/authoring.js
@@ -822,7 +822,8 @@ function Authoring() {
     };
 
     this.getNextLevelSelectedCategory = function() {
-        return this.subject.all(by.className('levelup')).all(by.css('[ng-click="selectTerm(activeTerm)"]'));
+        return this.subject.all(by.className('levelup')).all(
+            by.css('[ng-click="allowEntireCat && selectTerm(activeTerm)"]'));
     };
 
     this.getItemSource = function() {

--- a/test-server/requirements.txt
+++ b/test-server/requirements.txt
@@ -2,4 +2,4 @@ gunicorn==19.7.1
 honcho==1.0.1
 newrelic>=2.66,<2.67
 
-git+git://github.com/superdesk/superdesk-core.git@3e4f3fc#egg=Superdesk-Core
+git+git://github.com/superdesk/superdesk-core.git@2c7d5bb#egg=Superdesk-Core


### PR DESCRIPTION
This commit add "authors" field using a drop-down list similar to
subjects.

A new "selectEntireCategory" variable has been added to MetaTermsDirective to indicate if the parent category can be selected as a whole, or if a subcategory is needed.

A new sub_label can be used in terms. If present, the display of the
term show the term first in a label, then the sub_label.

SDESK-1703