### PR TITLE
fix: upgrade angular-embed package to latest version in repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "angular": "1.6.9",
     "angular-contenteditable": "0.3.9",
     "angular-dynamic-locale": "0.1.32",
-    "angular-embed": "superdesk/angular-embed#27a3238",
+    "angular-embed": "superdesk/angular-embed#d75968e",
     "angular-embedly": "Urigo/angular-embedly#0.0.8",
     "angular-gettext": "2.3.10",
     "angular-history": "decipherinc/angular-history#v0.8.0",


### PR DESCRIPTION
Upgrading package in order to avoid issues with instagram embeds