### PR TITLE
fix(editor3): fix 3 dots menu not working after item publishing

### DIFF
--- a/scripts/core/editor3/components/HighlightsPopup.jsx
+++ b/scripts/core/editor3/components/HighlightsPopup.jsx
@@ -110,6 +110,7 @@ export class HighlightsPopup extends Component {
     renderCustom() {
         render(this.component(), document.getElementById('react-placeholder'));
         document.addEventListener('click', this.onDocumentClick);
+        this.rendered = true;
     }
 
     /**
@@ -119,7 +120,8 @@ export class HighlightsPopup extends Component {
      */
     unmountCustom() {
         unmountComponentAtNode(document.getElementById('react-placeholder'));
-        document.addEventListener('click', this.onDocumentClick);
+        document.removeEventListener('click', this.onDocumentClick);
+        this.rendered = false;
     }
 
     /**
@@ -155,6 +157,12 @@ export class HighlightsPopup extends Component {
         // Waiting one cycle allows the selection to be rendered in the browser
         // so that we can correctly retrieve its position.
         setTimeout(() => this.props.highlight ? this.renderCustom() : this.unmountCustom(), 0);
+    }
+
+    componentWillUnmount() {
+        if (this.rendered) {
+            this.unmountCustom();
+        }
     }
 
     render() {


### PR DESCRIPTION
menu was rendered but only for a few miliseconds, click handler
on HighlightsPopup removed it right away, because it was never removed
once registered.

SDESK-2241