### PR TITLE
Fix isNew option always being true

### DIFF
--- a/scripts/apps/authoring/authoring/controllers/AssociationController.js
+++ b/scripts/apps/authoring/authoring/controllers/AssociationController.js
@@ -196,7 +196,7 @@ export function AssociationController(config, send, api, $q, superdesk,
 
         if (item.renditions && item.renditions.original && self.isImage(item.renditions.original)) {
             scope.loading = true;
-            return renditions.crop(item, {isNew: true, editable: scope.editable, isAssociated: true})
+            return renditions.crop(item, {isNew: false, editable: scope.editable, isAssociated: true})
                 .then((rendition) => {
                     self.updateItemAssociation(scope, rendition, customRel, callback);
                 })

--- a/scripts/apps/authoring/authoring/services/RenditionsService.js
+++ b/scripts/apps/authoring/authoring/services/RenditionsService.js
@@ -80,7 +80,7 @@ export function RenditionsService(metadata, $q, api, superdesk, _) {
                 poi: clonedPicture.poi || {x: 0.5, y: 0.5},
                 showAoISelectionButton: true,
                 showMetadataEditor: true,
-                isNew: options.isNew || true,
+                isNew: 'isNew' in options ? options.isNew : true,
                 isAssociated: options.isAssociated || false,
                 editable: options.editable || true,
                 defaultTab: options.defaultTab || false,


### PR DESCRIPTION
Fixes SDESK-2735

When you clicked EDIT on an image and you didn't do anything, the SAVE button was enabled and CANCEL button would ask for confirmation. Both things didn't make any sense having the image untouched.