### PR TITLE
[SDESK-2808] Always handle pasted HTML to parse content consistently

### DIFF
--- a/scripts/core/editor3/components/handlePastedText.js
+++ b/scripts/core/editor3/components/handlePastedText.js
@@ -81,12 +81,6 @@ function processPastedHtml(props, html) {
             .filter((style) => editorFormat.includes(style))
             .map((style) => inlineStyles[style]);
 
-    if (!hasAtomicBlocks && acceptedInlineStyles.length === Object.keys(inlineStyles).length) {
-        // If we are not changing atomic blocks nor removing styles
-        // we let draftjs handle the paste
-        return NOT_HANDLED;
-    }
-
     let contentState = editorState.getCurrentContent();
     let selection = editorState.getSelection();
     let blocks = [];


### PR DESCRIPTION
We should always parse HTML paste to keep the content consistent and to avoid bugs like this one: `sup` and `sub` tags are not being handled by draft-js automatically