### PR TITLE
Extend the Drag&Drop UI to support files on the editor

### DIFF
--- a/scripts/core/editor3/components/BaseUnstyledComponent.jsx
+++ b/scripts/core/editor3/components/BaseUnstyledComponent.jsx
@@ -29,22 +29,21 @@ class BaseUnstyledComponent extends React.Component {
         if (block) {
             event.preventDefault();
             event.stopPropagation();
-            this.setState({over: false});
             this.props.dispatch(moveBlock(block, this.getDropBlockKey(), this.dropInsertionMode));
         }
+
+        this.setState({over: false});
     }
 
     onDragOver(event) {
-        if (isEditorBlockEvent(event)) {
-            if (this.leaveTimeout) {
-                clearTimeout(this.leaveTimeout);
-                this.leaveTimeout = null;
-            }
-
-            event.preventDefault();
-            event.stopPropagation();
-            this.setState({over: true});
+        if (this.leaveTimeout) {
+            clearTimeout(this.leaveTimeout);
+            this.leaveTimeout = null;
         }
+
+        event.preventDefault();
+        event.stopPropagation();
+        this.setState({over: true});
     }
 
     onDragLeave(event) {


### PR DESCRIPTION
We already had the feature that shows the drop area when dragging existing media files inside the editor. Now that features works with external files too, so when you drag a file from your computer, or an existing one in superdesk, it will also show the drop area.