### PR TITLE
Fix validating unresolved suggestions before publishing

### DIFF
--- a/scripts/apps/authoring/authoring/helpers.js
+++ b/scripts/apps/authoring/authoring/helpers.js
@@ -1,5 +1,7 @@
 import {stripHtmlTags} from 'core/utils';
 import {fieldHasUnresolvedSuggestions} from 'core/editor3/helpers/highlights';
+import {initializeHighlights} from 'core/editor3/helpers/highlights';
+import {EditorState, convertFromRaw} from 'draft-js';
 
 export const CONTENT_FIELDS_DEFAULTS = Object.freeze({
     headline: '',
@@ -198,7 +200,10 @@ export function itemHasUnresolvedSuggestions(item) {
 
             const rawState = fieldValue[0];
 
-            return fieldHasUnresolvedSuggestions(rawState);
+            const contentState = convertFromRaw(rawState);
+            const editorState = initializeHighlights(EditorState.createWithContent(contentState));
+
+            return fieldHasUnresolvedSuggestions(editorState);
         })
         .length > 0;
 }

--- a/scripts/core/editor3/helpers/highlights.js
+++ b/scripts/core/editor3/helpers/highlights.js
@@ -1,4 +1,4 @@
-import {RichUtils, EditorState, convertFromRaw, Modifier} from 'draft-js';
+import {RichUtils, EditorState, Modifier} from 'draft-js';
 import {highlightsConfig} from '../highlightsConfig';
 import {editor3DataKeys, getCustomDataFromEditor, setCustomDataForEditor} from './editor3CustomData';
 import {getDraftCharacterListForSelection} from './getDraftCharacterListForSelection';
@@ -817,9 +817,7 @@ export function getSuggestionData(editorState, styleName) {
     };
 }
 
-export function fieldHasUnresolvedSuggestions(rawState) {
-    const contentState = convertFromRaw(rawState);
-    const editorState = EditorState.createWithContent(contentState);
+export function fieldHasUnresolvedSuggestions(editorState) {
     const highlights = getHighlightsState(editorState);
 
     return Object.keys(highlights.highlightsData || {})


### PR DESCRIPTION
The issue was that due to an invalid state being passed to a function, an empty state would be returned instead which of course had no unresolved suggestions.