### PR TITLE
fix(editor3): fix image drop on editor3 in firefox

### DIFF
--- a/scripts/core/editor3/actions/editor3.jsx
+++ b/scripts/core/editor3/actions/editor3.jsx
@@ -44,22 +44,18 @@ export function handleEditorTab(e) {
 /**
  * @ngdoc method
  * @name dragDrop
- * @param {Event} e
- * @return {String} action
+ * @param {DataTransfer} transfer
+ * @return {String} mediaType
  * @description Creates the editor drop action.
  */
-export function dragDrop(e) {
-    const transfer = e.originalEvent.dataTransfer;
-
-    if (transfer.types[0] === 'Files') {
-        e.preventDefault();
-        e.stopPropagation();
+export function dragDrop(transfer, mediaType) {
+    if (mediaType === 'Files') {
         return insertMedia(transfer.files);
     }
 
     return {
         type: 'EDITOR_DRAG_DROP',
-        payload: e
+        payload: transfer.getData(mediaType),
     };
 }
 

--- a/scripts/core/editor3/components/tests/editor3.spec.jsx
+++ b/scripts/core/editor3/components/tests/editor3.spec.jsx
@@ -17,7 +17,7 @@ describe('editor3.component', () => {
     it('should not accept dragging over invalid items', () => {
         const wrapper = shallow(<Editor3 editorFormat={['media']} editorState={editorState} />);
         const {onDragOver} = wrapper.instance();
-        const makeEvent = (t) => ({originalEvent: {dataTransfer: {types: [t]}}});
+        const makeEvent = (t) => ({originalEvent: {dataTransfer: {types: ['foo', t]}}});
 
         [
             'application/superdesk.item.picture',

--- a/scripts/core/editor3/reducers/editor3.jsx
+++ b/scripts/core/editor3/reducers/editor3.jsx
@@ -115,17 +115,11 @@ const onTab = (state, e) => {
 /**
  * @ngdoc method
  * @name dragDrop
- * @param {Event} e dragdrop event
+ * @param {String} data event data
  * @return {Object} New state
  * @description Handles the dragdrop event over the editor.
  */
-const dragDrop = (state, e) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    const eventData = e.originalEvent.dataTransfer;
-    const mediaType = eventData.types[0];
-    const data = eventData.getData(mediaType);
+const dragDrop = (state, data) => {
     const media = JSON.parse(data);
     const editorState = addMedia(state.editorState, media);
 

--- a/scripts/core/editor3/reducers/tests/reducers.spec.jsx
+++ b/scripts/core/editor3/reducers/tests/reducers.spec.jsx
@@ -31,15 +31,7 @@ describe('editor3.reducers', () => {
     });
 
     it('EDITOR_DRAG_DROP', () => {
-        const event = new DragEvent('drop');
-        const getData = jasmine.createSpy().and.callFake(() => '{"a": 1}');
-
-        event.originalEvent = {
-            dataTransfer: {
-                getData: getData,
-                types: ['superdesk/image']
-            }
-        };
+        const data = '{"a": 1}';
 
         const startState = {
             editorState: EditorState.createEmpty(),
@@ -48,7 +40,7 @@ describe('editor3.reducers', () => {
 
         const {editorState} = reducer(startState, {
             type: 'EDITOR_DRAG_DROP',
-            payload: event
+            payload: data
         });
 
         const contentState = editorState.getCurrentContent();
@@ -58,7 +50,6 @@ describe('editor3.reducers', () => {
         expect(entity.getType()).toBe('MEDIA');
         expect(entity.getMutability()).toBe('MUTABLE');
         expect(entity.getData()).toEqual({media: {a: 1}});
-        expect(getData).toHaveBeenCalledWith('superdesk/image');
     });
 
     it('HIGHLIGHTS_RENDER highlight', () => {


### PR DESCRIPTION
firefox is using x-moz-file as first dataTransfer type
and Files second, so updated the code to handle valid types
on any position in dataTransfer.types

SDESK-2227