### PR TITLE
core/editor3: better accommodate longer texts in highlights popup

### DIFF
--- a/scripts/core/editor3/components/HighlightsPopup.jsx
+++ b/scripts/core/editor3/components/HighlightsPopup.jsx
@@ -39,6 +39,8 @@ export class HighlightsPopup extends Component {
     position() {
         const {left: editorLeft} = this.props.editorNode.getBoundingClientRect();
         const rect = getVisibleSelectionRect(window);
+        const maxHeight = $('div.auth-screen').height();
+        const maxTop = maxHeight - 60/* top & bottom bar */ - 250/* max dropdown height */;
 
         let top = 150;
         let left = editorLeft - 260;
@@ -51,6 +53,7 @@ export class HighlightsPopup extends Component {
             top = rect.top - topPadding;
         }
 
+        top = top > maxTop ? maxTop : top; // don't cut off bottom side of dropdown.
         this.lastTop = top; // if we lose rect, keep this for next time.
 
         return {top, left};
@@ -78,6 +81,13 @@ export class HighlightsPopup extends Component {
                 console.error('Invalid highlight type in HighlightsPopup.jsx: ', type);
             }
         };
+
+        const activeDropdown = $('.highlights-popup .dropdown__menu');
+
+        if (activeDropdown.length) {
+            // popup open, reset scroll position.
+            activeDropdown[0].scrollTo(0, 0);
+        }
 
         // We need to create a new provider here because this component gets rendered
         // outside the editor tree and loses context.

--- a/scripts/core/editor3/styles.scss
+++ b/scripts/core/editor3/styles.scss
@@ -433,6 +433,11 @@
 			padding: 5px 10px 0 10px;
 		}
 
+		.DraftEditor-root {
+			max-height: 150px;
+			overflow-y: auto;
+		}
+
 		.Editor3-styleButton {
 			padding: 5px;
 			i { font-size: 13px; }
@@ -494,6 +499,8 @@
 	.dropdown__menu {
 		width: 250px;
 		padding: 15px;
+		max-height: 250px;
+		overflow-y: auto;
 	}
 
 	&__header {


### PR DESCRIPTION
Depending on the editor's scroll position, at times the popup would be
cut off at the bottom, making it impossible to see the entire content.
This change fixes the problem by introducting a maximum height to the
popup and a scroll bar. It also introduces a limit as to how far down
the popup is displayed.

A similar approach is applied to the annotation editor to allow for
longer texts by making the editor have a maximum height and an automatic
scrollbar.

Fixes SDESK-2184

Change-Id: I02460d367edceb0aa029c2980bf547d4065ef919