### PR TITLE
Disable drag for mouse and touch on media carousel

### DIFF
--- a/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.js
+++ b/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.js
@@ -140,6 +140,8 @@ export function ItemCarouselDirective($timeout) {
                 carousel = elem.find(carouselContainerSelector).owlCarousel({
                     items: 1,
                     autoHeight: true,
+                    mouseDrag: false, // disable mouse & touch drag to allow contenteditable
+                    touchDrag: false,
                 });
 
                 // Initialize sortable function for thumbnails


### PR DESCRIPTION
SDESK-3012

This will allow media titles to be editable with `contenteditable="true"`