### PR TITLE
SDFID-192 Display meta sub_label even if it's disabled

### DIFF
--- a/scripts/apps/authoring/metadata/views/metadata-terms.html
+++ b/scripts/apps/authoring/metadata/views/metadata-terms.html
@@ -57,7 +57,9 @@
         <li ng-if="!disabled && t.sub_label" class="pull-left"
             ng-repeat="t in selectedItems track by t[uniqueField]"
             ng-click="removeTerm(t)"><label>{{getLocaleName(t)}}:</label>{{t.sub_label}}<i class="icon-close-small"></i></li>
-        <li ng-if="disabled" class="pull-left disabled"
+        <li ng-if="disabled && t.sub_label" class"pull-left"
+            ng-repeat="t in selectedItems track by t[uniqueField]"><label>{{getLocaleName(t)}}:</label>{{t.sub_label}}</li>
+        <li ng-if="disabled && !t.sub_label" class="pull-left disabled"
             ng-repeat="t in selectedItems track by t[uniqueField]">{{getLocaleName(t)}}</li>
     </ul>
 </div>


### PR DESCRIPTION
When `disabled === true` it wouldn't show the `sub_label`