### PR TITLE
SDFID-105 Show correct timestamp on package item preview

### DIFF
--- a/scripts/apps/packaging/views/sd-package-item-preview.html
+++ b/scripts/apps/packaging/views/sd-package-item-preview.html
@@ -21,8 +21,8 @@
     </div>
 
     <div class="package-item__item-creator">
-      Created <time sd-datetime data-date="item.firstcreated" data-from-now="true"></time>
-	 <span ng-if="userLookup[data.original_creator]" translate>by <b>{{userLookup[data.original_creator].display_name}}</b></span>
+      Created <time sd-datetime data-date="data.versioncreated" data-from-now="true"></time>
+   <span ng-if="userLookup[data.original_creator]" translate>by <b>{{userLookup[data.original_creator].display_name}}</b></span>
     </div>
 
     <div class="package-item__item-abstract" ng-if="data.abstract" ng-bind-html="data.abstract"></div>

--- a/scripts/apps/packaging/views/sd-package-item-preview.html
+++ b/scripts/apps/packaging/views/sd-package-item-preview.html
@@ -21,7 +21,7 @@
     </div>
 
     <div class="package-item__item-creator">
-      Created <time sd-datetime data-date="data.versioncreated" data-from-now="true"></time>
+      Created <time sd-datetime data-date="data.firstcreated" data-from-now="true"></time>
    <span ng-if="userLookup[data.original_creator]" translate>by <b>{{userLookup[data.original_creator].display_name}}</b></span>
     </div>
 


### PR DESCRIPTION
Date was always `few seconds ago` because the variable didn't exist and `data-from-now` was taking that as "0 secs" I guess.

I'm still not sure if the date I'm displaying now it's the one that we want, I think it's the time the package was created, not added to the current item