### PR TITLE
feat (editor3): Remove embed block (SDFID-152)

### DIFF
--- a/scripts/core/editor3/components/embeds/EmbedBlock.jsx
+++ b/scripts/core/editor3/components/embeds/EmbedBlock.jsx
@@ -1,18 +1,26 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
 import {QumuWidget} from './QumuWidget';
+import * as actions from '../../actions';
 
 /**
  * @ngdoc React
  * @module superdesk.core.editor3
- * @name EmbedBlock
+ * @name EmbedBlockComponent
  * @param {Object} block Information about the block where this component renders.
  * @description This component renders an embed block within the editor, using oEmbed data
  * retrieved from iframe.ly
  */
-export class EmbedBlock extends Component {
+export class EmbedBlockComponent extends Component {
+    constructor(props) {
+        super(props);
+
+        this.onClickDelete = this.onClickDelete.bind(this);
+    }
+
     /**
-     * @name EmbedBlock#runScripts
+     * @name EmbedBlockComponent#runScripts
      * @param {string} html
      * @description Runs and imports all the scripts in the given HTML.
      */
@@ -59,10 +67,21 @@ export class EmbedBlock extends Component {
         return data.html !== oldData.html;
     }
 
+    onClickDelete() {
+        const {block, removeBlock} = this.props;
+
+        removeBlock(block.getKey());
+    }
+
     embedBlock({html}) {
         this.runScripts(html);
 
-        return <div className="embed-block" dangerouslySetInnerHTML={{__html: html}} />;
+        return <div className="embed-block embed-block__remove">
+            <a className="btn btn--small btn--icon-only-circle pull-right" onClick={this.onClickDelete}>
+                <i className="icon-close-small" />
+            </a>
+            <div className="embed-block__wrapper" dangerouslySetInnerHTML={{__html: html}} />
+        </div>;
     }
 
     render() {
@@ -74,7 +93,14 @@ export class EmbedBlock extends Component {
     }
 }
 
-EmbedBlock.propTypes = {
+EmbedBlockComponent.propTypes = {
     block: PropTypes.object.isRequired,
-    contentState: PropTypes.object.isRequired
+    contentState: PropTypes.object.isRequired,
+    removeBlock: PropTypes.func.isRequired
 };
+
+const mapDispatchToProps = (dispatch) => ({
+    removeBlock: (blockKey) => dispatch(actions.removeBlock(blockKey))
+});
+
+export const EmbedBlock = connect(null, mapDispatchToProps)(EmbedBlockComponent);

--- a/scripts/core/editor3/components/media/MediaBlock.jsx
+++ b/scripts/core/editor3/components/media/MediaBlock.jsx
@@ -83,8 +83,8 @@ export class MediaBlockComponent extends Component {
         const mediaType = data.type;
 
         return (
-            <div className="image-block image-block__remove sd-shadow--z1" onClick={(e) => e.stopPropagation()}>
-                <a className="btn btn--small btn--icon-only-circle" onClick={this.onClickDelete}>
+            <div className="image-block sd-shadow--z1 image-block__remove" onClick={(e) => e.stopPropagation()}>
+                <a className="btn btn--small btn--icon-only-circle pull-right" onClick={this.onClickDelete}>
                     <i className="icon-close-small" />
                 </a>
                 <div className="image-block__wrapper">

--- a/scripts/core/editor3/components/tests/editor3.spec.jsx
+++ b/scripts/core/editor3/components/tests/editor3.spec.jsx
@@ -3,6 +3,7 @@ import {shallow, mount} from 'enzyme';
 import {Editor3Component as Editor3} from '../Editor3';
 import {blockRenderer} from '../blockRenderer';
 import {EditorState} from 'draft-js';
+import mockStore from './utils';
 
 const editorState = EditorState.createEmpty();
 
@@ -105,8 +106,9 @@ describe('editor3.blockRenderer', () => {
         const block = {getType: () => 'atomic', getEntityAt: () => 'entity_key'};
         const contentState = {getEntity: () => ({getType: () => 'EMBED', getData: () => ({data: {html: 'abc'}})})};
         const component = blockRenderer(block).component({block, contentState});
+        const {options} = mockStore();
 
         expect(component).not.toBe(null);
-        expect(mount(component).name()).toBe('EmbedBlock');
+        expect(mount(component, options).name()).toBe('Connect(EmbedBlockComponent)');
     });
 });

--- a/scripts/core/editor3/components/tests/embeds.spec.jsx
+++ b/scripts/core/editor3/components/tests/embeds.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 import mockStore, {embedBlockAndContent} from './utils';
-import {EmbedBlock} from '../embeds';
+import {EmbedBlockComponent as EmbedBlock} from '../embeds/EmbedBlock';
 import {EmbedInputComponent as EmbedInput} from '../embeds/EmbedInput';
 
 describe('editor3.components.embed-block', () => {
@@ -9,8 +9,8 @@ describe('editor3.components.embed-block', () => {
         const {block, contentState} = embedBlockAndContent();
         const wrapper = shallow(<EmbedBlock block={block} contentState={contentState} />);
 
-        expect(wrapper.find('.embed-block').html())
-            .toBe('<div class="embed-block"><h1>Embed Title</h1></div>');
+        expect(wrapper.find('.embed-block__wrapper').html())
+            .toBe('<div class="embed-block__wrapper"><h1>Embed Title</h1></div>');
     });
 });
 

--- a/scripts/core/editor3/reducers/toolbar.jsx
+++ b/scripts/core/editor3/reducers/toolbar.jsx
@@ -181,12 +181,11 @@ const removeBlock = (state, {blockKey}) => {
     const {editorState} = state;
     const contentState = editorState.getCurrentContent();
 
-    const afterKey = contentState.getKeyAfter(blockKey);
     const targetRange = new SelectionState({
         anchorKey: blockKey,
         anchorOffset: 0,
-        focusKey: afterKey,
-        focusOffset: 0
+        focusKey: blockKey,
+        focusOffset: 1
     });
     let newContentState = Modifier.setBlockType(
         contentState,
@@ -232,3 +231,4 @@ const applyEmbed = (state, code) => {
 const setPopup = (state, {type, data}) => ({...state, popup: {type, data}});
 
 export default toolbar;
+

--- a/scripts/core/editor3/styles.scss
+++ b/scripts/core/editor3/styles.scss
@@ -132,11 +132,10 @@ $editor-styleButton-active-color:#5890ff;
 
     .image-block {
         position: relative;
+        padding: 1rem;
 
-        &__remove > .btn {
-            position: absolute;
-            top: 1rem;
-            right: 1rem;
+        &__remove .btn {
+            margin-bottom: 1rem;
         }
     }
 

--- a/scripts/core/editor3/styles.scss
+++ b/scripts/core/editor3/styles.scss
@@ -130,7 +130,7 @@ $editor-styleButton-active-color:#5890ff;
 		}
 	}
 
-    .image-block {
+    .image-block, .embed-block {
         position: relative;
         padding: 1rem;
 


### PR DESCRIPTION
* Uses `react-redux` in `EmbedBlock`
* Fixes tests to fit previous change
* Adds remove button to embeds (+ css)

This should have been done in https://github.com/superdesk/superdesk-client-core/pull/2042, so it's the same feature.