### PR TITLE
fix(editor3): fix annotations type select box styling

### DIFF
--- a/scripts/apps/authoring/styles/themes.scss
+++ b/scripts/apps/authoring/styles/themes.scss
@@ -282,7 +282,7 @@ body, html {
     }
     //labels
     .field {
-        label {
+        > label {
             @include text-normal();
             background: rgba(0, 0, 0, 0.4);
             @include border-radius(2px);
@@ -300,7 +300,7 @@ body, html {
             letter-spacing: 0.1em;
         }
         &.active {
-            label {
+            > label {
                 background: $sd-blue;
                 @include transition(all ease 0.6s);
             }

--- a/scripts/core/editor3/components/annotations/AnnotationInput.jsx
+++ b/scripts/core/editor3/components/annotations/AnnotationInput.jsx
@@ -130,14 +130,16 @@ class AnnotationInputBody extends Component {
                             </select>
                         </div>
                     }
-                    <label className="sd-line-input__label">Annotation Body</label>
-                    <Editor
-                        onChange={this.onChange}
-                        editorFormat={['bold', 'italic', 'underline', 'link']}
-                        editorState={this.initialContent}
-                        language={language}
-                        disableSpellchecker={!spellcheckerEnabled}
-                    />
+                    <div className="sd-line-input">
+                        <label className="sd-line-input__label">Annotation Body</label>
+                        <Editor
+                            onChange={this.onChange}
+                            editorFormat={['bold', 'italic', 'underline', 'link']}
+                            editorState={this.initialContent}
+                            language={language}
+                            disableSpellchecker={!spellcheckerEnabled}
+                        />
+                    </div>
                     <div className="pull-right">
                         {typeof annotation === 'object' &&
                             <button


### PR DESCRIPTION
`.sd-line-input__label` got overriden by `.main-article .field label` styles

SDESK-2329