### PR TITLE
SDFID-260 Display translations for metadata values in preview

### DIFF
--- a/scripts/apps/authoring/authoring/directives/FullPreviewDirective.js
+++ b/scripts/apps/authoring/authoring/directives/FullPreviewDirective.js
@@ -44,6 +44,19 @@ export function FullPreviewDirective(api, $timeout, config, content) {
                 }, 200, false);
                 return false;
             };
+
+            scope.getLocaleName = function(term) {
+                if (!term) {
+                    return 'None';
+                }
+
+                if (term.translations && scope.item.language
+                    && term.translations.name[scope.item.language]) {
+                    return term.translations.name[scope.item.language];
+                }
+
+                return term.name;
+            };
         }
     };
 }

--- a/scripts/apps/authoring/views/full-preview.html
+++ b/scripts/apps/authoring/views/full-preview.html
@@ -34,7 +34,7 @@
                     </div>
                     <div class="preview-data">
                         <span ng-repeat="service in item.anpa_category">
-                            {{service.name}}
+                            {{getLocaleName(service)}}
                         </span>
                     </div>
                 </div>
@@ -55,7 +55,7 @@
                     </div>
                     <div class="preview-data">
                         <span ng-repeat="genre in item.genre">
-                            {{genre.name}}
+                            {{getLocaleName(genre)}}
                         </span>
                     </div>
                 </div>
@@ -65,8 +65,8 @@
                         <label translate>Subject</label>
                     </div>
                     <div class="preview-data">
-                        <span ng-repeat="subject in item.subject | mergeWords:'name' : 'subject_custom': true">
-                            {{subject}}
+                        <span ng-repeat="subject in item.subject | filter:{'scheme':'subject_custom'}">
+                            {{getLocaleName(subject)}}
                         </span>
                     </div>
                 </div>
@@ -76,7 +76,7 @@
                     </div>
                     <div class="preview-data">
                         <span ng-repeat="topic in item.subject|filter:filterKey">
-                            {{topic.name}}
+                            {{getLocaleName(topic)}}
                         </span>
                     </div>
                 </div>
@@ -86,7 +86,7 @@
                     </div>
                     <div class="preview-data">
                         <span ng-repeat="place in item.place">
-                            {{place.name}}
+                            {{getLocaleName(place)}}
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
I created a function just like [this one](https://github.com/superdesk/superdesk-client-core/blob/0238618032a55590d901377d0a4984aad836ab4c/scripts/apps/authoring/metadata/metadata.js#L842) and then exposed it for the preview html.

Also, I had to apply a `filter` to `item.subject` because the previous one was only extracting the property `name`, and I needed the actual object