### PR TITLE
[SETTINGS] [METADATA] restrict "popup width" field to categories and …

### DIFF
--- a/scripts/apps/vocabularies/views/vocabulary-config-modal.html
+++ b/scripts/apps/vocabularies/views/vocabulary-config-modal.html
@@ -33,7 +33,7 @@
                     required>
             </div>
 
-            <div class="sd-line-input sd-line-input--boxed" ng-if="vocabulary.service || vocabulary._id === 'categories'">
+            <div class="sd-line-input sd-line-input--boxed" ng-if="vocabulary.service && vocabulary.field_type === null || vocabulary._id === 'categories'">
                 <label for="cv_popup_width" class="sd-line-input__label" translate>Width of the popup window (in pixels)</label>
                 <input id="cv_popup_width" class="sd-line-input__input"
                     type="number"

--- a/test-server/requirements.txt
+++ b/test-server/requirements.txt
@@ -1,3 +1,3 @@
 gunicorn==19.7.1
 honcho==1.0.1
-superdesk-core==1.22
+superdesk-core==1.22.1


### PR DESCRIPTION
…controlled vocabularies

This patch check that vocabulary.field_type is null, excluding custom
text, date, media and embed fields.

SDESK-3127