### PR TITLE
SDESK-2197 Fix instagram embeds not being shown and facebook videos too big on preview

### DIFF
--- a/scripts/apps/archive/directives/HtmlPreview.js
+++ b/scripts/apps/archive/directives/HtmlPreview.js
@@ -7,6 +7,9 @@ export function HtmlPreview($sce) {
         link: function(scope, elem, attrs) {
             scope.$watch('sdHtmlPreview', (html) => {
                 scope.html = $sce.trustAsHtml(html);
+                if (window.hasOwnProperty('instgrm')) {
+                    window.instgrm.Embeds.process();
+                }
             });
         }
     };

--- a/scripts/core/editor3/components/Editor3.jsx
+++ b/scripts/core/editor3/components/Editor3.jsx
@@ -233,6 +233,12 @@ export class Editor3Component extends React.Component {
         this.editorNode = ReactDOM.findDOMNode(this.refs.editor);
     }
 
+    componentDidUpdate() {
+        if (window.hasOwnProperty('instgrm')) {
+            window.instgrm.Embeds.process();
+        }
+    }
+
     render() {
         const {
             readOnly,

--- a/styles/sass/archive-preview.scss
+++ b/styles/sass/archive-preview.scss
@@ -268,7 +268,7 @@
                     width: 100%;
                     height: 200px;
                     background: $sd-background url(~images/loading-large.gif) center center no-repeat;
-                }                
+                }
             }
             figure {
                 margin: 10px 0 8px 0;
@@ -347,6 +347,11 @@
                 border-left: 3px solid rgba(160, 160, 160, 0.5);
                 padding: 4px 0 4px 14px;
                 font-style: italic;
+            }
+            .embed-block {
+                iframe {
+                    width: 97%;
+                }
             }
         }
     }
@@ -1230,7 +1235,7 @@ $lightbox-composite-condensed : 100px;
             color: #d25932;
             line-height: 116.6%;
         }
-        
+
         .stage {
             font-size: 10px;
             @include text-light();


### PR DESCRIPTION
This fixes some things about embeds.

* If you embed an instagram picture, it wouldn't show (just the frame) on the preview (one click on a monitoring item)
* Same thing happened for editor3 when you double click a monitoring item to edit it, the embed picture wouldn't show (just the frame)
* Embedding a facebook video would overflow the body on preview item, just a css issue (iframe too big)

I would like some feedback about the fixes for the instagram issue. Basically it would work reloading a page, because `window.instgrm.Embed.process()` is always being called. But when loading the item dinamically (clicking on a monitoring item) this wouldn't run so instagram embeds would not be on an iframe.

So, for the editor3 component, I used `componentDidUpdate` to handle it at post-render. For the angular component I do it on the `HtmlPreview` watch.