### PR TITLE
Add missing data to suggestion history

### DIFF
--- a/scripts/core/editor3/reducers/suggestions.jsx
+++ b/scripts/core/editor3/reducers/suggestions.jsx
@@ -657,7 +657,7 @@ const processSuggestion = (state, {data, suggestion}, accepted) => {
     });
     editorState = EditorState.acceptSelection(editorState, selection);
 
-    editorState = moveToSuggestionsHistory(editorState, suggestion, accepted);
+    editorState = moveToSuggestionsHistory(editorState, data, suggestion, accepted);
 
     return saveEditorStatus(state, editorState, 'change-block-data');
 };


### PR DESCRIPTION
`data` about suggestion was missing in one function call