### PR TITLE
(fix): Fixing the unit test for planning.

### DIFF
--- a/scripts/apps/search/components/PhotoDeskInfo.jsx
+++ b/scripts/apps/search/components/PhotoDeskInfo.jsx
@@ -1,21 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import _ from 'lodash';
 import {createMarkUp} from '../helpers';
 import * as fields from '../components/fields';
 import {getLabelForFieldId} from 'apps/workspace/helpers/getLabelForFieldId';
 
 import {DEFAULT_GRID_VIEW_FIELDS_CONFIG} from 'apps/search/constants';
 
-/* globals __SUPERDESK_CONFIG__: true */
-const gridViewFieldsConfig = __SUPERDESK_CONFIG__.gridViewFields || DEFAULT_GRID_VIEW_FIELDS_CONFIG;
 const customFieldsNotSupportedHere = {};
 
 /**
  * PhotoDesk Info - renders item metadata
  */
 export function PhotoDeskInfo(props) {
-    const {datetime} = props.svc;
-
+    const {datetime, config} = props.svc;
+    const gridViewFieldsConfig = _.get(config, 'gridViewFields', DEFAULT_GRID_VIEW_FIELDS_CONFIG);
     const item = props.item;
 
     return (


### PR DESCRIPTION
Unit test for planning was failing as `__SUPERDESK_CONFIG__` is not defined.  Using the `config` service instead.

