### PR TITLE
core/editor3: re-enable links in annotation editor

### DIFF
--- a/scripts/core/editor3/components/annotations/AnnotationInput.jsx
+++ b/scripts/core/editor3/components/annotations/AnnotationInput.jsx
@@ -31,7 +31,7 @@ class AnnotationInputBody extends Component {
 
         let body = null;
         let annotationTypes = ng.get('metadata').values.annotation_types;
-        let type = annotationTypes.length > 0 ? annotationTypes[0].qcode : '';
+        let type = annotationTypes && annotationTypes.length > 0 ? annotationTypes[0].qcode : '';
 
         if (editing) {
             ({annotationType: type, msg: body} = data.annotation.data);
@@ -133,7 +133,7 @@ class AnnotationInputBody extends Component {
                     <label className="sd-line-input__label">Annotation Body</label>
                     <Editor
                         onChange={this.onChange}
-                        editorFormat={['bold', 'italic', 'underline', 'anchor']}
+                        editorFormat={['bold', 'italic', 'underline', 'link']}
                         editorState={this.initialContent}
                     />
                     <div className="pull-right">

--- a/scripts/core/editor3/components/links/LinkInput.jsx
+++ b/scripts/core/editor3/components/links/LinkInput.jsx
@@ -24,8 +24,13 @@ export class LinkInputComponent extends Component {
 
         this.tabs = [
             {label: gettext('URL'), render: this.renderURL.bind(this)},
-            {label: gettext('Attachment'), render: this.renderAttachment.bind(this)}
         ];
+
+        if (props.item) {
+            this.tabs.push(
+                {label: gettext('Attachment'), render: this.renderAttachment.bind(this)}
+            );
+        }
 
         this.activeTab = 0;
         this.state = {};
@@ -135,7 +140,7 @@ LinkInputComponent.propTypes = {
     applyLink: PropTypes.func.isRequired,
     hidePopups: PropTypes.func.isRequired,
     data: PropTypes.object,
-    item: PropTypes.object.isRequired,
+    item: PropTypes.object
 };
 
 const mapStateToProps = (state) => ({


### PR DESCRIPTION
In a previous commit the formatting option name for links was changed to
'link' from 'anchor'. The change was omitted in the annotation input
component. This commit fixes that.

Additionally, it removes the requirement of having `item` set in the
LinkInput and hides the "Attachements" tab when it's not.

Change-Id: I59b7bc60827bf06db2bc2c7f919119bf3fa06ad3