### PR TITLE
SDFID-283 Make comments dropdown scrollable to prevent bottom overlapping

### DIFF
--- a/scripts/core/ui/components/dropdown.jsx
+++ b/scripts/core/ui/components/dropdown.jsx
@@ -7,7 +7,7 @@ export function Dropdown(props) {
 
     return (
         <div className={className}>
-            <div className="dropdown__menu">{props.children}</div>
+            <div className="dropdown__menu dropdown__menu--scrollable">{props.children}</div>
         </div>
     );
 }


### PR DESCRIPTION
The comments popup didn't have a `max-height` so it would overlap with the bottom when there were long comments.

Now it renders a `dropdown__menu--scrollable` that has a `max-height` and `overflow-y: scroll`