### PR TITLE
Fix e2e test for "Custom text fields"

### DIFF
--- a/spec/content_profile_spec.js
+++ b/spec/content_profile_spec.js
@@ -75,7 +75,7 @@ describe('Content profiles', () => {
         metadata.openCustomTextFields();
         expect(metadata.items().count()).toBe(0);
 
-        metadata.addNew('custom', FIELD_LABEL);
+        metadata.addNew('custom', FIELD_LABEL, 'custom help');
         expect(metadata.items().count()).toBe(1);
 
         contentProfiles.openContentProfileSettings();

--- a/spec/helpers/metadata.js
+++ b/spec/helpers/metadata.js
@@ -9,10 +9,11 @@ class MetadataHelper {
         element(by.buttonText('Custom text fields')).click();
     }
 
-    addNew(id, label) {
+    addNew(id, label, help) {
         element(by.partialButtonText('Add New')).click();
         element(by.model('vocabulary._id')).sendKeys(id);
         element(by.model('vocabulary.display_name')).sendKeys(label);
+        element(by.model('vocabulary.helper_text')).sendKeys(help);
         element(by.buttonText('Save')).click();
     }
 

--- a/test-server/requirements.txt
+++ b/test-server/requirements.txt
@@ -1,5 +1,5 @@
-gunicorn==19.6.0
-honcho==0.6.6
+gunicorn==19.7.1
+honcho==1.0.1
 newrelic>=2.66,<2.67
 
-git+git://github.com/superdesk/superdesk-core.git@dc7ef76#egg=Superdesk-Core
+git+git://github.com/superdesk/superdesk-core.git@3e4f3fc#egg=Superdesk-Core


### PR DESCRIPTION
It was caused by race condition in merging two pull requests
- #1800 which added a test at Aug 22, 2017, but  merged at Sep 1, 2017
- #1805 which added `text helper` at Aug 24, 2017 and merged at Aug 25, 2017