### PR TITLE
[AUTHORING] [METADATA]: raise limit of authors to 200

### DIFF
--- a/scripts/apps/authoring/metadata/metadata.js
+++ b/scripts/apps/authoring/metadata/metadata.js
@@ -1021,7 +1021,7 @@ function MetadataService(api, subscribersService, config, vocabularies, $rootSco
 
             self.values.authors = [];
 
-            return api.get('/users', {is_author: 1}).then((result) => {
+            return api.get('/users', {is_author: 1, max_results: 200}).then((result) => {
                 var first;
 
                 _.each(result._items, (user) => {


### PR DESCRIPTION
authors fetching was using the default max_results (i.e. 25), resulting
in trouble when a instance has more authors.
This patch is a quick fix to raise this limit to the maximum (200)
before checking a more clean solution which need discussion (should we
fetch all the pages, or use pagination?).

SDFID-195