### PR TITLE
[SDFID-427] Don't close highlights popup when clicking on a modal

### DIFF
--- a/scripts/core/editor3/components/HighlightsPopup.jsx
+++ b/scripts/core/editor3/components/HighlightsPopup.jsx
@@ -171,9 +171,10 @@ export class HighlightsPopup extends Component {
         const {editorNode} = this.props;
         const onPopup = t.closest('.editor-popup').length || t.closest('.mentions-input__suggestions').length;
         const onEditor = t.closest(editorNode).length;
+        const onModal = t.closest('.modal__dialog');
 
-        if (!onPopup && !onEditor) {
-            // if the click occurred outside the editor and the popup we close it
+        if (!onPopup && !onEditor && !onModal) {
+            // if the click occurred outside the editor, the popup and the modal, we close it
             this.unmountCustom();
         }
     }


### PR DESCRIPTION
Basically the problem was that clicking on 'Cancel' was closing the modal because you were clicking outside of the popup. Now I added a check to see if you are clicking on a modal.

# Before

![before](https://user-images.githubusercontent.com/4324982/40668538-10c3871a-6365-11e8-84d3-ee4e0fbd7c17.gif)


# After

![after](https://user-images.githubusercontent.com/4324982/40668593-39c5bbba-6365-11e8-9d40-f3c846ea38d5.gif)
