### PR TITLE
fix(polyfills): isLinkExternal should also return false if the protocol is data

### DIFF
--- a/scripts/core/polyfills/open-external-links-in-new-tab.js
+++ b/scripts/core/polyfills/open-external-links-in-new-tab.js
@@ -1,6 +1,9 @@
 function isLinkExternal(href) {
     try {
-        return new URL(href).host !== window.location.host;
+        const url = new URL(href);
+
+        // Check if the hosts are different, or if the href protocol is data not http
+        return url.host !== window.location.host && url.protocol !== 'data:';
     } catch (e) {
         // will throw if string is not a valid link
         return false;


### PR DESCRIPTION
* This was causing an exception to be thrown when using the exporting functionality of Highcharts