### PR TITLE
core/editor3: disallow placing annotations on top of eachother

### DIFF
--- a/scripts/core/editor3/components/toolbar/SelectionButton.jsx
+++ b/scripts/core/editor3/components/toolbar/SelectionButton.jsx
@@ -11,14 +11,15 @@ import {connect} from 'react-redux';
  * @description SelectionButton is a button that can be added to the toolbar, which only
  * becomes active and clickable when a selection is made in the editor. This is for actions
  * that are bound exclusively to having text selected in the editor, such as: links, comments,
- * annotations, etc.
+ * annotations, etc. Note that a precondition prop may be supplied which precedes any other condition.
  */
-const SelectionButtonComponent = ({editorState, onClick, tooltip, iconName}) => {
+const SelectionButtonComponent = ({editorState, onClick, tooltip, iconName, precondition}) => {
     const isCollapsed = editorState.getSelection().isCollapsed();
-    const cx = classNames({inactive: isCollapsed});
+    const inactive = !precondition || isCollapsed;
+    const cx = classNames({inactive});
 
     const clickHandler = () => {
-        if (!isCollapsed) {
+        if (!inactive) {
             onClick({
                 selection: editorState.getSelection()
             });
@@ -36,9 +37,14 @@ const SelectionButtonComponent = ({editorState, onClick, tooltip, iconName}) => 
 
 SelectionButtonComponent.propTypes = {
     iconName: PropTypes.string.isRequired,
-    tooltip: PropTypes.string,
     editorState: PropTypes.object.isRequired,
+    tooltip: PropTypes.string,
+    precondition: PropTypes.bool,
     onClick: PropTypes.func.isRequired
+};
+
+SelectionButtonComponent.defaultProps = {
+    precondition: true
 };
 
 const mapStateToProps = (state) => ({

--- a/scripts/core/editor3/components/toolbar/index.jsx
+++ b/scripts/core/editor3/components/toolbar/index.jsx
@@ -69,15 +69,21 @@ class ToolbarComponent extends Component {
         this.scrollContainer.off('scroll', this.onScroll);
     }
 
+    /**
+     * @ngdoc method
+     * @name Toolbar#canAnnotate
+     * @description canAnnotate is called as a precondition to the SelectionButton for creating
+     * an annotation. It returns true if the current selection does not overlap any annotation.
+     */
     canAnnotate() {
         const {editorState} = this.props;
         const content = editorState.getCurrentContent();
 
-        return getHighlights(content).some((highlight, rawSelection) => {
+        return !getHighlights(content).some((highlight, rawSelection) => {
             if (highlight.type !== 'ANNOTATION') {
-                return true;
+                return false;
             }
-            return !selectionsOverlap(
+            return selectionsOverlap(
                 content,
                 editorState.getSelection(),
                 new SelectionState(JSON.parse(rawSelection))

--- a/scripts/core/editor3/reducers/highlights/styles.jsx
+++ b/scripts/core/editor3/reducers/highlights/styles.jsx
@@ -133,3 +133,36 @@ function selectionIn(content, a, b) {
 
     return false;
 }
+
+// edgeLeft returns a new selection comprised of only the start position of s.
+function edgeLeft(s) {
+    return new SelectionState({
+        anchorKey: s.getStartKey(),
+        anchorOffset: s.getStartOffset(),
+        focusKey: s.getStartKey(),
+        focusOffset: s.getStartOffset(),
+        isBackward: false
+    });
+}
+
+// edgeRight returns a new selection comprised of only the end position of s.
+function edgeRight(s) {
+    return new SelectionState({
+        anchorKey: s.getEndKey(),
+        anchorOffset: s.getEndOffset(),
+        focusKey: s.getEndKey(),
+        focusOffset: s.getEndOffset(),
+        isBackward: false
+    });
+}
+
+// selectionsOverlap returns true if selections a and b overlap in content.
+export function selectionsOverlap(content, a, b) {
+    const aStart = edgeLeft(a);
+    const aEnd = edgeRight(a);
+    const bStart = edgeLeft(b);
+    const bEnd = edgeRight(b);
+    const isIn = selectionIn.bind(this, content);
+
+    return isIn(aStart, b) || isIn(aEnd, b) || isIn(bStart, a) || isIn(bEnd, a);
+}

--- a/superdesk.config.js
+++ b/superdesk.config.js
@@ -36,7 +36,8 @@ module.exports = function(grunt) {
         },
         features: {
             swimlane: {columnsLimit: 4},
-            editor3: true
+            editor3: true,
+            editorHighlights: true
         },
         auth: {google: false},
         ingest: {


### PR DESCRIPTION
This change also changes the `SelectionButton` to additionally allow a `precondition` prop which will supersede any other condition.