### PR TITLE
[AUTHORING] display dynamic word count in authoring header, instead o…

### DIFF
--- a/scripts/apps/authoring/authoring/directives/WordCount.js
+++ b/scripts/apps/authoring/authoring/directives/WordCount.js
@@ -12,11 +12,14 @@ export function WordCount() {
     return {
         scope: {
             item: '=',
-            html: '@'
+            html: '@',
+            countOnly: '@'
         },
-        template: '<span class="char-count words" translate>{{numWords}} words</span>',
+        template: '<span ng-if="!countOnly" class="char-count words" translate>{{numWords}} words</span>' +
+                  '<span ng-if="countOnly" class="char-count words">{{numWords}}</span>',
         link: function wordCountLink(scope, elem, attrs) {
             scope.html = scope.html || false;
+            scope.countOnly = scope.countOnly || false;
             scope.numWords = 0;
             scope.$watch('item', () => {
                 var input = scope.item || '';

--- a/scripts/apps/authoring/views/authoring-header.html
+++ b/scripts/apps/authoring/views/authoring-header.html
@@ -18,7 +18,7 @@
             </div>
         </div>
         <div ng-if="item.type === 'text'">
-            <label class="word-count"><b>{{ item.word_count || 0 }}</b> <span translate translate-n="item.word_count" translate-plural="WORDS">WORD</span></label>
+            <label class="word-count"><b sd-word-count data-item="item.body_html" data-html="true" data-count-only="true"></b> <span translate translate-n="item.word_count" translate-plural="WORDS">WORD</span></label>
         </div>
         <div ng-if="item.signal">
             <span class="signal">{{ item.signal}}</span>


### PR DESCRIPTION
…f value from backend

word count in header was displaying item.word_count, i.e. the value
stored in the backend, resulting in confustion for user. This patch
change it by displaying the same counter as the one on top of body.
sdWordCount directive has a new argument "countOnly" to only display the
counter (and not " words" after it).

fixes SDFID-194