### PR TITLE
Display commented text on unresolved comments inside widget

### DIFF
--- a/scripts/apps/archive/directives/HtmlPreview.js
+++ b/scripts/apps/archive/directives/HtmlPreview.js
@@ -1,4 +1,4 @@
-import {getCustomMetadata} from 'core/editor3/helpers/editor3CustomData';
+import {getAnnotations} from 'core/editor3/helpers/editor3CustomData';
 import {META_FIELD_NAME} from '../../../core/editor3/helpers/fieldsMeta';
 import {highlightsConfig} from '../../../core/editor3/highlightsConfig';
 import ng from 'core/services/ng';
@@ -20,7 +20,7 @@ function getAllAnnotations(item) {
     const annotations = [];
 
     for (const field in item[META_FIELD_NAME]) {
-        annotations.push(...getCustomMetadata(item, field, highlightsConfig.ANNOTATION.type));
+        annotations.push(...getAnnotations(item, field, highlightsConfig.ANNOTATION.type));
     }
 
     return annotations;

--- a/scripts/apps/authoring/track-changes/inline-comments.js
+++ b/scripts/apps/authoring/track-changes/inline-comments.js
@@ -46,19 +46,17 @@ function getCommentsFromField(customFields, resolved = true) {
     if (resolved) {
         return (obj) => ({
             fieldName: getLabelForFieldId(getFieldId(obj.contentKey), customFields),
-            comments:
-        getCustomDataFromEditorRawState(
-            obj[fieldsMetaKeys.draftjsState],
-            editor3DataKeys.RESOLVED_COMMENTS_HISTORY
-        ) || [],
+            comments: getCustomDataFromEditorRawState(
+                obj[fieldsMetaKeys.draftjsState],
+                editor3DataKeys.RESOLVED_COMMENTS_HISTORY
+            ) || [],
         });
     } else {
         return (obj) => {
-            const highlightsObject =
-        getCustomDataFromEditorRawState(
-            obj[fieldsMetaKeys.draftjsState],
-            editor3DataKeys.MULTIPLE_HIGHLIGHTS
-        ).highlightsData || {};
+            const highlightsObject = getCustomDataFromEditorRawState(
+                obj[fieldsMetaKeys.draftjsState],
+                editor3DataKeys.MULTIPLE_HIGHLIGHTS
+            ).highlightsData || {};
 
             for (const id in highlightsObject) {
                 // Add id to highlight so we can retrieve data from the state

--- a/scripts/apps/authoring/track-changes/inline-comments.js
+++ b/scripts/apps/authoring/track-changes/inline-comments.js
@@ -102,7 +102,9 @@ function InlineCommentsCtrl($scope, userList, metadata, content) {
                 fieldName: getLabelForFieldId(getFieldId(contentKey)),
                 comments: comments,
             };
-        });
+        })
+            .filter((obj) => obj.comments.length > 0);
+
 
         const allComments = []
             .concat(...resolvedComments.map((obj) => obj.comments))

--- a/scripts/apps/authoring/track-changes/views/inline-comments-widget.html
+++ b/scripts/apps/authoring/track-changes/views/inline-comments-widget.html
@@ -26,7 +26,7 @@
                             </div>
                         </li>
                     </ul>
-                    <div ng-show="!!item.data.commentedText" class="commented-text">
+                    <div ng-if="!!item.data.commentedText" class="commented-text">
                         <div translate>Selected text:</div>
                         <span class="text" title="{{ item.data.commentedText }}">
                             "{{ item.data.commentedText }}"

--- a/scripts/apps/authoring/track-changes/views/inline-comments-widget.html
+++ b/scripts/apps/authoring/track-changes/views/inline-comments-widget.html
@@ -26,7 +26,7 @@
                             </div>
                         </li>
                     </ul>
-                    <div ng-if="!!item.data.commentedText" class="commented-text">
+                    <div class="commented-text">
                         <div translate>Selected text:</div>
                         <span class="text" title="{{ item.data.commentedText }}">
                             "{{ item.data.commentedText }}"

--- a/scripts/core/editor3/helpers/editor3CustomData.js
+++ b/scripts/core/editor3/helpers/editor3CustomData.js
@@ -83,6 +83,20 @@ export function getCustomDataFromEditorRawState(rawState, key) {
     return getCustomDataFromEditor(EditorState.createWithContent(convertFromRaw(rawState)), key);
 }
 
+export function getAnnotations(item, field, highlightType, logger = {}) {
+    const highlights = getCustomMetadata(item, field, highlightType, logger);
+
+    return highlights.map(({styleName, obj}) => {
+        const annotationId = parseInt(styleName.split('-')[1], 10);
+
+        return {
+            id: annotationId,
+            type: obj.data.annotationType,
+            body: toHTML(convertFromRaw(JSON.parse(obj.data.msg)), logger),
+        };
+    });
+}
+
 export function getCustomMetadata(item, field, highlightType, logger = {}) {
     const contentStateRaw = getFieldMetadata(item, field, fieldsMetaKeys.draftjsState);
 
@@ -95,21 +109,13 @@ export function getCustomMetadata(item, field, highlightType, logger = {}) {
             getDraftSelectionForEntireContent(editorState)
         );
 
-        const annotations = allStyleNames
+        return allStyleNames
             .filter(styleNameBelongsToHighlight)
             .filter((h) => getHighlightTypeFromStyleName(h) === highlightType)
-            .map((h) => {
-                const obj = getHighlightData(editorState, h);
-                const annotationId = parseInt(h.split('-')[1], 10);
-
-                return {
-                    id: annotationId,
-                    type: obj.data.annotationType,
-                    body: toHTML(convertFromRaw(JSON.parse(obj.data.msg)), logger),
-                };
-            });
-
-        return annotations;
+            .map((styleName) => ({
+                styleName: styleName,
+                obj: getHighlightData(editorState, styleName),
+            }));
     }
 
     return [];

--- a/scripts/core/editor3/helpers/highlights.js
+++ b/scripts/core/editor3/helpers/highlights.js
@@ -1,5 +1,4 @@
 import {RichUtils, EditorState} from 'draft-js';
-
 import {highlightsConfig} from '../highlightsConfig';
 import {editor3DataKeys, getCustomDataFromEditor, setCustomDataForEditor} from './editor3CustomData';
 import {getDraftCharacterListForSelection} from './getDraftCharacterListForSelection';
@@ -843,6 +842,24 @@ export function getRangeAndTextForStyle(editorState, style) {
         selection: newSelection,
         highlightedText: startText + endText,
     };
+}
+
+export function getRangeAndTextForStyleInRawState(rawEditorState, highlightId) {
+    let highlightedText = '';
+
+    for (const {inlineStyleRanges, text} of rawEditorState.blocks) {
+        for (const {offset, length, style} of inlineStyleRanges) {
+            if (style === highlightId) {
+                const textRange = text.substring(offset, length);
+
+                highlightedText = highlightedText.length > 0
+                    ? highlightedText = `${highlightedText}${paragraphSeparator}${textRange}`
+                    : highlightedText = textRange;
+            }
+        }
+    }
+
+    return {highlightedText};
 }
 
 /**

--- a/scripts/core/editor3/helpers/highlights.js
+++ b/scripts/core/editor3/helpers/highlights.js
@@ -850,7 +850,7 @@ export function getRangeAndTextForStyleInRawState(rawEditorState, highlightId) {
     for (const {inlineStyleRanges, text} of rawEditorState.blocks) {
         for (const {offset, length, style} of inlineStyleRanges) {
             if (style === highlightId) {
-                const textRange = text.substring(offset, length);
+                const textRange = text.substring(offset, offset + length);
 
                 highlightedText = highlightedText.length > 0
                     ? highlightedText = `${highlightedText}${paragraphSeparator}${textRange}`

--- a/scripts/core/editor3/store/index.js
+++ b/scripts/core/editor3/store/index.js
@@ -9,7 +9,7 @@ import {Editor3} from '../components/Editor3';
 import {PopupTypes, forceUpdate} from '../actions';
 import {fieldsMetaKeys, setFieldMetadata, getFieldMetadata, FIELD_KEY_SEPARATOR} from '../helpers/fieldsMeta';
 import {getContentStateFromHtml} from '../html/from-html';
-import {getCustomMetadata} from '../helpers/editor3CustomData';
+import {getAnnotations} from '../helpers/editor3CustomData';
 import {highlightsConfig} from '../highlightsConfig';
 import {
     initializeHighlights,
@@ -72,7 +72,7 @@ export default function createEditorStore(props, isReact = false) {
  * @param {Object} item
  */
 function generateAnnotations(item, logger) {
-    item.annotations = getCustomMetadata(item, 'body_html', highlightsConfig.ANNOTATION.type, logger);
+    item.annotations = getAnnotations(item, 'body_html', highlightsConfig.ANNOTATION.type, logger);
 }
 
 /**


### PR DESCRIPTION
We don't save commented text on each comment before they are resolved
(as the highlighted text can change in the editor) so these comments
were lacking the "commented text" property in the view.

Now we search inside the editor content for highlighted text for each
comment. It was a bit tricky to do as we sometimes have orphan comments
(their text was deleted but they were not) that could appear on the
sidebar widget but not on the editor.

SDFID-441