### PR TITLE
[SDESK-2805] Fix bug when toggling suggested style

### DIFF
--- a/scripts/core/editor3/reducers/suggestions.jsx
+++ b/scripts/core/editor3/reducers/suggestions.jsx
@@ -177,6 +177,10 @@ function applyStyleSuggestion(editorState, type, style, data) {
         if (oldData.originalStyle === style && data.originalStyle === '' ||
             oldData.originalStyle === '' && data.originalStyle === style) {
             // the style is toggled back, so no suggestion is added
+
+            // restore the selection
+            newEditorState = EditorState.acceptSelection(newEditorState, selection);
+
             return newEditorState;
         } else {
             data.originalStyle = oldData.originalStyle;


### PR DESCRIPTION
When you suggest an inline style change, if you toggle it back in
suggestion mode it would remove the suggestion but not the style, so
you would have to toggle it back again but that would end up in a
new suggestion to toggle the style off.

This commit fixes that bug, that was actually created by modifying the
editor selection when handling the suggestion highlight.