### PR TITLE
fix(ngtemplates): Fixed issue with ngtemplates on windows

### DIFF
--- a/tasks/options/ngtemplates.js
+++ b/tasks/options/ngtemplates.js
@@ -78,7 +78,17 @@ module.exports = {
                     return 'export default [];\r\n';
                 }
 
-                let abs = (p) => path.join(process.cwd(), 'node_modules', p);
+                // abs returns the correct absolute path to be used with a require call. On Windows,
+                // it correctly converts backslash (\) characters to forward-slash (/).
+                let abs = (p) => {
+                    let abspath = path.join(process.cwd(), 'node_modules', p);
+
+                    if (/^win/.test(process.platform)) {
+                        return abspath.replace(/\\/g, '/');
+                    }
+                    return abspath;
+                };
+
                 let data = 'export default [\r\n\trequire("' + abs(paths[0]) + '").default.name';
 
                 for (var i = 1; i < paths.length; i++) {


### PR DESCRIPTION
There is issue with adding external apps on windows platform because of slash (not recognizing `\`), so I modified gen-apps task a little.

Now it test if it is windows, then it convert all `\` to `/`.