### PR TITLE
Correctly assign default options to fix cropping issues

### DIFF
--- a/scripts/apps/authoring/authoring/services/RenditionsService.js
+++ b/scripts/apps/authoring/authoring/services/RenditionsService.js
@@ -75,13 +75,11 @@ export function RenditionsService(metadata, $q, api, superdesk, _) {
             }
 
             const cropOptions = { // default options
-                ...{
-                    isNew: true,
-                    isAssociated: false,
-                    editable: true,
-                    defaultTab: false,
-                    showMetadata: false,
-                },
+                isNew: true,
+                isAssociated: false,
+                editable: true,
+                defaultTab: false,
+                showMetadata: false,
                 ...options,
             };
 

--- a/scripts/apps/authoring/authoring/services/RenditionsService.js
+++ b/scripts/apps/authoring/authoring/services/RenditionsService.js
@@ -74,17 +74,28 @@ export function RenditionsService(metadata, $q, api, superdesk, _) {
                 withRatio = self.renditions;
             }
 
+            const cropOptions = { // default options
+                ...{
+                    isNew: true,
+                    isAssociated: false,
+                    editable: true,
+                    defaultTab: false,
+                    showMetadata: false,
+                },
+                ...options,
+            };
+
             return superdesk.intent('edit', 'crop', {
                 item: clonedPicture,
                 renditions: withRatio,
                 poi: clonedPicture.poi || {x: 0.5, y: 0.5},
                 showAoISelectionButton: true,
                 showMetadataEditor: true,
-                isNew: 'isNew' in options ? options.isNew : true,
-                isAssociated: options.isAssociated || false,
-                editable: options.editable || true,
-                defaultTab: options.defaultTab || false,
-                showMetadata: options.showMetadata || false,
+                isNew: cropOptions.isNew,
+                isAssociated: cropOptions.isAssociated,
+                editable: cropOptions.editable,
+                defaultTab: cropOptions.defaultTab,
+                showMetadata: cropOptions.showMetadata,
             })
                 .then((result) => {
                     let renditionNames = [];

--- a/scripts/core/editor3/actions/tests/toolbar.spec.jsx
+++ b/scripts/core/editor3/actions/tests/toolbar.spec.jsx
@@ -18,7 +18,7 @@ describe('editor3.actions.toolbar', () => {
 
         $rootScope.$apply(); // settles promise
 
-        expect(renditions.crop).toHaveBeenCalledWith('image_data');
+        expect(renditions.crop).toHaveBeenCalledWith('image_data', {isNew: false});
         expect(dispatch).toHaveBeenCalledWith({
             type: 'TOOLBAR_UPDATE_IMAGE',
             payload: {entityKey: 'key', media: 'cropped_image'},

--- a/scripts/core/editor3/actions/toolbar.jsx
+++ b/scripts/core/editor3/actions/toolbar.jsx
@@ -91,7 +91,7 @@ export function cropImage(entityKey, entityData) {
     const {media} = entityData;
 
     return (dispatch) => {
-        renditions.crop(media).then((cropped) => {
+        renditions.crop(media, {isNew: false}).then((cropped) => {
             dispatch({
                 type: 'TOOLBAR_UPDATE_IMAGE',
                 payload: {


### PR DESCRIPTION
We had some issues already because we assign default options with `option || true` which is fine for objects but not for booleans.

This commit fixes all the errors related to those default options while cropping, which were causing the error of the "Edit button" not working at all for body images

SDESK-3100