### PR TITLE
fix(editor): Fixed issue with image description editor (Fixed by Gabriel & Nemanja)

### DIFF
--- a/scripts/core/editor3/components/images/ImageBlock.jsx
+++ b/scripts/core/editor3/components/images/ImageBlock.jsx
@@ -76,6 +76,7 @@ export class ImageBlockComponent extends Component {
                         <Textarea
                             placeholder={gettext('Title')}
                             onFocus={setLocked}
+                            onClick={setLocked}
                             className="image-block__title"
                             value={data.headline}
                             onChange={this.onChange}
@@ -84,6 +85,7 @@ export class ImageBlockComponent extends Component {
                     <Textarea
                         placeholder={gettext('Caption')}
                         onFocus={setLocked}
+                        onClick={setLocked}
                         className="image-block__description"
                         value={data.description_text}
                         onChange={this.onChange}


### PR DESCRIPTION
SDFID-119 - Typing into the description field of an image crashes the editor