### PR TITLE
Allow images to be editable even on external sources

### DIFF
--- a/scripts/core/editor3/components/media/MediaBlock.jsx
+++ b/scripts/core/editor3/components/media/MediaBlock.jsx
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
+import ng from 'core/services/ng';
 import * as actions from '../../actions';
 import Textarea from 'react-textarea-autosize';
 
@@ -134,6 +135,8 @@ export class MediaBlockComponent extends Component {
         const rendition = data.renditions.viewImage || data.renditions.original;
         const alt = data.alt_text || data.description_text || data.caption;
         const mediaType = data.type;
+        const {features} = ng.get('config');
+        const editable = data._type !== 'externalsource' || _.get(features, 'editFeaturedImage', true);
 
         var {gettextCatalog} = this.props.blockProps.svc;
 
@@ -166,7 +169,7 @@ export class MediaBlockComponent extends Component {
                                     </span>
                                 </div>
                                 {
-                                    data.source !== 'Superdesk' ? null : (
+                                    editable && (
                                         <div className="image-block__icons-block">
                                             <a className="image-block__image-edit"
                                                 onClick={this.onClick}><i className="icon-pencil"/></a>

--- a/scripts/core/editor3/components/tests/utils.jsx
+++ b/scripts/core/editor3/components/tests/utils.jsx
@@ -71,7 +71,7 @@ export function stateWithLink() {
 export function imageBlockAndContent() {
     return createBlockAndContent('MEDIA', {
         media: {
-            source: 'Superdesk', // make sure edit icon is visible
+            _type: 'archive', // make sure edit icon is visible
             renditions: {original: {href: 'image_href'}},
             alt_text: 'image_alt_text',
             headline: 'image_headline',


### PR DESCRIPTION
Unless 'editFeaturedImage' feature is set to false, images should be editable by default.
This will fix an issue with some deployments where 'source' is not set to 'Superdesk'.

SDESK-3118