### PR TITLE
[SDESK-2941] Save annotation IDs as integer instead of string

### DIFF
--- a/scripts/core/editor3/store/index.js
+++ b/scripts/core/editor3/store/index.js
@@ -83,8 +83,9 @@ function generateAnnotations(item, logger) {
                 if (key.startsWith('ANNOTATION-')) {
                     let annotation = {};
 
-                    annotation.id = key.split('-')[1];
-                    annotation.type = highlight.data.annotationType;
+                    const annotationIdString = key.split('-')[1];
+
+                    annotation.id = parseInt(annotationIdString, 10);
                     annotation.body = toHTML(convertFromRaw(JSON.parse(highlight.data.msg)), logger);
                     annotations.push(annotation);
                 }


### PR DESCRIPTION
There's also a PR on superdesk-core