### PR TITLE
fix(translate): use langOverride after loading translations

### DIFF
--- a/scripts/core/lang/index.js
+++ b/scripts/core/lang/index.js
@@ -1,14 +1,18 @@
 /* globals __SUPERDESK_CONFIG__: true */
+
+import {get} from 'lodash';
+
 const appConfig = __SUPERDESK_CONFIG__;
+const LANG_OVERRIDE = appConfig.langOverride || {};
 
-let lang = appConfig.langOverride;
-
-if (Object.keys(lang).length > 0) {
-    angular.module('gettext').run(['gettextCatalog', (catalog) => {
-        for (let k of Object.keys(lang)) {
-            catalog.setStrings(k, lang[k]);
-        }
-    }]);
+/**
+ * Add langOverride strings to catalog for given language
+ *
+ * @param {gettextCatalog} catalog
+ * @param {String} lang
+ */
+export function addLangOverride(catalog, lang) {
+    catalog.setStrings(lang, get(LANG_OVERRIDE, lang, {}));
 }
 
 /**

--- a/scripts/core/services/translate.js
+++ b/scripts/core/services/translate.js
@@ -1,4 +1,5 @@
 require('angular-dynamic-locale');
+import {addLangOverride} from 'core/lang';
 
 /**
  * Translate module
@@ -37,6 +38,9 @@ export default angular.module('superdesk.core.translate', [
                 if (gettextCatalog.currentLanguage !== 'en') {
                     gettextCatalog.loadRemoteSync('languages/' + gettextCatalog.currentLanguage + '.json');
                 }
+
+                // add lang override strings
+                $rootScope.$applyAsync(() => addLangOverride(gettextCatalog, gettextCatalog.currentLanguage));
 
                 // set locale for date/time management
                 moment.locale(gettextCatalog.currentLanguage);


### PR DESCRIPTION
when loading translations later it sets the strings after lang override was used which would override the override config. so now it will apply it only when translations are fetched