### PR TITLE
fix(editor3): fix selecting text in table shows editor format options

### DIFF
--- a/scripts/core/editor3/components/tables/TableBlock.jsx
+++ b/scripts/core/editor3/components/tables/TableBlock.jsx
@@ -107,6 +107,11 @@ export class TableBlockComponent extends Component {
         setActiveCell(i, j, block.key);
     }
 
+    // onMouseDown is used in the main editor to set focus and stop table editing
+    onMouseDown(event) {
+        event.stopPropagation();
+    }
+
     render() {
         const {numRows, numCols, withHeader} = this.data();
 
@@ -116,7 +121,7 @@ export class TableBlockComponent extends Component {
         });
 
         return (
-            <div className={cx}>
+            <div className={cx} onMouseDown={this.onMouseDown}>
                 <table>
                     <tbody>
                         {Array.from(new Array(numRows)).map((v, i) =>


### PR DESCRIPTION
onMouseDown is used in editor3 component so it must be stopped in embedded table editor