### PR TITLE
[INGEST] disabled autocompletion on password for feeding service

### DIFF
--- a/scripts/apps/ingest/views/settings/apConfig.html
+++ b/scripts/apps/ingest/views/settings/apConfig.html
@@ -4,7 +4,7 @@
 </div>
 <div class="field">
     <label for="ap_password" translate>Password</label>
-    <input type="password" id="ap_password" placeholder="{{:: 'password'|translate }}" ng-model="provider.config.password" required ng-change="$parent.setConfig(provider)">
+    <input type="password" id="ap_password" placeholder="{{:: 'password'|translate }}" ng-model="provider.config.password" required ng-change="$parent.setConfig(provider)" autocomplete="new-password">
 </div>
 <div class="field">
     <label for="ap_idList" translate>idList</label>

--- a/scripts/apps/ingest/views/settings/emailConfig.html
+++ b/scripts/apps/ingest/views/settings/emailConfig.html
@@ -21,7 +21,9 @@
     <label for="email-server-password" translate>Password</label>
     <input type="password" id="email-user=password" placeholder="{{:: 'Email Password'|translate }}"
       ng-model="provider.config.password" required
-      ng-change="$parent.setConfig(provider)">
+      ng-change="$parent.setConfig(provider)"
+      autocomplete="new-password"
+      >
     <div class="error" ng-show="error.code === 6000" translate>Authentication error.</div>
 </div>
 <div class="field">

--- a/scripts/apps/ingest/views/settings/ftp-config.html
+++ b/scripts/apps/ingest/views/settings/ftp-config.html
@@ -10,7 +10,7 @@
 </div>
 <div class="field">
     <label for="ftp_password" translate>Password</label>
-    <input type="password" id="ftp_password" placeholder="{{ :: 'Password'|translate }}" ng-model="provider.config.password" ng-change="$parent.setConfig(provider)">
+    <input type="password" id="ftp_password" placeholder="{{ :: 'Password'|translate }}" ng-model="provider.config.password" ng-change="$parent.setConfig(provider)" autocomplete="new-password">
 </div>
 <div class="field">
     <label for="ftp_path" translate>Path</label>

--- a/scripts/apps/ingest/views/settings/ingest-sources-content.html
+++ b/scripts/apps/ingest/views/settings/ingest-sources-content.html
@@ -36,6 +36,11 @@
 
     <div class="modal__body">
         <form name="editForm" sd-wizard data-name="ingestSources" data-current-step="step.current" data-finish="cancel()">
+            <!-- XXX: The dummy text and password inputs below are here to avoid autocompletion in Firefox, as autocomplete="off" is not working
+                      and without it, superdesk login/password will be used as default /o\ (cf. SDESK-2745) -->
+            <input type="text" style="display:none">
+            <input type="password" style="display:none">
+
             <fieldset>
                 <div sd-wizard-step data-title="{{ 'General' | translate }}" data-code="general">
                     <div class="field">

--- a/scripts/apps/ingest/views/settings/reutersConfig.html
+++ b/scripts/apps/ingest/views/settings/reutersConfig.html
@@ -12,5 +12,5 @@
 </div>
 <div class="field">
     <label for="reuters_password" translate>Password</label>
-    <input type="password" id="reuters_password" placeholder="{{:: 'password'|translate }}" ng-model="provider.config.password" required ng-change="$parent.setConfig(provider)">
+    <input type="password" id="reuters_password" placeholder="{{:: 'password'|translate }}" ng-model="provider.config.password" required ng-change="$parent.setConfig(provider)" autocomplete="new-password">
 </div>

--- a/scripts/apps/ingest/views/settings/ritzauConfig.html
+++ b/scripts/apps/ingest/views/settings/ritzauConfig.html
@@ -4,7 +4,7 @@
 </div>
 <div class="field">
     <label for="ritzau_password" translate>Password</label>
-    <input type="password" id="ritzau_password" placeholder="{{:: 'password'|translate }}" ng-model="provider.config.password" required ng-change="$parent.setConfig(provider)">
+    <input type="password" id="ritzau_password" placeholder="{{:: 'password'|translate }}" ng-model="provider.config.password" required ng-change="$parent.setConfig(provider)" autocomplete="new-password">
 </div>
 <div class="field">
     <label for="ritzau_url" translate>Url</label>

--- a/scripts/apps/ingest/views/settings/rssConfig.html
+++ b/scripts/apps/ingest/views/settings/rssConfig.html
@@ -34,7 +34,9 @@
         placeholder="{{:: 'Password'|translate }}"
         ng-model="provider.config.password"
         ng-required="provider.config.auth_required"
-        ng-change="$parent.setConfig(provider)">
+        ng-change="$parent.setConfig(provider)"
+        autocomplete="new-password"
+        >
   </div>
 </fieldset>
 

--- a/scripts/apps/ingest/views/settings/searchConfig.html
+++ b/scripts/apps/ingest/views/settings/searchConfig.html
@@ -4,5 +4,5 @@
 </div>
 <div class="field">
     <label for="reuters_password" translate>Password</label>
-    <input type="text" id="reuters_password" placeholder="{{ 'password'|translate }}" ng-model="provider.config.password" ng-change="$parent.setConfig(provider)">
+    <input type="text" id="reuters_password" placeholder="{{ 'password'|translate }}" ng-model="provider.config.password" ng-change="$parent.setConfig(provider)" autocomplete="new-password">
 </div>

--- a/scripts/apps/ingest/views/settings/twitterConfig.html
+++ b/scripts/apps/ingest/views/settings/twitterConfig.html
@@ -9,7 +9,8 @@
     <label for="twitter-consumer_secret" translate>twitter consumer_secret</label>
     <input type="password" id="twitter-consumer_secret" placeholder="{{:: 'twitter consumer_secret'|translate }}"
       ng-model="provider.config.consumer_secret" required
-      ng-change="$parent.setConfig(provider)">
+      ng-change="$parent.setConfig(provider)"
+      autocomplete="new-password">
 </div>
 <div class="field">
     <label for="twitter-access_token_key" translate>twitter access_token_key</label>
@@ -21,7 +22,9 @@
     <label for="twitter-access_token_secret" translate>twitter access_token_secret</label>
     <input type="password" id="twitter-access_token_secret" placeholder="{{:: 'twitter access_token_secret'|translate }}"
       ng-model="provider.config.access_token_secret" required
-      ng-change="$parent.setConfig(provider)">
+      ng-change="$parent.setConfig(provider)"
+      autocomplete="new-password"
+      >
 </div>
 <div class="field">
     <label for="twitter-screen_names" translate>twitter screen_names</label>

--- a/scripts/apps/ingest/views/settings/wufoo.html
+++ b/scripts/apps/ingest/views/settings/wufoo.html
@@ -8,5 +8,7 @@
     <label for="wufoo_api-key" translate>API key</label>
     <input type="password" id="wufoo_api-key" placeholder="{{:: 'Wufoo API Key'|translate }}"
         ng-model="provider.config.wufoo_api_key" required
-        ng-change="$parent.setConfig(provider)">
+        ng-change="$parent.setConfig(provider)"
+        autocomplete="new-password"
+        >
 </div>


### PR DESCRIPTION
autocomplete="off" on `<input>` is not respected anymore by modern
browsers, and autocomplete="off" on `<form>` is not working either.
Furthermore, Chromium respect autocomplete="new-password" but Firefox
is not (as of 59.0.2).
A hack is used for Firefox with dummy login/password field, which
disable autocompletion, as it seems to be the only working way (beside
setting password with code).
For Chromium, autocomplete="new-password" should be used for each new
password input.

SDESK-2745