### PR TITLE
SD-5581 - update superdesk.pot file, as of Jan 2018

### DIFF
--- a/po/superdesk.pot
+++ b/po/superdesk.pot
@@ -4,17 +4,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: \n"
 
-#: scripts/apps/archive/views/upload.html:66
-#: scripts/apps/authoring/views/change-image.html:99
-msgid "--- Not selected ---"
-msgstr ""
-
-#: scripts/apps/desks/views/desk-config-modal.html:131
-msgid ": OFF"
-msgstr ""
-
-#: scripts/apps/desks/views/desk-config-modal.html:134
-msgid ": ON"
+#: scripts/core/lang/missing-translations-strings.js:27
+msgid "\"GENRE 'null value not allowed'"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:18
@@ -49,10 +40,6 @@ msgstr ""
 msgid "'HEADLINE is a required field'"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:29
-msgid "'must be of list type'\""
-msgstr ""
-
 #: scripts/core/lang/missing-translations-strings.js:25
 msgid "'PLACE is a required field'"
 msgstr ""
@@ -73,15 +60,11 @@ msgstr ""
 msgid "'URGENCY is a required field'"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.js:31
-msgid "\" sent at:"
+#: scripts/core/lang/missing-translations-strings.js:29
+msgid "'must be of list type'\""
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:27
-msgid "\"GENRE 'null value not allowed'"
-msgstr ""
-
-#: scripts/apps/highlights/services/HighlightsService.js:58
+#: scripts/apps/highlights/services/HighlightsService.js:59
 msgid "(Global)"
 msgstr ""
 
@@ -89,75 +72,26 @@ msgstr ""
 msgid "(no matches)"
 msgstr ""
 
-#: scripts/apps/analytics/views/saved-activity-reports.html:10
-#: scripts/apps/search/views/saved-searches.html:10
-msgid "[Global]"
+#: scripts/apps/products/views/products-config-modal.html:28
+#: scripts/apps/products/views/products-config-modal.html:36
+msgid "*"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-routing-general.html:16
-msgid "[none]"
+#: scripts/apps/publish/views/subscribers.html:122
+msgid "* For Content API only subscriber destinations are not required."
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:295
-msgid "{{ field }} cannot be earlier than now!"
+#: scripts/apps/authoring/compare-versions/views/compare-versions.html:17
+msgid "* choose article version from dropdown menu"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:283
-msgid "{{ field }} date is required!"
-msgstr ""
-
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:291
-msgid "{{ field }} is not a valid date!"
-msgstr ""
-
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:287
-msgid "{{ field }} time is required!"
-msgstr ""
-
-#: scripts/apps/search/views/multi-action-bar.html:5
-msgid "{{ multi.count }} Item selected"
-msgid_plural "{{ multi.count }} Items selected"
-msgstr[0] ""
-msgstr[1] ""
-
-#: scripts/apps/publish/views/publish-queue.html:71
-msgid "{{ multiSelectCount}} Item selected"
-msgid_plural "{{ multiSelectCount }} Items selected"
-msgstr[0] ""
-msgstr[1] ""
-
-#: scripts/apps/dictionaries/views/dictionary-config-modal.html:52
-msgid "{{ wordsCount }} word"
-msgid_plural "{{ $count }} words"
-msgstr[0] ""
-msgstr[1] ""
-
-#: scripts/apps/users/views/edit-form.html:107
-msgid "{{error.email}}"
-msgstr ""
-
-#: scripts/core/itemList/views/relatedItem-list-widget.html:38
-msgid "{{item.state}}"
-msgstr ""
-
-#: scripts/apps/desks/views/desk-config-modal.html:181
-msgid "{{selected.is_visible ? 'ON' : 'OFF'}}"
-msgstr ""
-
-#: scripts/apps/desks/views/desk-config-modal.html:185
-msgid "{{selected.local_readonly ? 'ON' : 'OFF'}}"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:35
-msgid "{{status}} Ingest Channel {{name}}"
-msgstr ""
-
-#: scripts/apps/archive/views/upload.html:98
+#: scripts/apps/archive/views/upload-attachments.html:53
+#: scripts/apps/archive/views/upload.html:104
 msgid "* fields are required"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:35
-#: scripts/apps/users/views/edit-form.html:29
+#: scripts/apps/products/views/products-config-modal.html:25
+#: scripts/apps/publish/views/subscribers.html:46
 msgid "* mandatory fields"
 msgstr ""
 
@@ -165,20 +99,24 @@ msgstr ""
 msgid "*at least one visible or hidden recipient needed"
 msgstr ""
 
-#: scripts/apps/products/views/products-config-modal.html:22
-#: scripts/apps/publish/views/subscribers.html:77
+#: scripts/apps/products/views/products-config-modal.html:44
+#: scripts/apps/publish/views/subscribers.html:85
 msgid "*comma separated values"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:178
+#: scripts/apps/archive/views/upload.html:72
+msgid "--- Not selected ---"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:222
 msgid "1 month"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:176
+#: scripts/apps/publish/views/subscribers.html:220
 msgid "1 week"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:180
+#: scripts/apps/publish/views/subscribers.html:224
 msgid "1 year"
 msgstr ""
 
@@ -226,11 +164,7 @@ msgstr ""
 msgid "19th update"
 msgstr ""
 
-#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:41
-msgid "2 character limit"
-msgstr ""
-
-#: scripts/apps/publish/views/subscribers.html:177
+#: scripts/apps/publish/views/subscribers.html:221
 msgid "2 weeks"
 msgstr ""
 
@@ -270,7 +204,7 @@ msgstr ""
 msgid "6 Hours"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:179
+#: scripts/apps/publish/views/subscribers.html:223
 msgid "6 months"
 msgstr ""
 
@@ -290,7 +224,21 @@ msgstr ""
 msgid "9th update"
 msgstr ""
 
-#: scripts/apps/workspace/content/controllers/ContentProfilesController.js:56
+#: scripts/apps/desks/views/desk-config-modal.html:152
+msgid ": OFF"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:155
+msgid ": ON"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:222
+msgid ""
+"<i class=\"icon-warning-sign\"></i>\n"
+"                                    Please enter valid twitter account"
+msgstr ""
+
+#: scripts/apps/workspace/content/controllers/ContentProfilesController.js:84
 msgid "A content profile with this name already exists."
 msgstr ""
 
@@ -298,12 +246,50 @@ msgstr ""
 msgid "A link was sent to the specified email address. Please use it to reset your password. It is valid a limited amount of time."
 msgstr ""
 
-#: scripts/apps/search/views/search-parameters.html:173
+#: scripts/apps/search/views/search-parameters.html:186
 msgid "AAP Image Keyword"
 msgstr ""
 
-#: scripts/apps/dictionaries/views/dictionary-config-modal.html:82
-#: scripts/apps/dictionaries/views/dictionary-config-modal.html:97
+#: scripts/core/lang/missing-translations-strings.js:42
+msgid "ABSTRACT is too long"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:21
+msgid "ACTIVE/INACTIVE"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:91
+msgid "ADD ABBREVIATION"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:62
+msgid "ADD WORD"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:239
+#: scripts/apps/content-filters/views/production-test-view.html:23
+#: scripts/apps/search/services/SearchService.js:45
+msgid "ANPA Category"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:26
+msgid "ANPA Take Key"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/wufoo.html:8
+msgid "API key"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:330
+msgid "APPLY CROPS"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:358
+msgid "AUTHORS"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:84
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:99
 msgid "Abbreviation"
 msgstr ""
 
@@ -311,49 +297,58 @@ msgstr ""
 msgid "Abbreviation already exists. Do you want to overwrite it?"
 msgstr ""
 
-#: scripts/apps/authoring/views/article-edit.html:77
-#: scripts/apps/authoring/views/article-edit.html:97
-#: scripts/apps/packaging/views/sd-package-edit.html:19
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:17
+#: scripts/apps/dictionaries/views/settings.html:30
+msgid "Abbreviations Dictionary"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:128
+#: scripts/apps/authoring/views/article-edit.html:153
+#: scripts/apps/authoring/views/theme-select.html:45
+#: scripts/apps/authoring/views/theme-select.html:96
+#: scripts/apps/workspace/content/constants.js:68
 msgid "Abstract"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:42
-msgid "ABSTRACT is too long"
+#: scripts/apps/authoring/views/theme-select.html:47
+#: scripts/apps/authoring/views/theme-select.html:98
+msgid "Abstract example"
+msgstr ""
+
+#: scripts/apps/dashboard/views/workspace.html:9
+msgid "Accept"
 msgstr ""
 
 #: scripts/apps/monitoring/views/desk-notifications.html:19
 msgid "Acknowledge"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-routing-content.html:71
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:72
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:21
-#: scripts/apps/publish/views/publish-queue.html:100
+#: scripts/apps/publish/views/publish-queue.html:104
 msgid "Action"
 msgstr ""
 
+#: scripts/apps/authoring/authoring/constants.js:9
 #: scripts/apps/desks/views/settings.html:22
-#: scripts/apps/monitoring/views/item-actions-menu.html:14
-#: scripts/apps/templates/views/templates.html:32
-#: scripts/apps/workspace/content/views/profile-settings.html:23
+#: scripts/apps/monitoring/views/item-actions-menu.html:13
+#: scripts/apps/templates/views/templates.html:33
+#: scripts/apps/workspace/content/views/profile-settings.html:26
 msgid "Actions"
 msgstr ""
 
+#: scripts/apps/contacts/views/search-panel.html:97
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:18
-#: scripts/apps/users/controllers/UserListController.js:142
-#: scripts/apps/workspace/content/views/profile-settings.html:36
-#: scripts/apps/workspace/content/views/profile-settings.html:93
+#: scripts/apps/internal-destinations/views/settings.html:40
+#: scripts/apps/users/controllers/UserListController.js:143
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:97
+#: scripts/apps/workspace/content/views/profile-settings.html:104
+#: scripts/apps/workspace/content/views/profile-settings.html:38
 msgid "Active"
 msgstr ""
 
-#: scripts/apps/analytics/directives/ActivityReportContainer.js:11
-#: scripts/apps/analytics/views/activity-report-panel.html:4
-#: scripts/apps/analytics/views/activity-report-view.html:2
-msgid "Activity Report"
-msgstr ""
-
-#: scripts/apps/analytics/directives/SavedActivityReports.js:109
-msgid "Activity report deleted"
+#: scripts/apps/internal-destinations/views/settings.html:7
+#: scripts/apps/workspace/content/views/profile-settings.html:7
+msgid "Active only"
 msgstr ""
 
 #: scripts/apps/users/views/activity-feed.html:4
@@ -366,43 +361,23 @@ msgid "Activity stream widget"
 msgstr ""
 
 #: scripts/apps/authoring/metadata/views/metadata-target-publishing.html:6
-#: scripts/apps/content-filters/views/manage-filters.html:82
+#: scripts/apps/content-filters/views/manage-filters.html:78
 #: scripts/apps/content-filters/views/manage-filters.html:90
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:10
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:53
-#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:61
 msgid "Add"
 msgstr ""
 
-#: scripts/core/editor2/views/add-content.html:14
-msgid "add a picture"
+#: scripts/apps/contacts/views/list.html:16
+msgid "Add Contacts"
 msgstr ""
 
-#: scripts/apps/dictionaries/views/dictionary-config-modal.html:89
-msgid "ADD ABBREVIATION"
+#: scripts/apps/workspace/content/views/schema-editor.html:107
+#: scripts/apps/workspace/content/views/schema-editor.html:7
+msgid "Add Field"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/rssConfig.html:87
-msgid "Add alias"
-msgstr ""
-
-#: scripts/core/editor2/views/add-content.html:9
-msgid "add an embed"
-msgstr ""
-
-#: scripts/core/editor2/views/block-text.html:14
-msgid "Add content here"
-msgstr ""
-
-#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:54
-msgid "Add content slugline"
-msgstr ""
-
-#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:58
-msgid "Add description"
-msgstr ""
-
-#: scripts/apps/content-filters/views/manage-filters.html:127
+#: scripts/apps/content-filters/views/manage-filters.html:113
 msgid "Add Filter Statement"
 msgstr ""
 
@@ -410,255 +385,240 @@ msgstr ""
 msgid "Add Ingest Sources"
 msgstr ""
 
-#: scripts/apps/packaging/views/search.html:10
-msgid "Add items"
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:158
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:179
+msgid "Add Item"
 msgstr ""
 
-#: scripts/apps/archive/views/upload.html:91
-msgid "Add more files"
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:5
+#: scripts/apps/content-filters/views/manage-filters.html:4
+#: scripts/apps/desks/views/settings.html:8
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:5
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:5
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:7
+#: scripts/apps/internal-destinations/views/settings.html:10
+#: scripts/apps/products/views/products.html:15
+#: scripts/apps/publish/views/subscribers.html:14
+#: scripts/apps/search-providers/views/search-provider-config.html:5
+#: scripts/apps/templates/views/templates.html:20
+#: scripts/apps/users/views/settings-roles.html:5
+#: scripts/apps/vocabularies/views/vocabulary-config.html:13
+#: scripts/apps/vocabularies/views/vocabulary-config.html:19
+#: scripts/apps/vocabularies/views/vocabulary-config.html:25
+#: scripts/apps/vocabularies/views/vocabulary-config.html:31
+#: scripts/apps/vocabularies/views/vocabulary-config.html:7
+#: scripts/apps/workspace/content/views/profile-settings.html:10
+msgid "Add New"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:31
+msgid "Add New Content Filter"
+msgstr ""
+
+#: scripts/apps/workspace/content/views/profile-settings.html:55
+msgid "Add New Content Profile"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:5
+msgid "Add New Desk"
+msgstr ""
+
+#: scripts/apps/internal-destinations/views/settings.html:32
+#: scripts/apps/publish/views/subscribers.html:131
+msgid "Add New Destination"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:29
+msgid "Add New Filter Condition"
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:4
+msgid "Add New Product"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:59
+msgid "Add New Rule"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:27
+msgid "Add New Rule Set"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:30
+msgid "Add New Scheme"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:28
+msgid "Add New Search Provider"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:34
+msgid "Add New Source"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:38
+msgid "Add New Subscriber"
+msgstr ""
+
+#: scripts/apps/templates/views/template-editor-modal.html:4
+msgid "Add New Template"
 msgstr ""
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:5
 msgid "Add New {{(isAbbreviations() ? 'Abbreviations' : '') | translate}} Dictionary"
 msgstr ""
 
-#: scripts/apps/dictionaries/views/settings.html:14
-msgid "Add New Abbreviations Dictionary"
+#: scripts/apps/ingest/views/dashboard/dashboard.html:5
+msgid "Add Sources"
 msgstr ""
 
-#: scripts/apps/content-filters/views/manage-filters.html:33
-#: scripts/apps/content-filters/views/manage-filters.html:7
-msgid "Add New Content Filter"
+#: scripts/apps/dashboard/views/workspace.html:92
+msgid "Add This Widget"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/profile-settings.html:53
-#: scripts/apps/workspace/content/views/profile-settings.html:7
-msgid "Add New Content Profile"
+#: scripts/apps/ingest/views/settings/rssConfig.html:91
+msgid "Add alias"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:5
-#: scripts/apps/desks/views/settings.html:7
-msgid "Add New Desk"
+#: scripts/apps/authoring/views/authoring-header.html:367
+msgid "Add author"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:123
-msgid "Add New Destination"
+#: scripts/core/editor2/views/block-text.html:14
+msgid "Add content here"
 msgstr ""
 
-#: scripts/apps/dictionaries/views/settings.html:11
-msgid "Add New Dictionary"
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:55
+msgid "Add content slugline"
 msgstr ""
 
-#: scripts/apps/content-filters/views/manage-filter-conditions.html:32
-#: scripts/apps/content-filters/views/manage-filter-conditions.html:6
-msgid "Add New Filter Condition"
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:58
+msgid "Add description"
 msgstr ""
 
-#: scripts/apps/groups/views/groups-config-modal.html:5
-#: scripts/apps/groups/views/settings.html:7
-msgid "Add New Group"
+#: scripts/apps/packaging/views/search.html:10
+msgid "Add items"
 msgstr ""
 
-#: scripts/apps/dictionaries/views/settings.html:8
-msgid "Add New Personal Dictionary"
+#: scripts/apps/archive/views/upload.html:97
+msgid "Add more files"
 msgstr ""
 
-#: scripts/apps/products/views/products-config-modal.html:4
-#: scripts/apps/products/views/products.html:5
-msgid "Add New Product"
+#: scripts/apps/dictionaries/views/settings.html:7
+msgid "Add new"
 msgstr ""
 
-#: scripts/apps/users/views/settings-roles.html:6
-msgid "Add New Role"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ingest-routing-content.html:5
-msgid "Add New Routing Scheme"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ingest-routing-content.html:58
-msgid "Add New Rule"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ingest-rules-content.html:29
-#: scripts/apps/ingest/views/settings/ingest-rules-content.html:6
-msgid "Add New Rule Set"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ingest-routing-content.html:31
-msgid "Add New Scheme"
-msgstr ""
-
-#: scripts/apps/search-providers/views/search-provider-config.html:28
-#: scripts/apps/search-providers/views/search-provider-config.html:5
-msgid "Add New Search Provider"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:31
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:5
-msgid "Add New Source"
-msgstr ""
-
-#: scripts/apps/publish/views/subscribers.html:27
-#: scripts/apps/publish/views/subscribers.html:5
-msgid "Add New Subscriber"
-msgstr ""
-
-#: scripts/apps/templates/views/template-editor-modal.html:4
-#: scripts/apps/templates/views/templates.html:18
-msgid "Add New Template"
-msgstr ""
-
-#: scripts/apps/dashboard/views/workspace.html:63
+#: scripts/apps/dashboard/views/workspace.html:62
 msgid "Add new widget"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-rules-content.html:37
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:32
 msgid "Add rule"
 msgstr ""
 
-#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:65
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:66
 msgid "Add task description"
-msgstr ""
-
-#: scripts/apps/dashboard/views/workspace.html:91
-msgid "Add This Widget"
 msgstr ""
 
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:56
 msgid "Add title"
 msgstr ""
 
-#: scripts/apps/packaging/index.js:70
-msgid "Add to current"
+#: scripts/apps/search/views/multi-action-bar.html:13
+#: scripts/apps/search/views/multi-action-bar.html:70
+msgid "Add to Current Package"
 msgstr ""
 
-#: scripts/apps/search/views/multi-action-bar.html:14
-msgid "Add to Current Package"
+#: scripts/apps/packaging/index.js:70
+msgid "Add to current"
 msgstr ""
 
 #: scripts/core/editor2/views/block-text.html:26
 msgid "Add to dictionary"
 msgstr ""
 
-#: scripts/apps/dictionaries/views/dictionary-config-modal.html:62
-msgid "ADD WORD"
+#: scripts/apps/dashboard/views/workspace.html:13
+msgid "Add widget"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:30
-msgid "added new {{ type }} item about \"{{ subject }}\""
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:30
-msgid "added new {{ type }} item with empty header/title"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:33
-msgid "added new task {{ subject }} of type {{ type }}"
-msgstr ""
-
-#: scripts/apps/users/views/user-list-item.html:9
-msgid "admin"
-msgstr ""
-
-#: scripts/core/menu/views/menu.html:37
+#: scripts/core/menu/views/menu.html:38
 msgid "Admin tools"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:119
-msgid "administrator"
+#: scripts/apps/users/views/edit-form.html:41
+msgid "Administrator"
 msgstr ""
 
 #: scripts/apps/search/views/search-panel.html:7
 msgid "Advanced Search"
 msgstr ""
 
-#: scripts/apps/monitoring/views/monitoring-view.html:72
-#: scripts/apps/users/views/user-preferences.html:60
-msgid "all"
-msgstr ""
-
-#: scripts/apps/templates/directives/TemplatesDirective.js:292
-#: scripts/apps/users/controllers/UserListController.js:147
+#: scripts/apps/contacts/views/search-panel.html:83
+#: scripts/apps/internal-destinations/views/settings.html:6
+#: scripts/apps/templates/directives/TemplatesDirective.js:311
+#: scripts/apps/users/controllers/UserListController.js:148
+#: scripts/apps/workspace/content/views/profile-settings.html:6
 msgid "All"
 msgstr ""
 
-#: scripts/core/menu/notifications/views/notifications.html:40
+#: scripts/core/menu/notifications/views/notifications.html:41
 msgid "All good so far."
+msgstr ""
+
+#: scripts/apps/search/controllers/MultiActionBarController.js:145
+msgid "All items were published successfully."
 msgstr ""
 
 #: scripts/apps/authoring/views/opened-articles.html:3
 msgid "All opened items"
 msgstr ""
 
-#: scripts/apps/search/directives/ItemRepo.js:44
-msgid "all photos"
+#: scripts/apps/users/views/list.html:14
+msgid "All user types"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:104
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:115
 msgid "Allow Remove Ingested Items"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:165
-#: scripts/apps/groups/views/groups-config-modal.html:27
-#: scripts/apps/highlights/views/highlights_config_modal.html:16
-msgid "already exists"
-msgstr ""
-
-#: scripts/apps/archive/views/upload.html:50
-msgid "Alt text"
-msgstr ""
-
-#: scripts/apps/authoring/views/change-image.html:83
+#: scripts/apps/archive/views/metadata-associateditem-view.html:15
+#: scripts/apps/authoring/views/change-image.html:101
 msgid "Alt Text"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:306
+#: scripts/apps/archive/views/upload.html:56
+msgid "Alt text"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:327
 msgid "An Item can't have both Embargo and Publish Schedule."
 msgstr ""
 
-#: scripts/apps/analytics/index.js:34
-#: scripts/apps/analytics/views/analytics.html:3
-#: scripts/apps/workspace/views/workspace-sidenav-items.html:72
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:121
+msgid "An error occured when testing config."
+msgstr ""
+
+#: scripts/apps/workspace/views/workspace-sidenav-items.html:79
 msgid "Analytics"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-header.html:181
-#: scripts/apps/content-filters/views/production-test-view.html:23
-#: scripts/apps/search/services/SearchService.js:30
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:14
-msgid "ANPA Category"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:26
-msgid "ANPA Take Key"
 msgstr ""
 
 #: scripts/apps/dashboard/workspace-tasks/views/desk-stages.html:6
 msgid "Any"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:160
+#: scripts/apps/archive/views/metadata-view.html:161
 msgid "Aperture"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:137
+#: scripts/apps/publish/views/subscribers.html:145
 msgid "Applied Global Block Filters"
-msgstr ""
-
-#: scripts/apps/authoring/views/article-edit.html:229
-msgid "APPLY CROPS"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:8
-msgid "archive"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:10
 msgid "Archive"
 msgstr ""
 
-#: scripts/apps/search/views/item-repo.html:10
+#: scripts/apps/search/views/item-repo.html:7
 msgid "Archived"
 msgstr ""
 
@@ -670,11 +630,24 @@ msgstr ""
 msgid "Archived Management"
 msgstr ""
 
-#: scripts/apps/highlights/controllers/HighlightsConfig.js:63
+#: scripts/apps/archive/views/preview.html:45
+#: scripts/apps/authoring/views/authoring-topbar.html:32
+msgid "Archived from"
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.js:101
+msgid "Are you sure you want to delete Ingest Source?"
+msgstr ""
+
+#: scripts/apps/search-providers/directive.js:68
+msgid "Are you sure you want to delete Search Provider?"
+msgstr ""
+
+#: scripts/apps/highlights/controllers/HighlightsConfig.js:65
 msgid "Are you sure you want to delete configuration?"
 msgstr ""
 
-#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:67
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:69
 msgid "Are you sure you want to delete content filter?"
 msgstr ""
 
@@ -682,19 +655,11 @@ msgstr ""
 msgid "Are you sure you want to delete current workspace?"
 msgstr ""
 
-#: scripts/apps/content-filters/controllers/FilterConditionsController.js:90
+#: scripts/apps/content-filters/controllers/FilterConditionsController.js:107
 msgid "Are you sure you want to delete filter condition?"
 msgstr ""
 
-#: scripts/apps/groups/controllers/GroupsConfigController.js:24
-msgid "Are you sure you want to delete group?"
-msgstr ""
-
-#: scripts/apps/ingest/directives/IngestSourcesContent.js:98
-msgid "Are you sure you want to delete Ingest Source?"
-msgstr ""
-
-#: scripts/apps/products/controllers/ProductsConfigController.js:84
+#: scripts/apps/products/controllers/ProductsConfigController.js:169
 msgid "Are you sure you want to delete product?"
 msgstr ""
 
@@ -706,15 +671,7 @@ msgstr ""
 msgid "Are you sure you want to delete saved search?"
 msgstr ""
 
-#: scripts/apps/search-providers/directive.js:71
-msgid "Are you sure you want to delete Search Provider?"
-msgstr ""
-
-#: scripts/apps/analytics/directives/SavedActivityReports.js:106
-msgid "Are you sure you want to delete the activity report?"
-msgstr ""
-
-#: scripts/apps/templates/directives/TemplatesDirective.js:259
+#: scripts/apps/templates/directives/TemplatesDirective.js:277
 msgid "Are you sure you want to delete the template?"
 msgstr ""
 
@@ -730,16 +687,17 @@ msgstr ""
 msgid "Are you sure you want to delete user role?"
 msgstr ""
 
-#: scripts/apps/users/views/user-preferences.html:26
+#: scripts/apps/users/views/user-preferences.html:40
 msgid "Article Defaults"
 msgstr ""
 
 #: scripts/apps/archive/views/preview.html:17
 #: scripts/apps/authoring/views/authoring-header.html:4
+#: scripts/core/directives/FiletypeIconDirective.js:29
 msgid "Article Type"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:68
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:72
 msgid "Article Type(s)"
 msgstr ""
 
@@ -748,8 +706,8 @@ msgstr ""
 msgid "Assets URL"
 msgstr ""
 
-#: scripts/apps/archive/views/upload.html:63
-#: scripts/apps/authoring/views/change-image.html:96
+#: scripts/apps/archive/views/upload.html:69
+#: scripts/apps/authoring/views/change-image.html:114
 msgid "Assign Rights"
 msgstr ""
 
@@ -761,45 +719,76 @@ msgstr ""
 msgid "Assignee"
 msgstr ""
 
-#: scripts/apps/authoring/versioning/history/views/publish_queue.html:17
-#: scripts/apps/authoring/versioning/history/views/publish_queue.html:22
-msgid "at"
+#: scripts/apps/search/views/item-preview.html:23
+msgid "Assignment"
 msgstr ""
 
-#: scripts/apps/templates/views/template-editor-modal.html:150
+#: scripts/apps/workspace/views/workspace-sidenav-items.html:31
+msgid "Assignments"
+msgstr ""
+
+#: scripts/apps/templates/views/template-editor-modal.html:159
 msgid "At"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:4
-msgid "audio"
+#: scripts/apps/contacts/views/edit-form.html:32
+msgid "At minimum  {{contactForm.first_name ? '\\'first name, last name\\'' : '\\'organisation\\'' | translate}} and at least one of [mobile, phone, email, twitter, facebook, instagram] fields are required."
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/rssConfig.html:18
+#: scripts/apps/archive/index.js:98
+#: scripts/apps/authoring/attachments/attachments.html:53
+msgid "Attach files"
+msgstr ""
+
+#: scripts/apps/authoring/attachments/attachments.js:141
+msgid "Attachments"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:77
+msgid "Audio"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/rssConfig.html:22
 msgid "Authentication Info"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:154
+#: scripts/apps/publish/views/subscribers.html:172
+#: scripts/apps/publish/views/subscribers.html:198
 msgid "Authentication Token"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/reutersConfig.html:7
-msgid "authentication url"
+#: scripts/apps/ingest/views/settings/emailConfig.html:25
+#: scripts/apps/ingest/views/settings/emailConfig.html:32
+msgid "Authentication error."
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:22
-msgid "authoring"
+#: scripts/apps/users/views/edit-form.html:42
+msgid "Author"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/index.js:76
+#: scripts/apps/users/views/edit-form.html:32
+msgid "Author info"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.js:79
+#: scripts/apps/authoring/compare-versions/index.js:26
 #: scripts/apps/authoring/multiedit/multiedit.js:300
 msgid "Authoring"
 msgstr ""
 
-#: scripts/apps/templates/views/templates.html:55
+#: scripts/apps/desks/views/desk-config-modal.html:65
+msgid "Authoring desks are for content creation, and items within it are protected from accidental publication. Publishing is only permitted  from production desks."
+msgstr ""
+
+#: scripts/apps/users/views/list.html:15
+msgid "Authors only"
+msgstr ""
+
+#: scripts/apps/templates/views/templates.html:56
 msgid "Automated item creation"
 msgstr ""
 
-#: scripts/apps/templates/views/template-editor-modal.html:138
+#: scripts/apps/templates/views/template-editor-modal.html:147
 msgid "Automatically create item"
 msgstr ""
 
@@ -807,17 +796,17 @@ msgstr ""
 msgid "Automatically insert items from"
 msgstr ""
 
-#: scripts/apps/dashboard/world-clock/configuration.html:34
+#: scripts/apps/dashboard/world-clock/configuration.html:32
 msgid "Available clock"
 msgstr ""
 
-#: scripts/core/editor2/editor.js:1046
+#: scripts/core/editor2/editor.js:1057
 msgid "B"
 msgstr ""
 
-#: scripts/apps/dashboard/views/workspace.html:82
+#: scripts/apps/dashboard/views/workspace.html:83
 #: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:58
-#: scripts/core/itemList/views/relatedItem-list-widget.html:55
+#: scripts/core/itemList/views/relatedItem-list-widget.html:60
 msgid "Back"
 msgstr ""
 
@@ -829,19 +818,27 @@ msgstr ""
 msgid "Back to original view"
 msgstr ""
 
-#: scripts/apps/users/views/edit.html:5
-msgid "Back to Users list"
+#: scripts/apps/users/views/edit.html:4
+msgid "Back to users list"
 msgstr ""
 
 #: scripts/apps/authoring/comments/views/comments-widget.html:17
 msgid "Be the first..."
 msgstr ""
 
+#: scripts/core/directives/views/phone-home-modal-directive.html:7
+msgid "Before you start using your new newsroom, please tell us a little about yourself:"
+msgstr ""
+
 #: scripts/core/directives/PasswordStrengthDirective.js:40
 msgid "Better"
 msgstr ""
 
-#: scripts/apps/search/views/search-parameters.html:201
+#: scripts/apps/users/views/edit-form.html:219
+msgid "Biography"
+msgstr ""
+
+#: scripts/apps/search/views/search-parameters.html:223
 msgid "Black&White"
 msgstr ""
 
@@ -850,34 +847,36 @@ msgstr ""
 msgid "Blank headline received"
 msgstr ""
 
-#: scripts/apps/content-filters/views/manage-filters.html:57
+#: scripts/apps/content-filters/views/manage-filters.html:55
 msgid "Block API"
 msgstr ""
 
-#: scripts/apps/products/views/products-config-modal.html:35
+#: scripts/apps/products/views/products-config-modal.html:57
 msgid "Blocking"
 msgstr ""
 
-#: scripts/apps/authoring/views/article-edit.html:183
-#: scripts/apps/authoring/views/article-edit.html:202
-#: scripts/apps/packaging/views/sd-package-edit.html:31
+#: scripts/apps/authoring/views/article-edit.html:260
+#: scripts/apps/authoring/views/article-edit.html:290
+#: scripts/apps/authoring/views/theme-select.html:105
+#: scripts/apps/authoring/views/theme-select.html:54
 msgid "Body"
 msgstr ""
 
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:23
-msgid "Body footer"
-msgstr ""
-
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:18
+#: scripts/apps/workspace/content/constants.js:69
 #: scripts/core/lang/missing-translations-strings.js:26
 msgid "Body HTML"
 msgstr ""
 
-#: scripts/core/editor2/editor.js:1044
-msgid "bold"
+#: scripts/apps/workspace/content/constants.js:74
+msgid "Body footer"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:72
+#: scripts/apps/authoring/views/theme-select.html:107
+#: scripts/apps/authoring/views/theme-select.html:56
+msgid "Body text example"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:80
 msgid "Both"
 msgstr ""
 
@@ -885,47 +884,36 @@ msgstr ""
 msgid "Broadcast"
 msgstr ""
 
-#: scripts/apps/archive/views/preview.html:7
-#: scripts/apps/authoring/suggest/SuggestView.html:23
-#: scripts/apps/authoring/suggest/SuggestView.html:71
-#: scripts/apps/authoring/versioning/history/views/history.html:17
-#: scripts/apps/authoring/versioning/history/views/history.html:22
-#: scripts/apps/authoring/versioning/history/views/history.html:55
-#: scripts/apps/authoring/versioning/versions/views/versions.html:6
-#: scripts/apps/authoring/views/authoring.html:8
-#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:2
-msgid "by"
-msgstr ""
-
 #: scripts/core/lang/missing-translations-strings.js:26
 msgid "By"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/ArticleEditDirective.js:121
-msgid "By {{ display_name }}"
-msgstr ""
-
-#: scripts/apps/packaging/views/sd-package-item-preview.html:25
-msgid "by <b>{{userLookup[data.original_creator].display_name}}</b>"
-msgstr ""
-
-#: scripts/apps/users/views/user-preferences.html:55
+#: scripts/apps/users/views/user-preferences.html:69
 msgid "By selecting the categories you are interested in, the system will only display these in a menu for setting the content item's categories (along with any of its existing categories)."
 msgstr ""
 
-#: scripts/apps/users/views/user-preferences.html:92
+#: scripts/apps/users/views/user-preferences.html:106
 msgid "By selecting the desks as your preferred desks, they appear first in the order when sending or publishing items."
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:79
-msgid "byline"
+#: scripts/apps/archive/views/metadata-view.html:73
+#: scripts/apps/authoring/views/article-edit.html:176
+#: scripts/apps/search/views/search-parameters.html:38
+#: scripts/apps/users/views/edit-form.html:205
+#: scripts/apps/workspace/content/constants.js:70
+msgid "Byline"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:73
-#: scripts/apps/authoring/views/article-edit.html:113
-#: scripts/apps/search/views/search-parameters.html:37
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:19
-msgid "Byline"
+#: scripts/apps/authoring/views/authoring-header.html:314
+msgid "COMPANY"
+msgstr ""
+
+#: scripts/apps/workspace/views/workspace-dropdown.html:33
+msgid "CREATE NEW WORKSPACE"
+msgstr ""
+
+#: scripts/apps/workspace/views/workspace-dropdown.html:21
+msgid "CUSTOM WORKSPACES"
 msgstr ""
 
 #: scripts/core/itemList/views/relatedItem-list-widget.html:32
@@ -936,51 +924,67 @@ msgstr ""
 msgid "Can be associated as an update"
 msgstr ""
 
-#: scripts/apps/analytics/views/save-activity-report.html:9
+#: scripts/apps/ingest/views/settings/rssConfig.html:9
+msgid "Can't connect to host."
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/rssConfig.html:10
+msgid "Can't parse the RSS."
+msgstr ""
+
 #: scripts/apps/archive/views/archived-kill.html:13
+#: scripts/apps/archive/views/export.html:33
 #: scripts/apps/archive/views/resend-configuration.html:28
-#: scripts/apps/archive/views/upload.html:100
+#: scripts/apps/archive/views/upload-attachments.html:55
+#: scripts/apps/archive/views/upload.html:106
+#: scripts/apps/authoring/attachments/attachments.html:86
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:100
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:49
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:62
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:76
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:90
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:74
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:86
 #: scripts/apps/authoring/comments/views/comments-widget.html:28
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:22
 #: scripts/apps/authoring/multiedit/views/sd-multiedit-dropdown.html:15
+#: scripts/apps/authoring/views/authoring-topbar.html:144
 #: scripts/apps/authoring/views/change-image.html:5
-#: scripts/apps/authoring/views/change-image.html:50
+#: scripts/apps/authoring/views/change-image.html:52
 #: scripts/apps/authoring/views/confirm-media-associated.html:19
-#: scripts/apps/content-filters/views/manage-filter-conditions.html:76
-#: scripts/apps/content-filters/views/manage-filters.html:128
+#: scripts/apps/authoring/views/theme-select.html:118
+#: scripts/apps/contacts/views/edit-form.html:6
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:89
+#: scripts/apps/content-filters/views/manage-filters.html:139
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:12
-#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:86
-#: scripts/apps/desks/views/desk-config-modal.html:124
-#: scripts/apps/desks/views/desk-config-modal.html:155
-#: scripts/apps/dictionaries/views/dictionary-config-modal.html:122
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:87
+#: scripts/apps/desks/views/desk-config-modal.html:175
+#: scripts/apps/desks/views/desk-config-modal.html:184
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:124
 #: scripts/apps/highlights/views/highlights_config_modal.html:52
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:11
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:54
-#: scripts/apps/ingest/views/settings/ingest-routing-content.html:89
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:88
 #: scripts/apps/ingest/views/settings/ingest-routing-filter.html:29
-#: scripts/apps/ingest/views/settings/ingest-rules-content.html:66
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:173
-#: scripts/apps/products/views/products-config-modal.html:57
-#: scripts/apps/publish/views/publish-queue.html:122
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:56
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:186
+#: scripts/apps/internal-destinations/views/settings.html:60
+#: scripts/apps/monitoring/views/aggregate-settings.html:137
+#: scripts/apps/products/views/products-config-modal.html:77
+#: scripts/apps/publish/views/publish-queue.html:126
 #: scripts/apps/publish/views/publish-queue.html:78
-#: scripts/apps/publish/views/subscribers.html:193
+#: scripts/apps/publish/views/subscribers.html:236
 #: scripts/apps/search-providers/views/search-provider-config.html:80
 #: scripts/apps/search/views/item-globalsearch.html:20
 #: scripts/apps/search/views/save-search.html:28
-#: scripts/apps/templates/views/create-template.html:41
-#: scripts/apps/templates/views/template-editor-modal.html:188
-#: scripts/apps/users/views/edit-form.html:168
-#: scripts/apps/users/views/edit-form.html:202
+#: scripts/apps/templates/views/create-template.html:39
+#: scripts/apps/templates/views/template-editor-modal.html:198
+#: scripts/apps/users/views/edit-form.html:274
 #: scripts/apps/users/views/edit-form.html:4
-#: scripts/apps/users/views/settings-roles.html:51
+#: scripts/apps/users/views/settings-roles.html:56
 #: scripts/apps/users/views/user-preferences.html:5
 #: scripts/apps/users/views/user-privileges.html:6
-#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:59
-#: scripts/apps/workspace/content/views/profile-settings.html:106
-#: scripts/apps/workspace/content/views/profile-settings.html:71
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:177
+#: scripts/apps/workspace/content/views/profile-settings.html:117
+#: scripts/apps/workspace/content/views/profile-settings.html:78
 #: scripts/apps/workspace/views/edit-workspace-modal.html:19
 #: scripts/core/activity/views/activity-chooser.html:9
 #: scripts/core/editor2/views/block-embed.html:3
@@ -994,33 +998,37 @@ msgstr ""
 msgid "Cancel Selection"
 msgstr ""
 
-#: scripts/apps/authoring/editor/views/find-replace.html:17
+#: scripts/apps/archive/views/metadata-associateditem-view.html:7
+#: scripts/apps/authoring/views/article-edit.html:350
+#: scripts/apps/authoring/views/article-edit.html:371
+msgid "Caption"
+msgstr ""
+
+#: scripts/apps/authoring/editor/views/find-replace.html:18
 msgid "Case Sensitive"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:9
-msgid "categories"
+#: scripts/apps/authoring/views/full-preview.html:44
+#: scripts/apps/content-api/services/ContentAPISearchService.js:27
+#: scripts/apps/legal-archive/services/LegalArchiveService.js:24
+#: scripts/apps/legal-archive/tests/legal.spec.js:74
+#: scripts/apps/workspace/content/constants.js:64
+msgid "Category"
 msgstr ""
 
-#: scripts/apps/analytics/views/activity-report-parameters.html:44
-#: scripts/apps/authoring/views/full-preview.html:44
-#: scripts/apps/legal-archive/services/LegalArchiveService.js:11
-msgid "Category"
+#: scripts/apps/users/views/edit-form.html:12
+msgid "Change Photo"
 msgstr ""
 
 #: scripts/apps/users/config.js:119
 msgid "Change avatar"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:10
-msgid "Change Photo"
-msgstr ""
-
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:38
 msgid "Channel has gone strangely quiet."
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:92
+#: scripts/apps/desks/views/desk-config-modal.html:120
 msgid "Character limit exceeded, desk can not be created/updated."
 msgstr ""
 
@@ -1028,32 +1036,24 @@ msgstr ""
 msgid "Character limit exceeded, dictionary can not be created/updated."
 msgstr ""
 
-#: scripts/apps/groups/views/groups-config-modal.html:28
-msgid "Character limit exceeded, group can not be created/updated."
-msgstr ""
-
 #: scripts/apps/highlights/views/highlights_config_modal.html:15
 msgid "Character limit exceeded, highlight can not be created/updated."
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:166
+#: scripts/apps/desks/views/desk-config-modal.html:193
 msgid "Character limit exceeded, stage can not be created/updated."
-msgstr ""
-
-#: scripts/apps/authoring/authoring/directives/CharacterCount.js:12
-msgid "characters"
 msgstr ""
 
 #: scripts/core/views/sdselect.html:13
 msgid "Check all"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:219
-#: scripts/apps/authoring/views/authoring-topbar.html:227
+#: scripts/apps/authoring/views/authoring-topbar.html:267
+#: scripts/apps/authoring/views/authoring-topbar.html:276
 msgid "Check spelling"
 msgstr ""
 
-#: scripts/apps/authoring/metadata/views/metadata-terms.html:26
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:33
 msgid "Choose entire category"
 msgstr ""
 
@@ -1061,34 +1061,45 @@ msgstr ""
 msgid "Choose highlight list"
 msgstr ""
 
-#: scripts/apps/authoring/views/theme-select.html:9
-msgid "Choose Normal Theme"
+#: scripts/apps/contacts/views/edit-form.html:282
+#: scripts/apps/contacts/views/search-panel.html:61
+msgid "City"
 msgstr ""
 
-#: scripts/apps/authoring/views/theme-select.html:27
-msgid "Choose Proofread Theme"
-msgstr ""
-
-#: scripts/apps/workspace/content/views/schema-editor.html:98
+#: scripts/apps/workspace/content/views/schema-editor.html:74
 msgid "Clean Pasted HTML"
 msgstr ""
 
-#: scripts/apps/dashboard/world-clock/configuration.html:38
-#: scripts/apps/legal-archive/views/legal_archive.html:73
+#: scripts/apps/dashboard/world-clock/configuration.html:36
+#: scripts/apps/legal-archive/views/legal_archive.html:91
 #: scripts/core/ui/views/sd-timezone.html:26
 msgid "Clear"
 msgstr ""
 
-#: scripts/apps/users/views/user-preferences.html:65
-msgid "Clear all selected"
-msgstr ""
-
-#: scripts/apps/search/views/search-parameters.html:206
+#: scripts/apps/search/views/search-parameters.html:228
 msgid "Clear Edge"
 msgstr ""
 
+#: scripts/apps/users/views/user-preferences.html:79
+msgid "Clear all selected"
+msgstr ""
+
+#: scripts/apps/authoring/views/send-item.html:61
+msgid "Clear embargo"
+msgstr ""
+
+#: scripts/apps/contacts/views/search-panel.html:107
+#: scripts/apps/content-api/views/search-panel.html:22
 #: scripts/apps/search/views/save-search.html:9
 msgid "Clear filters"
+msgstr ""
+
+#: scripts/apps/authoring/views/send-item.html:74
+msgid "Clear schedule"
+msgstr ""
+
+#: scripts/apps/content-filters/views/filter-search.html:42
+msgid "Clear search"
 msgstr ""
 
 #: scripts/apps/users/config.js:90
@@ -1099,32 +1110,29 @@ msgstr ""
 msgid "Click to capture using camera. Be sure that you allow camera accessibility."
 msgstr ""
 
-#: scripts/apps/dashboard/world-clock/configuration.html:9
+#: scripts/apps/dashboard/world-clock/configuration.html:5
 msgid "Clock type"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:89
-#: scripts/apps/authoring/views/authoring-topbar.html:91
-#: scripts/apps/authoring/views/dashboard-articles.html:5
+#: scripts/apps/authoring/views/authoring-topbar.html:96
+#: scripts/apps/authoring/views/authoring-topbar.html:99
+#: scripts/apps/authoring/views/dashboard-articles.html:4
 #: scripts/apps/authoring/views/full-preview.html:9
+#: scripts/apps/authoring/views/preview-formatted.html:29
 #: scripts/apps/content-filters/views/production-test.html:10
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:136
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:150
 #: scripts/core/menu/views/about.html:35
 #: scripts/core/menu/views/about.html:5
 msgid "Close"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:13
-msgid "closed"
+#: scripts/apps/authoring/authoring/index.js:237
+msgid "Close current item"
 msgstr ""
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:9
 #: scripts/apps/search-providers/views/search-provider-config.html:14
 msgid "Closed"
-msgstr ""
-
-#: scripts/apps/authoring/authoring/index.js:204
-msgid "Closes current item"
 msgstr ""
 
 #: scripts/apps/vocabularies/services/SchemaFactory.js:6
@@ -1135,31 +1143,27 @@ msgstr ""
 msgid "Combine with current"
 msgstr ""
 
-#: scripts/core/menu/notifications/views/notifications.html:26
-msgid "commented on"
-msgstr ""
-
-#: scripts/apps/authoring/comments/comments.js:135
+#: scripts/apps/authoring/comments/comments.js:136
 msgid "Comments"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:8
-msgid "compact"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-header.html:251
-msgid "COMPANY"
-msgstr ""
-
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:30
+#: scripts/apps/workspace/content/constants.js:81
 msgid "Company Codes"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:4
-msgid "composite"
+#: scripts/core/directives/views/phone-home-modal-directive.html:29
+msgid "Company/Organisation"
 msgstr ""
 
-#: scripts/apps/legal-archive/index.js:35
+#: scripts/apps/authoring/compare-versions/views/compare-versions.html:2
+msgid "Compare Versions"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:184
+msgid "Compare versions"
+msgstr ""
+
+#: scripts/apps/legal-archive/index.js:37
 msgid "Confidential data"
 msgstr ""
 
@@ -1167,11 +1171,11 @@ msgstr ""
 msgid "Configuration"
 msgstr ""
 
-#: scripts/apps/highlights/controllers/HighlightsConfig.js:67
+#: scripts/apps/highlights/controllers/HighlightsConfig.js:69
 msgid "Configuration deleted."
 msgstr ""
 
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:97
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:107
 msgid "Configuration has changed. {{ message }} Would you like to save the story to your workspace?"
 msgstr ""
 
@@ -1179,8 +1183,8 @@ msgstr ""
 msgid "Configuration name"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:194
-msgid "confirm"
+#: scripts/apps/authoring/views/theme-select.html:9
+msgid "Configure Editor themes"
 msgstr ""
 
 #: scripts/core/services/modalService.js:5
@@ -1202,92 +1206,97 @@ msgstr ""
 msgid "Connection string"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:5
-msgid "content"
+#: scripts/apps/ingest/views/settings/rssConfig.html:7
+msgid "Connection timed out."
 msgstr ""
 
 #: scripts/apps/content-filters/views/production-test-view.html:52
-#: scripts/apps/legal-archive/views/legal_archive.html:92
+#: scripts/apps/legal-archive/views/legal_archive.html:114
 #: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:62
 #: scripts/apps/packaging/views/search-widget-preview.html:5
 #: scripts/apps/search/views/item-preview.html:8
-#: scripts/apps/workspace/views/workspace-sidenav-items.html:37
+#: scripts/apps/workspace/views/workspace-sidenav-items.html:44
 msgid "Content"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:152
-msgid "Content API Tokens"
+#: scripts/apps/publish/views/subscribers.html:157
+msgid "Content API"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:235
-msgid "Content expiry"
+#: scripts/apps/content-api/controllers/ContentAPIController.js:18
+#: scripts/apps/content-api/index.js:20
+msgid "Content API Search"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:195
+msgid "Content API Tokens"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:21
 msgid "Content Expiry"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:192
-msgid "Content expiry:"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/rssConfig.html:39
+#: scripts/apps/ingest/views/settings/rssConfig.html:43
 msgid "Content Field Aliases"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/rssConfig.html:47
+#: scripts/apps/ingest/views/settings/rssConfig.html:51
 msgid "Content Field Name"
 msgstr ""
 
+#: scripts/apps/content-filters/views/content-filter-select.html:1
+#: scripts/apps/content-filters/views/manage-filters.html:104
 #: scripts/apps/ingest/views/settings/ingest-routing-filter.html:2
-#: scripts/apps/products/views/products-config-modal.html:26
+#: scripts/apps/products/views/products-config-modal.html:48
 msgid "Content Filter"
 msgstr ""
 
-#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:41
-msgid "Content filter saved."
-msgstr ""
-
-#: scripts/apps/products/views/products-config-modal.html:33
+#: scripts/apps/products/views/products-config-modal.html:55
 msgid "Content Filter Type"
 msgstr ""
 
-#: scripts/apps/content-filters/index.js:36
-#: scripts/apps/content-filters/views/filter-search-result.html:28
-#: scripts/apps/content-filters/views/manage-filters.html:5
-#: scripts/apps/content-filters/views/manage-filters.html:85
+#: scripts/apps/content-filters/index.js:37
+#: scripts/apps/content-filters/views/filter-search-result.html:24
+#: scripts/apps/content-filters/views/settings.html:3
 msgid "Content Filters"
 msgstr ""
 
-#: scripts/apps/templates/views/template-editor-modal.html:20
-#: scripts/apps/templates/views/template-editor-modal.html:25
+#: scripts/apps/templates/views/template-editor-modal.html:21
+#: scripts/apps/templates/views/template-editor-modal.html:26
 msgid "Content Profile"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:73
 #: scripts/apps/workspace/content/index.js:32
-#: scripts/apps/workspace/content/views/profile-settings.html:4
+#: scripts/apps/workspace/content/views/profile-settings.html:3
 #: scripts/core/lang/missing-translations-strings.js:26
 msgid "Content Profiles"
 msgstr ""
 
-#: scripts/apps/publish/views/publish-queue.html:90
+#: scripts/apps/publish/views/publish-queue.html:94
 msgid "Content Type"
-msgstr ""
-
-#: scripts/apps/search/views/search-filters.html:2
-msgid "Content types"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:10
 msgid "Content Types"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:271
+#: scripts/apps/desks/views/desk-config-modal.html:225
+msgid "Content expiry:"
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:43
+msgid "Content filter saved."
+msgstr ""
+
+#: scripts/apps/search/views/search-filters.html:2
+msgid "Content types"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:322
 msgid "Continue"
 msgstr ""
 
-#: scripts/apps/archive/index.js:180
+#: scripts/apps/archive/index.js:224
 msgid "Copy"
 msgstr ""
 
@@ -1295,59 +1304,69 @@ msgstr ""
 msgid "Copyright"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:171
-#: scripts/apps/archive/views/upload.html:58
-#: scripts/apps/authoring/views/change-image.html:91
+#: scripts/apps/archive/views/metadata-associateditem-view.html:32
+#: scripts/apps/archive/views/metadata-view.html:172
+#: scripts/apps/archive/views/upload.html:64
+#: scripts/apps/authoring/views/change-image.html:110
 msgid "Copyright holder"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:175
-#: scripts/apps/archive/views/upload.html:73
-#: scripts/apps/authoring/views/change-image.html:106
+#: scripts/apps/archive/views/metadata-associateditem-view.html:36
+#: scripts/apps/archive/views/metadata-view.html:176
+#: scripts/apps/archive/views/upload.html:79
+#: scripts/apps/authoring/views/change-image.html:123
 msgid "Copyright notice"
 msgstr ""
 
-#: scripts/apps/analytics/views/activity-report-parameters.html:9
-msgid "Correct"
-msgstr ""
-
-#: scripts/apps/authoring/authoring/index.js:133
+#: scripts/apps/authoring/authoring/index.js:149
 msgid "Correct item"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:7
-msgid "corrected"
+#: scripts/apps/authoring/versioning/history/views/history.html:167
+msgid "Corrected by"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:11
 msgid "Correction"
 msgstr ""
 
-#: scripts/apps/authoring/versioning/history/views/history.html:64
-msgid "Correction issued by"
+#: scripts/apps/contacts/views/edit-form.html:306
+#: scripts/apps/contacts/views/search-panel.html:75
+msgid "Country"
 msgstr ""
 
-#: scripts/apps/monitoring/views/item-actions-menu.html:28
-msgid "Corrections"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:29
-msgid "create"
-msgstr ""
-
-#: scripts/apps/archive/views/list.html:9
+#: scripts/apps/archive/views/list.html:8
 #: scripts/apps/highlights/views/create_highlights_button_directive.html:2
-#: scripts/apps/monitoring/views/monitoring-view.html:59
-#: scripts/apps/templates/services/TemplatesService.js:56
+#: scripts/apps/templates/services/TemplatesService.js:64
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:7
 msgid "Create"
 msgstr ""
 
-#: scripts/apps/archive/index.js:158
+#: scripts/apps/archive/index.js:202
 msgid "Create Broadcast"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:45
+msgid "Create New Task"
+msgstr ""
+
+#: scripts/apps/monitoring/index.js:71
+#: scripts/apps/search/views/multi-action-bar.html:10
+#: scripts/apps/search/views/multi-action-bar.html:67
+#: scripts/apps/workspace/content/views/sd-content-create.html:51
+msgid "Create Package"
+msgstr ""
+
+#: scripts/apps/monitoring/index.js:69
+msgid "Create a broadcast"
 msgstr ""
 
 #: scripts/apps/highlights/views/settings.html:8
 msgid "Create configuration"
+msgstr ""
+
+#: scripts/apps/contacts/views/list.html:15
+msgid "Create contact"
 msgstr ""
 
 #: scripts/apps/highlights/views/create_highlights_button_directive.html:2
@@ -1358,20 +1377,18 @@ msgstr ""
 msgid "Create highlight configuration"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/sd-content-create.html:2
-msgid "Create new item"
-msgstr ""
-
-#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:44
-msgid "Create New Task"
+#: scripts/apps/desks/views/desk-config-modal.html:195
+msgid "Create new Stage"
 msgstr ""
 
 #: scripts/apps/workspace/views/edit-workspace-modal.html:3
 msgid "Create new Workspace"
 msgstr ""
 
-#: scripts/apps/workspace/views/workspace-dropdown.html:33
-msgid "CREATE NEW WORKSPACE"
+#: scripts/apps/monitoring/views/monitoring-view.html:68
+#: scripts/apps/workspace/content/index.js:42
+#: scripts/apps/workspace/content/views/sd-content-create.html:2
+msgid "Create new item"
 msgstr ""
 
 #: scripts/apps/packaging/index.js:46
@@ -1379,8 +1396,8 @@ msgstr ""
 msgid "Create package"
 msgstr ""
 
-#: scripts/apps/search/views/multi-action-bar.html:11
-msgid "Create Package"
+#: scripts/apps/users/views/list.html:3
+msgid "Create user"
 msgstr ""
 
 #: scripts/apps/archive/views/metadata-view.html:88
@@ -1388,65 +1405,56 @@ msgstr ""
 #: scripts/apps/authoring/suggest/SuggestView.html:21
 #: scripts/apps/authoring/suggest/SuggestView.html:69
 #: scripts/apps/authoring/views/authoring.html:7
-#: scripts/apps/legal-archive/services/LegalArchiveService.js:9
-#: scripts/apps/search/services/SearchService.js:28
-#: scripts/apps/users/views/list.html:32
+#: scripts/apps/contacts/services/ContactsService.js:22
+#: scripts/apps/content-api/services/ContentAPISearchService.js:23
+#: scripts/apps/legal-archive/services/LegalArchiveService.js:22
+#: scripts/apps/legal-archive/tests/legal.spec.js:72
+#: scripts/apps/search/services/SearchService.js:43
+#: scripts/apps/users/views/list.html:37
 msgid "Created"
-msgstr ""
-
-#: scripts/apps/authoring/versioning/history/views/history.html:11
-msgid "Created by"
-msgstr ""
-
-#: scripts/apps/search/views/search-filters.html:143
-#: scripts/apps/search/views/search-filters.html:165
-msgid "Created from"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:34
 msgid "Created Ingest Channel {{name}}"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:31
-msgid "created new version {{ version }} for item {{ type }} about \"{{ subject }}\""
+#: scripts/apps/authoring/versioning/history/views/history.html:6
+msgid "Created by"
+msgstr ""
+
+#: scripts/apps/search/views/search-filters.html:144
+#: scripts/apps/search/views/search-filters.html:166
+msgid "Created from"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:116
+msgid "Created from highlight"
 msgstr ""
 
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:2
 msgid "Created on"
 msgstr ""
 
-#: scripts/apps/search/views/search-filters.html:147
-#: scripts/apps/search/views/search-filters.html:169
+#: scripts/apps/search/views/search-filters.html:148
+#: scripts/apps/search/views/search-filters.html:170
 msgid "Created until"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:37
-msgid "created user {{user}}"
 msgstr ""
 
 #: scripts/apps/archive/views/media-view.html:45
 msgid "Created:"
 msgstr ""
 
-#: scripts/apps/monitoring/index.js:55
-msgid "Creates a broadcast"
-msgstr ""
-
-#: scripts/apps/monitoring/index.js:56
-msgid "Creates a new take"
-msgstr ""
-
-#: scripts/apps/workspace/content/index.js:42
-msgid "Creates new item"
-msgstr ""
-
-#: scripts/apps/search/views/search-parameters.html:116
+#: scripts/apps/search/views/search-parameters.html:115
 msgid "Creator"
 msgstr ""
 
-#: scripts/apps/archive/views/upload.html:54
+#: scripts/apps/ingest/views/settings/ftp-config.html:9
+msgid "Credentials error."
+msgstr ""
+
+#: scripts/apps/archive/views/upload.html:60
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:68
-#: scripts/apps/authoring/views/change-image.html:87
+#: scripts/apps/authoring/views/change-image.html:106
 msgid "Credit"
 msgstr ""
 
@@ -1454,8 +1462,8 @@ msgstr ""
 msgid "Credits"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:154
-#: scripts/apps/publish/views/subscribers.html:128
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:168
+#: scripts/apps/publish/views/subscribers.html:137
 msgid "Critical Errors"
 msgstr ""
 
@@ -1467,11 +1475,7 @@ msgstr ""
 msgid "Cumulative time per call"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:183
-msgid "current"
-msgstr ""
-
-#: scripts/apps/authoring/views/dashboard-articles.html:3
+#: scripts/apps/authoring/views/dashboard-articles.html:5
 msgid "Currently working on"
 msgstr ""
 
@@ -1479,12 +1483,32 @@ msgstr ""
 msgid "Currently working on:"
 msgstr ""
 
-#: scripts/apps/workspace/views/workspace-dropdown.html:21
-msgid "CUSTOM WORKSPACES"
+#: scripts/apps/vocabularies/views/settings.html:15
+msgid "Custom date fields"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/settings.html:21
+msgid "Custom embed fields"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/settings.html:18
+msgid "Custom media fields"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/settings.html:12
+msgid "Custom text fields"
 msgstr ""
 
 #: scripts/apps/dashboard/index.js:42
 msgid "Customize your widgets and views"
+msgstr ""
+
+#: scripts/apps/workspace/views/workspace-dropdown.html:10
+msgid "DESKS"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:32
+msgid "DONE"
 msgstr ""
 
 #: scripts/apps/dashboard/controllers/DashboardController.js:11
@@ -1493,7 +1517,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: scripts/apps/dashboard/views/workspace.html:52
+#: scripts/apps/dashboard/views/workspace.html:54
 msgid "Dashboard is empty."
 msgstr ""
 
@@ -1502,9 +1526,9 @@ msgid "Date"
 msgstr ""
 
 #: scripts/apps/archive/views/metadata-view.html:69
-#: scripts/apps/authoring/views/article-edit.html:132
-#: scripts/apps/users/views/user-preferences.html:28
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:20
+#: scripts/apps/authoring/views/article-edit.html:201
+#: scripts/apps/users/views/user-preferences.html:41
+#: scripts/apps/workspace/content/constants.js:71
 msgid "Dateline"
 msgstr ""
 
@@ -1512,49 +1536,29 @@ msgstr ""
 msgid "Dates"
 msgstr ""
 
-#: scripts/apps/desks/views/content-expiry.html:3
-msgid "day"
-msgstr ""
-
-#: scripts/apps/desks/views/content-expiry.html:20
-msgid "days"
-msgstr ""
-
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:44
 #: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:2
 msgid "Days"
 msgstr ""
 
-#: scripts/apps/users/views/settings-privileges.html:14
-#: scripts/apps/users/views/settings-roles.html:14
-#: scripts/apps/users/views/user-preferences.html:68
-msgid "default"
-msgstr ""
-
-#: scripts/apps/users/views/settings-roles.html:43
-#: scripts/apps/workspace/content/views/schema-editor.html:34
+#: scripts/apps/workspace/content/views/schema-editor.html:44
 msgid "Default"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:81
+#: scripts/apps/desks/views/desk-config-modal.html:110
 msgid "Default Content Profile"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:130
+#: scripts/apps/desks/views/desk-config-modal.html:99
+msgid "Default Content Template"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:159
 msgid "Default Desk"
 msgstr ""
 
-#: scripts/apps/highlights/views/highlights_config_modal.html:21
-msgid "default template"
-msgstr ""
-
-#: scripts/apps/workspace/content/views/schema-editor.html:52
-msgid "Default value"
-msgstr ""
-
-#: scripts/apps/analytics/views/saved-activity-reports.html:15
-#: scripts/apps/analytics/views/saved-activity-reports.html:28
-msgid "Delete activity report"
+#: scripts/apps/authoring/views/theme-select.html:15
+msgid "Default Theme"
 msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:64
@@ -1566,7 +1570,7 @@ msgstr ""
 msgid "Delete search"
 msgstr ""
 
-#: scripts/apps/dashboard/views/workspace.html:33
+#: scripts/apps/dashboard/views/workspace.html:35
 msgid "Delete workspace"
 msgstr ""
 
@@ -1578,70 +1582,41 @@ msgstr ""
 msgid "Delivery type"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:66
+#: scripts/apps/authoring/views/authoring-topbar.html:72
 msgid "Deschedule"
 msgstr ""
 
-#: scripts/apps/analytics/views/save-activity-report-dialog.html:7
+#: scripts/apps/authoring/versioning/history/views/history.html:17
+msgid "Descheduled by"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:11
+#: scripts/apps/archive/views/metadata-view.html:212
 #: scripts/apps/archive/views/upload.html:46
+#: scripts/apps/archive/views/upload.html:52
+#: scripts/apps/authoring/attachments/attachments.html:75
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:146
-#: scripts/apps/authoring/views/article-edit.html:248
-#: scripts/apps/authoring/views/article-edit.html:263
-#: scripts/apps/authoring/views/change-image.html:79
+#: scripts/apps/authoring/views/article-edit.html:571
+#: scripts/apps/authoring/views/change-image.html:86
+#: scripts/apps/authoring/views/change-image.html:91
+#: scripts/apps/authoring/views/change-image.html:97
 #: scripts/apps/search/views/save-search-dialog.html:7
-#: scripts/apps/search/views/search-parameters.html:165
-#: scripts/core/editor2/views/block-embed.html:17
+#: scripts/apps/search/views/search-parameters.html:178
+#: scripts/apps/workspace/content/views/profile-settings.html:69
+#: scripts/apps/workspace/content/views/profile-settings.html:99
+#: scripts/core/editor2/views/block-embed.html:30
 msgid "Description"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/profile-settings.html:63
-#: scripts/apps/workspace/content/views/profile-settings.html:88
-msgid "Description:"
-msgstr ""
-
-#: scripts/apps/analytics/views/activity-report-parameters.html:14
-#: scripts/apps/analytics/views/activity-report-view.html:11
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:158
 #: scripts/apps/desks/views/actionpicker.html:4
-#: scripts/apps/templates/views/create-template.html:31
-#: scripts/apps/templates/views/template-editor-modal.html:63
+#: scripts/apps/templates/views/create-template.html:29
+#: scripts/apps/templates/views/template-editor-modal.html:70
 msgid "Desk"
-msgstr ""
-
-#: scripts/apps/desks/controllers/DeskConfigController.js:40
-msgid "Desk deleted."
-msgstr ""
-
-#: scripts/apps/desks/views/desk-config-modal.html:24
-msgid "Desk description"
-msgstr ""
-
-#: scripts/apps/desks/services/DesksFactory.js:368
-msgid "Desk has been modified elsewhere. Please reload the desks."
-msgstr ""
-
-#: scripts/apps/desks/views/desk-config-modal.html:51
-msgid "Desk language"
-msgstr ""
-
-#: scripts/apps/desks/views/settings.html:5
-msgid "Desk management"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:11
 msgid "Desk Management"
-msgstr ""
-
-#: scripts/apps/desks/views/desk-config-modal.html:18
-msgid "Desk name"
-msgstr ""
-
-#: scripts/apps/archive/index.js:222
-msgid "Desk not specified. Please select Desk or configure a default desk."
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:21
-msgid "desk Output"
 msgstr ""
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:121
@@ -1654,49 +1629,65 @@ msgstr ""
 msgid "Desk Scheduled Output"
 msgstr ""
 
-#: scripts/apps/templates/views/create-template.html:22
-msgid "Desk template"
-msgstr ""
-
 #: scripts/apps/templates/views/sd-template-select.html:17
 msgid "Desk Templates"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:41
+#: scripts/apps/desks/views/desk-config-modal.html:58
 #: scripts/apps/desks/views/settings.html:49
 msgid "Desk Type"
 msgstr ""
 
-#: scripts/apps/desks/directives/DeskeditBasic.js:72
+#: scripts/apps/desks/controllers/DeskConfigController.js:40
+msgid "Desk deleted."
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:25
+msgid "Desk description"
+msgstr ""
+
+#: scripts/apps/desks/services/DesksFactory.js:368
+msgid "Desk has been modified elsewhere. Please reload the desks."
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:73
+msgid "Desk language"
+msgstr ""
+
+#: scripts/apps/desks/views/settings.html:3
+msgid "Desk management"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:16
+msgid "Desk name"
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskeditBasic.js:74
 msgid "Desk with name  already exists."
 msgstr ""
 
-#: scripts/apps/authoring/versioning/versions/views/versions.html:10
-msgid "desk:"
-msgstr ""
-
-#: scripts/apps/templates/views/templates.html:46
+#: scripts/apps/templates/views/templates.html:47
 msgid "Desk(s)"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:177
-#: scripts/apps/desks/index.js:67
+#: scripts/apps/authoring/views/authoring-topbar.html:226
+#: scripts/apps/desks/index.js:66
 #: scripts/apps/monitoring/views/aggregate-settings.html:8
 #: scripts/apps/search/views/search-filters.html:18
-#: scripts/apps/templates/views/template-editor-modal.html:64
+#: scripts/apps/templates/views/template-editor-modal.html:81
 msgid "Desks"
 msgstr ""
 
-#: scripts/apps/workspace/views/workspace-dropdown.html:10
-msgid "DESKS"
-msgstr ""
-
-#: scripts/apps/authoring/views/send-item.html:23
-#: scripts/apps/publish/views/publish-queue.html:94
+#: scripts/apps/authoring/views/send-item.html:31
+#: scripts/apps/publish/views/publish-queue.html:98
 msgid "Destination"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:115
+#: scripts/apps/internal-destinations/views/settings.html:45
+msgid "Destination name"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:120
 msgid "Destinations"
 msgstr ""
 
@@ -1712,6 +1703,10 @@ msgstr ""
 msgid "Dictionaries List Management"
 msgstr ""
 
+#: scripts/apps/dictionaries/views/settings.html:20
+msgid "Dictionary"
+msgstr ""
+
 #: scripts/apps/dictionaries/controllers/DictionaryConfigController.js:84
 msgid "Dictionary deleted."
 msgstr ""
@@ -1720,7 +1715,7 @@ msgstr ""
 msgid "Dictionary file"
 msgstr ""
 
-#: scripts/apps/dictionaries/views/settings.html:6
+#: scripts/apps/dictionaries/views/settings.html:3
 msgid "Dictionary management"
 msgstr ""
 
@@ -1733,11 +1728,12 @@ msgid "Dictionary saved successfully"
 msgstr ""
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:44
-msgid "Dictionary with name \"{{ dictionary.name }}\" already exists."
+msgid "Dictionary with name \"{{ dictionary.name}}\" already exists."
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:209
-#: scripts/apps/archive/views/upload.html:77
+#: scripts/apps/archive/views/metadata-associateditem-view.html:45
+#: scripts/apps/archive/views/metadata-view.html:208
+#: scripts/apps/archive/views/upload.html:83
 msgid "Dimensions"
 msgstr ""
 
@@ -1745,17 +1741,8 @@ msgstr ""
 msgid "Disable user"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:12
-#: scripts/apps/users/views/user-list-item.html:14
-msgid "disabled"
-msgstr ""
-
-#: scripts/apps/users/controllers/UserListController.js:146
+#: scripts/apps/users/controllers/UserListController.js:147
 msgid "Disabled"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:31
-msgid "disabled user {{user}}"
 msgstr ""
 
 #: scripts/core/notification/notification.js:102
@@ -1766,8 +1753,8 @@ msgstr ""
 msgid "Displaying news ingest statistics. You can switch color themes or graph sources."
 msgstr ""
 
-#: scripts/core/keyboard/keyboard.js:406
-#: scripts/core/keyboard/keyboard.js:414
+#: scripts/core/keyboard/keyboard.js:410
+#: scripts/core/keyboard/keyboard.js:419
 msgid "Displays active keyboard shortcuts"
 msgstr ""
 
@@ -1779,60 +1766,59 @@ msgstr ""
 msgid "Do you want to add an image to this update?"
 msgstr ""
 
-#: scripts/apps/archive/index.js:105
+#: scripts/apps/archive/index.js:120
 msgid "Do you want to delete the item permanently?"
 msgstr ""
 
-#: scripts/apps/search/controllers/MultiActionBarController.js:83
+#: scripts/apps/search/controllers/MultiActionBarController.js:85
 msgid "Do you want to delete these items permanently?"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:71
+msgid "Do you want to publish the article?"
 msgstr ""
 
 #: scripts/apps/dictionaries/controllers/DictionaryEditController.js:145
 msgid "Do you want to remove Abbreviation?"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:165
-msgid "Do you want to reset the password for user {{ user.full_name }} ?"
+#: scripts/apps/users/views/edit-form.html:235
+msgid "Do you want to reset the password for user {{ user.full_name}} ?"
 msgstr ""
 
 #: scripts/core/auth/reset-password.html:71
 msgid "Don't have token? Get it."
 msgstr ""
 
-#: scripts/apps/authoring/macros/views/macros-replace.html:9
-msgid "done"
-msgstr ""
-
-#: scripts/apps/authoring/editor/views/find-replace.html:35
-#: scripts/apps/dashboard/views/workspace.html:100
+#: scripts/apps/authoring/editor/views/find-replace.html:36
+#: scripts/apps/dashboard/views/workspace.html:77
 #: scripts/apps/dashboard/workspace-tasks/tasks.js:8
-#: scripts/apps/desks/views/desk-config-modal.html:101
-#: scripts/apps/desks/views/desk-config-modal.html:272
-#: scripts/apps/desks/views/desk-config-modal.html:300
-#: scripts/apps/desks/views/desk-config-modal.html:320
-#: scripts/apps/groups/views/groups-config-modal.html:57
-#: scripts/apps/monitoring/views/aggregate-settings.html:138
+#: scripts/apps/desks/views/desk-config-modal.html:129
+#: scripts/apps/desks/views/desk-config-modal.html:323
+#: scripts/apps/desks/views/desk-config-modal.html:351
+#: scripts/apps/desks/views/desk-config-modal.html:370
+#: scripts/apps/monitoring/views/aggregate-settings.html:139
 #: scripts/apps/users/views/change-avatar.html:73
 msgid "Done"
 msgstr ""
 
-#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:31
-msgid "DONE"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:6
-msgid "draft"
+#: scripts/apps/authoring/attachments/attachments.html:25
+msgid "Download"
 msgstr ""
 
 #: scripts/apps/archive/views/upload.html:9
 msgid "Drag Your Files Here"
 msgstr ""
 
+#: scripts/apps/authoring/attachments/attachments.html:48
+msgid "Drag one or more files here to upload them, or just click the button below."
+msgstr ""
+
 #: scripts/apps/users/views/change-avatar.html:27
 msgid "Drop it here"
 msgstr ""
 
-#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:74
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:75
 msgid "Due"
 msgstr ""
 
@@ -1845,7 +1831,9 @@ msgstr ""
 msgid "Due time"
 msgstr ""
 
-#: scripts/apps/archive/index.js:140
+#: scripts/apps/archive/index.js:174
+#: scripts/apps/archive/index.js:198
+#: scripts/apps/authoring/authoring/constants.js:10
 msgid "Duplicate"
 msgstr ""
 
@@ -1853,36 +1841,59 @@ msgstr ""
 msgid "Duplicate Content within a Desk"
 msgstr ""
 
-#: scripts/apps/authoring/versioning/history/views/history.html:15
-msgid "Duplicated from"
+#: scripts/apps/archive/index.js:178
+#: scripts/apps/authoring/views/send-item.html:19
+msgid "Duplicate To"
+msgstr ""
+
+#: scripts/apps/monitoring/index.js:68
+msgid "Duplicate an item"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:41
+msgid "Duplicate created by"
+msgstr ""
+
+#: scripts/apps/archive/index.js:157
+msgid "Duplicate in place"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:30
+msgid "Duplicated by"
 msgstr ""
 
 #: scripts/apps/search/views/item-preview.html:14
 msgid "Duplicates"
 msgstr ""
 
-#: scripts/apps/monitoring/index.js:54
-msgid "Duplicates an item"
+#: scripts/apps/publish/views/subscribers.html:59
+msgid "E-Mail to broadcast Kill Events"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:51
-msgid "E-Mail to broadcast Kill Events"
+#: scripts/apps/authoring/views/authoring-header.html:337
+msgid "ED. NOTE"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:331
+msgid "EDIT CROPS"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:19
+msgid "Ed Note"
 msgstr ""
 
 #: scripts/apps/authoring/views/full-preview.html:95
 msgid "Ed. Note"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-header.html:273
-msgid "ED. NOTE"
-msgstr ""
-
-#: scripts/apps/authoring/authoring/index.js:93
-#: scripts/apps/authoring/views/authoring-topbar.html:61
+#: scripts/apps/authoring/attachments/attachments.html:29
+#: scripts/apps/authoring/authoring/index.js:96
+#: scripts/apps/authoring/views/authoring-topbar.html:67
 #: scripts/apps/desks/views/settings.html:24
-#: scripts/apps/desks/views/stage-item-list.html:24
-#: scripts/apps/templates/views/templates.html:34
-#: scripts/apps/workspace/content/views/profile-settings.html:25
+#: scripts/apps/internal-destinations/views/settings.html:20
+#: scripts/apps/templates/views/templates.html:35
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:6
+#: scripts/apps/workspace/content/views/profile-settings.html:28
 msgid "Edit"
 msgstr ""
 
@@ -1894,74 +1905,37 @@ msgstr ""
 msgid "Edit \"{{desk.edit.name}}\" Desk"
 msgstr ""
 
-#: scripts/apps/groups/views/groups-config-modal.html:6
-msgid "Edit \"{{group.edit.name}}\" Group"
-msgstr ""
-
 #: scripts/apps/products/views/products-config-modal.html:5
 msgid "Edit \"{{product.edit.name}}\" Product"
 msgstr ""
 
-#: scripts/apps/dictionaries/views/dictionary-config-modal.html:6
-msgid "Edit {{(isAbbreviations() ? 'Abbreviations' : '') | translate}} Dictionary"
+#: scripts/apps/authoring/attachments/attachments.html:62
+msgid "Edit Attachment"
 msgstr ""
 
-#: scripts/apps/analytics/views/saved-activity-reports.html:14
-#: scripts/apps/analytics/views/saved-activity-reports.html:27
-msgid "Edit activity report"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-topbar.html:76
-msgid "Edit and Correct"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-topbar.html:81
-msgid "Edit and Kill"
-msgstr ""
-
-#: scripts/apps/highlights/views/settings.html:20
-msgid "Edit configuration"
-msgstr ""
-
-#: scripts/apps/content-filters/views/manage-filters.html:21
-#: scripts/apps/content-filters/views/manage-filters.html:32
+#: scripts/apps/content-filters/views/manage-filters.html:18
+#: scripts/apps/content-filters/views/manage-filters.html:30
 msgid "Edit Content Filter"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/profile-settings.html:25
+#: scripts/apps/workspace/content/views/profile-settings.html:28
 msgid "Edit Content Profile"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/index.js:165
+#: scripts/apps/authoring/authoring/index.js:198
 msgid "Edit Crop"
 msgstr ""
 
-#: scripts/apps/authoring/views/article-edit.html:230
-msgid "EDIT CROPS"
+#: scripts/apps/internal-destinations/views/settings.html:33
+msgid "Edit Destination"
 msgstr ""
 
-#: scripts/apps/desks/views/desk_users.html:8
-#: scripts/apps/desks/views/desk-tasks.html:8
-#: scripts/apps/desks/views/desk.html:8
-#: scripts/apps/desks/views/settings.html:24
-#: scripts/apps/desks/views/slugline.html:8
-msgid "Edit desk"
-msgstr ""
-
-#: scripts/apps/dictionaries/views/settings.html:32
-msgid "Edit dictionary"
-msgstr ""
-
-#: scripts/apps/content-filters/views/manage-filter-conditions.html:20
-#: scripts/apps/content-filters/views/manage-filter-conditions.html:31
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:18
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:28
 msgid "Edit Filter Condition"
 msgstr ""
 
-#: scripts/apps/groups/views/settings.html:17
-msgid "Edit group"
-msgstr ""
-
-#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:104
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:109
 msgid "Edit Ingest Source"
 msgstr ""
 
@@ -1969,42 +1943,16 @@ msgstr ""
 msgid "Edit Ingest Sources"
 msgstr ""
 
-#: scripts/apps/archive/views/media-view.html:51
-msgid "Edit metadata"
-msgstr ""
-
-#: scripts/apps/products/views/product-test.html:26
-#: scripts/apps/products/views/products.html:14
-msgid "Edit product"
-msgstr ""
-
-#: scripts/apps/users/views/settings-roles.html:17
-msgid "Edit role"
-msgstr ""
-
-#: scripts/apps/users/views/settings-roles.html:26
+#: scripts/apps/users/views/settings-roles.html:30
 msgid "Edit Role"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-rules-content.html:17
-msgid "Edit rule set"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ingest-rules-content.html:28
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:26
 msgid "Edit Rule set"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-routing-content.html:16
-msgid "Edit scheme"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ingest-routing-content.html:30
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:29
 msgid "Edit Scheme"
-msgstr ""
-
-#: scripts/apps/search/views/saved-searches.html:14
-#: scripts/apps/search/views/saved-searches.html:27
-msgid "Edit search"
 msgstr ""
 
 #: scripts/apps/search-providers/views/search-provider-config.html:16
@@ -2012,21 +1960,16 @@ msgstr ""
 msgid "Edit Search Provider"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:19
-msgid "Edit source"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:30
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:33
 msgid "Edit Source"
 msgstr ""
 
-#: scripts/apps/content-filters/views/filter-search-result.html:62
-#: scripts/apps/publish/views/subscribers.html:16
-#: scripts/apps/publish/views/subscribers.html:26
+#: scripts/apps/publish/views/subscribers.html:25
+#: scripts/apps/publish/views/subscribers.html:37
 msgid "Edit Subscriber"
 msgstr ""
 
-#: scripts/apps/templates/views/templates.html:34
+#: scripts/apps/templates/views/templates.html:35
 msgid "Edit Template"
 msgstr ""
 
@@ -2034,54 +1977,113 @@ msgstr ""
 msgid "Edit Unique Name"
 msgstr ""
 
+#: scripts/apps/monitoring/index.js:65
+msgid "Edit an item"
+msgstr ""
+
+#: scripts/apps/monitoring/index.js:67
+msgid "Edit an item in a new Window"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:82
+msgid "Edit and Correct"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:87
+msgid "Edit and Kill"
+msgstr ""
+
+#: scripts/apps/highlights/views/settings.html:16
+msgid "Edit configuration"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-tasks.html:8
+#: scripts/apps/desks/views/desk.html:8
+#: scripts/apps/desks/views/desk_users.html:8
+#: scripts/apps/desks/views/settings.html:24
+#: scripts/apps/desks/views/slugline.html:8
+msgid "Edit desk"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/settings.html:51
+msgid "Edit dictionary"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.js:112
+msgid "Edit in new Window"
+msgstr ""
+
+#: scripts/apps/archive/views/media-view.html:51
+msgid "Edit metadata"
+msgstr ""
+
+#: scripts/apps/products/views/product-test.html:35
+#: scripts/apps/products/views/products.html:24
+msgid "Edit product"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:16
+msgid "Edit role"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:14
+msgid "Edit rule set"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:14
+msgid "Edit scheme"
+msgstr ""
+
+#: scripts/apps/search/views/saved-searches.html:14
+#: scripts/apps/search/views/saved-searches.html:27
+msgid "Edit search"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:21
+msgid "Edit source"
+msgstr ""
+
 #: scripts/apps/desks/views/user-role-items.html:14
 #: scripts/apps/desks/views/user-role-items.html:22
 msgid "Edit user"
 msgstr ""
 
-#: scripts/apps/vocabularies/views/vocabulary-config.html:11
+#: scripts/apps/vocabularies/views/vocabulary-config.html:44
 msgid "Edit vocabulary"
 msgstr ""
 
-#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:6
-msgid "Edit Vocabulary"
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:6
+msgid "Edit {{(isAbbreviations() ? 'Abbreviations' : '') | translate}} Dictionary"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/profile-settings.html:78
+#: scripts/apps/workspace/content/views/profile-settings.html:85
 msgid "Editing"
 msgstr ""
 
-#: scripts/apps/search/views/search-parameters.html:193
+#: scripts/apps/search/views/search-parameters.html:215
 msgid "Editor's Choice"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/schema-editor.html:21
+#: scripts/apps/workspace/content/views/profile-settings.html:107
 msgid "Editor3"
 msgstr ""
 
 #: scripts/apps/archive/views/metadata-view.html:65
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:16
+#: scripts/apps/workspace/content/constants.js:67
 msgid "Editorial Note"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:94
-msgid "email"
-msgstr ""
-
-#: scripts/apps/users/views/list.html:31
+#: scripts/apps/contacts/views/search-panel.html:47
+#: scripts/apps/users/views/list.html:36
 #: scripts/core/auth/reset-password.html:13
 msgid "Email"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/emailConfig.html:37
-msgid "Email Filter"
+#: scripts/core/directives/views/phone-home-modal-directive.html:14
+msgid "Email Address"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/emailConfig.html:27
-msgid "Email mailbox"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/emailConfig.html:21
+#: scripts/apps/ingest/views/settings/emailConfig.html:22
 msgid "Email Password"
 msgstr ""
 
@@ -2090,34 +2092,30 @@ msgstr ""
 msgid "Email Server"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/emailConfig.html:8
 #: scripts/apps/ingest/views/settings/emailConfig.html:9
 msgid "Email Server Port"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/emailConfig.html:15
+#: scripts/apps/ingest/views/settings/emailConfig.html:16
 msgid "Email User"
 msgstr ""
 
-#: scripts/apps/archive/views/item-state.html:2
-msgid "embargo"
+#: scripts/apps/ingest/views/settings/emailConfig.html:29
+msgid "Email mailbox"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:316
-#: scripts/apps/authoring/views/send-item.html:43
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:337
+#: scripts/apps/authoring/views/send-item.html:52
 msgid "Embargo"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:130
+#: scripts/apps/archive/views/metadata-view.html:131
 msgid "Embargo Timestamp"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/sd-content-create.html:22
-msgid "Empty Package"
-msgstr ""
-
-#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:31
-#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:45
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:113
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:125
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:150
 msgid "Enable / Disable"
 msgstr ""
 
@@ -2129,15 +2127,15 @@ msgstr ""
 msgid "Enable user"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-routing-general.html:54
-msgid "End time"
-msgstr ""
-
 #: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:12
 msgid "End Time (exclusive)"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/rssConfig.html:67
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:54
+msgid "End time"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/rssConfig.html:71
 msgid "Enter field alias"
 msgstr ""
 
@@ -2149,71 +2147,110 @@ msgstr ""
 msgid "Enter web url"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:5
-msgid "error"
-msgstr ""
-
 #: scripts/apps/archive/views/upload.html:22
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:148
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:162
 msgid "Error"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:231
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:241
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:252
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:262
 msgid "Error creating highlight."
+msgstr ""
+
+#: scripts/apps/vocabularies/controllers/VocabularyConfigController.js:103
+msgid "Error removing the vocabulary."
 msgstr ""
 
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:21
 msgid "Error sending as"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:186
+#: scripts/apps/dictionaries/controllers/DictionaryEditController.js:25
+msgid "Error. Dictionary not saved."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:562
+msgid "Error. Item not published."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:212
+msgid "Error. Item not updated."
+msgstr ""
+
+#: scripts/apps/search/directives/SavedSearches.js:83
+msgid "Error. Saved search not deleted."
+msgstr ""
+
+#: scripts/apps/search/directives/SaveSearch.js:70
+msgid "Error. Search could not be saved."
+msgstr ""
+
+#: scripts/apps/users/controllers/SessionsDeleteCommand.js:13
+msgid "Error. Sessions could not be cleared."
+msgstr ""
+
+#: scripts/apps/users/controllers/UserDeleteCommand.js:22
+msgid "Error. User Profile cannot be disabled."
+msgstr ""
+
+#: scripts/apps/users/controllers/UserEnableCommand.js:19
+msgid "Error. User Profile cannot be enabled."
+msgstr ""
+
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.js:34
+msgid "Error. Vocabulary not saved."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:207
+#: scripts/apps/authoring/authoring/services/LockService.js:18
 #: scripts/apps/authoring/macros/macros.js:80
-#: scripts/apps/content-filters/controllers/FilterConditionsController.js:75
-#: scripts/apps/content-filters/controllers/FilterConditionsController.js:77
-#: scripts/apps/content-filters/controllers/FilterConditionsController.js:80
-#: scripts/apps/content-filters/controllers/FilterConditionsController.js:96
-#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:123
+#: scripts/apps/contacts/directives/ContactEditDirective.js:109
+#: scripts/apps/content-filters/controllers/FilterConditionsController.js:113
+#: scripts/apps/content-filters/controllers/FilterConditionsController.js:92
+#: scripts/apps/content-filters/controllers/FilterConditionsController.js:94
+#: scripts/apps/content-filters/controllers/FilterConditionsController.js:97
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:125
-#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:47
-#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:50
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:127
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:49
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:52
-#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:55
-#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:73
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:54
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:57
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:75
 #: scripts/apps/content-filters/controllers/ProductionTestController.js:112
 #: scripts/apps/content-filters/controllers/ProductionTestController.js:114
 #: scripts/apps/desks/controllers/DeskConfigController.js:44
 #: scripts/apps/desks/directives/DeskeditPeople.js:54
-#: scripts/apps/desks/directives/DeskeditStages.js:188
+#: scripts/apps/desks/directives/DeskeditStages.js:186
 #: scripts/apps/dictionaries/controllers/DictionaryEditController.js:19
 #: scripts/apps/ingest/directives/IngestRoutingContent.js:100
 #: scripts/apps/ingest/directives/IngestRulesContent.js:49
-#: scripts/apps/products/controllers/ProductsConfigController.js:125
-#: scripts/apps/products/controllers/ProductsConfigController.js:71
-#: scripts/apps/products/controllers/ProductsConfigController.js:74
-#: scripts/apps/products/controllers/ProductsConfigController.js:76
-#: scripts/apps/products/controllers/ProductsConfigController.js:90
+#: scripts/apps/products/controllers/ProductsConfigController.js:148
+#: scripts/apps/products/controllers/ProductsConfigController.js:151
+#: scripts/apps/products/controllers/ProductsConfigController.js:153
+#: scripts/apps/products/controllers/ProductsConfigController.js:155
+#: scripts/apps/products/controllers/ProductsConfigController.js:174
+#: scripts/apps/products/controllers/ProductsConfigController.js:216
 #: scripts/apps/publish/controllers/PublishQueueController.js:163
-#: scripts/apps/publish/directives/SubscribersDirective.js:140
-#: scripts/apps/search-providers/directive.js:43
-#: scripts/apps/templates/directives/TemplatesDirective.js:265
+#: scripts/apps/publish/directives/SubscribersDirective.js:175
+#: scripts/apps/search-providers/directive.js:40
+#: scripts/apps/templates/directives/TemplatesDirective.js:283
 #: scripts/apps/templates/helpers.js:4
 #: scripts/apps/templates/helpers.js:7
 #: scripts/apps/users/controllers/UserDeleteCommand.js:18
 #: scripts/apps/users/controllers/UserDeleteCommand.js:20
 #: scripts/apps/users/controllers/UserEnableCommand.js:15
 #: scripts/apps/users/controllers/UserEnableCommand.js:17
-#: scripts/apps/users/directives/UserEditDirective.js:132
+#: scripts/apps/users/directives/UserEditDirective.js:141
 #: scripts/apps/users/directives/UserRolesDirective.js:60
-#: scripts/apps/vocabularies/controllers/VocabularyEditController.js:34
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.js:30
 msgid "Error:"
 msgstr ""
 
-#: scripts/apps/search-providers/directive.js:46
+#: scripts/apps/search-providers/directive.js:43
 msgid "Error: A Search Provider with type  already exists."
 msgstr ""
 
-#: scripts/apps/products/controllers/ProductsConfigController.js:92
+#: scripts/apps/products/controllers/ProductsConfigController.js:176
 msgid "Error: Failed to delete product."
 msgstr ""
 
@@ -2225,47 +2262,47 @@ msgstr ""
 msgid "Error: Failed to re-schedule"
 msgstr ""
 
-#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:127
-msgid "Error: Failed to save content filter."
-msgstr ""
-
-#: scripts/apps/content-filters/controllers/FilterConditionsController.js:82
-msgid "Error: Failed to save filter condition."
-msgstr ""
-
-#: scripts/apps/search-providers/directive.js:50
+#: scripts/apps/search-providers/directive.js:47
 msgid "Error: Failed to save Search Provider."
 msgstr ""
 
-#: scripts/apps/publish/directives/SubscribersDirective.js:149
+#: scripts/apps/publish/directives/SubscribersDirective.js:184
 msgid "Error: Failed to save Subscriber."
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:129
+msgid "Error: Failed to save content filter."
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterConditionsController.js:99
+msgid "Error: Failed to save filter condition."
 msgstr ""
 
 #: scripts/apps/templates/helpers.js:11
 msgid "Error: Failed to save template."
 msgstr ""
 
-#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:59
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:61
 msgid "Error: Failed to test content filter."
 msgstr ""
 
-#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:57
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:59
 msgid "Error: Internal error in Filter testing"
 msgstr ""
 
-#: scripts/apps/publish/directives/SubscribersDirective.js:224
+#: scripts/apps/publish/directives/SubscribersDirective.js:269
 msgid "Error: Please re-assign new format for each destination as the changed subscriber type has formats which are not supported by existing destination(s)."
 msgstr ""
 
-#: scripts/core/itemList/itemList.js:83
+#: scripts/core/itemList/itemList.js:103
 msgid "Error: Slugline required."
 msgstr ""
 
-#: scripts/apps/publish/directives/SubscribersDirective.js:146
+#: scripts/apps/publish/directives/SubscribersDirective.js:181
 msgid "Error: Subscriber must have at least one destination."
 msgstr ""
 
-#: scripts/apps/publish/directives/SubscribersDirective.js:143
+#: scripts/apps/publish/directives/SubscribersDirective.js:178
 msgid "Error: Subscriber with Name  already exists."
 msgstr ""
 
@@ -2273,68 +2310,24 @@ msgstr ""
 msgid "Error: The dictionary already exists."
 msgstr ""
 
-#: scripts/apps/ingest/directives/IngestSourcesContent.js:109
+#: scripts/apps/ingest/directives/IngestSourcesContent.js:112
 msgid "Error: Unable to delete Ingest Source"
 msgstr ""
 
-#: scripts/apps/search-providers/directive.js:82
+#: scripts/apps/search-providers/directive.js:79
 msgid "Error: Unable to delete Search Provider."
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:80
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:85
 msgid "Error: Unique Name is not unique."
-msgstr ""
-
-#: scripts/apps/analytics/directives/SavedActivityReports.js:112
-msgid "Error. Activity report not deleted."
-msgstr ""
-
-#: scripts/apps/dictionaries/controllers/DictionaryEditController.js:25
-msgid "Error. Dictionary not saved."
-msgstr ""
-
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:602
-msgid "Error. Item not published."
-msgstr ""
-
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:191
-msgid "Error. Item not updated."
-msgstr ""
-
-#: scripts/apps/search/directives/SavedSearches.js:83
-msgid "Error. Saved search not deleted."
-msgstr ""
-
-#: scripts/apps/search/directives/SaveSearch.js:69
-msgid "Error. Search could not be saved."
-msgstr ""
-
-#: scripts/apps/users/controllers/SessionsDeleteCommand.js:13
-msgid "Error. Sessions could not be cleared."
-msgstr ""
-
-#: scripts/apps/analytics/directives/ActivityReportPanel.js:122
-msgid "Error. The activity could not be generated."
-msgstr ""
-
-#: scripts/apps/analytics/directives/SaveActivityReport.js:37
-msgid "Error. The activity report could not be saved."
-msgstr ""
-
-#: scripts/apps/users/controllers/UserDeleteCommand.js:22
-msgid "Error. User Profile cannot be disabled."
-msgstr ""
-
-#: scripts/apps/users/controllers/UserEnableCommand.js:19
-msgid "Error. User Profile cannot be enabled."
-msgstr ""
-
-#: scripts/apps/vocabularies/controllers/VocabularyEditController.js:37
-msgid "Error. Vocabulary not saved."
 msgstr ""
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:7
 msgid "Exact"
+msgstr ""
+
+#: scripts/apps/search/views/search-parameters.html:130
+msgid "Exclude spiked content"
 msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:69
@@ -2342,34 +2335,56 @@ msgstr ""
 msgid "Exit"
 msgstr ""
 
-#: scripts/apps/archive/views/item-preview.html:19
-#: scripts/apps/archive/views/preview.html:89
-msgid "expires"
-msgstr ""
-
-#: scripts/apps/publish/views/subscribers.html:159
-msgid "expires:"
-msgstr ""
-
-#: scripts/apps/archive/views/metadata-view.html:96
+#: scripts/apps/archive/views/metadata-view.html:97
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:92
 msgid "Expiry"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:112
+#: scripts/apps/archive/index.js:297
+#: scripts/apps/archive/views/export.html:32
+#: scripts/apps/archive/views/export.html:4
+#: scripts/apps/authoring/views/authoring-topbar.html:122
+#: scripts/apps/search/views/multi-action-bar.html:26
+#: scripts/apps/search/views/multi-action-bar.html:83
 msgid "Export"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:161
+#: scripts/apps/authoring/views/authoring-topbar.html:203
+msgid ""
+"Export\n"
+"                        <i class=\"icon-download-right-thin dropdown__submenu-icon\"></i>\n"
+"                        <div sd-export=\"\" ng-if=\"export\"></div>"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:105
+msgid "Exported by"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:162
 msgid "Exposure time"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:6
-msgid "failed"
+#: scripts/apps/publish/views/ftp-config.html:30
+msgid "FTP File Extension"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ftp-config.html:17
+#: scripts/apps/publish/views/ftp-config.html:20
+msgid "FTP Server Path"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ftp-config.html:33
+#: scripts/apps/ingest/views/settings/ftp-config.html:37
+msgid "FTP Server Path, keep empty to use default path"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ftp-config.html:3
+#: scripts/apps/publish/views/ftp-config.html:4
+msgid "FTP Server URL"
 msgstr ""
 
 #: scripts/apps/archive/directives/ArchivedItemKill.js:28
-#: scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.js:27
+#: scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.js:48
 msgid "Failed to apply kill template to the item."
 msgstr ""
 
@@ -2377,52 +2392,56 @@ msgstr ""
 msgid "Failed to associate update:"
 msgstr ""
 
-#: scripts/apps/archive/related-item-widget/relatedItem.js:147
-msgid "Failed to associate as take:"
-msgstr ""
-
-#: scripts/apps/archive/index.js:234
-msgid "Failed to generate new take."
-msgstr ""
-
-#: scripts/apps/authoring/authoring/services/AuthoringService.js:103
+#: scripts/apps/authoring/authoring/services/AuthoringService.js:104
 msgid "Failed to generate update:"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/services/LockService.js:15
+#: scripts/apps/authoring/authoring/services/LockService.js:19
 msgid "Failed to get a lock on the item!"
 msgstr ""
 
-#: scripts/apps/ingest/controllers/ExternalSourceController.js:30
+#: scripts/apps/ingest/controllers/ExternalSourceController.js:28
+#: scripts/apps/ingest/services/SendService.js:134
+#: scripts/apps/ingest/services/SendService.js:58
 msgid "Failed to get item."
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:631
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:598
 msgid "Failed to publish and continue."
 msgstr ""
 
-#: scripts/apps/authoring/authoring/services/AuthoringService.js:122
+#: scripts/apps/authoring/authoring/services/AuthoringService.js:123
 msgid "Failed to remove link:"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/SendItem.js:478
-msgid "Failed to send and continue."
+#: scripts/apps/contacts/directives/ContactsSearchResultsDirective.js:66
+#: scripts/apps/content-api/directives/ContentAPISearchResultsDirective.js:67
+#: scripts/apps/search/directives/SearchResults.js:243
+msgid "Failed to run the query!"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/SendItem.js:445
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.js:234
+msgid "Failed to save the area of interest:"
+msgstr ""
+
+#: scripts/apps/authoring/tests/changeImage.spec.js:91
+msgid "Failed to save the area of interest: Failed to call picture_crop."
+msgstr ""
+
+#: scripts/apps/authoring/tests/changeImage.spec.js:125
+msgid "Failed to save the area of interest: Failed to call picture_renditions."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/SendItem.js:455
 msgid "Failed to send and publish."
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:9
-msgid "feature"
-msgstr ""
-
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:27
+#: scripts/apps/workspace/content/constants.js:78
 msgid "Feature Image"
 msgstr ""
 
-#: scripts/apps/search/views/search-parameters.html:135
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:28
+#: scripts/apps/search/views/search-parameters.html:138
+#: scripts/apps/workspace/content/constants.js:79
 msgid "Feature Media"
 msgstr ""
 
@@ -2430,138 +2449,134 @@ msgstr ""
 msgid "Feature Preview"
 msgstr ""
 
-#: scripts/apps/authoring/views/article-edit.html:55
+#: scripts/apps/authoring/views/article-edit.html:83
 msgid "Featured Image"
 msgstr ""
 
-#: scripts/apps/authoring/views/article-edit.html:66
+#: scripts/apps/authoring/views/article-edit.html:99
 #: scripts/apps/authoring/views/confirm-media-associated.html:8
-#: scripts/apps/packaging/views/sd-package-edit.html:37
 msgid "Featured Media"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:61
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:65
 msgid "Feed Parser"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/reutersConfig.html:3
-msgid "feed url"
 msgstr ""
 
 #: scripts/apps/ingest/views/settings/reutersConfig.html:2
 msgid "Feed URL"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:56
+#: scripts/core/menu/views/menu.html:45
+msgid "Feedback"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:60
 msgid "Feeding Service"
 msgstr ""
 
-#: scripts/apps/ingest/index.js:105
+#: scripts/apps/ingest/index.js:106
+#: scripts/apps/ingest/index.js:137
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:2
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:23
-#: scripts/apps/search/views/multi-action-bar.html:43
+#: scripts/apps/search/views/multi-action-bar.html:102
+#: scripts/apps/search/views/multi-action-bar.html:49
 msgid "Fetch"
-msgstr ""
-
-#: scripts/apps/authoring/views/send-item.html:83
-msgid "fetch and open"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:12
 msgid "Fetch Content To a Desk"
 msgstr ""
 
-#: scripts/apps/search/views/multi-action-bar.html:46
-msgid "Fetch to"
-msgstr ""
-
-#: scripts/apps/authoring/views/send-item.html:13
-#: scripts/apps/ingest/index.js:95
+#: scripts/apps/authoring/views/send-item.html:15
+#: scripts/apps/authoring/views/send-item.html:23
+#: scripts/apps/ingest/index.js:122
+#: scripts/apps/ingest/index.js:96
 msgid "Fetch To"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:6
-msgid "fetched"
+#: scripts/apps/search/views/multi-action-bar.html:105
+#: scripts/apps/search/views/multi-action-bar.html:52
+msgid "Fetch to"
 msgstr ""
 
-#: scripts/apps/authoring/versioning/history/views/history.html:54
-msgid "Fetched as"
+#: scripts/apps/authoring/versioning/history/views/history.html:65
+msgid "Fetched by"
 msgstr ""
 
-#: scripts/apps/archive/views/fetched-desks.html:2
-msgid "fetched in"
-msgstr ""
-
-#: scripts/apps/content-filters/views/filter-search.html:6
-#: scripts/apps/content-filters/views/manage-filter-conditions.html:43
+#: scripts/apps/content-filters/views/filter-search.html:9
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:44
 msgid "Field"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/rssConfig.html:50
+#: scripts/apps/ingest/views/settings/rssConfig.html:54
 msgid "Field Alias"
 msgstr ""
 
 #: scripts/apps/publish/views/file-config.html:11
 #: scripts/apps/publish/views/file-config.html:9
+#: scripts/apps/publish/views/ftp-config.html:28
 msgid "File Extension"
+msgstr ""
+
+#: scripts/apps/archive/views/upload-attachments.html:33
+msgid "File Name"
+msgstr ""
+
+#: scripts/apps/archive/views/upload-attachments.html:39
+msgid "File Size"
 msgstr ""
 
 #: scripts/apps/profiling/views/profiling.html:37
 msgid "File name/line"
 msgstr ""
 
-#: scripts/apps/monitoring/views/monitoring-view.html:94
+#: scripts/apps/monitoring/views/monitoring-view.html:101
 msgid "File types"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/emailConfig.html:36
-#: scripts/apps/ingest/views/settings/ingest-routing-content.html:68
+#: scripts/apps/ingest/views/settings/emailConfig.html:39
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:69
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:11
 #: scripts/core/views/sdselect.html:10
 msgid "Filter"
 msgstr ""
 
-#: scripts/apps/content-filters/controllers/FilterConditionsController.js:69
-msgid "Filter condition saved."
+#: scripts/apps/content-filters/views/manage-filters.html:99
+msgid "Filter Condition"
 msgstr ""
 
 #: scripts/apps/content-filters/views/filter-search-result.html:7
-#: scripts/apps/content-filters/views/manage-filter-conditions.html:4
-#: scripts/apps/content-filters/views/manage-filters.html:77
-#: scripts/apps/content-filters/views/settings.html:12
+#: scripts/apps/content-filters/views/settings.html:13
 msgid "Filter Conditions"
 msgstr ""
 
-#: scripts/apps/content-filters/views/manage-filters.html:115
-msgid "Filter Preview"
-msgstr ""
-
-#: scripts/apps/content-filters/views/settings.html:19
+#: scripts/apps/content-filters/views/settings.html:18
 msgid "Filter Search"
 msgstr ""
 
-#: scripts/apps/content-filters/views/manage-filters.html:70
+#: scripts/apps/content-filters/views/manage-filters.html:63
 msgid "Filter Statement"
-msgstr ""
-
-#: scripts/apps/content-filters/views/manage-filters.html:119
-msgid "Filter Test"
 msgstr ""
 
 #: scripts/apps/content-filters/views/production-test.html:4
 msgid "Filter Test Results"
 msgstr ""
 
-#: scripts/apps/templates/views/templates.html:6
+#: scripts/apps/content-filters/controllers/FilterConditionsController.js:86
+msgid "Filter condition saved."
+msgstr ""
+
+#: scripts/apps/products/views/products.html:4
+#: scripts/apps/publish/views/subscribers.html:4
+#: scripts/apps/templates/views/templates.html:7
 msgid "Filter:"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-select.html:8
-msgid "filter: \"{{ filter }}\""
-msgstr ""
-
-#: scripts/apps/archive/views/list.html:17
-#: scripts/apps/content-filters/views/settings.html:6
+#: scripts/apps/archive/views/list.html:15
+#: scripts/apps/contacts/views/list.html:4
+#: scripts/apps/content-api/views/list.html:4
+#: scripts/apps/content-api/views/search-panel.html:8
+#: scripts/apps/content-filters/views/settings.html:8
 #: scripts/apps/search/views/search-panel.html:34
 #: scripts/apps/search/views/search.html:3
 msgid "Filters"
@@ -2571,11 +2586,11 @@ msgstr ""
 msgid "Find"
 msgstr ""
 
-#: scripts/apps/authoring/editor/find-replace.js:94
+#: scripts/apps/authoring/editor/find-replace.js:92
 msgid "Find and Replace"
 msgstr ""
 
-#: scripts/apps/search/index.js:58
+#: scripts/apps/search/index.js:61
 msgid "Find live and archived content"
 msgstr ""
 
@@ -2583,58 +2598,61 @@ msgstr ""
 msgid "Find your colleagues"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:37
-msgid "first name"
+#: scripts/apps/contacts/views/search-panel.html:16
+#: scripts/core/directives/views/phone-home-modal-directive.html:19
+msgid "First Name"
 msgstr ""
 
 #: scripts/apps/search/views/search-filters.html:106
 msgid "Flags"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:164
+#: scripts/apps/archive/views/metadata-view.html:165
 msgid "Flash"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:162
+#: scripts/apps/archive/views/metadata-view.html:163
 msgid "Focal length"
 msgstr ""
 
-#: scripts/apps/authoring/views/article-edit.html:299
-#: scripts/apps/authoring/views/article-edit.html:322
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:24
-msgid "Footer"
+#: scripts/apps/authoring/views/theme-select.html:18
+#: scripts/apps/authoring/views/theme-select.html:69
+msgid "Font"
 msgstr ""
 
-#: scripts/apps/monitoring/views/aggregate-settings.html:3
-msgid "for \"{{settings.desk.name}}\" Desk"
+#: scripts/apps/authoring/views/article-edit.html:414
+#: scripts/apps/authoring/views/article-edit.html:437
+#: scripts/apps/workspace/content/constants.js:75
+msgid "Footer"
 msgstr ""
 
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:19
 msgid "For Publication"
 msgstr ""
 
-#: scripts/core/auth/login-modal.html:48
+#: scripts/core/auth/login-modal.html:60
 msgid "Forgot password?"
 msgstr ""
 
-#: scripts/apps/authoring/views/preview-formatted.html:15
+#: scripts/apps/authoring/views/preview-formatted.html:18
 #: scripts/apps/publish/views/destination.html:10
 msgid "Format"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/schema-editor.html:102
+#: scripts/apps/workspace/content/views/schema-editor.html:79
 msgid "Format options"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/emailConfig.html:32
+#: scripts/apps/ingest/views/settings/emailConfig.html:35
 msgid "Formatted Email Parser"
 msgstr ""
 
-#: scripts/apps/authoring/views/preview-formatted.html:11
+#: scripts/apps/archive/views/export.html:10
+#: scripts/apps/authoring/views/preview-formatted.html:13
 msgid "Formatters"
 msgstr ""
 
-#: scripts/core/datetime/datetime.js:203
+#: scripts/core/datetime/datetime.js:229
 msgid "Friday"
 msgstr ""
 
@@ -2642,29 +2660,11 @@ msgstr ""
 msgid "From Desk"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/sd-content-create.html:36
-msgid "From template"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ftp-config.html:15
-#: scripts/apps/publish/views/ftp-config.html:20
-msgid "FTP Server Path"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ftp-config.html:3
-#: scripts/apps/publish/views/ftp-config.html:4
-msgid "FTP Server URL"
-msgstr ""
-
-#: scripts/apps/workspace/content/views/schema-editor.html:92
+#: scripts/apps/workspace/content/views/schema-editor.html:67
 msgid "Full"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:32
-msgid "full name"
-msgstr ""
-
-#: scripts/apps/users/views/list.html:28
+#: scripts/apps/users/views/list.html:33
 msgid "Full name"
 msgstr ""
 
@@ -2672,133 +2672,103 @@ msgstr ""
 msgid "Function"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:11
-#: scripts/apps/groups/views/groups-config-modal.html:11
-#: scripts/apps/ingest/views/settings/ingest-routing-content.html:65
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:37
-#: scripts/apps/publish/views/subscribers.html:33
-#: scripts/apps/users/views/edit-form.html:29
-#: scripts/core/keyboard/keyboard.js:406
-#: scripts/core/keyboard/keyboard.js:413
+#: scripts/apps/authoring/views/authoring-header.html:104
+msgid "GENRE"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:196
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:96
+#: scripts/apps/legal-archive/views/legal_archive.html:48
+msgid "GUID"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:10
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:66
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:40
+#: scripts/apps/publish/views/subscribers.html:43
+#: scripts/core/keyboard/keyboard.js:409
+#: scripts/core/keyboard/keyboard.js:418
 msgid "General"
 msgstr ""
 
-#: scripts/apps/analytics/views/activity-report-panel.html:28
-msgid "Generate"
+#: scripts/apps/users/views/edit-form.html:29
+msgid "General info"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:182
+#: scripts/apps/authoring/views/article-edit.html:558
+msgid "Generate From URL"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:226
 msgid "Generate token"
 msgstr ""
 
 #: scripts/apps/archive/views/metadata-view.html:57
 #: scripts/apps/authoring/views/full-preview.html:54
-#: scripts/apps/search/services/SearchService.js:33
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:9
+#: scripts/apps/search/services/SearchService.js:48
+#: scripts/apps/workspace/content/constants.js:59
 msgid "Genre"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-header.html:80
-msgid "GENRE"
 msgstr ""
 
 #: scripts/apps/search/views/search-filters.html:67
 msgid "Genres"
 msgstr ""
 
-#: scripts/apps/ingest/index.js:121
-msgid "Get from external source"
-msgstr ""
-
 #: scripts/core/auth/reset-password.html:17
 msgid "Get token"
 msgstr ""
 
-#: scripts/apps/content-filters/views/manage-filters.html:45
+#: scripts/apps/content-filters/views/manage-filters.html:48
 msgid "Global Block"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:131
-#: scripts/apps/desks/views/desk-config-modal.html:211
+#: scripts/apps/desks/views/desk-config-modal.html:152
+#: scripts/apps/desks/views/desk-config-modal.html:251
 msgid "Global Read"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:180
+#: scripts/apps/desks/views/desk-config-modal.html:213
 msgid "Global Read:"
-msgstr ""
-
-#: scripts/apps/analytics/views/saved-activity-reports.html:19
-msgid "Global Saved Activity Reports"
 msgstr ""
 
 #: scripts/apps/search/views/saved-searches.html:19
 msgid "Global Saved Searches"
 msgstr ""
 
-#: scripts/apps/legal-archive/views/legal_archive.html:72
+#: scripts/apps/legal-archive/views/legal_archive.html:90
 #: scripts/apps/search/views/item-globalsearch.html:19
 msgid "Go"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:18
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:20
 msgid "Go to items"
 msgstr ""
 
-#: scripts/apps/analytics/views/activity-report-grouping.html:6
-msgid "Group by desk"
-msgstr ""
-
-#: scripts/apps/groups/controllers/GroupsConfigController.js:28
-msgid "Group deleted."
-msgstr ""
-
-#: scripts/apps/groups/views/groups-config-modal.html:22
-msgid "Group description"
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:47
+msgid "Go-To"
 msgstr ""
 
 #: scripts/apps/authoring/macros/views/macros-widget.html:3
 msgid "Group Macros"
 msgstr ""
 
-#: scripts/apps/groups/views/settings.html:5
-msgid "Group management"
-msgstr ""
-
-#: scripts/apps/groups/views/groups-config-modal.html:18
-msgid "Group name"
-msgstr ""
-
-#: scripts/apps/groups/views/groups-config-modal.html:27
-msgid "Group with name"
-msgstr ""
-
-#: scripts/apps/analytics/views/activity-report-panel.html:17
-msgid "Grouping"
-msgstr ""
-
-#: scripts/apps/groups/index.js:21
-msgid "Groups"
-msgstr ""
-
 #: scripts/core/lang/missing-translations-strings.js:17
 msgid "Groups Management"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:197
-#: scripts/apps/authoring/metadata/views/metadata-widget.html:96
-#: scripts/apps/legal-archive/views/legal_archive.html:30
-msgid "GUID"
-msgstr ""
-
-#: scripts/core/editor2/editor.js:1022
+#: scripts/core/editor2/editor.js:1033
 msgid "H1"
 msgstr ""
 
-#: scripts/core/editor2/editor.js:1034
+#: scripts/core/editor2/editor.js:1045
 msgid "H2"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/schema-editor.html:93
+#: scripts/core/lang/missing-translations-strings.js:42
+msgid "HEADLINE is too long"
+msgstr ""
+
+#: scripts/apps/workspace/content/views/schema-editor.html:68
 msgid "Half"
 msgstr ""
 
@@ -2806,34 +2776,28 @@ msgstr ""
 msgid "Have password? Sign in."
 msgstr ""
 
-#: scripts/core/editor2/editor.js:1020
-msgid "header type 1"
-msgstr ""
-
-#: scripts/core/editor2/editor.js:1032
-msgid "header type 2"
-msgstr ""
-
-#: scripts/apps/authoring/views/article-edit.html:18
-#: scripts/apps/authoring/views/article-edit.html:2
+#: scripts/apps/authoring/views/article-edit.html:31
+#: scripts/apps/authoring/views/article-edit.html:9
+#: scripts/apps/authoring/views/theme-select.html:36
+#: scripts/apps/authoring/views/theme-select.html:87
 #: scripts/apps/content-filters/views/production-test-view.html:20
-#: scripts/apps/legal-archive/views/legal_archive.html:42
+#: scripts/apps/legal-archive/views/legal_archive.html:60
 #: scripts/apps/packaging/views/sd-package-edit.html:4
-#: scripts/apps/publish/views/publish-queue.html:89
-#: scripts/apps/search/views/search-parameters.html:13
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:7
+#: scripts/apps/publish/views/publish-queue.html:93
+#: scripts/apps/search/views/search-parameters.html:14
+#: scripts/apps/workspace/content/constants.js:57
 msgid "Headline"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:42
-msgid "HEADLINE is too long"
-msgstr ""
-
-#: scripts/apps/users/views/edit-form.html:115
+#: scripts/apps/users/views/edit-form.html:138
 msgid "Help us translate Superdesk"
 msgstr ""
 
-#: scripts/apps/authoring/views/article-edit.html:279
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:39
+msgid "Helper text"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:393
 msgid "Helplines/Contact Information"
 msgstr ""
 
@@ -2841,8 +2805,12 @@ msgstr ""
 msgid "Hidden recipients (blind carbon copy)"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/schema-editor.html:25
+#: scripts/apps/workspace/content/views/schema-editor.html:33
 msgid "Hide Date"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:564
+msgid "Hide Preview"
 msgstr ""
 
 #: scripts/apps/authoring/views/full-preview.html:5
@@ -2853,12 +2821,8 @@ msgstr ""
 msgid "Hide sent/queued items"
 msgstr ""
 
-#: scripts/core/views/sdSlider.html:3
-msgid "high"
-msgstr ""
-
-#: scripts/apps/monitoring/views/monitoring-view.html:105
-#: scripts/apps/monitoring/views/monitoring-view.html:75
+#: scripts/apps/monitoring/views/monitoring-view.html:108
+#: scripts/apps/monitoring/views/monitoring-view.html:83
 msgid "Highlight Package"
 msgstr ""
 
@@ -2866,28 +2830,27 @@ msgstr ""
 msgid "Highlight with name"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:29
-msgid "highlights"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-topbar.html:168
+#: scripts/apps/authoring/views/authoring-topbar.html:218
 #: scripts/apps/highlights/index.js:60
-#: scripts/apps/monitoring/views/item-actions-menu.html:24
-#: scripts/apps/templates/services/TemplatesService.js:57
+#: scripts/apps/templates/services/TemplatesService.js:65
 #: scripts/apps/workspace/views/workspace-sidenav-items.html:17
 msgid "Highlights"
-msgstr ""
-
-#: scripts/apps/highlights/views/settings.html:6
-msgid "Highlights configurations"
 msgstr ""
 
 #: scripts/apps/highlights/index.js:68
 msgid "Highlights View"
 msgstr ""
 
+#: scripts/apps/highlights/views/settings.html:3
+msgid "Highlights configurations"
+msgstr ""
+
 #: scripts/core/lang/missing-translations-strings.js:12
 msgid "Highlights/Summary List Management"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/versioning.js:6
+msgid "History"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:13
@@ -2900,24 +2863,11 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
-#: scripts/apps/highlights/views/highlights_config_modal.html:44
-msgid "hours"
-msgstr ""
-
 #: scripts/core/ui/views/sd-timepicker-popup.html:15
 msgid "Hours"
 msgstr ""
 
-#: scripts/apps/desks/views/content-expiry.html:22
-#: scripts/apps/desks/views/content-expiry.html:4
-msgid "hr"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:93
-msgid "hrs"
-msgstr ""
-
-#: scripts/core/editor2/editor.js:1061
+#: scripts/core/editor2/editor.js:1072
 msgid "I"
 msgstr ""
 
@@ -2937,6 +2887,22 @@ msgstr ""
 msgid "I'm sorry but there was an error when saving the rule set."
 msgstr ""
 
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:15
+msgid "ID"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:24
+msgid "ID conflicts with system field."
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:22
+msgid "ID must be unique."
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:26
+msgid "ID must contain only letters, digits and characters -, _."
+msgstr ""
+
 #: scripts/core/ui/views/sd-timezone.html:17
 msgid "If not set, the UTC+0 time zone is assumed."
 msgstr ""
@@ -2948,6 +2914,10 @@ msgstr ""
 
 #: scripts/core/editor2/views/block-text.html:27
 msgid "Ignore word"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:61
+msgid "Image"
 msgstr ""
 
 #: scripts/core/upload/crop-directive.js:39
@@ -2962,81 +2932,56 @@ msgstr ""
 msgid "Import user"
 msgstr ""
 
-#: scripts/core/ui/views/sd-timepicker-popup.html:7
-msgid "in 1 h"
-msgstr ""
-
 #: scripts/core/ui/views/datepicker-wrapper.html:8
 msgid "In 2 days"
-msgstr ""
-
-#: scripts/core/ui/views/sd-timepicker-popup.html:8
-msgid "in 2 h"
-msgstr ""
-
-#: scripts/core/ui/views/sd-timepicker-popup.html:6
-msgid "in 30 min"
 msgstr ""
 
 #: scripts/apps/dashboard/workspace-tasks/tasks.js:7
 msgid "In Progress"
 msgstr ""
 
-#: scripts/apps/search/views/search-parameters.html:127
-msgid "In Spiked"
+#: scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.js:24
+msgid ""
+"In the story {{ slugline }} sent at: {{ date }}\r\n"
+"\r\n"
+"This is corrected repeat."
 msgstr ""
 
-#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:67
-msgid "in the last 24 hours."
-msgstr ""
-
-#: scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.js:31
-msgid "In the story \""
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:5
-msgid "in_progress"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:5
-msgid "in-progress"
-msgstr ""
-
-#: scripts/apps/users/views/edit-form.html:13
-#: scripts/apps/users/views/user-list-item.html:15
-msgid "inactive"
-msgstr ""
-
-#: scripts/apps/users/controllers/UserListController.js:145
-#: scripts/apps/workspace/content/views/profile-settings.html:37
+#: scripts/apps/users/controllers/UserListController.js:146
+#: scripts/apps/workspace/content/views/profile-settings.html:39
 msgid "Inactive"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:241
+#: scripts/apps/search/views/search-parameters.html:131
+msgid "Include spiked content"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:287
 msgid "Incoming Rule"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:196
+#: scripts/apps/desks/views/desk-config-modal.html:235
 msgid "Incoming Rule:"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:177
-#: scripts/apps/desks/views/desk-config-modal.html:223
+#: scripts/apps/desks/views/desk-config-modal.html:210
+#: scripts/apps/desks/views/desk-config-modal.html:263
 msgid "Incoming Stage"
 msgstr ""
 
-#: scripts/apps/archive/views/upload.html:69
-#: scripts/apps/authoring/views/change-image.html:102
+#: scripts/apps/archive/views/upload.html:75
+#: scripts/apps/authoring/views/change-image.html:119
 msgid "Indefinite Usage"
 msgstr ""
 
-#: scripts/apps/authoring/metadata/metadata.js:1095
+#: scripts/apps/authoring/metadata/metadata.js:1165
 msgid "Info"
 msgstr ""
 
-#: scripts/apps/ingest/index.js:64
-#: scripts/apps/search/views/item-repo.html:7
-#: scripts/apps/workspace/views/workspace-sidenav-items.html:91
+#: scripts/apps/ingest/index.js:65
+#: scripts/apps/ingest/views/settings/settings.html:3
+#: scripts/apps/search/views/item-repo.html:4
+#: scripts/apps/workspace/views/workspace-sidenav-items.html:107
 msgid "Ingest"
 msgstr ""
 
@@ -3044,7 +2989,7 @@ msgstr ""
 msgid "Ingest Channels"
 msgstr ""
 
-#: scripts/apps/ingest/index.js:72
+#: scripts/apps/ingest/index.js:73
 #: scripts/apps/ingest/views/dashboard/dashboard.html:2
 msgid "Ingest Dashboard"
 msgstr ""
@@ -3055,32 +3000,29 @@ msgstr ""
 
 #: scripts/apps/archive/views/metadata-view.html:26
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:83
-#: scripts/apps/publish/views/publish-queue.html:93
+#: scripts/apps/publish/views/publish-queue.html:97
+#: scripts/apps/workspace/content/constants.js:65
 msgid "Ingest Provider"
-msgstr ""
-
-#: scripts/apps/archive/views/metadata-view.html:126
-msgid "Ingest provider sequence"
 msgstr ""
 
 #: scripts/apps/publish/views/publish-queue.html:30
 msgid "Ingest Provider:"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-routing-content.html:3
-msgid "Ingest Routing Schemes"
+#: scripts/apps/ingest/views/settings/settings.html:14
+msgid "Ingest Routing"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-rules-content.html:4
+#: scripts/apps/ingest/views/settings/settings.html:11
 msgid "Ingest Rule sets"
 msgstr ""
 
-#: scripts/apps/ingest/directives/IngestSourcesContent.js:103
+#: scripts/apps/ingest/directives/IngestSourcesContent.js:106
 msgid "Ingest Source deleted."
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:3
-msgid "Ingest sources"
+#: scripts/apps/ingest/views/settings/settings.html:8
+msgid "Ingest Sources"
 msgstr ""
 
 #: scripts/apps/ingest/ingest-stats-widget/stats.js:7
@@ -3088,19 +3030,20 @@ msgstr ""
 msgid "Ingest Stats"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:6
-msgid "ingested"
+#: scripts/apps/archive/views/metadata-view.html:127
+msgid "Ingest provider sequence"
 msgstr ""
 
-#: scripts/core/editor2/editor.js:1117
-msgid "insert table"
+#: scripts/apps/authoring/authoring/index.js:242
+msgid "Instant Spellchecking, when automatic spellchecking turned off"
 msgstr ""
 
-#: scripts/apps/search/directives/ItemRepo.js:41
-msgid "inside subscription"
+#: scripts/apps/internal-destinations/index.js:67
+#: scripts/apps/internal-destinations/views/settings.html:3
+msgid "Internal Destinations"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:74
+#: scripts/apps/users/views/edit-form.html:198
 msgid "Invalid format. Only Alphanumerics are allowed."
 msgstr ""
 
@@ -3108,7 +3051,7 @@ msgstr ""
 msgid "Is Default"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:163
+#: scripts/apps/archive/views/metadata-view.html:164
 msgid "Iso"
 msgstr ""
 
@@ -3120,20 +3063,27 @@ msgstr ""
 msgid "It will update existing template."
 msgstr ""
 
-#: scripts/core/editor2/editor.js:1059
-msgid "italic"
-msgstr ""
-
-#: scripts/apps/archive/controllers/DuplicateController.js:13
+#: scripts/apps/archive/controllers/DuplicateController.js:18
+#: scripts/apps/ingest/services/SendService.js:106
 msgid "Item Duplicated"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/SendItem.js:636
-msgid "Item fetched."
+#: scripts/apps/ingest/controllers/ExternalSourceController.js:24
+#: scripts/apps/ingest/services/SendService.js:127
+#: scripts/apps/ingest/services/SendService.js:54
+msgid "Item Fetched."
 msgstr ""
 
-#: scripts/apps/ingest/controllers/ExternalSourceController.js:26
-msgid "Item Fetched."
+#: scripts/apps/translations/services/TranslationService.js:57
+msgid "Item Translated"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:125
+msgid "Item Unlocked"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/SendItem.js:599
+msgid "Item fetched."
 msgstr ""
 
 #: scripts/apps/archive/directives/ArchivedItemKill.js:42
@@ -3144,12 +3094,12 @@ msgstr ""
 msgid "Item has been resent."
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:487
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:461
 msgid "Item has changed since it was opened. Please close and reopen the item to continue. Regrettably, your changes cannot be saved."
 msgstr ""
 
 #: scripts/apps/authoring/versioning/views/versioning.html:6
-#: scripts/apps/legal-archive/views/legal_archive.html:98
+#: scripts/apps/legal-archive/views/legal_archive.html:123
 #: scripts/apps/search/views/item-preview.html:17
 msgid "Item history"
 msgstr ""
@@ -3158,28 +3108,24 @@ msgstr ""
 msgid "Item is already in this package."
 msgstr ""
 
-#: scripts/apps/archive/related-item-widget/relatedItem.js:142
-msgid "item is associated as a take."
+#: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.js:138
+msgid "Item is locked. Cannot associate media item."
 msgstr ""
 
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:143
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:138
 msgid "Item locked"
-msgstr ""
-
-#: scripts/apps/archive/related-item-widget/relatedItem.js:125
-msgid "item metadata associated."
 msgstr ""
 
 #: scripts/apps/search/directives/ItemGlobalSearch.js:46
 msgid "Item not found..."
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:428
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:411
 msgid "Item published."
 msgstr ""
 
-#: scripts/apps/dashboard/workspace-tasks/tasks.js:192
-#: scripts/apps/dashboard/workspace-tasks/tasks.js:259
+#: scripts/apps/dashboard/workspace-tasks/tasks.js:187
+#: scripts/apps/dashboard/workspace-tasks/tasks.js:254
 msgid "Item saved."
 msgstr ""
 
@@ -3187,29 +3133,20 @@ msgstr ""
 msgid "Item sent to Subscriber"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/SendItem.js:531
-#: scripts/apps/authoring/authoring/directives/SendItem.js:608
+#: scripts/apps/authoring/authoring/directives/SendItem.js:504
+#: scripts/apps/authoring/authoring/directives/SendItem.js:571
 msgid "Item sent."
-msgstr ""
-
-#: scripts/apps/translations/services/TranslationService.js:57
-msgid "Item Translated"
 msgstr ""
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:11
 msgid "Item type stats"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:130
-msgid "Item Unlocked"
-msgstr ""
-
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:171
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:192
 msgid "Item updated."
 msgstr ""
 
-#: scripts/apps/analytics/views/activity-report-view.html:11
-#: scripts/apps/analytics/views/activity-report-view.html:5
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:85
 #: scripts/core/views/sdSearchList.html:36
 msgid "Items"
 msgstr ""
@@ -3218,45 +3155,56 @@ msgstr ""
 msgid "Items Count"
 msgstr ""
 
+#: scripts/apps/contacts/views/edit-form.html:87
+#: scripts/apps/contacts/views/search-panel.html:39
+#: scripts/apps/users/views/edit-form.html:212
+msgid "Job Title"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:84
+msgid "KEYWORDS"
+msgstr ""
+
 #: scripts/core/keyboard/views/keyboard-modal.html:3
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: scripts/apps/analytics/views/activity-report-parameters.html:58
 #: scripts/apps/archive/views/metadata-view.html:21
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:39
 #: scripts/apps/content-filters/views/production-test-view.html:21
 #: scripts/apps/search/views/search-parameters.html:77
+#: scripts/apps/workspace/content/constants.js:82
 msgid "Keywords"
 msgstr ""
 
 #: scripts/apps/archive/views/archived-kill.html:14
-#: scripts/apps/templates/services/TemplatesService.js:55
+#: scripts/apps/templates/services/TemplatesService.js:63
 msgid "Kill"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/index.js:109
+#: scripts/apps/authoring/authoring/index.js:125
 msgid "Kill item"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:7
-msgid "killed"
-msgstr ""
-
-#: scripts/apps/authoring/versioning/history/views/history.html:69
+#: scripts/apps/authoring/versioning/history/views/history.html:168
 msgid "Killed by"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/profile-settings.html:59
-#: scripts/apps/workspace/content/views/profile-settings.html:84
-msgid "Label:"
+#: scripts/apps/authoring/views/authoring-header.html:170
+msgid "LANGUAGE"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:116
+#: scripts/apps/workspace/content/views/profile-settings.html:62
+#: scripts/apps/workspace/content/views/profile-settings.html:92
+msgid "Label"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:117
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:47
 #: scripts/apps/desks/views/settings.html:53
-#: scripts/apps/templates/views/template-editor-modal.html:100
-#: scripts/apps/users/views/edit-form.html:113
+#: scripts/apps/templates/views/template-editor-modal.html:109
+#: scripts/apps/users/views/edit-form.html:135
+#: scripts/apps/workspace/content/constants.js:83
 msgid "Language"
 msgstr ""
 
@@ -3264,20 +3212,15 @@ msgstr ""
 msgid "Language code"
 msgstr ""
 
-#: scripts/apps/authoring/views/theme-select.html:14
-#: scripts/apps/authoring/views/theme-select.html:32
-msgid "Large font"
-msgstr ""
-
 #: scripts/apps/highlights/views/highlights_config_modal.html:44
 msgid "Last"
 msgstr ""
 
-#: scripts/apps/search/views/search-filters.html:181
+#: scripts/apps/search/views/search-filters.html:182
 msgid "Last 24 Hours"
 msgstr ""
 
-#: scripts/apps/search/views/search-filters.html:183
+#: scripts/apps/search/views/search-filters.html:184
 msgid "Last 8 Hours"
 msgstr ""
 
@@ -3299,26 +3242,13 @@ msgstr ""
 msgid "Last Month"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:43
-msgid "last name"
-msgstr ""
-
-#: scripts/apps/profiling/views/profiling.html:24
-#: scripts/apps/publish/views/publish-queue.html:63
-msgid "Last refreshed at"
+#: scripts/apps/contacts/views/search-panel.html:24
+#: scripts/core/directives/views/phone-home-modal-directive.html:24
+msgid "Last Name"
 msgstr ""
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:30
 msgid "Last Time Updated"
-msgstr ""
-
-#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:75
-msgid "last update and last item arrived."
-msgstr ""
-
-#: scripts/apps/archive/views/metadata-view.html:92
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:15
-msgid "Last updated"
 msgstr ""
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:14
@@ -3330,23 +3260,38 @@ msgstr ""
 msgid "Last Week"
 msgstr ""
 
+#: scripts/apps/profiling/views/profiling.html:24
+#: scripts/apps/publish/views/publish-queue.html:65
+msgid "Last refreshed at"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:92
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:17
+msgid "Last updated"
+msgstr ""
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:50
+msgid "Learn more about Superdesk at <a href=\"https://www.superdesk.org/\" title=\"Superdesk\" target=\"_blank\">www.superdesk.org</a>. For help and support, join the discussion on <a href=\"https://forum.sourcefabric.org/categories/superdesk-dev\" title=\"Superdesk forum\" target=\"_blank\">Superdesk forums</a>."
+msgstr ""
+
 #: scripts/apps/archive/views/item-preview.html:10
 #: scripts/apps/archive/views/metadata-view.html:190
 #: scripts/apps/archive/views/preview.html:40
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:24
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:29
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:76
-#: scripts/apps/authoring/views/authoring-header.html:39
+#: scripts/apps/authoring/views/authoring-header.html:40
 #: scripts/apps/search/views/search-filters.html:110
+#: scripts/apps/templates/views/template-editor-modal.html:98
 #: scripts/core/itemList/views/relatedItem-list-widget.html:39
 msgid "Legal"
 msgstr ""
 
-#: scripts/apps/legal-archive/index.js:34
+#: scripts/apps/legal-archive/index.js:36
 msgid "Legal Archive"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/schema-editor.html:37
+#: scripts/apps/workspace/content/views/schema-editor.html:49
 msgid "Length"
 msgstr ""
 
@@ -3354,23 +3299,23 @@ msgstr ""
 msgid "Line: {{ cursor.line }}, Column: {{ cursor.column }}"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/services/AuthoringService.js:119
+#: scripts/apps/authoring/authoring/services/AuthoringService.js:120
 msgid "Link has been removed"
 msgstr ""
 
-#: scripts/core/auth/auth.js:56
+#: scripts/core/auth/auth.js:58
 msgid "Link sent. Please check your email inbox."
 msgstr ""
 
-#: scripts/apps/authoring/versioning/history/views/history.html:26
-msgid "Linked as take by"
+#: scripts/apps/authoring/versioning/history/views/history.html:120
+msgid "Linked by"
 msgstr ""
 
 #: scripts/apps/vocabularies/services/SchemaFactory.js:7
 msgid "List Name"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:144
+#: scripts/apps/authoring/views/authoring-topbar.html:176
 msgid "Live suggestions"
 msgstr ""
 
@@ -3378,41 +3323,30 @@ msgstr ""
 msgid "Load more"
 msgstr ""
 
-#: scripts/apps/legal-archive/views/legal_archive.html:83
-#: scripts/apps/search/views/search-results.html:4
-#: scripts/core/editor2/views/add-embed.html:18
-msgid "loading"
-msgstr ""
-
-#: scripts/apps/desks/directives/DeskeditPeople.js:9
-#: scripts/apps/desks/directives/DeskeditStages.js:33
-msgid "loading..."
-msgstr ""
-
 #: scripts/apps/authoring/comments/views/comments-widget.html:19
-#: scripts/apps/dashboard/views/workspace.html:53
-#: scripts/apps/users/views/user-list-item.html:35
+#: scripts/apps/dashboard/views/workspace.html:55
+#: scripts/apps/users/views/user-list-item.html:38
 #: scripts/core/list/views/list-view.html:2
-#: scripts/core/menu/notifications/views/notifications.html:41
+#: scripts/core/menu/notifications/views/notifications.html:42
 msgid "Loading..."
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ftp-config.html:18
-#: scripts/apps/ingest/views/settings/ftp-config.html:19
+#: scripts/apps/ingest/views/settings/ftp-config.html:20
+#: scripts/apps/ingest/views/settings/ftp-config.html:21
 #: scripts/apps/publish/views/ftp-config.html:23
 #: scripts/apps/publish/views/ftp-config.html:25
 msgid "Local Path"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:215
+#: scripts/apps/desks/views/desk-config-modal.html:255
 msgid "Local Read Only"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:184
+#: scripts/apps/desks/views/desk-config-modal.html:217
 msgid "Local Read Only:"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:134
+#: scripts/apps/desks/views/desk-config-modal.html:155
 msgid "Local Readonly"
 msgstr ""
 
@@ -3434,35 +3368,42 @@ msgstr ""
 msgid "Log In"
 msgstr ""
 
+#: scripts/core/auth/login-modal.html:28
+msgid "Log In with Google"
+msgstr ""
+
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:41
-#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:82
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:87
 msgid "Log Messages"
 msgstr ""
 
-#: scripts/core/views/sdSlider.html:2
-msgid "low"
+#: scripts/apps/ingest/views/settings/wufoo.html:2
+msgid "Login"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:46
+msgid "MASTER"
 msgstr ""
 
 #: scripts/apps/desks/views/actionpicker.html:24
 msgid "Macro"
 msgstr ""
 
-#: scripts/apps/authoring/macros/macros.js:317
-#: scripts/apps/desks/views/desk-config-modal.html:308
+#: scripts/apps/authoring/macros/macros.js:323
+#: scripts/apps/desks/views/desk-config-modal.html:358
 msgid "Macros"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/emailConfig.html:26
+#: scripts/apps/ingest/views/settings/emailConfig.html:28
 msgid "Mailbox"
 msgstr ""
 
-#: scripts/apps/analytics/views/save-activity-report-dialog.html:11
-#: scripts/apps/search/views/save-search-dialog.html:11
-msgid "Make global"
+#: scripts/apps/templates/views/template-editor-modal.html:52
+msgid "Make Public"
 msgstr ""
 
-#: scripts/apps/templates/views/template-editor-modal.html:49
-msgid "Make Public"
+#: scripts/apps/search/views/save-search-dialog.html:11
+msgid "Make global"
 msgstr ""
 
 #: scripts/apps/users/views/change-avatar.html:47
@@ -3485,23 +3426,22 @@ msgstr ""
 msgid "Manage users"
 msgstr ""
 
-#: scripts/core/views/sdSearchList.html:17
-msgid "many"
-msgstr ""
-
-#: scripts/apps/desks/index.js:76
+#: scripts/apps/desks/index.js:75
+#: scripts/apps/monitoring/index.js:73
 msgid "Mark for desk"
 msgstr ""
 
 #: scripts/apps/highlights/index.js:45
+#: scripts/apps/monitoring/index.js:72
 msgid "Mark for highlight"
 msgstr ""
 
-#: scripts/apps/search/views/multi-action-bar.html:18
+#: scripts/apps/search/views/multi-action-bar.html:17
+#: scripts/apps/search/views/multi-action-bar.html:75
 msgid "Mark item"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:164
+#: scripts/apps/authoring/views/authoring-topbar.html:214
 msgid "Mark item for"
 msgstr ""
 
@@ -3513,15 +3453,15 @@ msgstr ""
 msgid "Marked Desks"
 msgstr ""
 
-#: scripts/apps/archive/views/marked_item_title.html:14
+#: scripts/apps/archive/views/marked_item_title.html:13
 msgid "Marked For"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-header.html:45
-msgid "MASTER"
+#: scripts/apps/authoring/versioning/history/views/history.html:77
+msgid "Marked by"
 msgstr ""
 
-#: scripts/apps/desks/index.js:54
+#: scripts/apps/desks/index.js:53
 msgid "Master Desk"
 msgstr ""
 
@@ -3533,79 +3473,69 @@ msgstr ""
 msgid "Match Prefix"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/schema-editor.html:41
-msgid "max"
-msgstr ""
-
-#: scripts/apps/workspace/content/views/schema-editor.html:46
+#: scripts/apps/workspace/content/views/schema-editor.html:58
 msgid "Max length should be bigger than 0 or empty."
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:109
+#: scripts/apps/publish/views/subscribers.html:114
 msgid "Maximum"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:70
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:25
+#: scripts/apps/content-filters/views/manage-filters.html:41
+msgid "Maximum 80 characters."
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:78
+#: scripts/apps/workspace/content/constants.js:76
 msgid "Media"
 msgstr ""
 
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:26
+#: scripts/apps/contacts/index.js:21
+msgid "Media Contacts"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.js:77
 msgid "Media Description"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:68
+#: scripts/apps/publish/views/subscribers.html:76
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:55
 msgid "Media Type"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:145
-msgid "member since"
-msgstr ""
-
-#: scripts/core/menu/notifications/views/notifications.html:30
-msgid "mentioned you"
-msgstr ""
-
-#: scripts/apps/publish/views/publish-queue.html:99
+#: scripts/apps/publish/views/publish-queue.html:103
 msgid "Message"
 msgstr ""
 
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:3
-#: scripts/apps/authoring/views/change-image.html:73
+#: scripts/apps/authoring/views/change-image.html:78
 #: scripts/apps/content-filters/views/production-test-view.html:55
-#: scripts/apps/legal-archive/views/legal_archive.html:95
+#: scripts/apps/legal-archive/views/legal_archive.html:119
 #: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:65
 #: scripts/apps/packaging/views/search-widget-preview.html:8
 #: scripts/apps/search/views/item-preview.html:11
-#: scripts/apps/templates/views/template-editor-modal.html:86
+#: scripts/apps/templates/views/template-editor-modal.html:92
+#: scripts/apps/vocabularies/index.js:40
 msgid "Metadata"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:8
-msgid "mgrid"
+#: scripts/apps/vocabularies/views/settings.html:3
+msgid "Metadata management"
 msgstr ""
 
-#: scripts/apps/desks/views/content-expiry.html:24
-#: scripts/apps/desks/views/content-expiry.html:5
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:81
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:97
-#: scripts/apps/workspace/content/views/schema-editor.html:39
-msgid "min"
-msgstr ""
-
-#: scripts/apps/workspace/content/views/schema-editor.html:43
+#: scripts/apps/workspace/content/views/schema-editor.html:55
 msgid "Min length shouldn't be bigger than max length."
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:122
+#: scripts/apps/authoring/views/authoring-topbar.html:154
 msgid "Minimize"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:107
+#: scripts/apps/publish/views/subscribers.html:112
 msgid "Minimum"
 msgstr ""
 
-#: scripts/apps/vocabularies/controllers/VocabularyEditController.js:54
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.js:60
 msgid "Minimum height and width should be greater than or equal to 200"
 msgstr ""
 
@@ -3613,11 +3543,7 @@ msgstr ""
 msgid "Minutes"
 msgstr ""
 
-#: scripts/apps/authoring/macros/views/macros-widget.html:31
-msgid "miscellaneous"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-header.html:38
+#: scripts/apps/authoring/views/authoring-header.html:39
 msgid "Missing Link"
 msgstr ""
 
@@ -3626,11 +3552,11 @@ msgstr ""
 msgid "Modified"
 msgstr ""
 
-#: scripts/apps/search/views/search-filters.html:153
+#: scripts/apps/search/views/search-filters.html:154
 msgid "Modified from"
 msgstr ""
 
-#: scripts/apps/search/views/search-filters.html:157
+#: scripts/apps/search/views/search-filters.html:158
 msgid "Modified until"
 msgstr ""
 
@@ -3638,12 +3564,12 @@ msgstr ""
 msgid "Modified:"
 msgstr ""
 
-#: scripts/core/datetime/datetime.js:199
+#: scripts/core/datetime/datetime.js:225
 msgid "Monday"
 msgstr ""
 
 #: scripts/apps/monitoring/config.js:5
-#: scripts/apps/monitoring/views/monitoring-view.html:20
+#: scripts/apps/monitoring/views/monitoring-view.html:21
 #: scripts/apps/workspace/views/workspace-sidenav-items.html:10
 #: scripts/core/lang/missing-translations-strings.js:39
 msgid "Monitoring"
@@ -3657,38 +3583,59 @@ msgstr ""
 msgid "Monitoring settings <span ng-if=\"settings.desk\" translate=\"\">for \"{{settings.desk.name}}\" Desk</span>"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:130
+#: scripts/apps/authoring/views/authoring-topbar.html:162
 msgid "More actions"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/sd-content-create.html:51
+#: scripts/apps/workspace/content/views/sd-content-create.html:43
 msgid "More templates..."
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ftp-config.html:36
+msgid "Move *NOT* ingested items (i.e. on error) to"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:14
 msgid "Move Content to another desk"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:250
+#: scripts/apps/monitoring/index.js:57
+msgid "Move focus to next stage or group"
+msgstr ""
+
+#: scripts/apps/monitoring/index.js:59
+msgid "Move focus to previous stage or group"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ftp-config.html:32
+msgid "Move ingested items to"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ftp-config.html:28
+msgid "Move items after ingestion"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:64
+msgid "Moved by"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:298
 msgid "Moved onto stage Rule"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:200
+#: scripts/apps/desks/views/desk-config-modal.html:239
 msgid "Moved onto stage Rule:"
 msgstr ""
 
-#: scripts/apps/authoring/versioning/history/views/history.html:42
-msgid "Moved to"
-msgstr ""
-
 #: scripts/apps/workspace/index.js:31
-msgid "Multi-selects(or deselects) an item"
+msgid "Multi-select (or deselect) an item"
 msgstr ""
 
 #: scripts/apps/authoring/multiedit/views/multiedit.html:2
-#: scripts/apps/authoring/views/authoring-topbar.html:154
+#: scripts/apps/authoring/views/authoring-topbar.html:194
 #: scripts/apps/authoring/views/opened-articles.html:18
-#: scripts/apps/search/views/multi-action-bar.html:27
+#: scripts/apps/search/views/multi-action-bar.html:30
+#: scripts/apps/search/views/multi-action-bar.html:87
 msgid "Multiedit"
 msgstr ""
 
@@ -3700,10 +3647,6 @@ msgstr ""
 msgid "My Profile"
 msgstr ""
 
-#: scripts/apps/analytics/views/saved-activity-reports.html:6
-msgid "My Saved Activity Reports"
-msgstr ""
-
 #: scripts/apps/search/views/saved-searches.html:6
 msgid "My Saved Searches"
 msgstr ""
@@ -3712,61 +3655,79 @@ msgstr ""
 msgid "My Templates"
 msgstr ""
 
-#: scripts/apps/analytics/views/save-activity-report-dialog.html:4
-#: scripts/apps/content-filters/views/manage-filter-conditions.html:38
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:17
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-dropdown.html:10
+msgid "NO SUGGESTIONS."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:28
+msgid "NTB Currency Macro"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:36
 #: scripts/apps/content-filters/views/manage-filters.html:39
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:13
 #: scripts/apps/publish/views/destination.html:4
-#: scripts/apps/publish/views/subscribers.html:45
+#: scripts/apps/publish/views/subscribers.html:53
 #: scripts/apps/search/views/save-search-dialog.html:4
 #: scripts/apps/templates/views/create-template.html:11
 #: scripts/apps/vocabularies/services/SchemaFactory.js:4
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:31
 msgid "Name"
 msgstr ""
 
-#: scripts/apps/content-filters/controllers/FilterConditionsController.js:75
-#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:50
-#: scripts/apps/products/controllers/ProductsConfigController.js:74
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:51
+msgid "Name is not unique."
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterConditionsController.js:92
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:52
+#: scripts/apps/products/controllers/ProductsConfigController.js:151
 msgid "Name needs to be unique"
 msgstr ""
 
-#: scripts/apps/desks/index.js:55
+#: scripts/apps/desks/index.js:54
 msgid "Navigate through the newsroom"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:189
-msgid "new"
-msgstr ""
-
-#: scripts/apps/users/views/settings-roles.html:27
+#: scripts/apps/users/views/settings-roles.html:31
 msgid "New Role"
 msgstr ""
 
-#: scripts/apps/authoring/views/change-image.html:29
+#: scripts/apps/authoring/views/change-image.html:30
 msgid "New size"
 msgstr ""
 
-#: scripts/apps/archive/index.js:206
-msgid "New Take"
+#: scripts/apps/desks/views/desk-config-modal.html:144
+msgid "New stage"
 msgstr ""
 
-#: scripts/apps/archive/index.js:229
-#: scripts/apps/authoring/authoring/directives/SendItem.js:473
-msgid "New take created."
-msgstr ""
-
-#: scripts/apps/archive/views/media-view.html:34
-#: scripts/apps/authoring/macros/views/macros-replace.html:8
-msgid "next"
-msgstr ""
-
-#: scripts/apps/groups/views/groups-config-modal.html:32
-#: scripts/apps/monitoring/views/aggregate-settings.html:137
+#: scripts/apps/monitoring/views/aggregate-settings.html:138
 msgid "Next"
 msgstr ""
 
 #: scripts/apps/users/config.js:155
 msgid "Next user"
+msgstr ""
+
+#: scripts/apps/templates/directives/TemplatesDirective.js:313
+msgid "No Desk"
+msgstr ""
+
+#: scripts/apps/highlights/views/search_highlights_dropdown_directive.html:6
+msgid "No Filter"
+msgstr ""
+
+#: scripts/apps/products/views/products.html:28
+msgid "No Products Found"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:29
+msgid "No Subscribers Found"
+msgstr ""
+
+#: scripts/apps/templates/directives/TemplateSelectDirective.js:38
+msgid "No Templates found."
 msgstr ""
 
 #: scripts/apps/desks/directives/MarkDesksDropdown.js:24
@@ -3788,7 +3749,7 @@ msgstr ""
 msgid "No available translations"
 msgstr ""
 
-#: scripts/apps/dashboard/world-clock/configuration.html:28
+#: scripts/apps/dashboard/world-clock/configuration.html:26
 msgid "No clock here!"
 msgstr ""
 
@@ -3796,19 +3757,11 @@ msgstr ""
 msgid "No comments so far."
 msgstr ""
 
-#: scripts/apps/templates/directives/TemplatesDirective.js:294
-msgid "No Desk"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/rssConfig.html:42
+#: scripts/apps/ingest/views/settings/rssConfig.html:46
 msgid "No field aliases defined."
 msgstr ""
 
-#: scripts/apps/highlights/views/search_highlights_dropdown_directive.html:6
-msgid "No Filter"
-msgstr ""
-
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:849
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:893
 msgid "No formatters found for"
 msgstr ""
 
@@ -3816,14 +3769,11 @@ msgstr ""
 msgid "No image"
 msgstr ""
 
-#: scripts/apps/desks/views/stage-item-list.html:2
-msgid "No items in this stage"
-msgstr ""
-
 #: scripts/apps/desks/views/slugline-items.html:4
 msgid "No items published"
 msgstr ""
 
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:11
 #: scripts/apps/authoring/multiedit/views/sd-multiedit-inner-dropdown.html:7
 msgid "No items to add!"
 msgstr ""
@@ -3840,78 +3790,46 @@ msgstr ""
 msgid "No of calls"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/sd-content-create.html:47
-msgid "No recent templates."
-msgstr ""
-
-#: scripts/apps/content-filters/controllers/FilterSearchController.js:111
-msgid "no results found"
-msgstr ""
-
-#: scripts/apps/users/views/settings-roles.html:22
+#: scripts/apps/users/views/settings-roles.html:21
 msgid "No roles created yet."
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-rules-content.html:58
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:53
 msgid "No rules defined in a set."
 msgstr ""
 
-#: scripts/core/auth/login-modal.html:36
+#: scripts/core/auth/login-modal.html:48
 #: scripts/core/auth/reset-password.html:33
 #: scripts/core/auth/reset-password.html:81
 #: scripts/core/auth/secure-login.html:34
 msgid "No server response so far.<br>Let me try again."
 msgstr ""
 
-#: scripts/apps/authoring/multiedit/views/sd-multiedit-dropdown.html:10
-msgid "NO SUGGESTIONS."
-msgstr ""
-
-#: scripts/apps/templates/directives/TemplateSelectDirective.js:38
-msgid "No Templates found."
-msgstr ""
-
-#: scripts/apps/users/views/list.html:23
+#: scripts/apps/users/views/list.html:28
 msgid "No user roles defined!"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:71
+#: scripts/apps/publish/views/subscribers.html:79
 msgid "Non-media"
 msgstr ""
 
-#: scripts/apps/profiling/views/profiling.html:10
-#: scripts/apps/users/views/user-preferences.html:64
-#: scripts/apps/workspace/content/views/schema-editor.html:62
-msgid "none"
-msgstr ""
-
-#: scripts/apps/archive/views/marked_item_title.html:23
+#: scripts/apps/archive/views/marked_item_title.html:22
 #: scripts/apps/authoring/metadata/views/metadata-dropdown.html:17
 #: scripts/apps/publish/views/publish-queue.html:23
 #: scripts/apps/publish/views/publish-queue.html:39
 #: scripts/apps/publish/views/publish-queue.html:54
-#: scripts/apps/templates/views/template-editor-modal.html:165
-#: scripts/apps/templates/views/template-editor-modal.html:78
+#: scripts/apps/templates/views/template-editor-modal.html:174
+#: scripts/apps/templates/views/template-editor-modal.html:74
 #: scripts/core/views/sdSearchList.html:32
 msgid "None"
 msgstr ""
 
-#: scripts/apps/authoring/views/theme-select.html:13
-#: scripts/apps/authoring/views/theme-select.html:31
-msgid "Normal font"
-msgstr ""
-
-#: scripts/apps/ingest/directives/IngestRoutingAction.js:59
+#: scripts/apps/ingest/directives/IngestRoutingAction.js:60
 msgid "Not"
 msgstr ""
 
-#: scripts/apps/content-filters/views/filter-search-result.html:60
-#: scripts/apps/publish/views/subscribers.html:14
+#: scripts/apps/publish/views/subscribers.html:23
 msgid "Not Active"
-msgstr ""
-
-#: scripts/apps/authoring/versioning/history/views/publish_queue.html:10
-msgid "Not been transmitted to any subscriber"
 msgstr ""
 
 #: scripts/apps/archive/views/item-preview.html:9
@@ -3920,19 +3838,20 @@ msgstr ""
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:13
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:18
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:75
-#: scripts/apps/authoring/views/authoring-header.html:41
-#: scripts/apps/templates/views/template-editor-modal.html:88
+#: scripts/apps/authoring/views/authoring-header.html:42
 msgid "Not For Publication"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/schema-editor.html:40
-#: scripts/apps/workspace/content/views/schema-editor.html:42
-#: scripts/apps/workspace/content/views/schema-editor.html:56
-#: scripts/apps/workspace/content/views/schema-editor.html:86
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:10
+msgid "Not been transmitted to any subscriber"
+msgstr ""
+
+#: scripts/apps/workspace/content/views/schema-editor.html:52
+#: scripts/apps/workspace/content/views/schema-editor.html:54
 msgid "Not set"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:127
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:141
 msgid "Notification"
 msgstr ""
 
@@ -3940,99 +3859,117 @@ msgstr ""
 msgid "Notification list"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:8
-msgid "notifications"
-msgstr ""
-
 #: scripts/apps/monitoring/views/desk-notifications.html:1
+#: scripts/apps/users/views/user-preferences.html:24
 #: scripts/core/menu/notifications/views/notifications.html:17
 msgid "Notifications"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:89
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:93
 msgid "Notify when idle for more than"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:28
-msgid "NTB Currency Macro"
-msgstr ""
-
-#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:66
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:71
 #: scripts/apps/users/activity-widget/configuration.html:6
 msgid "Number of items"
 msgstr ""
 
-#: scripts/core/list/views/sdPagination.html:21
-#: scripts/core/list/views/sdPaginationAlt.html:2
-#: scripts/core/views/sdSearchList.html:15
-msgid "of"
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:125
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:138
+#: scripts/apps/authoring/macros/views/macros-replace.html:3
+#: scripts/core/auth/auth.js:197
+#: scripts/core/directives/PasswordStrengthDirective.js:41
+#: scripts/core/services/modalService.js:6
+msgid "OK"
+msgstr ""
+
+#: scripts/apps/search/views/search-parameters.html:170
+msgid "Object Name (Slugline)"
 msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:37
 msgid "Off"
 msgstr ""
 
-#: scripts/apps/desks/views/content-expiry.html:9
-msgid "OFF"
-msgstr ""
-
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:21
 #: scripts/apps/authoring/multiedit/views/sd-multiedit-dropdown.html:14
 #: scripts/apps/search/views/save-search.html:29
-#: scripts/apps/users/views/settings-roles.html:52
+#: scripts/apps/users/views/settings-roles.html:57
 msgid "Ok"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:130
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:143
-#: scripts/apps/authoring/macros/views/macros-replace.html:3
-#: scripts/core/auth/auth.js:195
-#: scripts/core/directives/PasswordStrengthDirective.js:41
-#: scripts/core/services/modalService.js:6
-msgid "OK"
-msgstr ""
-
-#: scripts/apps/authoring/versioning/history/views/publish_queue.html:17
-#: scripts/apps/authoring/versioning/history/views/publish_queue.html:22
-#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:11
-msgid "on"
-msgstr ""
-
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:36
-#: scripts/apps/templates/views/template-editor-modal.html:144
+#: scripts/apps/templates/views/template-editor-modal.html:153
 msgid "On"
 msgstr ""
 
-#: scripts/apps/users/controllers/UserListController.js:143
+#: scripts/apps/users/controllers/UserListController.js:144
 msgid "Online"
+msgstr ""
+
+#: scripts/apps/archive/controllers/UploadController.js:84
+msgid "Only the following files are allowed:"
 msgstr ""
 
 #: scripts/core/auth/secure-login.html:28
 msgid "Oops! Authentication has been denied."
 msgstr ""
 
+#: scripts/core/auth/login-modal.html:41
+msgid "Oops! Invalid Username or Password.<br>Please try again."
+msgstr ""
+
 #: scripts/core/auth/reset-password.html:27
 msgid "Oops! Invalid user Email.<br>Please try again."
 msgstr ""
 
-#: scripts/core/auth/login-modal.html:30
-msgid "Oops! Invalid Username or Password.<br>Please try again."
-msgstr ""
-
-#: scripts/apps/users/views/user-list-item.html:36
+#: scripts/apps/users/views/user-list-item.html:39
 #: scripts/core/list/views/list-view.html:3
 msgid "Oops! There are no items."
 msgstr ""
 
-#: scripts/apps/authoring/authoring/index.js:147
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:142
+#: scripts/apps/authoring/authoring/index.js:163
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:156
 msgid "Open"
 msgstr ""
 
-#: scripts/apps/desks/views/desk_users.html:3
 #: scripts/apps/desks/views/desk-tasks.html:3
 #: scripts/apps/desks/views/desk.html:3
+#: scripts/apps/desks/views/desk_users.html:3
 #: scripts/apps/desks/views/slugline.html:3
 msgid "Open desk content"
+msgstr ""
+
+#: scripts/apps/workspace/index.js:26
+msgid "Open highlights"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.js:181
+msgid "Open in new Window"
+msgstr ""
+
+#: scripts/apps/workspace/index.js:25
+msgid "Open monitoring"
+msgstr ""
+
+#: scripts/apps/workspace/index.js:29
+msgid "Open personal"
+msgstr ""
+
+#: scripts/apps/workspace/index.js:30
+msgid "Open search"
+msgstr ""
+
+#: scripts/apps/workspace/index.js:28
+msgid "Open spike"
+msgstr ""
+
+#: scripts/apps/workspace/index.js:27
+msgid "Open tasks"
+msgstr ""
+
+#: scripts/apps/workspace/index.js:24
+msgid "Open workspace / dashboard"
 msgstr ""
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:18
@@ -4043,76 +3980,43 @@ msgstr ""
 msgid "Opened by"
 msgstr ""
 
-#: scripts/apps/workspace/index.js:26
-msgid "Opens highlights"
-msgstr ""
-
-#: scripts/apps/workspace/index.js:25
-msgid "Opens monitoring"
-msgstr ""
-
-#: scripts/apps/workspace/index.js:29
-msgid "Opens personal"
-msgstr ""
-
-#: scripts/apps/workspace/index.js:30
-msgid "Opens search"
-msgstr ""
-
-#: scripts/apps/workspace/index.js:28
-msgid "Opens spike"
-msgstr ""
-
-#: scripts/apps/workspace/index.js:27
-msgid "Opens tasks"
-msgstr ""
-
-#: scripts/apps/workspace/index.js:24
-msgid "Opens workspace"
-msgstr ""
-
-#: scripts/apps/analytics/views/activity-report-parameters.html:5
-msgid "Operation"
-msgstr ""
-
-#: scripts/apps/analytics/views/activity-report-parameters.html:22
-msgid "Operation date"
-msgstr ""
-
-#: scripts/apps/content-filters/views/filter-search.html:12
-#: scripts/apps/content-filters/views/manage-filter-conditions.html:49
+#: scripts/apps/content-filters/views/filter-search.html:17
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:53
 msgid "Operator"
 msgstr ""
 
-#: scripts/apps/archive/views/upload.html:11
-msgid "or"
-msgstr ""
-
-#: scripts/apps/users/views/change-avatar.html:29
-msgid "or Select from computer"
-msgstr ""
-
-#: scripts/apps/workspace/content/views/schema-editor.html:33
+#: scripts/apps/workspace/content/views/schema-editor.html:43
 msgid "Order"
 msgstr ""
 
+#: scripts/apps/contacts/services/ContactsService.js:21
+#: scripts/apps/contacts/views/search-panel.html:32
+msgid "Organisation"
+msgstr ""
+
 #: scripts/apps/archive/views/item-preview.html:24
-#: scripts/apps/archive/views/preview.html:95
-#: scripts/apps/authoring/views/article-edit.html:224
-#: scripts/apps/authoring/views/change-image.html:121
-#: scripts/apps/authoring/views/change-image.html:23
+#: scripts/apps/archive/views/preview.html:96
+#: scripts/apps/authoring/views/article-edit.html:325
+#: scripts/apps/authoring/views/change-image.html:138
+#: scripts/apps/authoring/views/change-image.html:24
 msgid "Original"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:104
-msgid "Original creator"
-msgstr ""
-
-#: scripts/apps/archive/views/metadata-view.html:100
+#: scripts/apps/archive/views/metadata-view.html:101
 msgid "Original ID"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/controllers/ChangeImageController.js:200
+#: scripts/apps/archive/views/metadata-associateditem-view.html:27
+#: scripts/apps/archive/views/metadata-view.html:31
+msgid "Original Source"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:105
+msgid "Original creator"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.js:207
+#: scripts/apps/authoring/tests/changeImage.spec.js:53
 msgid "Original size cannot be less than the required crop sizes."
 msgstr ""
 
@@ -4120,15 +4024,11 @@ msgstr ""
 msgid "Original source"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:31
-msgid "Original Source"
-msgstr ""
-
-#: scripts/apps/desks/views/desk-config-modal.html:259
+#: scripts/apps/desks/views/desk-config-modal.html:309
 msgid "Outgoing Rule"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:204
+#: scripts/apps/desks/views/desk-config-modal.html:243
 msgid "Outgoing Rule:"
 msgstr ""
 
@@ -4145,19 +4045,32 @@ msgstr ""
 msgid "Output/Scheduled"
 msgstr ""
 
-#: scripts/apps/users/views/edit.html:18
+#: scripts/apps/users/views/edit.html:17
 msgid "Overview"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:50
+#: scripts/apps/authoring/views/authoring-topbar.html:55
 msgid "P"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:56
+#: scripts/apps/authoring/views/authoring-topbar.html:62
 msgid "P & C"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/sd-content-create.html:29
+#: scripts/apps/authoring/views/authoring-header.html:146
+msgid "PLACE"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:192
+msgid "PRIORITY"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:11
+#: scripts/apps/authoring/views/authoring-header.html:7
+msgid "PROFILE"
+msgstr ""
+
+#: scripts/apps/workspace/content/views/sd-content-create.html:22
 msgid "Package current item"
 msgstr ""
 
@@ -4169,28 +4082,28 @@ msgstr ""
 msgid "Package preview"
 msgstr ""
 
-#: scripts/apps/authoring/packages/packages.js:36
+#: scripts/apps/authoring/packages/packages.js:43
 msgid "Packages"
-msgstr ""
-
-#: scripts/apps/monitoring/views/item-actions-menu.html:20
-msgid "Packaging"
 msgstr ""
 
 #: scripts/core/list/views/sdPaginationAlt.html:2
 msgid "Page"
 msgstr ""
 
-#: scripts/core/list/views/sdPagination.html:1
+#: scripts/core/list/views/sdPagination.html:2
 msgid "Page Size:"
 msgstr ""
 
-#: scripts/apps/analytics/views/activity-report-panel.html:16
+#: scripts/apps/legal-archive/views/legal_archive.html:20
+msgid "Pagination"
+msgstr ""
+
+#: scripts/apps/content-api/views/search-panel.html:5
 #: scripts/apps/search/views/search-panel.html:33
 msgid "Parameters"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ftp-config.html:22
+#: scripts/apps/ingest/views/settings/ftp-config.html:24
 msgid "Passive"
 msgstr ""
 
@@ -4198,21 +4111,12 @@ msgstr ""
 msgid "Passive mode"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/reutersConfig.html:15
-#: scripts/apps/ingest/views/settings/searchConfig.html:7
-#: scripts/apps/users/import/views/import-user.html:19
-#: scripts/apps/users/views/edit-form.html:84
-#: scripts/apps/users/views/edit-form.html:89
-#: scripts/core/auth/login-modal.html:14
-msgid "password"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/emailConfig.html:20
-#: scripts/apps/ingest/views/settings/ftp-config.html:10
-#: scripts/apps/ingest/views/settings/ftp-config.html:11
+#: scripts/apps/ingest/views/settings/emailConfig.html:21
+#: scripts/apps/ingest/views/settings/ftp-config.html:12
+#: scripts/apps/ingest/views/settings/ftp-config.html:13
 #: scripts/apps/ingest/views/settings/reutersConfig.html:14
-#: scripts/apps/ingest/views/settings/rssConfig.html:28
-#: scripts/apps/ingest/views/settings/rssConfig.html:30
+#: scripts/apps/ingest/views/settings/rssConfig.html:32
+#: scripts/apps/ingest/views/settings/rssConfig.html:34
 #: scripts/apps/ingest/views/settings/searchConfig.html:6
 #: scripts/apps/publish/views/ftp-config.html:11
 #: scripts/apps/publish/views/ftp-config.html:12
@@ -4224,93 +4128,80 @@ msgstr ""
 msgid "Password is too weak."
 msgstr ""
 
-#: scripts/core/auth/auth.js:67
+#: scripts/core/auth/auth.js:69
 msgid "Password was changed. You can login using your new password."
 msgstr ""
 
-#: scripts/core/auth/reset-password.html:55
-msgid "passwords must be same"
-msgstr ""
-
-#: scripts/core/editor2/views/add-content.html:19
-msgid "paste a block"
-msgstr ""
-
-#: scripts/core/editor2/editor.js:898
+#: scripts/core/editor2/editor.js:909
 msgid "Paste or type a full link"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ftp-config.html:14
+#: scripts/apps/ingest/views/settings/ftp-config.html:16
 #: scripts/apps/publish/views/ftp-config.html:19
 msgid "Path"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/fileConfig.html:3
-msgid "path to folder"
+#: scripts/apps/ingest/views/settings/fileConfig.html:4
+msgid "Path not found on server."
 msgstr ""
 
-#: scripts/apps/users/views/user-list-item.html:16
-msgid "pending"
+#: scripts/apps/ingest/views/settings/fileConfig.html:5
+msgid "Path should be directory."
 msgstr ""
 
-#: scripts/apps/users/controllers/UserListController.js:144
+#: scripts/apps/users/controllers/UserListController.js:145
 msgid "Pending"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:277
+#: scripts/apps/desks/views/desk-config-modal.html:327
 #: scripts/apps/desks/views/settings.html:38
-#: scripts/apps/groups/views/groups-config-modal.html:38
 msgid "People"
 msgstr ""
 
-#: scripts/apps/products/views/products-config-modal.html:34
+#: scripts/apps/products/views/products-config-modal.html:56
 msgid "Permitting"
 msgstr ""
 
-#: scripts/apps/dictionaries/views/settings.html:26
+#: scripts/apps/contacts/services/ContactsService.js:20
+msgid "Person (Last Name)"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/settings.html:45
 #: scripts/apps/monitoring/config.js:32
-#: scripts/apps/monitoring/controllers/AggregateCtrl.js:419
+#: scripts/apps/monitoring/controllers/AggregateCtrl.js:415
 #: scripts/apps/monitoring/views/aggregate-settings.html:102
 #: scripts/apps/monitoring/views/aggregate-settings.html:126
 #: scripts/apps/monitoring/views/aggregate-settings.html:37
-#: scripts/apps/templates/directives/TemplatesDirective.js:293
-#: scripts/apps/workspace/views/workspace-sidenav-items.html:46
+#: scripts/apps/templates/directives/TemplatesDirective.js:312
+#: scripts/apps/workspace/views/workspace-sidenav-items.html:53
 msgid "Personal"
 msgstr ""
 
-#: scripts/apps/dictionaries/views/dictionary-config-modal.html:45
-msgid "Personal dictionary for language \"{{ dictionary.language_id }}\" already exists."
+#: scripts/apps/dictionaries/views/settings.html:25
+msgid "Personal Dictionary"
 msgstr ""
 
-#: scripts/apps/monitoring/views/monitoring-view.html:22
+#: scripts/apps/monitoring/views/monitoring-view.html:33
 msgid "Personal Items"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:135
-msgid "phone number"
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:45
+msgid "Personal dictionary for language \"{{ dictionary.language_id}}\" already exists."
 msgstr ""
 
-#: scripts/apps/dictionaries/views/dictionary-config-modal.html:100
-#: scripts/apps/dictionaries/views/dictionary-config-modal.html:86
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:102
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:88
 msgid "Phrase"
 msgstr ""
 
-#: scripts/apps/dashboard/workspace-tasks/tasks.js:388
+#: scripts/apps/dashboard/workspace-tasks/tasks.js:383
 msgid "Pick task"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:4
-msgid "picture"
 msgstr ""
 
 #: scripts/apps/archive/views/metadata-view.html:61
 #: scripts/apps/authoring/views/full-preview.html:85
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:11
+#: scripts/apps/workspace/content/constants.js:61
 msgid "Place"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-header.html:119
-msgid "PLACE"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:7
@@ -4319,6 +4210,10 @@ msgstr ""
 
 #: scripts/apps/workspace/content/views/sd-content-create.html:8
 msgid "Plain text"
+msgstr ""
+
+#: scripts/apps/workspace/views/workspace-sidenav-items.html:87
+msgid "Planning"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:14
@@ -4345,28 +4240,46 @@ msgstr ""
 msgid "Please confirm you want to delete dictionary."
 msgstr ""
 
+#: scripts/apps/internal-destinations/index.js:36
+msgid "Please confirm you want to delete internal destination."
+msgstr ""
+
+#: scripts/apps/vocabularies/controllers/VocabularyConfigController.js:86
+msgid "Please confirm you want to delete the vocabulary."
+msgstr ""
+
 #: scripts/core/auth/login-modal.html:3
 msgid "Please log in again."
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:103
-msgid "please provide a valid email address"
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:114
+msgid "Please provide an article GUID"
 msgstr ""
 
-#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:112
-#: scripts/apps/products/controllers/ProductsConfigController.js:102
+#: scripts/apps/products/controllers/ProductsConfigController.js:193
 msgid "Please provide an article id"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:63
-msgid "please use only letters (a-z), numbers (0-9), dashes (&mdash;), underscores (_), apostrophes (') and periods (.)"
+#: scripts/apps/templates/views/create-template.html:18
+#: scripts/apps/templates/views/template-editor-modal.html:18
+#: scripts/apps/workspace/content/views/profile-settings.html:64
+#: scripts/apps/workspace/content/views/profile-settings.html:94
+msgid "Please use less than 40 characters"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:42
+msgid "Please use less than 80 characters"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:38
+msgid "Please use less than 80 characters."
 msgstr ""
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:40
 msgid "Please use plain text dictionary."
 msgstr ""
 
-#: scripts/apps/authoring/authoring/controllers/ChangeImageController.js:80
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.js:79
 msgid "Point of interest outside the crop  limits"
 msgstr ""
 
@@ -4378,11 +4291,15 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
+#: scripts/apps/contacts/views/search-panel.html:54
+msgid "Post Code"
+msgstr ""
+
 #: scripts/apps/authoring/comments/views/comments-widget.html:26
 msgid "Post on 'Enter'"
 msgstr ""
 
-#: scripts/apps/users/views/edit.html:21
+#: scripts/apps/users/views/edit.html:20
 msgid "Preferences"
 msgstr ""
 
@@ -4394,30 +4311,25 @@ msgstr ""
 msgid "Preserve Desk"
 msgstr ""
 
-#: scripts/apps/authoring/macros/views/macros-replace.html:7
-msgid "prev"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-topbar.html:102
-#: scripts/apps/authoring/views/authoring.html:22
-#: scripts/apps/desks/views/stage-item-list.html:23
-#: scripts/apps/users/views/user-preferences.html:35
+#: scripts/apps/authoring/views/article-edit.html:561
+#: scripts/apps/authoring/views/authoring-topbar.html:111
+#: scripts/apps/authoring/views/authoring.html:23
+#: scripts/apps/users/views/user-preferences.html:49
 msgid "Preview"
 msgstr ""
 
-#: scripts/apps/authoring/views/preview-formatted.html:5
+#: scripts/apps/authoring/views/preview-formatted.html:6
 msgid "Preview Formatted Story"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-header.html:46
+#: scripts/apps/authoring/authoring/index.js:240
+msgid "Preview formatted article, when previewFormats feature configured"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:47
 msgid "Preview master story"
 msgstr ""
 
-#: scripts/apps/archive/views/media-view.html:31
-msgid "previous"
-msgstr ""
-
-#: scripts/apps/groups/views/groups-config-modal.html:56
 #: scripts/apps/monitoring/views/aggregate-settings.html:136
 msgid "Previous"
 msgstr ""
@@ -4430,26 +4342,21 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: scripts/apps/analytics/views/activity-report-parameters.html:84
-#: scripts/apps/archive/directives/ItemPriority.js:19
 #: scripts/apps/archive/views/metadata-view.html:13
-#: scripts/apps/legal-archive/services/LegalArchiveService.js:13
-#: scripts/apps/search/services/SearchService.js:32
+#: scripts/apps/content-api/services/ContentAPISearchService.js:25
+#: scripts/apps/legal-archive/services/LegalArchiveService.js:26
+#: scripts/apps/legal-archive/tests/legal.spec.js:76
+#: scripts/apps/search/services/SearchService.js:47
 #: scripts/apps/search/views/search-filters.html:93
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:12
+#: scripts/apps/workspace/content/constants.js:62
 msgid "Priority"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-header.html:138
-msgid "PRIORITY"
 msgstr ""
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:65
 msgid "Private saved searches"
 msgstr ""
 
-#: scripts/apps/users/views/edit.html:24
-#: scripts/apps/users/views/settings.html:9
+#: scripts/apps/users/views/edit.html:23
 msgid "Privileges"
 msgstr ""
 
@@ -4467,59 +4374,63 @@ msgstr ""
 msgid "Problems occurred while fetching data."
 msgstr ""
 
-#: scripts/apps/products/views/products-config-modal.html:22
-msgid "Product codes"
+#: scripts/apps/products/views/products-config-modal.html:12
+msgid "Product Details"
 msgstr ""
 
-#: scripts/apps/products/controllers/ProductsConfigController.js:87
-msgid "Product deleted."
-msgstr ""
-
-#: scripts/apps/products/views/products-config-modal.html:18
-msgid "Product description"
-msgstr ""
-
-#: scripts/apps/products/controllers/ProductsConfigController.js:67
-msgid "Product is saved."
-msgstr ""
-
-#: scripts/apps/products/views/products.html:3
-msgid "Product management"
-msgstr ""
-
-#: scripts/apps/products/views/products-config-modal.html:14
-msgid "Product name"
-msgstr ""
-
-#: scripts/apps/products/views/settings.html:8
+#: scripts/apps/products/views/settings.html:11
 msgid "Product Test"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:20
-msgid "production"
+#: scripts/apps/products/views/products-config-modal.html:36
+msgid "Product Type"
 msgstr ""
 
-#: scripts/apps/search/views/item-repo.html:8
+#: scripts/apps/products/controllers/ProductsConfigController.js:153
+msgid "Product Type is required"
+msgstr ""
+
+#: scripts/apps/products/views/products.html:6
+msgid "Product Type:"
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:44
+msgid "Product codes"
+msgstr ""
+
+#: scripts/apps/products/controllers/ProductsConfigController.js:171
+msgid "Product deleted."
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:32
+msgid "Product description"
+msgstr ""
+
+#: scripts/apps/products/controllers/ProductsConfigController.js:143
+msgid "Product is saved."
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:28
+msgid "Product name"
+msgstr ""
+
+#: scripts/apps/search/views/item-repo.html:5
 msgid "Production"
 msgstr ""
 
 #: scripts/apps/products/index.js:18
-#: scripts/apps/products/views/settings.html:5
-#: scripts/apps/publish/views/subscribers.html:91
+#: scripts/apps/products/views/settings.html:8
+#: scripts/apps/publish/views/subscribers.html:160
+#: scripts/apps/publish/views/subscribers.html:96
 msgid "Products"
 msgstr ""
 
-#: scripts/apps/users/import/views/import-user.html:31
-msgid "profile"
+#: scripts/apps/products/views/settings.html:3
+msgid "Products management"
 msgstr ""
 
 #: scripts/core/menu/notifications/views/notifications.html:11
 msgid "Profile"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-header.html:11
-#: scripts/apps/authoring/views/authoring-header.html:7
-msgid "PROFILE"
 msgstr ""
 
 #: scripts/apps/profiling/views/profiling.html:6
@@ -4530,6 +4441,10 @@ msgstr ""
 msgid "Profiling Data"
 msgstr ""
 
+#: scripts/apps/authoring/views/theme-select.html:66
+msgid "Proofread Theme"
+msgstr ""
+
 #: scripts/core/auth/reset-password.html:11
 msgid "Provide your email in order to get 'Reset Token'. Once you get it, use it to reset your password."
 msgstr ""
@@ -4538,19 +4453,19 @@ msgstr ""
 msgid "Provided image URL is not valid."
 msgstr ""
 
-#: scripts/apps/search/views/search-parameters.html:143
+#: scripts/apps/search/views/search-parameters.html:146
 msgid "Provider"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:34
-msgid "Provider {{name}} has gone strangely quiet. Last activity was on {{last}}"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:46
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:49
 msgid "Provider Name"
 msgstr ""
 
-#: scripts/apps/ingest/directives/IngestSourcesContent.js:264
+#: scripts/apps/search-providers/views/search-provider-config.html:51
+msgid "Provider Type"
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.js:268
 msgid "Provider saved!"
 msgstr ""
 
@@ -4558,40 +4473,36 @@ msgstr ""
 msgid "Provider sequence"
 msgstr ""
 
-#: scripts/apps/search-providers/views/search-provider-config.html:51
-msgid "Provider Type"
+#: scripts/core/lang/missing-translations-strings.js:34
+msgid "Provider {{name}} has gone strangely quiet. Last activity was on {{last}}"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:4
-msgid "publish"
+#: scripts/apps/archive/views/metadata-view.html:122
+msgid "PubStatus"
 msgstr ""
 
-#: scripts/apps/analytics/views/activity-report-parameters.html:8
-#: scripts/apps/authoring/views/authoring-topbar.html:48
-#: scripts/apps/authoring/views/authoring-topbar.html:49
-#: scripts/apps/authoring/views/send-item.html:8
+#: scripts/apps/contacts/views/search-panel.html:91
+msgid "Public"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:72
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:73
+#: scripts/apps/authoring/views/authoring-topbar.html:53
+#: scripts/apps/authoring/views/authoring-topbar.html:54
+#: scripts/apps/authoring/views/send-item.html:11
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:26
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:29
-#: scripts/apps/publish/index.js:39
+#: scripts/apps/search/views/multi-action-bar.html:43
 msgid "Publish"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:54
-#: scripts/apps/authoring/views/authoring-topbar.html:55
-msgid "Publish and Continue"
-msgstr ""
-
-#: scripts/apps/authoring/views/send-item.html:104
-msgid "publish from"
-msgstr ""
-
-#: scripts/apps/publish/index.js:48
+#: scripts/apps/publish/index.js:50
 msgid "Publish Queue"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:135
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:327
-#: scripts/apps/authoring/views/send-item.html:55
+#: scripts/apps/archive/views/metadata-view.html:136
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:348
+#: scripts/apps/authoring/views/send-item.html:65
 msgid "Publish Schedule"
 msgstr ""
 
@@ -4599,32 +4510,33 @@ msgstr ""
 msgid "Publish Without Media"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:7
-msgid "published"
+#: scripts/apps/authoring/views/authoring-topbar.html:60
+#: scripts/apps/authoring/views/authoring-topbar.html:61
+msgid "Publish and Continue"
 msgstr ""
 
 #: scripts/apps/dashboard/workspace-tasks/views/desk-stages.html:22
-#: scripts/apps/search/views/item-repo.html:9
+#: scripts/apps/search/views/item-repo.html:6
 msgid "Published"
 msgstr ""
 
-#: scripts/apps/authoring/versioning/history/views/history.html:59
-msgid "Published by"
-msgstr ""
-
-#: scripts/apps/legal-archive/views/legal_archive.html:62
+#: scripts/apps/legal-archive/views/legal_archive.html:80
 msgid "Published From"
 msgstr ""
 
-#: scripts/apps/legal-archive/views/legal_archive.html:66
+#: scripts/apps/legal-archive/views/legal_archive.html:84
 msgid "Published Until"
 msgstr ""
 
-#: scripts/apps/publish/views/publish-queue.html:91
+#: scripts/apps/authoring/versioning/history/views/history.html:166
+msgid "Published by"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:95
 msgid "Publishing Action"
 msgstr ""
 
-#: scripts/apps/authoring/views/send-item.html:54
+#: scripts/apps/authoring/views/send-item.html:64
 msgid "Publishing Schedule"
 msgstr ""
 
@@ -4632,15 +4544,11 @@ msgstr ""
 msgid "Pubstatus"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:121
-msgid "PubStatus"
-msgstr ""
-
 #: scripts/apps/vocabularies/services/SchemaFactory.js:5
 msgid "QCode"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/schema-editor.html:94
+#: scripts/apps/workspace/content/views/schema-editor.html:69
 msgid "Quarter"
 msgstr ""
 
@@ -4648,24 +4556,20 @@ msgstr ""
 msgid "Query Text"
 msgstr ""
 
-#: scripts/apps/publish/views/publish-queue.html:95
+#: scripts/apps/publish/views/publish-queue.html:99
 msgid "Queued at"
 msgstr ""
 
-#: scripts/apps/authoring/macros/views/macros-widget.html:14
-msgid "quick list"
+#: scripts/apps/authoring/views/authoring-header.html:31
+msgid "RELATED"
 msgstr ""
 
-#: scripts/core/editor2/editor.js:1067
-msgid "quote"
+#: scripts/apps/ingest/views/settings/rssConfig.html:4
+msgid "RSS Feed URL"
 msgstr ""
 
 #: scripts/apps/search/views/search-panel.html:13
 msgid "Raw"
-msgstr ""
-
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:47
-msgid "Go-To"
 msgstr ""
 
 #: scripts/apps/users/config.js:147
@@ -4676,15 +4580,23 @@ msgstr ""
 msgid "Read users"
 msgstr ""
 
-#: scripts/apps/monitoring/views/monitoring-view.html:118
+#: scripts/apps/authoring/views/authoring-topbar.html:37
+msgid "Read-only"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:121
 msgid "Rearrange Groups"
 msgstr ""
 
-#: scripts/apps/dashboard/views/workspace.html:6
+#: scripts/apps/dashboard/views/workspace.html:5
 msgid "Rearrange widgets"
 msgstr ""
 
-#: scripts/apps/users/views/list.html:37
+#: scripts/apps/workspace/content/views/sd-content-create.html:29
+msgid "Recent templates"
+msgstr ""
+
+#: scripts/apps/users/views/list.html:42
 msgid "Recently added"
 msgstr ""
 
@@ -4701,11 +4613,10 @@ msgid "Recipients (visible to everybody)"
 msgstr ""
 
 #: scripts/apps/monitoring/views/monitoring-group-header.html:24
-#: scripts/apps/monitoring/views/monitoring-group-header.html:45
-#: scripts/apps/monitoring/views/monitoring-group-header.html:60
-#: scripts/apps/monitoring/views/monitoring-view.html:48
+#: scripts/apps/monitoring/views/monitoring-group-header.html:57
+#: scripts/apps/monitoring/views/monitoring-view.html:59
 #: scripts/apps/profiling/views/profiling.html:23
-#: scripts/apps/publish/views/publish-queue.html:64
+#: scripts/apps/publish/views/publish-queue.html:66
 #: scripts/apps/search/views/search.html:9
 msgid "Refresh"
 msgstr ""
@@ -4718,25 +4629,24 @@ msgstr ""
 msgid "Refreshing..."
 msgstr ""
 
-#: scripts/apps/archive/related-item-widget/relatedItem.js:90
+#: scripts/apps/archive/related-item-widget/relatedItem.js:103
 msgid "Relate an item"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-header.html:30
-msgid "RELATED"
-msgstr ""
-
 #: scripts/apps/archive/related-item-widget/relatedItem.js:8
-#: scripts/apps/archive/related-item-widget/relatedItem.js:85
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:29
+#: scripts/apps/archive/related-item-widget/relatedItem.js:98
+#: scripts/apps/workspace/content/constants.js:80
 msgid "Related Items"
 msgstr ""
 
-#: scripts/apps/archive/views/marked_item_title.html:21
+#: scripts/apps/archive/views/marked_item_title.html:20
+#: scripts/apps/authoring/attachments/attachments.html:33
 #: scripts/apps/desks/views/settings.html:26
-#: scripts/apps/ingest/index.js:82
-#: scripts/apps/ingest/views/settings/rssConfig.html:75
-#: scripts/apps/search/views/multi-action-bar.html:49
+#: scripts/apps/ingest/index.js:83
+#: scripts/apps/ingest/views/settings/rssConfig.html:79
+#: scripts/apps/internal-destinations/views/settings.html:21
+#: scripts/apps/search/views/multi-action-bar.html:108
+#: scripts/apps/search/views/multi-action-bar.html:55
 #: scripts/apps/search/views/search-filters.html:11
 #: scripts/apps/search/views/search-filters.html:112
 #: scripts/apps/search/views/search-filters.html:120
@@ -4746,24 +4656,40 @@ msgstr ""
 #: scripts/apps/search/views/search-filters.html:73
 #: scripts/apps/search/views/search-filters.html:86
 #: scripts/apps/search/views/search-filters.html:99
-#: scripts/apps/templates/views/templates.html:35
-#: scripts/apps/workspace/content/views/profile-settings.html:26
+#: scripts/apps/templates/views/templates.html:36
+#: scripts/apps/workspace/content/views/profile-settings.html:29
 msgid "Remove"
 msgstr ""
 
-#: scripts/apps/highlights/views/settings.html:21
-msgid "Remove configuration"
+#: scripts/apps/content-filters/views/manage-filters.html:19
+msgid "Remove Content Filter"
 msgstr ""
 
-#: scripts/apps/content-filters/views/manage-filters.html:22
-msgid "Remove Content Filter"
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:19
+msgid "Remove Filter Condition"
+msgstr ""
+
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-article.html:9
+msgid "Remove Item"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:17
+msgid "Remove Search Provider"
+msgstr ""
+
+#: scripts/apps/templates/views/templates.html:36
+msgid "Remove Template"
+msgstr ""
+
+#: scripts/apps/highlights/views/settings.html:17
+msgid "Remove configuration"
 msgstr ""
 
 #: scripts/apps/desks/views/settings.html:26
 msgid "Remove desk"
 msgstr ""
 
-#: scripts/apps/dictionaries/views/settings.html:33
+#: scripts/apps/dictionaries/views/settings.html:52
 msgid "Remove dictionary"
 msgstr ""
 
@@ -4775,27 +4701,11 @@ msgstr ""
 msgid "Remove filter"
 msgstr ""
 
-#: scripts/apps/content-filters/views/manage-filter-conditions.html:21
-msgid "Remove Filter Condition"
-msgstr ""
-
-#: scripts/core/editor2/editor.js:1073
-msgid "remove formatting"
-msgstr ""
-
-#: scripts/apps/groups/views/settings.html:18
-msgid "Remove group"
-msgstr ""
-
-#: scripts/apps/authoring/multiedit/views/sd-multiedit-article.html:9
-msgid "Remove Item"
-msgstr ""
-
 #: scripts/apps/authoring/multiedit/views/multiedit.html:17
 msgid "Remove panel"
 msgstr ""
 
-#: scripts/apps/products/views/products.html:15
+#: scripts/apps/products/views/products.html:25
 msgid "Remove product"
 msgstr ""
 
@@ -4803,40 +4713,36 @@ msgstr ""
 msgid "Remove publish action"
 msgstr ""
 
-#: scripts/apps/users/views/settings-roles.html:18
+#: scripts/apps/users/views/settings-roles.html:17
 msgid "Remove role"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-rules-content.html:18
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:15
 msgid "Remove rule set"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-routing-content.html:17
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:15
 msgid "Remove scheme"
 msgstr ""
 
-#: scripts/apps/search-providers/views/search-provider-config.html:17
-msgid "Remove Search Provider"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:20
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:22
 msgid "Remove source"
 msgstr ""
 
-#: scripts/apps/templates/views/templates.html:35
-msgid "Remove Template"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:32
-msgid "removed item {{ type }} about {{ subject }}"
-msgstr ""
-
-#: scripts/apps/dashboard/views/workspace.html:27
-msgid "Rename workspace"
+#: scripts/apps/vocabularies/views/vocabulary-config.html:49
+msgid "Remove vocabulary"
 msgstr ""
 
 #: scripts/apps/workspace/views/edit-workspace-modal.html:4
 msgid "Rename Workspace"
+msgstr ""
+
+#: scripts/apps/dashboard/views/workspace.html:29
+msgid "Rename workspace"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:122
+msgid "Reopened by"
 msgstr ""
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:83
@@ -4847,62 +4753,61 @@ msgstr ""
 msgid "Reorder stages and saved searches for view"
 msgstr ""
 
-#: scripts/apps/authoring/macros/views/macros-replace.html:6
-msgid "replace"
-msgstr ""
-
-#: scripts/apps/authoring/editor/views/find-replace.html:29
+#: scripts/apps/authoring/editor/views/find-replace.html:30
 msgid "Replace"
 msgstr ""
 
-#: scripts/apps/authoring/editor/views/find-replace.html:30
+#: scripts/apps/authoring/editor/views/find-replace.html:31
 msgid "Replace All"
 msgstr ""
 
-#: scripts/apps/authoring/editor/views/find-replace.html:12
+#: scripts/apps/authoring/editor/views/find-replace.html:13
 msgid "Replace with"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:38
-msgid "replaced item {{ type }} about {{ subject }}"
-msgstr ""
-
-#: scripts/apps/workspace/content/views/schema-editor.html:29
-#: scripts/core/ui/ui.js:1341
+#: scripts/apps/workspace/content/views/schema-editor.html:38
+#: scripts/core/ui/ui.js:1063
 msgid "Required"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:501
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:475
 msgid "Required field {{ key }} is missing. ..."
 msgstr ""
 
-#: scripts/apps/authoring/authoring/controllers/ChangeImageController.js:91
+#: scripts/apps/archive/controllers/UploadController.js:57
+msgid "Required field(s) are missing"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.js:90
 msgid "Required field(s) missing"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/rssConfig.html:14
+#: scripts/apps/ingest/views/settings/rssConfig.html:18
 msgid "Requires Authentication"
 msgstr ""
 
 #: scripts/apps/archive/views/resend-configuration.html:25
-#: scripts/apps/publish/views/publish-queue.html:125
+#: scripts/apps/publish/views/publish-queue.html:129
 #: scripts/apps/publish/views/publish-queue.html:77
 msgid "Resend"
-msgstr ""
-
-#: scripts/apps/archive/index.js:239
-msgid "Resend item"
 msgstr ""
 
 #: scripts/apps/archive/views/resend-configuration.html:4
 msgid "Resend To"
 msgstr ""
 
+#: scripts/apps/archive/index.js:251
+msgid "Resend item"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:169
+msgid "Resent by"
+msgstr ""
+
 #: scripts/apps/profiling/views/profiling.html:22
 msgid "Reset"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:169
 #: scripts/core/auth/reset-password.html:60
 msgid "Reset password"
 msgstr ""
@@ -4916,52 +4821,42 @@ msgstr ""
 msgid "Restore"
 msgstr ""
 
-#: scripts/apps/authoring/versioning/history/views/history.html:38
-msgid "Restored by"
-msgstr ""
-
-#: scripts/apps/products/views/product-test.html:8
+#: scripts/apps/products/views/product-test.html:15
 msgid "Result Type"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:6
-msgid "retrying"
-msgstr ""
-
-#: scripts/apps/authoring/versioning/versions/views/versions.html:16
-msgid "revert"
-msgstr ""
-
-#: scripts/apps/publish/views/subscribers.html:162
+#: scripts/apps/publish/views/subscribers.html:180
+#: scripts/apps/publish/views/subscribers.html:206
 msgid "Revoke"
 msgstr ""
 
-#: scripts/apps/authoring/versioning/history/views/history.html:21
+#: scripts/apps/authoring/versioning/history/views/history.html:143
+msgid "Rewrite link is removed"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:154
 msgid "Rewritten by"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:124
-msgid "role"
+#: scripts/apps/authoring/versioning/history/views/history.html:146
+msgid "Rewritten link is removed"
 msgstr ""
 
-#: scripts/apps/users/views/list.html:30
+#: scripts/apps/users/views/edit-form.html:145
+#: scripts/apps/users/views/list.html:35
 #: scripts/apps/users/views/user-privileges.html:17
 msgid "Role"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:36
-msgid "role {{role}} is granted new privileges: Please re-login."
-msgstr ""
-
-#: scripts/apps/users/views/settings-roles.html:39
+#: scripts/apps/users/views/settings-roles.html:45
 msgid "Role Description"
 msgstr ""
 
-#: scripts/apps/users/views/settings-roles.html:35
+#: scripts/apps/users/views/settings-roles.html:38
 msgid "Role Name"
 msgstr ""
 
-#: scripts/apps/users/views/settings.html:6
+#: scripts/apps/users/views/settings.html:8
 msgid "Roles"
 msgstr ""
 
@@ -4969,23 +4864,15 @@ msgstr ""
 msgid "Roles Management"
 msgstr ""
 
-#: scripts/apps/users/views/settings-privileges.html:3
+#: scripts/apps/users/views/settings.html:11
 msgid "Roles privileges"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:6
-msgid "routed"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/settings.html:12
-msgid "Routing"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:15
 msgid "Routing Rules Management"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:121
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:134
 msgid "Routing Scheme"
 msgstr ""
 
@@ -4993,16 +4880,12 @@ msgstr ""
 msgid "Routing scheme saved."
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/rssConfig.html:4
-msgid "RSS Feed URL"
-msgstr ""
-
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:2
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:3
 msgid "Rule name"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-rules-content.html:36
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:31
 msgid "Rule set name"
 msgstr ""
 
@@ -5010,86 +4893,103 @@ msgstr ""
 msgid "Rule set saved."
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/settings.html:9
-msgid "Rule sets"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:114
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:127
 msgid "Ruleset"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:210
+#: scripts/apps/authoring/views/authoring-topbar.html:258
 msgid "Run automatically"
 msgstr ""
 
-#: scripts/core/datetime/datetime.js:204
+#: scripts/apps/desks/views/desk-config-modal.html:85
+msgid "SERVICE"
+msgstr ""
+
+#: scripts/core/menu/notifications/views/notifications.html:12
+msgid "SIGN OUT"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:61
+msgid "SLUGLINE"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:42
+msgid "SLUGLINE is too long"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:53
+#: scripts/apps/workspace/content/constants.js:73
+msgid "SMS"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:60
+msgid "SMS Message"
+msgstr ""
+
+#: scripts/core/editor2/views/block-text.html:24
+msgid "SORRY, NO SUGGESTIONS."
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:27
+msgid "SOURCE"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:263
+msgid "SUBJECT"
+msgstr ""
+
+#: scripts/core/datetime/datetime.js:230
 msgid "Saturday"
 msgstr ""
 
-#: scripts/apps/analytics/views/save-activity-report.html:10
-#: scripts/apps/archive/views/upload.html:99
+#: scripts/apps/archive/views/upload.html:105
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:60
 #: scripts/apps/authoring/multiedit/views/sd-multiedit-article.html:3
-#: scripts/apps/authoring/views/authoring-topbar.html:94
+#: scripts/apps/authoring/views/authoring-topbar.html:102
 #: scripts/apps/authoring/views/change-image.html:10
-#: scripts/apps/authoring/views/change-image.html:51
-#: scripts/apps/content-filters/views/manage-filter-conditions.html:77
-#: scripts/apps/content-filters/views/manage-filters.html:129
+#: scripts/apps/authoring/views/change-image.html:53
+#: scripts/apps/authoring/views/theme-select.html:119
+#: scripts/apps/contacts/views/edit-form.html:3
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:90
+#: scripts/apps/content-filters/views/manage-filters.html:140
 #: scripts/apps/dashboard/views/configuration.html:9
-#: scripts/apps/dashboard/views/workspace.html:10
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:11
-#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:87
-#: scripts/apps/desks/views/desk-config-modal.html:125
-#: scripts/apps/desks/views/desk-config-modal.html:158
-#: scripts/apps/dictionaries/views/dictionary-config-modal.html:119
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:88
+#: scripts/apps/desks/views/desk-config-modal.html:178
+#: scripts/apps/desks/views/desk-config-modal.html:186
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:121
 #: scripts/apps/highlights/views/highlights_config_modal.html:53
-#: scripts/apps/ingest/views/settings/ingest-routing-content.html:90
-#: scripts/apps/ingest/views/settings/ingest-rules-content.html:67
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:174
-#: scripts/apps/products/views/products-config-modal.html:58
-#: scripts/apps/publish/views/subscribers.html:194
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:89
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:57
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:187
+#: scripts/apps/internal-destinations/views/settings.html:61
+#: scripts/apps/products/views/products-config-modal.html:78
+#: scripts/apps/publish/views/subscribers.html:237
 #: scripts/apps/search-providers/views/search-provider-config.html:81
-#: scripts/apps/templates/views/create-template.html:44
-#: scripts/apps/templates/views/template-editor-modal.html:189
+#: scripts/apps/templates/views/create-template.html:42
+#: scripts/apps/templates/views/template-editor-modal.html:199
 #: scripts/apps/users/views/edit-form.html:3
 #: scripts/apps/users/views/settings-privileges.html:4
 #: scripts/apps/users/views/user-preferences.html:4
 #: scripts/apps/users/views/user-privileges.html:5
-#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:56
-#: scripts/apps/workspace/content/views/profile-settings.html:105
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:174
+#: scripts/apps/workspace/content/views/profile-settings.html:116
 #: scripts/apps/workspace/views/edit-workspace-modal.html:20
 #: scripts/core/editor2/views/block-embed.html:4
 msgid "Save"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:100
-#: scripts/apps/desks/views/desk-config-modal.html:299
+#: scripts/apps/desks/views/desk-config-modal.html:128
+#: scripts/apps/desks/views/desk-config-modal.html:350
 msgid "Save & Continue"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/profile-settings.html:70
+#: scripts/apps/workspace/content/views/profile-settings.html:77
 msgid "Save &amp; Continue"
-msgstr ""
-
-#: scripts/apps/analytics/views/save-activity-report.html:2
-msgid "Save activity report"
-msgstr ""
-
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:75
-msgid "Save and publish"
-msgstr ""
-
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:89
-msgid "Save and send"
 msgstr ""
 
 #: scripts/apps/search/views/save-search.html:14
 msgid "Save As"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-topbar.html:136
-#: scripts/apps/templates/views/create-template.html:4
-msgid "Save as template"
 msgstr ""
 
 #: scripts/apps/search/views/save-search.html:15
@@ -5097,14 +4997,35 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
+#: scripts/apps/search/views/save-search.html:10
+msgid "Save Search"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:85
+msgid "Save and publish"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:99
+msgid "Save and send"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:168
+#: scripts/apps/templates/views/create-template.html:4
+msgid "Save as template"
+msgstr ""
+
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:46
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:59
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:74
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:88
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:84
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:98
 msgid "Save changes?"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:203
+#: scripts/apps/authoring/authoring/index.js:238
+msgid "Save current item"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:275
 msgid "Save password"
 msgstr ""
 
@@ -5112,71 +5033,58 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: scripts/apps/search/views/save-search.html:10
-msgid "Save Search"
-msgstr ""
-
-#: scripts/apps/analytics/views/activity-report-panel.html:7
 #: scripts/apps/search/views/search-panel.html:8
 msgid "Saved"
-msgstr ""
-
-#: scripts/apps/search/directives/SavedSearches.js:80
-msgid "Saved search removed"
 msgstr ""
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:45
 msgid "Saved Searches"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/index.js:205
-msgid "Saves current item"
+#: scripts/apps/search/directives/SavedSearches.js:80
+msgid "Saved search removed"
 msgstr ""
 
-#: scripts/apps/desks/directives/DeskeditBasic.js:39
+#: scripts/apps/contacts/directives/ContactEditDirective.js:84
+#: scripts/apps/desks/directives/DeskeditBasic.js:41
 #: scripts/apps/desks/directives/DeskeditPeople.js:39
-#: scripts/apps/desks/directives/DeskeditStages.js:100
-#: scripts/apps/groups/directives/GroupeditBasicDirective.js:25
-#: scripts/apps/users/directives/UserEditDirective.js:104
-#: scripts/core/notify/notify.js:50
+#: scripts/apps/desks/directives/DeskeditStages.js:110
+#: scripts/apps/users/directives/UserEditDirective.js:113
+#: scripts/core/notify/notify.js:51
 msgid "Saving..."
 msgstr ""
 
-#: scripts/apps/search/views/search-parameters.html:187
+#: scripts/apps/search/views/search-parameters.html:209
 msgid "Scanpix ID(s)"
 msgstr ""
 
-#: scripts/apps/templates/views/templates.html:50
+#: scripts/apps/templates/views/templates.html:51
 msgid "Sched. Desk / Stage"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-routing-content.html:74
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:75
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:42
 msgid "Schedule"
 msgstr ""
 
-#: scripts/apps/templates/views/template-editor-modal.html:161
+#: scripts/apps/templates/views/template-editor-modal.html:170
 msgid "Schedule Desk"
 msgstr ""
 
-#: scripts/apps/templates/views/template-editor-modal.html:173
+#: scripts/apps/templates/views/template-editor-modal.html:182
 msgid "Schedule Stage"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:7
-msgid "scheduled"
-msgstr ""
-
-#: scripts/apps/search/views/search-filters.html:177
+#: scripts/apps/search/views/search-filters.html:178
 msgid "Scheduled"
 msgstr ""
 
-#: scripts/apps/publish/views/publish-queue.html:96
+#: scripts/apps/publish/views/publish-queue.html:100
 msgid "Scheduled at"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:21
-msgid "scheduled Desk Output"
+#: scripts/apps/authoring/versioning/history/views/history.html:165
+msgid "Scheduled by"
 msgstr ""
 
 #: scripts/apps/workspace/content/views/schema-editor.html:2
@@ -5188,28 +5096,27 @@ msgstr ""
 msgid "Scheme name"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-routing-content.html:45
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:46
 msgid "Scheme rules"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:20
-msgid "search"
-msgstr ""
-
-#: scripts/apps/content-filters/views/filter-search.html:33
+#: scripts/apps/contacts/views/search-panel.html:108
+#: scripts/apps/contacts/views/search-panel.html:4
+#: scripts/apps/content-api/views/search-panel.html:23
+#: scripts/apps/content-filters/views/filter-search.html:43
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:52
-#: scripts/apps/legal-archive/views/legal_archive.html:20
+#: scripts/apps/legal-archive/views/legal_archive.html:38
 #: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:5
 #: scripts/apps/monitoring/views/monitoring-view.html:11
 #: scripts/apps/packaging/views/search.html:4
 #: scripts/apps/publish/views/publish-queue.html:8
 #: scripts/apps/search/directives/SearchContainer.js:9
-#: scripts/apps/search/index.js:60
+#: scripts/apps/search/index.js:63
 #: scripts/apps/search/views/item-searchbar.html:7
 #: scripts/apps/search/views/save-search.html:13
 #: scripts/apps/search/views/save-search.html:5
-#: scripts/apps/search/views/search-parameters.html:182
-#: scripts/apps/workspace/views/workspace-sidenav-items.html:54
+#: scripts/apps/search/views/search-parameters.html:204
+#: scripts/apps/workspace/views/workspace-sidenav-items.html:61
 #: scripts/core/itemList/views/relatedItem-list-widget.html:4
 #: scripts/core/itemList/views/relatedItem-list-widget.html:6
 #: scripts/core/lang/missing-translations-strings.js:21
@@ -5218,73 +5125,80 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: scripts/apps/dashboard/world-clock/configuration.html:37
-msgid "Search for clock"
-msgstr ""
-
-#: scripts/apps/search-providers/directive.js:76
+#: scripts/apps/search-providers/directive.js:73
 msgid "Search Provider deleted."
 msgstr ""
 
-#: scripts/apps/search-providers/views/search-provider-config.html:74
-msgid "search provider password"
-msgstr ""
-
-#: scripts/apps/search-providers/directive.js:37
+#: scripts/apps/search-providers/directive.js:34
 msgid "Search Provider saved."
 msgstr ""
 
-#: scripts/apps/search-providers/views/search-provider-config.html:69
-msgid "search provider username"
-msgstr ""
-
 #: scripts/apps/search-providers/index.js:35
-#: scripts/apps/search-providers/views/search-provider-config.html:3
-#: scripts/apps/search-providers/views/settings.html:4
+#: scripts/apps/search-providers/views/settings.html:3
 msgid "Search Providers"
 msgstr ""
 
-#: scripts/apps/analytics/views/saved-activity-reports.html:2
-msgid "Search saved activity reports"
+#: scripts/apps/dashboard/world-clock/configuration.html:35
+msgid "Search for clock"
+msgstr ""
+
+#: scripts/apps/content-api/index.js:21
+msgid "Search items is content API"
 msgstr ""
 
 #: scripts/apps/search/views/saved-searches.html:2
 msgid "Search saved searches"
 msgstr ""
 
-#: scripts/apps/search/directives/SaveSearch.js:58
+#: scripts/apps/search/directives/SaveSearch.js:59
 msgid "Search was saved successfully"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:85
-msgid "sec"
+#: scripts/apps/publish/views/http-push-config.html:17
+#: scripts/apps/publish/views/http-push-config.html:18
+msgid "Secret Token"
 msgstr ""
 
 #: scripts/core/auth/secure-login.html:18
 msgid "Secure Log In"
 msgstr ""
 
-#: scripts/core/auth/login-modal.html:27
+#: scripts/core/auth/login-modal.html:38
 msgid "Secure login"
 msgstr ""
 
+#: scripts/apps/products/views/products.html:10
+#: scripts/apps/publish/views/subscribers.html:9
 #: scripts/core/views/sdSearchList.html:3
 msgid "Select"
-msgstr ""
-
-#: scripts/apps/users/views/user-preferences.html:61
-msgid "Select all categories"
 msgstr ""
 
 #: scripts/apps/authoring/views/change-image.html:3
 msgid "Select Area of Interest"
 msgstr ""
 
+#: scripts/apps/archive/views/resend-configuration.html:10
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:34
+msgid "Select Subscribers"
+msgstr ""
+
+#: scripts/apps/workspace/views/workspace-dropdown.html:4
+msgid "Select Workspace"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:75
+msgid "Select all categories"
+msgstr ""
+
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:17
 msgid "Select color"
 msgstr ""
 
-#: scripts/apps/users/views/user-preferences.html:69
+#: scripts/apps/authoring/compare-versions/views/compare-versions.html:12
+msgid "Select current version."
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:83
 msgid "Select default categories only"
 msgstr ""
 
@@ -5300,6 +5214,14 @@ msgstr ""
 msgid "Select global saved searches"
 msgstr ""
 
+#: scripts/apps/monitoring/index.js:61
+msgid "Select next item on focused stage or group"
+msgstr ""
+
+#: scripts/apps/monitoring/index.js:63
+msgid "Select previous item on focused stage or group"
+msgstr ""
+
 #: scripts/apps/monitoring/views/aggregate-settings.html:79
 msgid "Select saved searches for view"
 msgstr ""
@@ -5312,29 +5234,16 @@ msgstr ""
 msgid "Select source"
 msgstr ""
 
-#: scripts/apps/archive/views/resend-configuration.html:10
-#: scripts/apps/ingest/views/settings/ingest-routing-action.html:34
-msgid "Select Subscribers"
-msgstr ""
-
 #: scripts/apps/templates/views/sd-template-select.html:3
 msgid "Select template"
 msgstr ""
 
-#: scripts/apps/authoring/views/change-image.html:56
+#: scripts/apps/authoring/views/change-image.html:58
 msgid "Select the area of interest"
 msgstr ""
 
 #: scripts/apps/archive/views/upload.html:12
 msgid "Select them from folder"
-msgstr ""
-
-#: scripts/apps/workspace/views/workspace-dropdown.html:4
-msgid "Select Workspace"
-msgstr ""
-
-#: scripts/core/views/sdSearchList.html:5
-msgid "selected"
 msgstr ""
 
 #: scripts/core/views/sdSearchList.html:21
@@ -5345,24 +5254,29 @@ msgstr ""
 msgid "Selected items"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:4
-msgid "send"
+#: scripts/core/directives/views/phone-home-modal-directive.html:39
+msgid "Send"
 msgstr ""
 
-#: scripts/apps/authoring/views/send-item.html:75
-msgid "send and continue"
+#: scripts/apps/authoring/views/authoring-topbar.html:128
+msgid "Send Correction"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:136
+msgid "Send Kill"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:9
 msgid "Send notifications via email"
 msgstr ""
 
-#: scripts/apps/authoring/views/send-item.html:3
-#: scripts/apps/search/views/multi-action-bar.html:37
+#: scripts/apps/authoring/views/send-item.html:7
+#: scripts/apps/search/views/multi-action-bar.html:40
+#: scripts/apps/search/views/multi-action-bar.html:96
 msgid "Send to"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:235
+#: scripts/apps/authoring/views/authoring-topbar.html:286
 msgid "Send to / Publish"
 msgstr ""
 
@@ -5374,11 +5288,11 @@ msgstr ""
 msgid "Sent/Queued as"
 msgstr ""
 
-#: scripts/apps/publish/views/publish-queue.html:87
+#: scripts/apps/publish/views/publish-queue.html:91
 msgid "Sequence No"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:104
+#: scripts/apps/publish/views/subscribers.html:109
 msgid "Sequence Number Settings"
 msgstr ""
 
@@ -5386,13 +5300,14 @@ msgstr ""
 msgid "Server Folder"
 msgstr ""
 
+#: scripts/apps/ingest/views/settings/emailConfig.html:6
+#: scripts/apps/ingest/views/settings/ftp-config.html:4
+msgid "Server not found."
+msgstr ""
+
 #: scripts/apps/archive/views/metadata-view.html:49
 #: scripts/apps/authoring/views/full-preview.html:33
 msgid "Service"
-msgstr ""
-
-#: scripts/apps/desks/views/desk-config-modal.html:62
-msgid "SERVICE"
 msgstr ""
 
 #: scripts/apps/search/views/search-filters.html:53
@@ -5403,12 +5318,17 @@ msgstr ""
 msgid "Sessions cleared"
 msgstr ""
 
+#: scripts/apps/users/views/settings-roles.html:50
+msgid "Set as default"
+msgstr ""
+
 #: scripts/apps/monitoring/views/aggregate-settings.html:111
 msgid "Set maximum items per stages and saved searches for view"
 msgstr ""
 
 #: scripts/apps/settings/directives/SettingsView.js:13
 #: scripts/apps/settings/index.js:16
+#: scripts/core/menu/views/menu.html:11
 msgid "Settings"
 msgstr ""
 
@@ -5416,15 +5336,25 @@ msgstr ""
 msgid "Short"
 msgstr ""
 
-#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:54
-msgid "Show"
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:55
+msgid ""
+"Show\n"
+"                <button class=\"dropdown__menu-close\"><i class=\"icon-close-small\"></i></button>"
 msgstr ""
 
 #: scripts/apps/archive/views/provider-menu.html:9
 msgid "Show All"
 msgstr ""
 
-#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:88
+#: scripts/apps/workspace/content/views/schema-editor.html:95
+msgid "Show Crops"
+msgstr ""
+
+#: scripts/apps/workspace/content/views/schema-editor.html:100
+msgid "Show Image Title"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:93
 msgid "Show all messages"
 msgstr ""
 
@@ -5432,42 +5362,30 @@ msgstr ""
 msgid "Show all saved searches"
 msgstr ""
 
-#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:96
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:101
 msgid "Show error messages"
 msgstr ""
 
-#: scripts/apps/desks/views/main.html:6
-msgid "show only online users"
+#: scripts/apps/search/index.js:70
+msgid "Show search modal"
 msgstr ""
 
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:3
 msgid "Show sent/queued items"
 msgstr ""
 
-#: scripts/apps/search/index.js:67
-msgid "Shows search modal"
-msgstr ""
-
-#: scripts/apps/users/views/change-avatar.html:15
-msgid "shows your initials instead"
-msgstr ""
-
-#: scripts/core/auth/login-modal.html:47
-msgid "Sign in as a different user."
-msgstr ""
-
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:21
+#: scripts/apps/workspace/content/constants.js:72
 #: scripts/core/lang/missing-translations-strings.js:13
 msgid "Sign Off"
 msgstr ""
 
-#: scripts/core/menu/notifications/views/notifications.html:12
-msgid "SIGN OUT"
+#: scripts/core/auth/login-modal.html:59
+msgid "Sign in as a different user."
 msgstr ""
 
 #: scripts/apps/archive/views/metadata-view.html:77
-#: scripts/apps/authoring/views/article-edit.html:338
-#: scripts/apps/users/views/edit-form.html:68
+#: scripts/apps/authoring/views/article-edit.html:463
+#: scripts/apps/users/views/edit-form.html:194
 msgid "Sign-Off"
 msgstr ""
 
@@ -5475,96 +5393,81 @@ msgstr ""
 msgid "Signal"
 msgstr ""
 
-#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:20
-msgid "since"
-msgstr ""
-
-#: scripts/apps/archive/views/upload.html:67
-#: scripts/apps/authoring/views/change-image.html:100
+#: scripts/apps/archive/views/upload.html:73
+#: scripts/apps/authoring/views/change-image.html:117
 msgid "Single Usage"
 msgstr ""
 
-#: scripts/apps/content-filters/controllers/FilterSearchController.js:30
-msgid "single value is required"
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:50
+msgid "Single line"
 msgstr ""
 
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:8
-msgid "Slug"
+#: scripts/core/directives/views/phone-home-modal-directive.html:41
+msgid "Skip"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:27
-msgid "slugline"
+#: scripts/apps/desks/views/desk-config-modal.html:41
+msgid "Slack Channel Name"
 msgstr ""
 
 #: scripts/apps/archive/views/metadata-view.html:5
 #: scripts/apps/authoring/views/full-preview.html:25
-#: scripts/apps/legal-archive/services/LegalArchiveService.js:12
-#: scripts/apps/legal-archive/views/legal_archive.html:49
-#: scripts/apps/search/services/SearchService.js:31
-#: scripts/apps/search/views/search-parameters.html:157
-#: scripts/apps/search/views/search-parameters.html:6
+#: scripts/apps/content-api/services/ContentAPISearchService.js:26
+#: scripts/apps/legal-archive/services/LegalArchiveService.js:25
+#: scripts/apps/legal-archive/tests/legal.spec.js:75
+#: scripts/apps/legal-archive/views/legal_archive.html:67
+#: scripts/apps/search/services/SearchService.js:46
+#: scripts/apps/search/views/search-parameters.html:7
+#: scripts/apps/workspace/content/constants.js:58
 msgid "Slugline"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-header.html:59
-msgid "SLUGLINE"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:42
-msgid "SLUGLINE is too long"
 msgstr ""
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:4
 msgid "Slugline Match"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:5
-msgid "sluglines"
-msgstr ""
-
 #: scripts/apps/archive/views/item-preview.html:11
 #: scripts/apps/archive/views/metadata-view.html:191
 #: scripts/apps/archive/views/preview.html:41
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:77
-#: scripts/apps/authoring/views/authoring-header.html:40
+#: scripts/apps/authoring/views/authoring-header.html:41
 #: scripts/apps/search/views/search-filters.html:118
 #: scripts/core/itemList/views/relatedItem-list-widget.html:40
 msgid "Sms"
 msgstr ""
 
-#: scripts/apps/authoring/views/article-edit.html:30
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:22
-msgid "SMS"
+#: scripts/apps/search/controllers/MultiActionBarController.js:93
+msgid "Some item/s are linked to in-progress planning coverage, spike anyway?"
 msgstr ""
 
-#: scripts/apps/authoring/views/article-edit.html:37
-msgid "SMS Message"
-msgstr ""
-
-#: scripts/apps/users/views/edit-form.html:109
-msgid "sorry, a user with this email already exists"
+#: scripts/apps/search/controllers/MultiActionBarController.js:143
+msgid "Some items could not be published."
 msgstr ""
 
 #: scripts/core/upload/crop-directive.js:53
 msgid "Sorry, but avatar must be at least 200x200 pixels big."
 msgstr ""
 
-#: scripts/core/auth/login-modal.html:32
+#: scripts/core/auth/login-modal.html:44
 #: scripts/core/auth/reset-password.html:29
 #: scripts/core/auth/reset-password.html:77
 #: scripts/core/auth/secure-login.html:30
 msgid "Sorry, but can't reach the server now.<br>Please try again later."
 msgstr ""
 
-#: scripts/core/upload/image-crop-directive.js:265
+#: scripts/core/upload/image-crop-directive.js:300
 msgid "Sorry, but image must be at least {{ r.width }}x{{ r.height }}, (it is {{ img.width }}x{{ img.height }})."
+msgstr ""
+
+#: scripts/apps/authoring/attachments/attachments.js:35
+msgid "Sorry, but some files are too big."
 msgstr ""
 
 #: scripts/apps/templates/views/create-template.html:14
 msgid "Sorry, but template name must be unique."
 msgstr ""
 
-#: scripts/core/auth/login-modal.html:31
+#: scripts/core/auth/login-modal.html:42
 #: scripts/core/auth/reset-password.html:28
 #: scripts/core/auth/reset-password.html:76
 #: scripts/core/auth/secure-login.html:29
@@ -5575,71 +5478,61 @@ msgstr ""
 msgid "Sorry, given workspace name is in use"
 msgstr ""
 
-#: scripts/core/editor2/views/block-text.html:24
-msgid "SORRY, NO SUGGESTIONS."
+#: scripts/apps/users/views/settings-roles.html:40
+msgid "Sorry, this role name already exists."
 msgstr ""
 
-#: scripts/apps/users/views/settings-roles.html:36
-msgid "sorry, this role name already exists."
+#: scripts/apps/authoring/attachments/attachments.js:28
+msgid "Sorry, too many files selected."
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:60
-msgid "sorry, this username is already taken."
+#: scripts/core/auth/login-modal.html:43
+msgid "Sorry, user not found."
 msgstr ""
 
-#: scripts/apps/search/views/item-sortbar.html:4
-msgid "Sort:"
-msgstr ""
-
-#: scripts/apps/monitoring/views/monitoring-view.html:110
+#: scripts/apps/legal-archive/views/legal_archive.html:25
+#: scripts/apps/monitoring/views/monitoring-view.html:113
 msgid "Sorting"
 msgstr ""
 
+#: scripts/apps/archive/views/metadata-associateditem-view.html:23
 #: scripts/apps/archive/views/metadata-view.html:36
 #: scripts/apps/content-filters/views/production-test-view.html:22
 #: scripts/apps/search-providers/views/search-provider-config.html:59
 msgid "Source"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-header.html:23
-msgid "SOURCE"
-msgstr ""
-
-#: scripts/apps/desks/views/desk-config-modal.html:28
-msgid "Source for User Created Articles"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:51
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:55
 msgid "Source Name"
-msgstr ""
-
-#: scripts/apps/search-providers/views/search-provider-config.html:60
-msgid "source of the search provider"
-msgstr ""
-
-#: scripts/apps/ingest/ingest-stats-widget/configuration.html:9
-msgid "Source stats"
 msgstr ""
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:3
 msgid "Source Type:"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/settings.html:6
+#: scripts/apps/desks/views/desk-config-modal.html:33
+msgid "Source for User Created Articles"
+msgstr ""
+
+#: scripts/apps/ingest/ingest-stats-widget/configuration.html:9
+msgid "Source stats"
+msgstr ""
+
 #: scripts/apps/search/views/search-filters.html:31
 msgid "Sources"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:201
+#: scripts/apps/authoring/views/authoring-topbar.html:250
 msgid "Spell Checker"
 msgstr ""
 
-#: scripts/apps/search/views/multi-action-bar.html:30
-#: scripts/apps/workspace/views/workspace-sidenav-items.html:31
+#: scripts/apps/search/views/multi-action-bar.html:33
+#: scripts/apps/search/views/multi-action-bar.html:90
+#: scripts/apps/workspace/views/workspace-sidenav-items.html:38
 msgid "Spike"
 msgstr ""
 
-#: scripts/apps/archive/index.js:94
+#: scripts/apps/archive/index.js:109
 msgid "Spike Item"
 msgstr ""
 
@@ -5647,84 +5540,82 @@ msgstr ""
 msgid "Spike Monitoring"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:7
-msgid "spiked"
+#: scripts/apps/monitoring/index.js:70
+msgid "Spike item(s)"
 msgstr ""
 
 #: scripts/apps/dashboard/workspace-tasks/views/desk-stages.html:17
 msgid "Spiked"
 msgstr ""
 
-#: scripts/apps/authoring/versioning/history/views/history.html:46
-msgid "Spiked from"
+#: scripts/apps/search/views/search-parameters.html:127
+msgid "Spiked Content"
 msgstr ""
 
-#: scripts/apps/monitoring/views/monitoring-view.html:21
+#: scripts/apps/monitoring/views/monitoring-view.html:32
 msgid "Spiked Items"
 msgstr ""
 
-#: scripts/apps/monitoring/index.js:57
-msgid "Spikes item(s)"
+#: scripts/apps/authoring/versioning/history/views/history.html:52
+msgid "Spiked by"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:21
-msgid "stage"
+#: scripts/apps/search/views/search-parameters.html:132
+msgid "Spiked only content"
 msgstr ""
 
 #: scripts/apps/desks/views/actionpicker.html:14
 msgid "Stage"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:229
-msgid "Stage description"
-msgstr ""
-
-#: scripts/apps/desks/views/desk-config-modal.html:188
-msgid "Stage description:"
-msgstr ""
-
-#: scripts/apps/desks/views/desk-config-modal.html:172
+#: scripts/apps/desks/views/desk-config-modal.html:202
 msgid "Stage Details"
 msgstr ""
 
-#: scripts/apps/desks/directives/DeskeditStages.js:140
+#: scripts/apps/desks/views/desk-config-modal.html:270
+msgid "Stage description"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:221
+msgid "Stage description:"
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskeditStages.js:137
 msgid "Stage has been modified elsewhere. Please reload the desks"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:165
+#: scripts/apps/desks/views/desk-config-modal.html:192
 msgid "Stage with name"
 msgstr ""
 
-#: scripts/apps/authoring/versioning/versions/views/versions.html:11
-msgid "stage:"
-msgstr ""
-
-#: scripts/apps/desks/views/desk-config-modal.html:110
+#: scripts/apps/desks/views/desk-config-modal.html:135
 #: scripts/apps/desks/views/settings.html:34
+#: scripts/apps/monitoring/views/monitoring-view.html:23
 msgid "Stages"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ingest-routing-general.html:50
-msgid "Start time"
 msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:7
 msgid "Start Time (inclusive)"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:185
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:50
+msgid "Start time"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:186
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:72
+#: scripts/apps/contacts/views/search-panel.html:68
 #: scripts/apps/content-filters/views/production-test-view.html:18
 msgid "State"
 msgstr ""
 
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:150
-#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:59
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:40
-#: scripts/apps/publish/views/publish-queue.html:98
-#: scripts/apps/publish/views/subscribers.html:37
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:64
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:43
+#: scripts/apps/publish/views/publish-queue.html:102
+#: scripts/apps/publish/views/subscribers.html:48
 #: scripts/apps/search-providers/views/search-provider-config.html:35
-#: scripts/apps/workspace/content/views/profile-settings.html:35
+#: scripts/apps/workspace/content/views/profile-settings.html:37
 msgid "Status"
 msgstr ""
 
@@ -5737,17 +5628,17 @@ msgstr ""
 msgid "Stored Procedure"
 msgstr ""
 
-#: scripts/apps/products/views/product-test.html:4
+#: scripts/apps/products/views/product-test.html:9
 msgid "Story GUID"
+msgstr ""
+
+#: scripts/apps/legal-archive/views/legal_archive.html:74
+#: scripts/apps/search/views/search-parameters.html:22
+msgid "Story Text"
 msgstr ""
 
 #: scripts/apps/archive/related-item-widget/relatedItem.js:172
 msgid "Story is associated as update."
-msgstr ""
-
-#: scripts/apps/legal-archive/views/legal_archive.html:56
-#: scripts/apps/search/views/search-parameters.html:21
-msgid "Story Text"
 msgstr ""
 
 #: scripts/core/directives/PasswordStrengthDirective.js:64
@@ -5758,38 +5649,29 @@ msgstr ""
 msgid "Strong"
 msgstr ""
 
-#: scripts/apps/analytics/views/activity-report-parameters.html:29
 #: scripts/apps/authoring/views/full-preview.html:65
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:15
+#: scripts/apps/workspace/content/constants.js:66
 msgid "Subject"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-header.html:203
-msgid "SUBJECT"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:7
 msgid "Subjects"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:6
-msgid "submitted"
-msgstr ""
-
-#: scripts/apps/analytics/views/activity-report-parameters.html:69
-#: scripts/apps/publish/views/publish-queue.html:92
+#: scripts/apps/publish/views/publish-queue.html:96
+#: scripts/apps/search/views/search-parameters.html:158
 msgid "Subscriber"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:77
+#: scripts/apps/publish/views/subscribers.html:85
 msgid "Subscriber codes"
 msgstr ""
 
-#: scripts/apps/publish/directives/SubscribersDirective.js:199
+#: scripts/apps/publish/directives/SubscribersDirective.js:229
 msgid "Subscriber could not be initialized!"
 msgstr ""
 
-#: scripts/apps/publish/directives/SubscribersDirective.js:134
+#: scripts/apps/publish/directives/SubscribersDirective.js:169
 msgid "Subscriber saved."
 msgstr ""
 
@@ -5797,139 +5679,127 @@ msgstr ""
 msgid "Subscriber:"
 msgstr ""
 
-#: scripts/apps/content-filters/views/filter-search-result.html:50
-#: scripts/apps/publish/views/settings.html:6
-#: scripts/apps/publish/views/subscribers.html:3
+#: scripts/apps/content-filters/views/filter-search-result.html:42
+#: scripts/apps/products/views/products-config-modal.html:16
+#: scripts/apps/publish/index.js:41
+#: scripts/apps/publish/views/settings.html:3
 msgid "Subscribers"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:27
-msgid "subscription"
-msgstr ""
-
-#: scripts/apps/search/views/search-parameters.html:210
-msgid "Subscription"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:5
-msgid "success"
 msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:7
 msgid "Summary"
 msgstr ""
 
-#: scripts/core/datetime/datetime.js:205
+#: scripts/core/datetime/datetime.js:231
 msgid "Sunday"
 msgstr ""
 
-#: scripts/core/menu/views/superdesk-view.html:27
+#: scripts/apps/contacts/controllers/ContactsController.js:20
+msgid "Superdesk Contacts Management"
+msgstr ""
+
+#: scripts/core/menu/views/superdesk-view.html:33
 msgid "Superdesk is experiencing network connection issues:/"
 msgstr ""
 
-#: scripts/core/menu/views/menu.html:22
+#: scripts/apps/monitoring/index.js:55
+msgid "Switch between grouped/single desk view"
+msgstr ""
+
+#: scripts/apps/monitoring/index.js:53
+msgid "Switch between grouped/single stage view"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:23
 msgid "Switch to feature preview"
 msgstr ""
 
-#: scripts/apps/legal-archive/views/legal_archive.html:9
-msgid "switch to grid view"
-msgstr ""
-
-#: scripts/apps/archive/views/list.html:23
+#: scripts/apps/archive/views/list.html:21
+#: scripts/apps/contacts/views/list.html:11
+#: scripts/apps/content-api/views/list.html:10
 #: scripts/apps/search/views/search.html:14
 msgid "Switch to grid view"
 msgstr ""
 
-#: scripts/apps/legal-archive/views/legal_archive.html:10
-msgid "switch to list view"
-msgstr ""
-
-#: scripts/apps/archive/views/list.html:24
+#: scripts/apps/archive/views/list.html:22
+#: scripts/apps/contacts/views/list.html:12
+#: scripts/apps/content-api/views/list.html:11
 #: scripts/apps/search/views/search.html:15
 msgid "Switch to list view"
 msgstr ""
 
-#: scripts/apps/monitoring/index.js:53
-msgid "Switches between single/grouped desk view"
-msgstr ""
-
-#: scripts/apps/monitoring/index.js:52
-msgid "Switches between single/grouped stage view"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-topbar.html:43
+#: scripts/apps/authoring/views/authoring-topbar.html:47
 msgid "T D"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:126
+msgid "TAKEKEY"
 msgstr ""
 
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:43
 msgid "Tags"
 msgstr ""
 
+#: scripts/apps/workspace/content/constants.js:60
+msgid "Take Key"
+msgstr ""
+
 #: scripts/apps/users/controllers/ChangeAvatarController.js:5
 msgid "Take a picture"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:121
+msgid "Take created by"
 msgstr ""
 
 #: scripts/apps/archive/views/metadata-view.html:41
 msgid "Take key"
 msgstr ""
 
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:10
-msgid "Take Key"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-header.html:100
-msgid "TAKEKEY"
+#: scripts/apps/authoring/versioning/history/views/history.html:149
+msgid "Take link is removed"
 msgstr ""
 
 #: scripts/core/itemList/views/relatedItem-list-widget.html:37
 msgid "Takes"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/SendItem.js:341
-msgid "Takes cannot be scheduled."
-msgstr ""
-
-#: scripts/apps/authoring/authoring/directives/SendItem.js:346
-msgid "Takes cannot have Embargo."
-msgstr ""
-
-#: scripts/apps/monitoring/views/monitoring-view.html:103
-#: scripts/apps/monitoring/views/monitoring-view.html:74
-msgid "Takes Package"
-msgstr ""
-
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:535
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:526
 msgid "Tansa is not responding. You can continue editing or publish the story."
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:149
+#: scripts/apps/archive/views/metadata-view.html:150
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:122
-#: scripts/apps/products/views/products-config-modal.html:38
-#: scripts/apps/templates/views/template-editor-modal.html:118
+#: scripts/apps/products/views/products-config-modal.html:60
+#: scripts/apps/templates/views/template-editor-modal.html:127
 msgid "Target Regions"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:154
+#: scripts/apps/archive/views/metadata-view.html:155
 msgid "Target Subscriber Types"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:144
+#: scripts/apps/archive/views/metadata-view.html:145
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:108
-#: scripts/apps/templates/views/template-editor-modal.html:107
+#: scripts/apps/templates/views/template-editor-modal.html:116
 msgid "Target Subscribers"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:60
+#: scripts/apps/publish/views/subscribers.html:68
 msgid "Target Type"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:6
+msgid "Target Type:"
 msgstr ""
 
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:130
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:46
-#: scripts/apps/templates/views/template-editor-modal.html:126
+#: scripts/apps/templates/views/template-editor-modal.html:135
 msgid "Target Types"
 msgstr ""
 
-#: scripts/apps/publish/views/subscribers.html:83
+#: scripts/apps/publish/views/subscribers.html:91
 msgid "Targetable by users"
 msgstr ""
 
@@ -5937,6 +5807,7 @@ msgstr ""
 msgid "Task Details"
 msgstr ""
 
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:2
 #: scripts/apps/workspace/views/workspace-sidenav-items.html:24
 msgid "Tasks"
 msgstr ""
@@ -5949,24 +5820,24 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
-#: scripts/apps/templates/views/template-editor-modal.html:16
-msgid "Template name"
-msgstr ""
-
 #: scripts/apps/templates/views/sd-template-select.html:9
 msgid "Template Name"
 msgstr ""
 
-#: scripts/apps/templates/directives/TemplatesDirective.js:208
+#: scripts/apps/templates/views/template-editor-modal.html:37
+msgid "Template Type"
+msgstr ""
+
+#: scripts/apps/templates/views/template-editor-modal.html:16
+msgid "Template name"
+msgstr ""
+
+#: scripts/apps/templates/directives/TemplatesDirective.js:212
 msgid "Template saved."
 msgstr ""
 
-#: scripts/apps/templates/views/templates.html:43
+#: scripts/apps/templates/views/templates.html:44
 msgid "Template type"
-msgstr ""
-
-#: scripts/apps/templates/views/template-editor-modal.html:34
-msgid "Template Type"
 msgstr ""
 
 #: scripts/apps/templates/index.js:36
@@ -5974,36 +5845,32 @@ msgstr ""
 msgid "Templates"
 msgstr ""
 
-#: scripts/apps/content-filters/views/manage-filters.html:121
+#: scripts/apps/content-filters/views/manage-filters.html:130
 msgid "Test"
 msgstr ""
 
-#: scripts/apps/content-filters/views/manage-filters.html:20
+#: scripts/apps/content-filters/views/manage-filters.html:17
 msgid "Test Filter Against Content"
 msgstr ""
 
-#: scripts/apps/products/views/product-test.html:14
+#: scripts/apps/products/views/product-test.html:24
 msgid "Test Products"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:4
-msgid "text"
+#: scripts/core/directives/views/phone-home-modal-directive.html:52
+msgid "The Superdesk project is developed and maintained on <a href=\"https://github.com/superdesk\" title=\"Superdesk GitHub\" target=\"_blank\">GitHub</a> by <a href=\"https://www.sourcefabric.org/\" title=\"Sourcefabric\" target=\"_blank\">Sourcefabric</a>."
 msgstr ""
 
 #: scripts/core/auth/reset-password.html:75
 msgid "The activation token is not valid.<br>"
 msgstr ""
 
-#: scripts/apps/analytics/directives/ActivityReportPanel.js:115
-msgid "The activity report was generated successfully"
-msgstr ""
-
-#: scripts/apps/analytics/directives/SaveActivityReport.js:28
-msgid "The activity report was saved successfully"
-msgstr ""
-
 #: scripts/apps/users/views/change-avatar.html:31
 msgid "The minimum image resolution is 200x200 pixels."
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:43
+msgid "The name of a Slack channel associated with this desk, the # is not required"
 msgstr ""
 
 #: scripts/apps/users/directives/ChangePasswordDirective.js:19
@@ -6014,19 +5881,31 @@ msgstr ""
 msgid "The password has been reset."
 msgstr ""
 
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.js:68
+msgid "The values should be unique for"
+msgstr ""
+
+#: scripts/apps/vocabularies/controllers/VocabularyConfigController.js:110
+msgid "The vocabulary is used in the following content types:"
+msgstr ""
+
 #: scripts/apps/archive/views/upload.html:18
 msgid "There are failed uploads."
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:237
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:258
 msgid "There are items locked or not published. Do you want to continue?"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:71
+#: scripts/apps/internal-destinations/views/settings.html:24
+msgid "There are no destinations defined."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:83
 msgid "There are some unsaved changes, do you want to save and publish it now?"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:85
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:95
 msgid "There are some unsaved changes, do you want to save and send it now?"
 msgstr ""
 
@@ -6038,7 +5917,7 @@ msgstr ""
 msgid "There are some unsaved changes, go to the article to save changes?"
 msgstr ""
 
-#: scripts/core/auth/auth.js:194
+#: scripts/core/auth/auth.js:196
 msgid "There are some unsaved changes. Please save them before signing out."
 msgstr ""
 
@@ -6050,15 +5929,12 @@ msgstr ""
 msgid "There is an error. Failed to associate update."
 msgstr ""
 
-#: scripts/apps/archive/related-item-widget/relatedItem.js:149
-msgid "There is an error. Failed to associate as take."
-msgstr ""
-
-#: scripts/apps/publish/views/subscribers.html:169
+#: scripts/apps/publish/views/subscribers.html:187
+#: scripts/apps/publish/views/subscribers.html:213
 msgid "There is no token for subscriber."
 msgstr ""
 
-#: scripts/apps/highlights/controllers/HighlightsConfig.js:57
+#: scripts/apps/highlights/controllers/HighlightsConfig.js:59
 msgid "There was a problem while saving highlights configuration"
 msgstr ""
 
@@ -6067,7 +5943,7 @@ msgstr ""
 msgid "There was a problem with your upload"
 msgstr ""
 
-#: scripts/apps/desks/directives/DeskeditBasic.js:68
+#: scripts/apps/desks/directives/DeskeditBasic.js:70
 msgid "There was a problem, desk not created/updated."
 msgstr ""
 
@@ -6075,48 +5951,48 @@ msgstr ""
 msgid "There was a problem, dictionary not created/updated."
 msgstr ""
 
-#: scripts/apps/groups/views/groups-config-modal.html:29
-msgid "There was a problem, group not created/updated."
-msgstr ""
-
 #: scripts/apps/search/directives/ItemGlobalSearch.js:56
 #: scripts/apps/search/directives/ItemGlobalSearch.js:88
 msgid "There was a problem, item can not open."
-msgstr ""
-
-#: scripts/apps/groups/directives/GroupeditPeopleDirective.js:46
-msgid "There was a problem, members not saved."
 msgstr ""
 
 #: scripts/apps/desks/directives/DeskeditPeople.js:56
 msgid "There was a problem, members not saved. Refresh Desks."
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:167
+#: scripts/apps/desks/views/desk-config-modal.html:194
 msgid "There was a problem, stage not created/updated."
 msgstr ""
 
-#: scripts/apps/desks/directives/DeskeditStages.js:190
+#: scripts/apps/desks/directives/DeskeditStages.js:188
 msgid "There was a problem, stage was not deleted."
 msgstr ""
 
-#: scripts/apps/users/directives/UserEditDirective.js:128
+#: scripts/apps/contacts/directives/ContactEditDirective.js:105
+msgid "There was an error when saving the contact."
+msgstr ""
+
+#: scripts/apps/users/directives/UserEditDirective.js:137
 msgid "There was an error when saving the user account."
 msgstr ""
 
-#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:75
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.js:77
 msgid "There was an error. Content filter cannot be deleted."
 msgstr ""
 
-#: scripts/apps/authoring/authoring/services/AuthoringService.js:105
+#: scripts/apps/authoring/authoring/services/AuthoringService.js:106
 msgid "There was an error. Failed to generate update."
 msgstr ""
 
-#: scripts/apps/authoring/authoring/services/AuthoringService.js:124
+#: scripts/apps/authoring/authoring/services/AuthoringService.js:125
 msgid "There was an error. Failed to remove link."
 msgstr ""
 
-#: scripts/apps/content-filters/controllers/FilterConditionsController.js:98
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.js:236
+msgid "There was an error. Failed to save the area of interest."
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterConditionsController.js:115
 msgid "There was an error. Filter condition cannot be deleted."
 msgstr ""
 
@@ -6132,23 +6008,40 @@ msgstr ""
 msgid "There was an error. Rule set cannot be deleted."
 msgstr ""
 
-#: scripts/apps/templates/directives/TemplatesDirective.js:267
+#: scripts/apps/templates/directives/TemplatesDirective.js:285
 msgid "There was an error. Template cannot be deleted."
 msgstr ""
 
-#: scripts/core/ui/ui.js:1320
+#: scripts/core/ui/ui.js:1042
 msgid "This field is required"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.js:34
-msgid "This is a corrected repeat."
+#: scripts/apps/contacts/views/edit-form.html:221
+#: scripts/apps/contacts/views/edit-form.html:236
+#: scripts/apps/contacts/views/edit-form.html:60
+#: scripts/apps/contacts/views/edit-form.html:70
+#: scripts/apps/contacts/views/edit-form.html:81
+#: scripts/apps/users/views/edit-form.html:120
+#: scripts/apps/users/views/edit-form.html:61
+#: scripts/apps/users/views/edit-form.html:69
+#: scripts/apps/users/views/edit-form.html:85
+msgid "This field is required."
 msgstr ""
 
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:141
+#: scripts/apps/authoring/views/theme-select.html:38
+#: scripts/apps/authoring/views/theme-select.html:89
+msgid "This is the headline"
+msgstr ""
+
+#: scripts/apps/archive/index.js:124
+msgid "This item is linked to in-progress planning coverage, spike anyway?"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:136
 msgid "This item was locked by <b></b>."
 msgstr ""
 
-#: scripts/apps/archive/views/preview.html:77
+#: scripts/apps/archive/views/preview.html:78
 msgid "This story has been rewritten by:"
 msgstr ""
 
@@ -6160,40 +6053,43 @@ msgstr ""
 msgid "This widget allows you to create literally any content view you may need in Superdesk, be it production or ingest. All you need is to select a desk, its stages or a saved search. Name your view once you are done. Enjoy!"
 msgstr ""
 
-#: scripts/core/datetime/datetime.js:202
+#: scripts/core/datetime/datetime.js:228
 msgid "Thursday"
 msgstr ""
 
-#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:74
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:79
 msgid "Time"
+msgstr ""
+
+#: scripts/apps/archive/views/upload.html:74
+#: scripts/apps/authoring/views/change-image.html:118
+msgid "Time Restricted"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:140
+#: scripts/core/ui/views/sd-timezone.html:1
+msgid "Time Zone"
 msgstr ""
 
 #: scripts/apps/profiling/views/profiling.html:34
 msgid "Time per call"
 msgstr ""
 
-#: scripts/apps/archive/views/upload.html:68
-#: scripts/apps/authoring/views/change-image.html:101
-msgid "Time Restricted"
-msgstr ""
-
-#: scripts/apps/archive/views/metadata-view.html:139
-#: scripts/core/ui/views/sd-timezone.html:1
-msgid "Time Zone"
-msgstr ""
-
 #: scripts/core/lang/missing-translations-strings.js:29
 msgid "Timezone"
 msgstr ""
 
+#: scripts/apps/archive/views/metadata-associateditem-view.html:3
 #: scripts/apps/archive/views/upload.html:41
+#: scripts/apps/authoring/attachments/attachments.html:68
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:142
-#: scripts/apps/authoring/views/change-image.html:75
+#: scripts/apps/authoring/views/change-image.html:81
+#: scripts/core/editor2/views/block-embed.html:20
 msgid "Title"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:41
-#: scripts/apps/authoring/views/authoring-topbar.html:42
+#: scripts/apps/authoring/views/authoring-topbar.html:45
+#: scripts/apps/authoring/views/authoring-topbar.html:46
 #: scripts/apps/search/views/search-parameters.html:102
 msgid "To Desk"
 msgstr ""
@@ -6209,19 +6105,19 @@ msgstr ""
 msgid "Today"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring.html:32
+#: scripts/apps/authoring/widgets/widgets.js:204
+msgid "Toggle Nth widget, where 'N' is order of widget it appears"
+msgstr ""
+
+#: scripts/apps/search/index.js:71
+msgid "Toggle search view"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring.html:33
 msgid "Toggle theme"
 msgstr ""
 
-#: scripts/apps/search/index.js:68
-msgid "Toggles search view"
-msgstr ""
-
-#: scripts/apps/authoring/widgets/widgets.js:175
-msgid "Toggles widget #"
-msgstr ""
-
-#: scripts/apps/publish/views/subscribers.html:175
+#: scripts/apps/publish/views/subscribers.html:219
 msgid "Token expiry"
 msgstr ""
 
@@ -6249,15 +6145,15 @@ msgstr ""
 msgid "Translate"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:191
+#: scripts/apps/authoring/views/authoring-topbar.html:241
 msgid "Translate item to"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-topbar.html:187
+#: scripts/apps/authoring/views/authoring-topbar.html:237
 msgid "Translations"
 msgstr ""
 
-#: scripts/apps/publish/views/publish-queue.html:97
+#: scripts/apps/publish/views/publish-queue.html:101
 msgid "Transmitted at"
 msgstr ""
 
@@ -6265,23 +6161,43 @@ msgstr ""
 msgid "Try again"
 msgstr ""
 
-#: scripts/core/auth/login-modal.html:41
+#: scripts/core/auth/login-modal.html:53
 #: scripts/core/auth/reset-password.html:38
 #: scripts/core/auth/reset-password.html:86
 #: scripts/core/auth/secure-login.html:39
 msgid "Trying to reconnect...<br>Please wait."
 msgstr ""
 
-#: scripts/core/datetime/datetime.js:200
+#: scripts/core/datetime/datetime.js:226
 msgid "Tuesday"
 msgstr ""
 
-#: scripts/core/menu/views/menu.html:23
+#: scripts/core/menu/views/menu.html:24
 msgid "Turn off feature preview"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:205
+#: scripts/apps/archive/views/metadata-view.html:204
 msgid "Type"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:18
+msgid "UPCOMING"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:35
+msgid "UPDATE"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:215
+msgid "URGENCY"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/reutersConfig.html:6
+msgid "URL for Authentication"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/rssConfig.html:8
+msgid "URL not found."
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:16
@@ -6297,24 +6213,20 @@ msgstr ""
 msgid "Uncheck all"
 msgstr ""
 
-#: scripts/core/editor2/editor.js:1052
-msgid "underline"
-msgstr ""
-
-#: scripts/apps/authoring/metadata/views/metadata-widget.html:100
-msgid "Unique name"
-msgstr ""
-
-#: scripts/apps/archive/views/metadata-view.html:201
+#: scripts/apps/archive/views/metadata-view.html:200
 #: scripts/apps/content-filters/views/production-test-view.html:19
-#: scripts/apps/legal-archive/views/legal_archive.html:36
-#: scripts/apps/publish/views/publish-queue.html:88
-#: scripts/apps/search/views/search-parameters.html:31
+#: scripts/apps/legal-archive/views/legal_archive.html:54
+#: scripts/apps/publish/views/publish-queue.html:92
+#: scripts/apps/search/views/search-parameters.html:32
 msgid "Unique Name"
 msgstr ""
 
 #: scripts/apps/search/views/item-globalsearch.html:11
 msgid "Unique Name/ID/GUID"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:100
+msgid "Unique name"
 msgstr ""
 
 #: scripts/apps/archive/directives/ArchivedItemKill.js:34
@@ -6325,7 +6237,7 @@ msgstr ""
 msgid "Unknown Error: Cannot resend the item"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:391
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:455
 msgid "Unknown Error: Item not published."
 msgstr ""
 
@@ -6333,15 +6245,11 @@ msgstr ""
 msgid "Unknown Error: There was a problem, desk was not deleted."
 msgstr ""
 
-#: scripts/apps/archive/index.js:269
-msgid "Unlink take"
-msgstr ""
-
-#: scripts/apps/archive/index.js:285
+#: scripts/apps/archive/index.js:281
 msgid "Unlink update"
 msgstr ""
 
-#: scripts/apps/authoring/versioning/history/views/history.html:30
+#: scripts/apps/authoring/versioning/history/views/history.html:137
 msgid "Unlinked by"
 msgstr ""
 
@@ -6355,50 +6263,46 @@ msgstr ""
 msgid "Unlock content"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/index.js:203
-msgid "Unlocks current item"
+#: scripts/apps/authoring/authoring/index.js:236
+msgid "Unlock current item"
 msgstr ""
 
-#: scripts/apps/search/views/multi-action-bar.html:34
+#: scripts/apps/authoring/versioning/history/views/history.html:91
+msgid "Unmarked by"
+msgstr ""
+
+#: scripts/apps/search/views/multi-action-bar.html:37
+#: scripts/apps/search/views/multi-action-bar.html:93
 msgid "Unspike"
 msgstr ""
 
-#: scripts/apps/archive/index.js:124
+#: scripts/apps/archive/index.js:141
 msgid "Unspike Item"
 msgstr ""
 
-#: scripts/apps/authoring/versioning/history/views/history.html:50
-msgid "Unspiked to"
+#: scripts/apps/authoring/versioning/history/views/history.html:63
+msgid "Unspiked by"
 msgstr ""
 
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:6
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:4
 #: scripts/apps/authoring/multiedit/views/sd-multiedit-dropdown.html:6
 #: scripts/apps/authoring/multiedit/views/sd-multiedit-inner-dropdown.html:4
-#: scripts/apps/authoring/views/dashboard-articles.html:22
+#: scripts/apps/authoring/views/dashboard-articles.html:21
 #: scripts/apps/authoring/views/opened-articles.html:9
 #: scripts/apps/workspace/views/workspace-dropdown.html:26
 #: scripts/apps/workspace/views/workspace-dropdown.html:5
 msgid "Untitled"
 msgstr ""
 
-#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:17
-msgid "UPCOMING"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:22
-msgid "update"
-msgstr ""
-
-#: scripts/apps/archive/index.js:253
-#: scripts/apps/authoring/views/authoring-topbar.html:71
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:130
+#: scripts/apps/archive/index.js:265
+#: scripts/apps/authoring/attachments/attachments.html:85
+#: scripts/apps/authoring/views/authoring-topbar.html:77
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:144
 msgid "Update"
 msgstr ""
 
-#: scripts/apps/authoring/views/authoring-header.html:34
-msgid "UPDATE"
-msgstr ""
-
-#: scripts/apps/authoring/authoring/services/AuthoringService.js:99
+#: scripts/apps/authoring/authoring/services/AuthoringService.js:100
 msgid "Update Created."
 msgstr ""
 
@@ -6406,7 +6310,7 @@ msgstr ""
 msgid "Update Cycle:"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/ingest-sources-content.html:77
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:81
 msgid "Update every"
 msgstr ""
 
@@ -6414,123 +6318,114 @@ msgstr ""
 #: scripts/apps/archive/views/metadata-view.html:192
 #: scripts/apps/archive/views/preview.html:42
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:78
-#: scripts/apps/authoring/views/authoring-header.html:42
-#: scripts/apps/legal-archive/services/LegalArchiveService.js:8
-#: scripts/apps/search/services/SearchService.js:27
-#: scripts/apps/workspace/content/views/profile-settings.html:40
+#: scripts/apps/authoring/views/authoring-header.html:43
+#: scripts/apps/contacts/services/ContactsService.js:23
+#: scripts/apps/content-api/services/ContentAPISearchService.js:22
+#: scripts/apps/legal-archive/services/LegalArchiveService.js:21
+#: scripts/apps/legal-archive/tests/legal.spec.js:71
+#: scripts/apps/search/services/SearchService.js:42
+#: scripts/apps/search/tests/search.spec.js:432
+#: scripts/apps/workspace/content/views/profile-settings.html:42
 #: scripts/core/itemList/views/relatedItem-list-widget.html:41
 msgid "Updated"
 msgstr ""
 
-#: scripts/apps/authoring/versioning/history/views/history.html:34
+#: scripts/apps/authoring/versioning/history/views/history.html:18
 msgid "Updated by"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:35
-msgid "updated Ingest Channel {{name}}"
+#: scripts/apps/archive/views/upload-attachments.html:54
+msgid "Upload"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:33
-msgid "updated task {{ subject }} for item {{ type }}"
+#: scripts/apps/workspace/content/views/sd-content-create.html:57
+msgid "Upload Media"
 msgstr ""
 
 #: scripts/apps/users/controllers/ChangeAvatarController.js:4
 msgid "Upload from computer"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/sd-content-create.html:58
-msgid "UPLOAD ITEM"
-msgstr ""
-
-#: scripts/apps/archive/index.js:83
+#: scripts/apps/archive/index.js:87
 msgid "Upload media"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:29
-msgid "uploaded media {{ name }}"
-msgstr ""
-
-#: scripts/apps/analytics/views/activity-report-parameters.html:77
-#: scripts/apps/archive/directives/ItemUrgency.js:19
 #: scripts/apps/archive/views/metadata-view.html:9
-#: scripts/apps/authoring/views/authoring-header.html:167
-#: scripts/apps/legal-archive/services/LegalArchiveService.js:10
-#: scripts/apps/search/services/SearchService.js:29
+#: scripts/apps/authoring/views/authoring-header.html:223
+#: scripts/apps/content-api/services/ContentAPISearchService.js:24
+#: scripts/apps/legal-archive/services/LegalArchiveService.js:23
+#: scripts/apps/legal-archive/tests/legal.spec.js:73
+#: scripts/apps/search/services/SearchService.js:44
+#: scripts/apps/search/tests/search.spec.js:433
 #: scripts/apps/search/views/search-filters.html:80
-#: scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.js:13
+#: scripts/apps/workspace/content/constants.js:63
 msgid "Urgency"
-msgstr ""
-
-#: scripts/apps/authoring/views/authoring-header.html:159
-msgid "URGENCY"
 msgstr ""
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:10
 msgid "Urgency stats"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/reutersConfig.html:6
-msgid "URL for Authentication"
+#: scripts/apps/authoring/views/article-edit.html:497
+#: scripts/apps/workspace/content/constants.js:84
+msgid "Usage Terms"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:179
+#: scripts/apps/archive/views/metadata-associateditem-view.html:40
+#: scripts/apps/archive/views/metadata-view.html:180
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:33
-#: scripts/apps/templates/views/template-editor-modal.html:93
+#: scripts/apps/templates/views/template-editor-modal.html:102
 msgid "Usage terms"
-msgstr ""
-
-#: scripts/apps/users/controllers/ChangeAvatarController.js:6
-msgid "Use a Web URL"
 msgstr ""
 
 #: scripts/apps/authoring/views/confirm-media-associated.html:17
 msgid "Use Media"
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/emailConfig.html:14
+#: scripts/apps/users/controllers/ChangeAvatarController.js:6
+msgid "Use a Web URL"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:128
+msgid "Use the article GUID for testing."
+msgstr ""
+
+#: scripts/apps/search/views/item-preview.html:20
+msgid "Used"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/emailConfig.html:15
 #: scripts/apps/users/views/user-privileges.html:16
 msgid "User"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:32
-msgid "user {{user}} has been added to desk {{desk}}: Please re-login."
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:36
-msgid "user {{user}} is granted new privileges: Please re-login."
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:37
-msgid "user {{user}} is updated to administrator: Please re-login."
-msgstr ""
-
-#: scripts/apps/users/config.js:36
-msgid "User management"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:16
 msgid "User Management"
 msgstr ""
 
-#: scripts/apps/users/directives/UserPrivilegesDirective.js:30
-msgid "User not found."
-msgstr ""
-
-#: scripts/apps/users/directives/UserPreferencesDirective.js:69
-#: scripts/core/services/preferencesService.js:218
-msgid "User preferences could not be saved..."
-msgstr ""
-
-#: scripts/apps/users/directives/UserPreferencesDirective.js:65
-msgid "User preferences saved"
-msgstr ""
-
 #: scripts/apps/users/import/views/import-user.html:28
 msgid "User Profile to Import"
 msgstr ""
 
-#: scripts/apps/users/views/edit-form.html:150
-msgid "user role"
+#: scripts/apps/users/config.js:64
+#: scripts/apps/users/views/settings.html:3
+msgid "User Roles"
+msgstr ""
+
+#: scripts/apps/users/config.js:36
+msgid "User management"
+msgstr ""
+
+#: scripts/apps/users/directives/UserPrivilegesDirective.js:30
+msgid "User not found."
+msgstr ""
+
+#: scripts/apps/users/directives/UserPreferencesDirective.js:74
+msgid "User preferences could not be saved..."
+msgstr ""
+
+#: scripts/apps/users/directives/UserPreferencesDirective.js:70
+msgid "User preferences saved"
 msgstr ""
 
 #: scripts/apps/users/directives/UserRolesDirective.js:29
@@ -6545,15 +6440,6 @@ msgstr ""
 msgid "User role updated."
 msgstr ""
 
-#: scripts/apps/users/config.js:64
-#: scripts/apps/users/views/settings-roles.html:4
-msgid "User Roles"
-msgstr ""
-
-#: scripts/apps/users/directives/UserEditDirective.js:110
-msgid "user saved."
-msgstr ""
-
 #: scripts/apps/users/views/user-preferences.html:9
 msgid "User settings"
 msgstr ""
@@ -6562,82 +6448,71 @@ msgstr ""
 msgid "User was not found, sorry."
 msgstr ""
 
-#: scripts/apps/users/directives/UserEditDirective.js:126
+#: scripts/apps/users/directives/UserEditDirective.js:135
 msgid "User was not found. The account might have been deleted."
 msgstr ""
 
-#: scripts/apps/ingest/views/settings/reutersConfig.html:11
-#: scripts/apps/ingest/views/settings/searchConfig.html:3
-#: scripts/apps/users/import/views/import-user.html:14
-#: scripts/apps/users/views/edit-form.html:49
-#: scripts/core/auth/login-modal.html:13
-msgid "username"
-msgstr ""
-
-#: scripts/apps/ingest/views/settings/ftp-config.html:6
 #: scripts/apps/ingest/views/settings/ftp-config.html:7
+#: scripts/apps/ingest/views/settings/ftp-config.html:8
 #: scripts/apps/ingest/views/settings/reutersConfig.html:10
-#: scripts/apps/ingest/views/settings/rssConfig.html:20
-#: scripts/apps/ingest/views/settings/rssConfig.html:22
+#: scripts/apps/ingest/views/settings/rssConfig.html:24
+#: scripts/apps/ingest/views/settings/rssConfig.html:26
 #: scripts/apps/ingest/views/settings/searchConfig.html:2
 #: scripts/apps/publish/views/ftp-config.html:7
 #: scripts/apps/publish/views/ftp-config.html:8
 #: scripts/apps/search-providers/views/search-provider-config.html:68
-#: scripts/apps/users/views/list.html:29
+#: scripts/apps/users/views/list.html:34
 msgid "Username"
-msgstr ""
-
-#: scripts/core/lang/missing-translations-strings.js:5
-msgid "users"
 msgstr ""
 
 #: scripts/apps/users/views/list.html:2
 msgid "Users"
 msgstr ""
 
+#: scripts/apps/users/config.js:54
+#: scripts/apps/users/views/edit.html:8
+msgid "Users Profile"
+msgstr ""
+
 #: scripts/core/lang/missing-translations-strings.js:8
 msgid "Users archive view format"
 msgstr ""
 
-#: scripts/apps/users/config.js:54
-#: scripts/apps/users/views/edit.html:9
-msgid "Users Profile"
+#: scripts/apps/archive/views/export.html:17
+#: scripts/apps/archive/views/export.html:18
+msgid "Validate"
 msgstr ""
 
-#: scripts/apps/content-filters/views/filter-search.html:18
-#: scripts/apps/content-filters/views/manage-filter-conditions.html:55
+#: scripts/apps/content-filters/views/filter-search.html:25
+#: scripts/apps/content-filters/views/filter-search.html:29
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:62
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:68
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:73
 msgid "Values"
-msgstr ""
-
-#: scripts/apps/authoring/versioning/versions/views/versions.html:14
-msgid "version"
 msgstr ""
 
 #: scripts/apps/archive/views/metadata-view.html:84
 msgid "Version"
 msgstr ""
 
-#: scripts/apps/archive/views/metadata-view.html:108
+#: scripts/apps/archive/views/metadata-view.html:109
 msgid "Version creator"
 msgstr ""
 
 #: scripts/apps/authoring/versioning/versioning.js:6
-msgid "Versioning"
-msgstr ""
-
 #: scripts/apps/authoring/versioning/views/versioning.html:3
 msgid "Versions"
 msgstr ""
 
-#: scripts/core/lang/missing-translations-strings.js:4
-msgid "video"
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:69
+msgid "Video"
 msgstr ""
 
-#: scripts/apps/desks/views/settings.html:44
-msgid "view all"
+#: scripts/apps/monitoring/index.js:64
+msgid "View an item"
 msgstr ""
 
-#: scripts/apps/users/views/list.html:63
+#: scripts/apps/users/views/list.html:67
 msgid "View full profile"
 msgstr ""
 
@@ -6645,82 +6520,82 @@ msgstr ""
 msgid "View name"
 msgstr ""
 
-#: scripts/apps/vocabularies/index.js:39
-msgid "Vocabularies"
+#: scripts/apps/contacts/index.js:22
+msgid "View/Manage media contacts"
 msgstr ""
 
-#: scripts/apps/vocabularies/views/settings.html:6
-msgid "Vocabularies management"
+#: scripts/apps/vocabularies/views/settings.html:9
+msgid "Vocabularies"
 msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.js:17
 msgid "Vocabularies Management"
 msgstr ""
 
-#: scripts/core/notification/notification.js:118
-msgid "vocabulary has been updated. Please re-login to see updated vocabulary values"
-msgstr ""
-
-#: scripts/apps/vocabularies/controllers/VocabularyEditController.js:26
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.js:20
 msgid "Vocabulary saved successfully"
 msgstr ""
 
-#: scripts/core/auth/auth.js:195
+#: scripts/apps/vocabularies/controllers/VocabularyConfigController.js:95
+msgid "Vocabulary was deleted."
+msgstr ""
+
+#: scripts/apps/archive/views/preview.html:51
+#: scripts/apps/authoring/suggest/SuggestView.html:16
+#: scripts/apps/authoring/suggest/SuggestView.html:64
+#: scripts/apps/authoring/views/authoring-header.html:21
+msgid "WORD"
+msgid_plural "WORDS"
+msgstr[0] ""
+msgstr[1] ""
+
+#: scripts/core/auth/auth.js:197
 msgid "Warning"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:128
-msgid "was unlocked by <b></b>."
+#: scripts/core/directives/views/phone-home-modal-directive.html:48
+msgid "We will send occasional updates on Superdesk developments to the email address you have provided. Your data will be kept secure and it won't be used for any other purpose. You may opt-out of receiving further email communications at any time."
 msgstr ""
 
 #: scripts/core/directives/PasswordStrengthDirective.js:39
 msgid "Weak"
 msgstr ""
 
-#: scripts/core/datetime/datetime.js:201
+#: scripts/core/datetime/datetime.js:227
 msgid "Wednesday"
+msgstr ""
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:4
+msgid "Welcome to Superdesk"
 msgstr ""
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:37
 msgid "When creating a highlights package"
 msgstr ""
 
-#: scripts/apps/workspace/content/views/schema-editor.html:90
+#: scripts/apps/workspace/content/views/schema-editor.html:65
 msgid "Width"
 msgstr ""
-
-#: scripts/apps/archive/views/preview.html:50
-#: scripts/apps/authoring/suggest/SuggestView.html:16
-#: scripts/apps/authoring/suggest/SuggestView.html:64
-#: scripts/apps/authoring/views/authoring-header.html:17
-msgid "WORD"
-msgid_plural "WORDS"
-msgstr[0] ""
-msgstr[1] ""
 
 #: scripts/apps/archive/views/metadata-view.html:17
 msgid "Word Count"
 msgstr ""
 
-#: scripts/apps/authoring/authoring/directives/WordCount.js:11
-msgid "words"
-msgstr ""
-
-#: scripts/apps/desks/views/desk-config-modal.html:115
+#: scripts/apps/desks/views/desk-config-modal.html:139
 msgid "Work stages"
 msgstr ""
 
-#: scripts/apps/desks/views/desk-config-modal.html:175
-#: scripts/apps/desks/views/desk-config-modal.html:219
+#: scripts/apps/desks/views/desk-config-modal.html:208
+#: scripts/apps/desks/views/desk-config-modal.html:259
 msgid "Working Stage"
 msgstr ""
 
-#: scripts/apps/archive/index.js:71
+#: scripts/apps/archive/index.js:75
 #: scripts/apps/dashboard/index.js:41
-#: scripts/apps/dashboard/views/workspace.html:22
-#: scripts/apps/dashboard/workspace-tasks/tasks.js:379
-#: scripts/apps/ingest/index.js:53
-#: scripts/apps/stream/index.js:15
+#: scripts/apps/dashboard/views/workspace.html:24
+#: scripts/apps/dashboard/workspace-tasks/tasks.js:374
+#: scripts/apps/ingest/index.js:54
+#: scripts/apps/stream/index.js:17
 msgid "Workspace"
 msgstr ""
 
@@ -6741,28 +6616,1448 @@ msgstr ""
 msgid "World clock removed:"
 msgstr ""
 
-#: scripts/apps/dashboard/world-clock/world-clock.js:214
+#: scripts/apps/dashboard/world-clock/world-clock.js:215
 #: scripts/core/lang/missing-translations-strings.js:40
 msgid "World clock widget"
 msgstr ""
 
-#: scripts/apps/monitoring/views/item-actions-menu.html:32
+#: scripts/apps/ingest/views/settings/wufoo.html:9
+msgid "Wufoo API Key"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/wufoo.html:3
+msgid "Wufoo login"
+msgstr ""
+
+#: scripts/apps/workspace/content/services/ContentService.js:67
+msgid "You are not allowed to create an article there."
+msgstr ""
+
+#: scripts/apps/workspace/content/services/ContentService.js:65
+msgid "You are not allowed to create article on readonly stage."
+msgstr ""
+
+#: scripts/apps/monitoring/views/item-actions-menu.html:19
 msgid "You don't have the privileges to perform any action"
 msgstr ""
 
 #: scripts/apps/authoring/authoring/controllers/ChangeImageController.js:134
-#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:211
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:232
 msgid "You have unsaved changes, do you want to continue?"
-msgstr ""
-
-#: scripts/apps/dashboard/world-clock/configuration.html:20
-msgid "Your clock"
 msgstr ""
 
 #: scripts/apps/users/import/views/import-user.html:11
 msgid "Your Credentials"
 msgstr ""
 
+#: scripts/apps/users/views/edit-form.html:182
+msgid "Your Slack user name without the leading @"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/configuration.html:18
+msgid "Your clock"
+msgstr ""
+
 #: scripts/core/auth/login-modal.html:3
 msgid "Your session has expired."
+msgstr ""
+
+#: scripts/apps/search/views/saved-searches.html:10
+msgid "[Global]"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:16
+msgid "[none]"
+msgstr ""
+
+#: scripts/core/editor2/views/add-content.html:14
+msgid "add a picture"
+msgstr ""
+
+#: scripts/core/editor2/views/add-content.html:9
+msgid "add an embed"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:33
+msgid "added new task {{ subject }} of type {{ type }}"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:30
+msgid "added new {{ type }} item about \"{{ subject }}\""
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:30
+msgid "added new {{ type }} item with empty header/title"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:251
+msgid "address"
+msgstr ""
+
+#: scripts/apps/users/views/user-list-item.html:12
+msgid "admin"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:107
+#: scripts/apps/monitoring/views/monitoring-view.html:81
+#: scripts/apps/users/views/user-preferences.html:74
+msgid "all"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:192
+#: scripts/apps/highlights/views/highlights_config_modal.html:16
+msgid "already exists"
+msgstr ""
+
+#: scripts/apps/archive/controllers/UploadController.js:86
+msgid "and"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:8
+msgid "archive"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:129
+msgid "as rewrite of"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:17
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:22
+msgid "at"
+msgstr ""
+
+#: scripts/apps/archive/controllers/UploadController.js:99
+#: scripts/core/lang/missing-translations-strings.js:4
+msgid "audio"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/reutersConfig.html:7
+msgid "authentication url"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-article.html:7
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:7
+msgid "author"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:22
+msgid "authoring"
+msgstr ""
+
+#: scripts/core/editor2/editor.js:1055
+msgid "bold"
+msgstr ""
+
+#: scripts/apps/archive/views/preview.html:7
+#: scripts/apps/authoring/suggest/SuggestView.html:23
+#: scripts/apps/authoring/suggest/SuggestView.html:71
+#: scripts/apps/authoring/versioning/versions/views/versions.html:6
+#: scripts/apps/authoring/views/authoring.html:8
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:2
+msgid "by"
+msgstr ""
+
+#: scripts/apps/packaging/views/sd-package-item-preview.html:25
+msgid "by <b>{{userLookup[data.original_creator].display_name}}</b>"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:9
+msgid "categories"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:134
+msgid "character limit"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/CharacterCount.js:12
+msgid "characters"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:15
+msgid "closed"
+msgstr ""
+
+#: scripts/core/menu/notifications/views/notifications.html:26
+msgid "commented on"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:8
+msgid "compact"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:4
+msgid "composite"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:265
+msgid "confirm"
+msgstr ""
+
+#: scripts/apps/contacts/directives/ContactEditDirective.js:101
+msgid "contact saved."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:5
+msgid "content"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:7
+msgid "corrected"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:29
+msgid "create"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:31
+msgid "created new version {{ version }} for item {{ type }} about \"{{ subject }}\""
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:37
+msgid "created user {{user}}"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:254
+msgid "current"
+msgstr ""
+
+#: scripts/apps/desks/views/content-expiry.html:3
+msgid "day"
+msgstr ""
+
+#: scripts/apps/desks/views/content-expiry.html:32
+msgid "days"
+msgstr ""
+
+#: scripts/apps/users/views/settings-privileges.html:15
+#: scripts/apps/users/views/settings-roles.html:14
+#: scripts/apps/users/views/user-preferences.html:82
+msgid "default"
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:21
+msgid "default template"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:21
+msgid "desk Output"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:9
+#: scripts/apps/authoring/versioning/versions/views/versions.html:10
+#: scripts/core/itemList/views/relatedItem-list-widget.html:43
+msgid "desk:"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:14
+#: scripts/apps/users/views/user-list-item.html:17
+msgid "disabled"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:31
+msgid "disabled user {{user}}"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-replace.html:9
+msgid "done"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:6
+msgid "draft"
+msgstr ""
+
+#: scripts/apps/authoring/views/send-item.html:114
+msgid "duplicate"
+msgstr ""
+
+#: scripts/apps/authoring/views/send-item.html:106
+msgid "duplicate and open"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:47
+msgid "duplicate id"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:220
+msgid "e.g. @cityofsydney"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:271
+msgid "e.g. Rhodes, CBD"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:235
+msgid "e.g. cityofsydney from <i>https://www.facebook.com/cityofsydney</i>"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:245
+msgid "e.g. cityofsydney from <i>https://www.instagram.com/cityofsydney</i>"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:51
+msgid "e.g. professor, commissioner"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:101
+#: scripts/apps/users/views/edit-form.html:114
+msgid "email"
+msgstr ""
+
+#: scripts/apps/archive/views/item-state.html:2
+msgid "embargo"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:5
+msgid "error"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:29
+msgid "example"
+msgstr ""
+
+#: scripts/apps/archive/views/item-preview.html:19
+#: scripts/apps/archive/views/preview.html:90
+msgid "expires"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:177
+#: scripts/apps/publish/views/subscribers.html:203
+msgid "expires:"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:231
+msgid "facebook"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:6
+msgid "failed"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:199
+msgid "fax"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:9
+msgid "feature"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/reutersConfig.html:3
+msgid "feed url"
+msgstr ""
+
+#: scripts/apps/authoring/views/send-item.html:135
+msgid "fetch"
+msgstr ""
+
+#: scripts/apps/authoring/views/send-item.html:127
+#: scripts/apps/authoring/views/send-item.html:85
+msgid "fetch and open"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:6
+msgid "fetched"
+msgstr ""
+
+#: scripts/apps/archive/views/fetched-desks.html:2
+msgid "fetched in"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-select.html:8
+msgid "filter: \"{{ filter }}\""
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:57
+#: scripts/apps/users/views/edit-form.html:59
+msgid "first name"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:3
+msgid "for \"{{settings.desk.name}}\" Desk"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:86
+msgid "for desk"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:83
+msgid "for highlight"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:36
+#: scripts/apps/authoring/versioning/history/views/history.html:58
+msgid "from"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:111
+msgid "from highlight"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:47
+msgid "full name"
+msgstr ""
+
+#: scripts/core/itemList/views/relatedItem-list-widget.html:45
+msgid "genre:"
+msgstr ""
+
+#: scripts/core/editor2/editor.js:1031
+msgid "header type 1"
+msgstr ""
+
+#: scripts/core/editor2/editor.js:1043
+msgid "header type 2"
+msgstr ""
+
+#: scripts/core/views/sdSlider.html:3
+msgid "high"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:29
+msgid "highlights"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:48
+msgid "honorific"
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:44
+msgid "hours"
+msgstr ""
+
+#: scripts/apps/desks/views/content-expiry.html:4
+#: scripts/apps/desks/views/content-expiry.html:40
+msgid "hr"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:97
+msgid "hrs"
+msgstr ""
+
+#: scripts/apps/archive/controllers/UploadController.js:89
+msgid "image"
+msgstr ""
+
+#: scripts/core/ui/views/sd-timepicker-popup.html:7
+msgid "in 1 h"
+msgstr ""
+
+#: scripts/core/ui/views/sd-timepicker-popup.html:8
+msgid "in 2 h"
+msgstr ""
+
+#: scripts/core/ui/views/sd-timepicker-popup.html:6
+msgid "in 30 min"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:72
+msgid "in the last 24 hours."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:5
+msgid "in-progress"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:5
+msgid "in_progress"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:15
+#: scripts/apps/users/views/edit-form.html:15
+#: scripts/apps/users/views/user-list-item.html:18
+msgid "inactive"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:6
+msgid "ingested"
+msgstr ""
+
+#: scripts/core/editor2/editor.js:1128
+msgid "insert table"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:242
+msgid "instagram"
+msgstr ""
+
+#: scripts/core/editor2/editor.js:1070
+msgid "italic"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem.js:155
+msgid "item metadata associated."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:7
+msgid "killed"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:67
+#: scripts/apps/users/views/edit-form.html:67
+msgid "last name"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:80
+msgid "last update and last item arrived."
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:132
+msgid "linked to"
+msgstr ""
+
+#: scripts/apps/contacts/views/search-results.html:4
+#: scripts/apps/content-api/views/search-results.html:4
+#: scripts/apps/legal-archive/views/legal_archive.html:103
+#: scripts/apps/search/views/search-results.html:4
+#: scripts/core/editor2/views/add-embed.html:18
+msgid "loading"
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskeditPeople.js:9
+#: scripts/apps/desks/directives/DeskeditStages.js:39
+msgid "loading..."
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:268
+msgid "locality"
+msgstr ""
+
+#: scripts/core/views/sdSlider.html:2
+msgid "low"
+msgstr ""
+
+#: scripts/core/views/sdSearchList.html:17
+msgid "many"
+msgstr ""
+
+#: scripts/apps/workspace/content/views/schema-editor.html:53
+msgid "max"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:53
+msgid "member since"
+msgstr ""
+
+#: scripts/core/menu/notifications/views/notifications.html:30
+msgid "mentioned you"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:8
+msgid "mgrid"
+msgstr ""
+
+#: scripts/apps/desks/views/content-expiry.html:48
+#: scripts/apps/desks/views/content-expiry.html:5
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:101
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:85
+#: scripts/apps/workspace/content/views/schema-editor.html:51
+msgid "min"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-widget.html:31
+msgid "miscellaneous"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:164
+msgid "mobile"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:260
+msgid "new"
+msgstr ""
+
+#: scripts/apps/archive/views/media-view.html:34
+#: scripts/apps/authoring/macros/views/macros-replace.html:8
+msgid "next"
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterSearchController.js:111
+msgid "no results found"
+msgstr ""
+
+#: scripts/apps/profiling/views/profiling.html:10
+#: scripts/apps/users/views/user-preferences.html:78
+msgid "none"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:314
+msgid "notes"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:8
+msgid "notifications"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:129
+#: scripts/apps/contacts/views/edit-form.html:168
+msgid "number"
+msgstr ""
+
+#: scripts/core/list/views/sdPagination.html:15
+#: scripts/core/list/views/sdPaginationAlt.html:2
+#: scripts/core/views/sdSearchList.html:15
+msgid "of"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:12
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:17
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:22
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:11
+msgid "on"
+msgstr ""
+
+#: scripts/apps/archive/views/upload.html:11
+msgid "or"
+msgstr ""
+
+#: scripts/apps/users/views/change-avatar.html:29
+msgid "or Select from computer"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:77
+msgid "organisation"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/reutersConfig.html:15
+#: scripts/apps/ingest/views/settings/searchConfig.html:7
+#: scripts/apps/users/import/views/import-user.html:19
+#: scripts/apps/users/views/edit-form.html:105
+#: scripts/apps/users/views/edit-form.html:96
+#: scripts/core/auth/login-modal.html:14
+msgid "password"
+msgstr ""
+
+#: scripts/core/auth/reset-password.html:55
+msgid "passwords must be same"
+msgstr ""
+
+#: scripts/core/editor2/views/add-content.html:19
+msgid "paste a block"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/fileConfig.html:3
+msgid "path to folder"
+msgstr ""
+
+#: scripts/apps/users/views/user-list-item.html:19
+msgid "pending"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:125
+msgid "phone"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:166
+msgid "phone number"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:4
+msgid "picture"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:111
+#: scripts/apps/users/views/edit-form.html:123
+msgid "please provide a valid email address"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:89
+msgid "please use only letters (a-z), numbers (0-9), dashes (&mdash;), underscores (_), apostrophes (') and periods (.)"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:274
+msgid "post code"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-replace.html:7
+msgid "prev"
+msgstr ""
+
+#: scripts/apps/archive/views/media-view.html:31
+msgid "previous"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:20
+msgid "production"
+msgstr ""
+
+#: scripts/apps/users/import/views/import-user.html:31
+msgid "profile"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:144
+#: scripts/apps/contacts/views/edit-form.html:183
+#: scripts/apps/contacts/views/edit-form.html:38
+msgid "public"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:4
+msgid "publish"
+msgstr ""
+
+#: scripts/apps/authoring/views/send-item.html:148
+msgid "publish from"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:7
+msgid "published"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-widget.html:14
+msgid "quick list"
+msgstr ""
+
+#: scripts/core/editor2/editor.js:1078
+msgid "quote"
+msgstr ""
+
+#: scripts/core/editor2/editor.js:1084
+msgid "remove formatting"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:100
+msgid "removed desk"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:97
+msgid "removed highlight"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:32
+msgid "removed item {{ type }} about {{ subject }}"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-replace.html:6
+msgid "replace"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:38
+msgid "replaced item {{ type }} about {{ subject }}"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:6
+msgid "retrying"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/versions/views/versions.html:16
+msgid "revert"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:160
+msgid "rewrite id"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:36
+msgid "role {{role}} is granted new privileges: Please re-login."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:6
+msgid "routed"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:7
+msgid "scheduled"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:21
+msgid "scheduled Desk Output"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:20
+msgid "search"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:74
+msgid "search provider password"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:69
+msgid "search provider username"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:89
+msgid "sec"
+msgstr ""
+
+#: scripts/core/views/sdSearchList.html:5
+msgid "selected"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:4
+msgid "send"
+msgstr ""
+
+#: scripts/apps/desks/views/main.html:6
+msgid "show only online users"
+msgstr ""
+
+#: scripts/apps/users/views/change-avatar.html:15
+msgid "shows your initials instead"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:20
+msgid "since"
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterSearchController.js:30
+msgid "single value is required"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:27
+msgid "slugline"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:5
+msgid "sluglines"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:129
+msgid "sorry, a user with this email already exists"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:86
+msgid "sorry, this username is already taken."
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:60
+msgid "source of the search provider"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:7
+msgid "spiked"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:21
+msgid "stage"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:10
+#: scripts/apps/authoring/versioning/versions/views/versions.html:11
+#: scripts/core/itemList/views/relatedItem-list-widget.html:44
+msgid "stage:"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:6
+msgid "submitted"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:27
+msgid "subscription"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:5
+msgid "success"
+msgstr ""
+
+#: scripts/apps/legal-archive/views/legal_archive.html:12
+msgid "switch to grid view"
+msgstr ""
+
+#: scripts/apps/legal-archive/views/legal_archive.html:13
+msgid "switch to list view"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:4
+msgid "text"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:72
+msgid "to"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:216
+msgid "twitter"
+msgstr ""
+
+#: scripts/core/editor2/editor.js:1063
+msgid "underline"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:22
+msgid "update"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:35
+msgid "updated Ingest Channel {{name}}"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:25
+msgid "updated fields"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:33
+msgid "updated task {{ subject }} for item {{ type }}"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:29
+msgid "uploaded media {{ name }}"
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:133
+#: scripts/apps/contacts/views/edit-form.html:172
+msgid "usage"
+msgstr ""
+
+#: scripts/apps/users/directives/UserEditDirective.js:119
+msgid "user saved."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:32
+msgid "user {{user}} has been added to desk {{desk}}: Please re-login."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:36
+msgid "user {{user}} is granted new privileges: Please re-login."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:37
+msgid "user {{user}} is updated to administrator: Please re-login."
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/reutersConfig.html:11
+#: scripts/apps/ingest/views/settings/searchConfig.html:3
+#: scripts/apps/users/import/views/import-user.html:14
+#: scripts/apps/users/views/edit-form.html:75
+#: scripts/core/auth/login-modal.html:13
+msgid "username"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:5
+msgid "users"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-article.html:5
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:13
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:6
+#: scripts/apps/authoring/versioning/history/views/history.html:108
+#: scripts/apps/authoring/versioning/history/views/history.html:126
+#: scripts/apps/authoring/versioning/history/views/history.html:140
+#: scripts/apps/authoring/versioning/history/views/history.html:157
+#: scripts/apps/authoring/versioning/history/views/history.html:173
+#: scripts/apps/authoring/versioning/history/views/history.html:22
+#: scripts/apps/authoring/versioning/history/views/history.html:33
+#: scripts/apps/authoring/versioning/history/views/history.html:44
+#: scripts/apps/authoring/versioning/history/views/history.html:55
+#: scripts/apps/authoring/versioning/history/views/history.html:69
+#: scripts/apps/authoring/versioning/history/views/history.html:80
+#: scripts/apps/authoring/versioning/history/views/history.html:9
+#: scripts/apps/authoring/versioning/history/views/history.html:94
+#: scripts/apps/authoring/versioning/versions/views/versions.html:14
+msgid "version"
+msgstr ""
+
+#: scripts/apps/archive/controllers/UploadController.js:94
+#: scripts/core/lang/missing-translations-strings.js:4
+msgid "video"
+msgstr ""
+
+#: scripts/apps/desks/views/settings.html:44
+msgid "view all"
+msgstr ""
+
+#: scripts/core/notification/notification.js:118
+msgid "vocabulary has been updated. Please re-login to see updated vocabulary values"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.js:123
+msgid "was unlocked by <b></b>."
+msgstr ""
+
+#: scripts/apps/contacts/views/edit-form.html:207
+msgid "website"
+msgstr ""
+
+#: scripts/apps/archive/views/export.html:17
+msgid "{{ 'Validate' | translate }}"
+msgstr ""
+
+#: scripts/apps/authoring/views/item-actions-by-intent.html:5
+msgid "{{ ::group._id }}"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:316
+msgid "{{ field }} cannot be earlier than now!"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:304
+msgid "{{ field }} date is required!"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:312
+msgid "{{ field }} is not a valid date!"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.js:308
+msgid "{{ field }} time is required!"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:557
+#: scripts/apps/authoring/views/article-edit.html:582
+msgid "{{ field.display_name }}"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:33
+msgid "{{ labels.saml }}"
+msgstr ""
+
+#: scripts/apps/search/views/multi-action-bar.html:4
+msgid "{{ multi.count}} Item selected"
+msgid_plural "{{ multi.count}} Items selected"
+msgstr[0] ""
+msgstr[1] ""
+
+#: scripts/apps/publish/views/publish-queue.html:71
+msgid "{{ multiSelectCount}} Item selected"
+msgid_plural "{{ multiSelectCount }} Items selected"
+msgstr[0] ""
+msgstr[1] ""
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:1
+msgid "{{ title }}"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:52
+msgid "{{ wordsCount}} word"
+msgid_plural "{{ $count}} words"
+msgstr[0] ""
+msgstr[1] ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:25
+msgid "{{:: monitoring.getGroupLabel(card, aggregate.settings.type)}}"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:127
+msgid "{{error.email}}"
+msgstr ""
+
+#: scripts/apps/authoring/views/full-preview.html:106
+#: scripts/apps/authoring/views/full-preview.html:120
+msgid "{{field.display_name}}"
+msgstr ""
+
+#: scripts/core/itemList/views/relatedItem-list-widget.html:38
+msgid "{{item.state | removeLodash}}"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:214
+msgid "{{selected.is_visible ? 'ON' : 'OFF'}}"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:218
+msgid "{{selected.local_readonly ? 'ON' : 'OFF'}}"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.js:35
+msgid "{{status}} Ingest Channel {{name}}"
+msgstr ""
+
+#
+# string on previous superdesk.pot file, not existing anymore on superdesk
+msgid "\" sent at:"
+msgstr ""
+
+msgid "{{ multi.count }} Item selected"
+msgstr ""
+
+msgid_plural "{{ multi.count }} Items selected"
+msgstr ""
+
+msgid "{{ wordsCount }} word"
+msgstr ""
+
+msgid_plural "{{ $count }} words"
+msgstr ""
+
+msgid "{{item.state}}"
+msgstr ""
+
+msgid "2 character limit"
+msgstr ""
+
+msgid "Activity Report"
+msgstr ""
+
+msgid "Activity report deleted"
+msgstr ""
+
+msgid "Add New Abbreviations Dictionary"
+msgstr ""
+
+msgid "Add New Dictionary"
+msgstr ""
+
+msgid "Add New Group"
+msgstr ""
+
+msgid "Add New Personal Dictionary"
+msgstr ""
+
+msgid "Add New Role"
+msgstr ""
+
+msgid "Add New Routing Scheme"
+msgstr ""
+
+msgid "administrator"
+msgstr ""
+
+msgid "all photos"
+msgstr ""
+
+msgid "Are you sure you want to delete group?"
+msgstr ""
+
+msgid "Are you sure you want to delete the activity report?"
+msgstr ""
+
+msgid "Back to Users list"
+msgstr ""
+
+msgid "By {{ display_name }}"
+msgstr ""
+
+msgid "byline"
+msgstr ""
+
+msgid "Character limit exceeded, group can not be created/updated."
+msgstr ""
+
+msgid "Choose Normal Theme"
+msgstr ""
+
+msgid "Choose Proofread Theme"
+msgstr ""
+
+msgid "Closes current item"
+msgstr ""
+
+msgid "Content expiry"
+msgstr ""
+
+msgid "Correct"
+msgstr ""
+
+msgid "Correction issued by"
+msgstr ""
+
+msgid "Corrections"
+msgstr ""
+
+msgid "Creates a broadcast"
+msgstr ""
+
+msgid "Creates a new take"
+msgstr ""
+
+msgid "Creates new item"
+msgstr ""
+
+msgid "Default value"
+msgstr ""
+
+msgid "Delete activity report"
+msgstr ""
+
+msgid "Description:"
+msgstr ""
+
+msgid "Desk not specified. Please select Desk or configure a default desk."
+msgstr ""
+
+msgid "Desk template"
+msgstr ""
+
+msgid "Dictionary with name \"{{ dictionary.name }}\" already exists."
+msgstr ""
+
+msgid "Do you want to reset the password for user {{ user.full_name }} ?"
+msgstr ""
+
+msgid "Duplicated from"
+msgstr ""
+
+msgid "Duplicates an item"
+msgstr ""
+
+msgid "Edit \"{{group.edit.name}}\" Group"
+msgstr ""
+
+msgid "Edit activity report"
+msgstr ""
+
+msgid "Edit group"
+msgstr ""
+
+msgid "Edit Vocabulary"
+msgstr ""
+
+msgid "Email Filter"
+msgstr ""
+
+msgid "Empty Package"
+msgstr ""
+
+msgid "Error. Activity report not deleted."
+msgstr ""
+
+msgid "Error. The activity could not be generated."
+msgstr ""
+
+msgid "Error. The activity report could not be saved."
+msgstr ""
+
+msgid "Failed to associate as take:"
+msgstr ""
+
+msgid "Failed to generate new take."
+msgstr ""
+
+msgid "Failed to send and continue."
+msgstr ""
+
+msgid "Fetched as"
+msgstr ""
+
+msgid "Filter Preview"
+msgstr ""
+
+msgid "Filter Test"
+msgstr ""
+
+msgid "From template"
+msgstr ""
+
+msgid "Generate"
+msgstr ""
+
+msgid "Get from external source"
+msgstr ""
+
+msgid "Global Saved Activity Reports"
+msgstr ""
+
+msgid "Group by desk"
+msgstr ""
+
+msgid "Group deleted."
+msgstr ""
+
+msgid "Group description"
+msgstr ""
+
+msgid "Group management"
+msgstr ""
+
+msgid "Group name"
+msgstr ""
+
+msgid "Group with name"
+msgstr ""
+
+msgid "Grouping"
+msgstr ""
+
+msgid "Groups"
+msgstr ""
+
+msgid "In Spiked"
+msgstr ""
+
+msgid "In the story \""
+msgstr ""
+
+msgid "Ingest Routing Schemes"
+msgstr ""
+
+msgid "Ingest sources"
+msgstr ""
+
+msgid "inside subscription"
+msgstr ""
+
+msgid "item is associated as a take."
+msgstr ""
+
+msgid "Label:"
+msgstr ""
+
+msgid "Large font"
+msgstr ""
+
+msgid "Linked as take by"
+msgstr ""
+
+msgid "Moved to"
+msgstr ""
+
+msgid "Multi-selects(or deselects) an item"
+msgstr ""
+
+msgid "My Saved Activity Reports"
+msgstr ""
+
+msgid "New Take"
+msgstr ""
+
+msgid "New take created."
+msgstr ""
+
+msgid "No items in this stage"
+msgstr ""
+
+msgid "No recent templates."
+msgstr ""
+
+msgid "Normal font"
+msgstr ""
+
+msgid "OFF"
+msgstr ""
+
+msgid "Opens highlights"
+msgstr ""
+
+msgid "Opens monitoring"
+msgstr ""
+
+msgid "Opens personal"
+msgstr ""
+
+msgid "Opens search"
+msgstr ""
+
+msgid "Opens spike"
+msgstr ""
+
+msgid "Opens tasks"
+msgstr ""
+
+msgid "Opens workspace"
+msgstr ""
+
+msgid "Operation"
+msgstr ""
+
+msgid "Operation date"
+msgstr ""
+
+msgid "Packaging"
+msgstr ""
+
+msgid "Personal dictionary for language \"{{ dictionary.language_id }}\" already exists."
+msgstr ""
+
+msgid "Product management"
+msgstr ""
+
+msgid "Remove group"
+msgstr ""
+
+msgid "Restored by"
+msgstr ""
+
+msgid "role"
+msgstr ""
+
+msgid "Routing"
+msgstr ""
+
+msgid "Rule sets"
+msgstr ""
+
+msgid "Save activity report"
+msgstr ""
+
+msgid "Saves current item"
+msgstr ""
+
+msgid "Search saved activity reports"
+msgstr ""
+
+msgid "send and continue"
+msgstr ""
+
+msgid "Show"
+msgstr ""
+
+msgid "Shows search modal"
+msgstr ""
+
+msgid "Slug"
+msgstr ""
+
+msgid "sorry, this role name already exists."
+msgstr ""
+
+msgid "Sort:"
+msgstr ""
+
+msgid "Spiked from"
+msgstr ""
+
+msgid "Spikes item(s)"
+msgstr ""
+
+msgid "Subscription"
+msgstr ""
+
+msgid "Switches between single/grouped desk view"
+msgstr ""
+
+msgid "Switches between single/grouped stage view"
+msgstr ""
+
+msgid "Takes cannot be scheduled."
+msgstr ""
+
+msgid "Takes cannot have Embargo."
+msgstr ""
+
+msgid "Takes Package"
+msgstr ""
+
+msgid "The activity report was generated successfully"
+msgstr ""
+
+msgid "The activity report was saved successfully"
+msgstr ""
+
+msgid "There is an error. Failed to associate as take."
+msgstr ""
+
+msgid "There was a problem, group not created/updated."
+msgstr ""
+
+msgid "There was a problem, members not saved."
+msgstr ""
+
+msgid "This is a corrected repeat."
+msgstr ""
+
+msgid "Toggles search view"
+msgstr ""
+
+msgid "Toggles widget #"
+msgstr ""
+
+msgid "Unlink take"
+msgstr ""
+
+msgid "Unlocks current item"
+msgstr ""
+
+msgid "Unspiked to"
+msgstr ""
+
+msgid "UPLOAD ITEM"
+msgstr ""
+
+msgid "user role"
+msgstr ""
+
+msgid "Versioning"
+msgstr ""
+
+msgid "Vocabularies management"
+msgstr ""
+
+msgid "words"
 msgstr ""


### PR DESCRIPTION
superdesk.pot file is a bit outdated, hopefully this PR renews it correctly!

produced with:

```
root@superdesk-tester:~# source  /opt/superdesk/activate.sh 
(env) root@superdesk-tester:~# cd /opt/superdesk/client/node_modules/superdesk-core
(env) root@superdesk-tester:/opt/superdesk/client/node_modules/superdesk-core# 
(env) root@superdesk-tester:/opt/superdesk/client/node_modules/superdesk-core# grunt nggettext_extract --verbose
```

Besides the new words this adds, I've noticed there are msgid's that exist on the current file and refer to words/files that don't appear anymore. My guess is these are outdated files, still older Superdesk installations might be using them, so I've included them on the end of the file. I'd like this pot file to replace the existing on https://www.transifex.com/sourcefabric/superdesk, in this case translations of these words hopefully won't disappear. 