### PR TITLE
[SDESK-1113] 'Send to' in action menu

### DIFF
--- a/scripts/apps/authoring/authoring/index.js
+++ b/scripts/apps/authoring/authoring/index.js
@@ -125,6 +125,15 @@ angular.module('superdesk.apps.authoring', [
                     return authoring.itemActions(item).edit;
                 }]
             })
+            .activity('move.item', {
+                label: gettext('Send to'),
+                icon: 'share-alt',
+                controller: ['data', 'send', (data, send) => {
+                    send.allAs([data.item]);
+                }],
+                filters: [{action: 'list', type: 'archive'}],
+                permissions: {move: 1}
+            })
             .activity('kill.text', {
                 label: gettext('Kill item'),
                 priority: 100,

--- a/scripts/apps/authoring/authoring/index.js
+++ b/scripts/apps/authoring/authoring/index.js
@@ -132,7 +132,9 @@ angular.module('superdesk.apps.authoring', [
                     send.allAs([data.item]);
                 }],
                 filters: [{action: 'list', type: 'archive'}],
-                permissions: {move: 1}
+                additionalCondition: ['authoring', 'item', 'config', (authoring, item, config) =>
+                    authoring.itemActions(item).move
+                ]
             })
             .activity('kill.text', {
                 label: gettext('Kill item'),


### PR DESCRIPTION
Inside the action menu for each item, there's a new "Send to" option that allows the user to send an item to another desk/stage without multi selection or opening the authoring