### PR TITLE
[SDESK-2906] Fix undo issue when pasting html

### DIFF
--- a/scripts/core/editor3/components/handlePastedText.js
+++ b/scripts/core/editor3/components/handlePastedText.js
@@ -129,11 +129,12 @@ function processPastedHtml(props, html) {
         selectionAfterInsert
     );
 
-    nextEditorState = EditorState.set(nextEditorState, {allowUndo: true});
-
     // for the first block recover the initial block data because on replaceWithFragment the block data is
     // replaced with the data from pasted fragment
     nextEditorState = setAllCustomDataForEditor(nextEditorState, customData);
+
+    // bring 'undo stack' back
+    nextEditorState = EditorState.set(nextEditorState, {allowUndo: true});
 
     onChange(nextEditorState);
 


### PR DESCRIPTION
Basically the 'undo stack' was registering two changes whenever the user
pasted html into the editor, and that would require pressing ctrl+z
twice which would cause an error in content