### PR TITLE
[SETTINGS][AUTHORING][VOCABULARIES] use popup_width in categories + h…

### DIFF
--- a/scripts/apps/authoring/authoring/directives/AuthoringHeaderDirective.js
+++ b/scripts/apps/authoring/authoring/directives/AuthoringHeaderDirective.js
@@ -157,6 +157,7 @@ export function AuthoringHeaderDirective(api, authoringWidgets, $rootScope, arch
 
             metadata.initialize().then(() => {
                 scope.helper_text = metadata.helper_text;
+                scope.popup_width = metadata.popup_width;
 
                 scope.$watch('item.anpa_category', (services) => {
                     var qcodes = _.map(services, 'qcode');

--- a/scripts/apps/authoring/metadata/metadata.js
+++ b/scripts/apps/authoring/metadata/metadata.js
@@ -1027,6 +1027,7 @@ function MetadataService(api, subscribersService, config, vocabularies, $rootSco
     var service = {
         values: {},
         helper_text: {},
+        popup_width: {},
         cvs: [],
         search_cvs: config.search_cvs || [
             {id: 'subject', name: 'Subject', field: 'subject', list: 'subjectcodes'},
@@ -1050,6 +1051,9 @@ function MetadataService(api, subscribersService, config, vocabularies, $rootSco
                     self.values[vocabulary._id] = vocabulary.items;
                     if (_.has(vocabulary, 'helper_text')) {
                         self.helper_text[vocabulary._id] = vocabulary.helper_text;
+                    }
+                    if (_.has(vocabulary, 'popup_width')) {
+                        self.popup_width[vocabulary._id] = vocabulary.popup_width;
                     }
                 });
                 self.cvs = result;

--- a/scripts/apps/authoring/views/authoring-header.html
+++ b/scripts/apps/authoring/views/authoring-header.html
@@ -258,6 +258,7 @@
                  data-header="true"
                  data-change="autosave(item)"
                  data-reload-list="false"
+                 data-cv="{popup_width: popup_width.categories}"
                  data-set-language="true"
                  tabindex="{{editor.anpa_category.order}}">
             </div>

--- a/scripts/apps/vocabularies/views/vocabulary-config-modal.html
+++ b/scripts/apps/vocabularies/views/vocabulary-config-modal.html
@@ -33,7 +33,7 @@
                     required>
             </div>
 
-            <div class="sd-line-input sd-line-input--boxed">
+            <div class="sd-line-input sd-line-input--boxed" ng-if="vocabulary.service || vocabulary._id === 'categories'">
                 <label for="cv_popup_width" class="sd-line-input__label" translate>Width of the popup window (in pixels)</label>
                 <input id="cv_popup_width" class="sd-line-input__input"
                     type="number"
@@ -90,7 +90,7 @@
             <div class="vocabulary-items__button-bar" ng-show="matchFieldTypeToTab('vocabularies', vocabulary.field_type)">
                 <button id="add-new-btn" class="btn btn--primary" ng-click="addItem()"><i class="icon-plus-sign"></i> {{'Add Item' | translate}}</button>
             </div>
-            
+
             <div ng-if="errorMessage" class="sd-line-input sd-line-input--invalid">
                 <p class="sd-line-input__message">{{ errorMessage }}</p>
             </div>
@@ -103,7 +103,7 @@
             </button>
             <button id="cancel-edit-btn" type="button" class="btn pull-right" ng-click="cancel()" translate>Cancel
             </button>
-            
+
         </div>
     </div>
 </form>


### PR DESCRIPTION
…ide field in settings

popup_width was not working in settings because the popup is not created
in the same way as for new controlled vocabularies. This patch fixes it.

In settings, the popup_width field was visible for all vocabularies, and it
was not making sense for most of them. This is not the case anymore,
service is used to check if it's a new CV, and the field is not
displayed otherwise, except for categories.

SDANSA-172