### PR TITLE
[SDESK-2746] Remove all suggestions when pressing DELETE key in suggestion mode

### DIFF
--- a/scripts/core/editor3/reducers/suggestions.jsx
+++ b/scripts/core/editor3/reducers/suggestions.jsx
@@ -347,6 +347,7 @@ const deleteCurrentSelection = (editorState, data) => {
     let newState = editorState;
 
     newState = initSelectionIterator(newState, backward);
+
     while (hasNextSelection(newState, selection, backward)) {
         newState = setDeleteSuggestionForCharacter(newState, data);
     }
@@ -436,7 +437,16 @@ const setDeleteSuggestionForCharacter = (editorState, data) => {
     if (currentData != null && currentData.type === 'ADD_SUGGESTION' &&
         currentData.author === data.author) {
         // if current character already a suggestion of current user, delete the character
-        return deleteCharacter(editorState);
+        let newState = deleteCharacter(editorState);
+
+        // also delete the suggestion if it was the last character of that suggestion
+        const textForHighlight = Highlights.getRangeAndTextForStyle(newState, currentStyle);
+
+        if (textForHighlight.highlightedText === '') {
+            newState = Highlights.removeHighlight(newState, currentStyle);
+        }
+
+        return newState;
     }
 
     const beforeStyle = Highlights.getHighlightStyleAtOffset(editorState, changeSuggestionsTypes, selection, -2);

--- a/scripts/core/editor3/reducers/suggestions.jsx
+++ b/scripts/core/editor3/reducers/suggestions.jsx
@@ -437,16 +437,7 @@ const setDeleteSuggestionForCharacter = (editorState, data) => {
     if (currentData != null && currentData.type === 'ADD_SUGGESTION' &&
         currentData.author === data.author) {
         // if current character already a suggestion of current user, delete the character
-        let newState = deleteCharacter(editorState);
-
-        // also delete the suggestion if it was the last character of that suggestion
-        const textForHighlight = Highlights.getRangeAndTextForStyle(newState, currentStyle);
-
-        if (textForHighlight.highlightedText === '') {
-            newState = Highlights.removeHighlight(newState, currentStyle);
-        }
-
-        return newState;
+        return deleteCharacter(editorState, currentStyle);
     }
 
     const beforeStyle = Highlights.getHighlightStyleAtOffset(editorState, changeSuggestionsTypes, selection, -2);
@@ -515,10 +506,11 @@ const resetSuggestion = (editorState, style) => {
  * @ngdoc method
  * @name deleteCharacter
  * @param {Object} editorState
+ * @param {String} style - style of the current selection (optional)
  * @return {Object} returns new state
  * @description Delete the current character.
  */
-const deleteCharacter = (editorState) => {
+const deleteCharacter = (editorState, style = null) => {
     let content;
     let selection;
     let newState;
@@ -528,7 +520,19 @@ const deleteCharacter = (editorState) => {
     selection = newState.getSelection();
 
     content = Modifier.removeRange(content, selection, 'forward');
-    return EditorState.push(newState, content, 'backspace-character');
+
+    newState = EditorState.push(newState, content, 'backspace-character');
+
+    if (style) {
+        const textForHighlight = Highlights.getRangeAndTextForStyle(newState, style);
+
+        if (textForHighlight.highlightedText === '') {
+            // also delete the suggestion if it was the last character of that suggestion
+            newState = Highlights.removeHighlight(newState, style);
+        }
+    }
+
+    return newState;
 };
 
 export default suggestions;


### PR DESCRIPTION
### The problem

When you do this:

![kapture 2018-04-10 at 16 16 27](https://user-images.githubusercontent.com/4324982/38562297-8d3678b8-3cda-11e8-8c28-7efda15bcf16.gif)

When you press the DELETE key it would only delete the text `suggestion` but not the suggestion itself. So whenever you wanted to publish the item, the suggestion would exist there forever and you couldn't publish as it was unresolved.

### The solution

As the processing of the DELETE key is handled char by char, it now removes the highlight if there's no more text for that suggestion ID.