### PR TITLE
[SDESK-1969](fix): Strip whitespace characters for certain fields before saving and publishing.

### DIFF
--- a/scripts/apps/archive/services/ArchiveService.js
+++ b/scripts/apps/archive/services/ArchiveService.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 ArchiveService.$inject = ['desks', 'session', 'api', '$q', 'search', '$location', 'config'];
 export function ArchiveService(desks, session, api, $q, search, $location, config) {
     /**
@@ -71,7 +73,7 @@ export function ArchiveService(desks, session, api, $q, search, $location, confi
     this.isPersonal = (item) => item.task && item.task.user && !item.task.desk;
 
     /**
-     *  Returns the list of items having the same slugline from datetime
+     *  Returns the list of items having the same slugline, type and genre from midnight onwards.
      *  @param {Object} item
      *  @param {Datetime} fromDateTime - from datetime
      *  @return {Object} the list of archive items
@@ -81,7 +83,7 @@ export function ArchiveService(desks, session, api, $q, search, $location, confi
             .format(config.view.dateformat);
         var params = {};
 
-        params.q = 'slugline.phrase:"' + item.slugline + '"'; // exact match
+        params.q = 'slugline.phrase:"' + _.trim(item.slugline) + '"'; // exact match
         params.ignoreKilled = true;
         params.ignoreDigital = true;
         params.afterversioncreated = beforeDateTime;
@@ -100,6 +102,10 @@ export function ArchiveService(desks, session, api, $q, search, $location, confi
                     must: [{term: {type: item.type}}]
                 }
             };
+
+            if (_.get(item, 'genre[0].qcode')) {
+                filter.bool.must.push({term: {'genre.qcode': _.get(item, 'genre[0].qcode')}});
+            }
 
             query.filter(filter);
         }

--- a/scripts/apps/archive/tests/archive.spec.js
+++ b/scripts/apps/archive/tests/archive.spec.js
@@ -90,7 +90,7 @@ describe('content', () => {
             expect(archiveService.isArchived(item)).toBe(true);
         }));
 
-        it('returns the related items', inject((archiveService, api, $q, search) => {
+        it('returns the related items', inject((archiveService, api, $q) => {
             spyOn(api, 'query').and.returnValue($q.when());
             archiveService.getRelatedItems({slugline: 'test'});
             expect(api.query).toHaveBeenCalled();

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.js
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.js
@@ -475,6 +475,9 @@ export function AuthoringDirective(superdesk, superdeskFlags, authoringWorkspace
                         if (value) {
                             if (typeof value === 'object' && hasNullValue(value)) {
                                 $scope.error[key] = true;
+                            } else if (typeof value === 'string' && authoring.schema[key].required &&
+                                helpers.removeWhitespaces(value) === '') {
+                                $scope.error[key] = true;
                             } else {
                                 $scope.error[key] = false;
                             }

--- a/scripts/apps/authoring/authoring/helpers.js
+++ b/scripts/apps/authoring/authoring/helpers.js
@@ -150,3 +150,33 @@ export function cleanHtml(data) {
         .replace(/&nbsp;/g, ' ')
         .replace(/\s\s+/g, ' ');
 }
+
+/**
+ * Removes whitespaces
+ * @param data
+ */
+export function removeWhitespaces(data) {
+    if (!data) {
+        return data;
+    }
+
+    return data
+        .replace(/&nbsp;/g, ' ')
+        .replace(/\s\s+/g, ' ')
+        .trim();
+}
+
+
+/**
+ * Removes whitespaces for fields
+ * @param data
+ */
+export function stripWhitespaces(item) {
+    var fields = ['headline', 'slugline', 'anpa_take_key', 'sms_message', 'abstract'];
+
+    _.each(fields, (key) => {
+        if (angular.isDefined(item[key])) {
+            item[key] = removeWhitespaces(item[key]);
+        }
+    });
+}

--- a/scripts/apps/authoring/authoring/services/AuthoringService.js
+++ b/scripts/apps/authoring/authoring/services/AuthoringService.js
@@ -212,6 +212,7 @@ export function AuthoringService($q, $location, api, lock, autosave, confirm, pr
         }
 
         helpers.stripHtml(updates);
+        helpers.stripWhitespaces(updates);
 
         // If the text equivalent of the body_html is empty then set the body empty
         if (angular.isDefined(updates.body_html)) {
@@ -280,6 +281,7 @@ export function AuthoringService($q, $location, api, lock, autosave, confirm, pr
         }
 
         helpers.stripHtml(diff);
+        helpers.stripWhitespaces(diff);
         autosave.stop(item);
 
         if (diff._etag) { // make sure we use orig item etag


### PR DESCRIPTION
- Strip whitespace characters before saving otherwise stories are blank stories could get published.
- Modified the related items queries to check for the genre as well.
