### PR TITLE
SDESK-1412 Trim html tags in open article headline

### DIFF
--- a/scripts/apps/authoring/authoring/helpers.js
+++ b/scripts/apps/authoring/authoring/helpers.js
@@ -1,3 +1,5 @@
+import {stripHtmlTags} from '../../../core/utils';
+
 export const CONTENT_FIELDS_DEFAULTS = Object.freeze({
     headline: '',
     slugline: '',
@@ -99,10 +101,9 @@ export function filterDefaultValues(diff, orig) {
 export function stripHtmlRaw(content) {
     if (content) {
         var elem = document.createElement('div');
-        var htmlRegex = /(<([^>]+)>)/ig;
 
         elem.innerHTML = content;
-        return elem.textContent.replace(htmlRegex, '');
+        return stripHtmlTags(elem.textContent);
     }
     return '';
 }

--- a/scripts/apps/authoring/authoring/helpers.js
+++ b/scripts/apps/authoring/authoring/helpers.js
@@ -1,4 +1,4 @@
-import {stripHtmlTags} from '../../../core/utils';
+import {stripHtmlTags} from 'core/utils';
 
 export const CONTENT_FIELDS_DEFAULTS = Object.freeze({
     headline: '',

--- a/scripts/apps/authoring/views/opened-articles.html
+++ b/scripts/apps/authoring/views/opened-articles.html
@@ -5,7 +5,7 @@
     <ul ng-if="workqueue.items.length" class="list" ng-class="{'full-width': !multiEdit.items.length}">
         <li ng-repeat="article in workqueue.items track by article._id" ng-class="{active: article === active}" style="width:{{ 100 / workqueue.items.length }}%">
             <a class="title" ng-click="edit(article, $event)" ng-href="{{ :: link(article) }}">
-                <span ng-show="article.headline || article.slugline">{{ article.headline || article.slugline }}</span>
+                <span ng-show="article.headline || article.slugline">{{ (article.headline || article.slugline) | trimHtmlTags }}</span>
                 <span ng-show="!article.headline && !article.slugline" translate>Untitled</span>
             </a>
 

--- a/scripts/apps/authoring/views/opened-articles.html
+++ b/scripts/apps/authoring/views/opened-articles.html
@@ -5,7 +5,7 @@
     <ul ng-if="workqueue.items.length" class="list" ng-class="{'full-width': !multiEdit.items.length}">
         <li ng-repeat="article in workqueue.items track by article._id" ng-class="{active: article === active}" style="width:{{ 100 / workqueue.items.length }}%">
             <a class="title" ng-click="edit(article, $event)" ng-href="{{ :: link(article) }}">
-                <span ng-show="article.headline || article.slugline">{{ (article.headline || article.slugline) | trimHtmlTags }}</span>
+                <span ng-show="article.headline || article.slugline">{{ (article.headline || article.slugline) | stripHtmlTags }}</span>
                 <span ng-show="!article.headline && !article.slugline" translate>Untitled</span>
             </a>
 

--- a/scripts/apps/templates/views/template-editor-modal.html
+++ b/scripts/apps/templates/views/template-editor-modal.html
@@ -63,8 +63,8 @@
 
         <form name="metadataForm">
             <div class="template-metadata">
-                <div ng-if="showDesks()">                    
-                    
+                <div ng-if="showDesks()">
+
                     <div for="template-desk" ng-if="template.template_type !== 'create'">
                         <div class="sd-line-input sd-line-input--is-select">
                             <label class="sd-line-input__label">{{:: 'Desk' | translate }}</label>
@@ -75,9 +75,9 @@
                                 <option ng-repeat="desk in desks._items track by desk._id" value="{{ desk._id }}"
                                 ng-selected="desk.selected">{{ :: desk.name }}</option>
                             </select>
-                        </div>                        
+                        </div>
                     </div>
-                    
+
                     <div for="template-desks" ng-if="template.template_type === 'create'" sd-toggle-box data-title="{{:: 'Desks' | translate }}" data-open="true">
                         <div class="multi-select" ng-if="template.template_type === 'create'">
                             <ul>
@@ -86,15 +86,15 @@
                                 </li>
                             </ul>
                         </div>
-                    </div>                    
+                    </div>
                 </div>
 
                 <div sd-toggle-box data-title="{{:: 'Metadata' | translate }}" data-open="false" id="template-editor-metadata">
                     <div class="field">
-                        <span sd-switch ng-model="item.flags.marked_for_not_publication"></span><label>Not For Publication</label>                        
+                        <span sd-switch ng-model="item.flags.marked_for_not_publication"></span><label>Not For Publication</label>
                     </div>
 
-                    <div class="field field--margin-double">                        
+                    <div class="field field--margin-double">
                         <span sd-switch ng-model="item.flags.marked_for_legal"></span><label translate>Legal</label>
                     </div>
 
@@ -167,7 +167,7 @@
                     <div ng-if="showScheduling() && template.schedule.is_active"
                              class="sd-line-input sd-line-input--is-select sd-line-input--required">
                         <label for="schedule-desk" class="sd-line-input__label" translate>Schedule Desk</label>
-                        <select id="schedule-desk" ng-model="template.schedule_desk" 
+                        <select id="schedule-desk" ng-model="template.schedule_desk"
                                 ng-change="updateStages(template.schedule_desk)" class="sd-line-input__select">
                             <option value="" translate>None</option>
                             <option ng-repeat="desk in desks._items track by desk._id" value="{{ desk._id }}"

--- a/scripts/core/filters/index.js
+++ b/scripts/core/filters/index.js
@@ -214,4 +214,8 @@ export default angular.module('superdesk.core.filters', [])
         var cleanedValue = value || '';
 
         return cleanedValue.replace('_', ' ');
-    });
+    })
+    .filter('trimHtmlTags', () => function(value) {
+        return value ? String(value).replace(/<[^>]+>/gm, '') : '';
+    })
+;

--- a/scripts/core/filters/index.js
+++ b/scripts/core/filters/index.js
@@ -1,3 +1,5 @@
+import {stripHtmlTags} from '../utils';
+
 export default angular.module('superdesk.core.filters', [])
     .filter('any', () => function(data, key) {
         return _.any(data, key);
@@ -215,7 +217,7 @@ export default angular.module('superdesk.core.filters', [])
 
         return cleanedValue.replace('_', ' ');
     })
-    .filter('trimHtmlTags', () => function(value) {
-        return value ? String(value).replace(/<[^>]+>/gm, '') : '';
+    .filter('stripHtmlTags', () => function(value) {
+        return stripHtmlTags(value);
     })
 ;

--- a/scripts/core/utils.js
+++ b/scripts/core/utils.js
@@ -1,0 +1,5 @@
+export function stripHtmlTags(value) {
+    const htmlRegex = /(<([^>]+)>)/ig;
+
+    return value ? String(value).replace(htmlRegex, '') : '';
+}


### PR DESCRIPTION
Removing tags on save was not a good idea because we might need those tags on the headline for styling.

I just created an angular filter to trim html tags and used it on the headline at the bottom bar.