### PR TITLE
Fix false failing in authoring_spec.js

### DIFF
--- a/spec/authoring_spec.js
+++ b/spec/authoring_spec.js
@@ -665,7 +665,6 @@ describe('authoring', () => {
         ctrlKey('x');
         authoring.sendAndpublish('Sports Desk');
         authoring.confirmSendTo(); // confirm unsaved changes
-        browser.sleep(1000);
         authoring.publishFrom('Sports Desk');
         assertToastMsg('error', 'BODY_HTML empty values not allowed'); // validation takes place
         authoring.writeText('Testing');

--- a/spec/helpers/authoring.js
+++ b/spec/helpers/authoring.js
@@ -196,6 +196,7 @@ function Authoring() {
         }
         browser.wait(() => ctx.element(this.add_content_button).isDisplayed(), 1000);
         ctx.element(this.add_content_button).click();
+        browser.wait(() => element(by.id('closeAuthoringBtn')).isDisplayed(), 2000);
         ctx.element(by.css('[ng-click="vm.triggerAction(\'addEmbed\')"]')).click();
         ctx.element(by.css('.add-embed__input input')).sendKeys(embedCode || 'embed code');
         ctx.element(by.css('[ng-click="vm.createBlockFromEmbed()"]')).click();
@@ -279,6 +280,7 @@ function Authoring() {
     };
 
     this.publishFrom = function(desk) {
+        browser.wait(() => this.publish_panel.isPresent(), 2000);
         this.publish_panel.click();
         this.selectDeskforSendTo(desk);
         this.sendAndPublishBtn.click();


### PR DESCRIPTION
Even it wasn't failing because of `protractor-flake`, it was usually
passing during second run, but it increase the time significantly,
because `authoring_spec.js` is huge...

From logs:
- https://test.superdesk.org/logs/3/all/20170920-113653-46-sdcpr-1801/check-e2e--part1.log.htm
- https://test.superdesk.org/logs/3/all/20170920-104852-52-sdcpr-1849/check-e2e--part1.log.htm