### PR TITLE
Fix undefined highlights with a new article

### DIFF
--- a/scripts/core/editor3/helpers/highlights.js
+++ b/scripts/core/editor3/helpers/highlights.js
@@ -496,7 +496,7 @@ export function getRangeAndTextForStyle(editorState, style) {
 function applyHighlightsStyleMap(editorState) {
     const highlights = getCustomDataFromEditor(editorState, editor3DataKeys.MULTIPLE_HIGHLIGHTS);
 
-    if (highlights === undefined) {
+    if (highlights === undefined || highlights.highlightsData === undefined) {
         return editorState;
     }
 


### PR DESCRIPTION
Just an additional check for https://github.com/superdesk/superdesk-client-core/pull/2140 that prevents a new article to throw an error