### PR TITLE
[SDESK-2904] Add + button to add media to carousel

### DIFF
--- a/scripts/apps/authoring/views/item-carousel.html
+++ b/scripts/apps/authoring/views/item-carousel.html
@@ -165,6 +165,9 @@
                     <img ng-if="item[item.fieldId] && item[item.fieldId].renditions.thumbnail" ng-src="{{item[item.fieldId].renditions.thumbnail.href}}">
                 </div>
             </div>
+            <div class="sd-media-carousel__thumb sd-media-carousel__thumb--add" ng-click="upload()" data-rel="{{item.fieldId}}" ng-if="carouselItems.length < maxUploads">
+                <i class="icon-plus-sign"></i>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Button was removed a while ago due to some issues with reordering, now it seems to work or at least I couldn't reproduce any bug

![image 2018-05-21 at 2 44 42 pm](https://user-images.githubusercontent.com/4324982/40308215-bb30a3a6-5d05-11e8-812a-518a4ee8982a.png)
