### PR TITLE
Bring annotations type back in content api

### DIFF
--- a/scripts/apps/authoring/authoring/authoring.spec.js
+++ b/scripts/apps/authoring/authoring/authoring.spec.js
@@ -76,12 +76,12 @@ describe('authoring', () => {
             $rootScope: {
                 $applyAsync: () => {
                     expect(JSON.stringify(context.item.annotations))
-                        .toEqual('[{"id":"1","type":"regular:001","body":"<p>123</p>"}]');
+                        .toEqual('[{"id":1,"type":"regular:001","body":"<p>123</p>"}]');
                 },
             },
         };
 
-        spyOn(context.$rootScope, '$applyAsync');
+        spyOn(context.$rootScope, '$applyAsync').and.callThrough();
         onChange.call(context, contentState);
         expect(context.$rootScope.$applyAsync).toHaveBeenCalled();
     }));

--- a/scripts/core/editor3/store/index.js
+++ b/scripts/core/editor3/store/index.js
@@ -86,6 +86,7 @@ function generateAnnotations(item, logger) {
                     const annotationIdString = key.split('-')[1];
 
                     annotation.id = parseInt(annotationIdString, 10);
+                    annotation.type = highlight.data.annotationType;
                     annotation.body = toHTML(convertFromRaw(JSON.parse(highlight.data.msg)), logger);
                     annotations.push(annotation);
                 }


### PR DESCRIPTION
Line was removed by mistake on a previous PR

SDESK-2947