### PR TITLE
feat(editor3): Extend service to allow spellchecker on multiple editors at the same time

### DIFF
--- a/scripts/core/editor3/directive.js
+++ b/scripts/core/editor3/directive.js
@@ -180,6 +180,11 @@ class Editor3Directive {
             $scope.$on('$destroy', editor3.unsetStore);
         }
 
+        // Expose the store in the editor3 spellchecker service
+        const storeIndex = editor3.addSpellcheckerStore(store);
+
+        $scope.$on('$destroy', () => editor3.removeSpellcheckerStore(storeIndex));
+
         ReactDOM.render(
             <Provider store={store}>
                 <Editor3

--- a/scripts/core/editor3/service.js
+++ b/scripts/core/editor3/service.js
@@ -4,11 +4,20 @@ import {toHTML} from './html';
 import {clearHighlights} from './reducers/find-replace';
 
 /**
- * @type {Object} Redux store
- * @description Holds the store of the currently active body editor of the open article.
+ * @type {Object} Redux stores
+ * @description Holds the store of the find and replace target
+ * of the open article.
  * @private
  */
 let store = null;
+
+/**
+ * @type {array} Redux stores
+ * @description Holds the stores of the editors on the open article
+ * if they are spellchecker targets
+ * @private
+ */
+let spellcheckerStores = [];
 
 /**
  * @ngdoc service
@@ -35,6 +44,18 @@ export class EditorService {
 
     /**
      * @ngdoc method
+     * @name editor3#addSpellcheckerStore
+     * @param {Object} redux store
+     * @description Registers the passed redux store with the spellchecker service
+     * @returns {Integer}
+     */
+    addSpellcheckerStore(s) {
+        spellcheckerStores.push(s);
+        return spellcheckerStores.length - 1;
+    }
+
+    /**
+     * @ngdoc method
      * @name editor3#version
      * @description Returns the editor version (this is for when using editorResolver).
      * @returns {string}
@@ -46,10 +67,20 @@ export class EditorService {
     /**
      * @ngdoc method
      * @name editor3#unsetStore
-     * @description Clears the store.
+     * @description Clears the find and replace store.
      */
     unsetStore() {
         store = null;
+    }
+
+    /**
+     * @ngdoc method
+     * @name editor3#removeSpellcheckerStore
+     * @param {Integer}
+     * @description Clears a spellchecker store
+     */
+    removeSpellcheckerStore(i) {
+        spellcheckerStores.slice(i, 1);
     }
 
     /**
@@ -128,7 +159,7 @@ export class EditorService {
         }
 
         if (typeof spellcheck !== 'undefined') {
-            store.dispatch(action.setAutoSpellchecker(spellcheck));
+            spellcheckerStores.map((s) => s.dispatch(action.setAutoSpellchecker(spellcheck)));
         }
     }
 


### PR DESCRIPTION
SDESK-2305

The service could only handle one store so the change in state would only affect to bodyHtml. I extended the service to have multiple stores for the spellchecker, but I had to keep the one, single store from the 'find and replace' feature, because we can't have that feature work on multiple stores.

Talking to Petr we came to the conclusion we should make a ticket to refactor this and have one single store with multiple editors inside (even if there's one low level store per editor) so we can have the find and replace work across multiple editors (like Headline, Abstract, Body...)