### PR TITLE
editor3: make h1-h6 formatting work the same in abstract as in the body

### DIFF
--- a/scripts/apps/authoring/styles/themes.scss
+++ b/scripts/apps/authoring/styles/themes.scss
@@ -477,13 +477,6 @@ body, html {
             padding: 6px 0;
         }
     }
-    .abstract, .abstract p, .abstract div {
-        min-height: 26px;
-        font-weight: 400 !important;
-        .text-editor {
-            min-height: 26px;
-        }
-    }
     .body {
         clear: left;
     }


### PR DESCRIPTION
SDESK-2847