### PR TITLE
Typing inside the editor highlights should expand the highlight and not split it

### DIFF
--- a/scripts/core/editor3/helpers/highlights.js
+++ b/scripts/core/editor3/helpers/highlights.js
@@ -856,14 +856,31 @@ function addCommentsForServer(editorState) {
  */
 export function handleBeforeInputHighlights(onChange, chars, editorState) {
     const selection = editorState.getSelection();
-    let {block, newOffset} = getBlockAndOffset(editorState, selection, -1);
 
-    if (block == null) {
-        ({block, newOffset} = getBlockAndOffset(editorState, selection, 1));
+    const {block: blockLeft, newOffset: newOffsetLeft} = getBlockAndOffset(editorState, selection, -1);
+    const {block: blockRight, newOffset: newOffsetRight} = getBlockAndOffset(editorState, selection, 1);
 
-        if (block == null) {
-            return 'not-handled';
-        }
+    const highlightsOnLeftExist = blockLeft != null
+        && blockLeft.getInlineStyleAt(newOffsetLeft).find(styleNameBelongsToHighlight) != null;
+
+    const highlightsOnRightExist = blockRight != null
+        && blockRight.getInlineStyleAt(newOffsetRight).find(styleNameBelongsToHighlight) != null;
+
+    if (highlightsOnLeftExist && highlightsOnRightExist) {
+        return 'not-handled';
+    }
+
+    let block = null;
+    let newOffset = null;
+
+    if (blockLeft != null) {
+        block = blockLeft;
+        newOffset = newOffsetLeft;
+    } else if (blockRight != null) {
+        block = blockRight;
+        newOffset = newOffsetRight;
+    } else {
+        return 'not-handled';
     }
 
     const characterStyles = block.getInlineStyleAt(newOffset);


### PR DESCRIPTION
SDESK-2721
The problem:
![highlights-get-split](https://user-images.githubusercontent.com/2076953/38237542-2cf9eb06-3730-11e8-8012-64d549556389.gif)
