### PR TITLE
Strip html tags from headline

### DIFF
--- a/scripts/apps/authoring/authoring/helpers.js
+++ b/scripts/apps/authoring/authoring/helpers.js
@@ -120,6 +120,8 @@ export function stripHtml(item) {
             item[key] = stripHtmlRaw(item[key]);
         }
     });
+
+    return item;
 }
 
 /**

--- a/scripts/apps/authoring/views/full-preview.html
+++ b/scripts/apps/authoring/views/full-preview.html
@@ -116,7 +116,7 @@
                     <div class="preview-data" sd-short-date ng-if="field.field_type === 'date'" data-date="item.extra[field._id]"></div>
                     <div class="preview-data preview-editor" ng-if="field.field_type === 'text'" ng-bind-html="getHtml(item.extra[field._id])"></div>
                 </div>
-                <div class="headline" order="{{editor.headline.order}}" ng-if="!editor.headline.hideOnPrint">{{item.headline}}</div>
+                <div class="headline" order="{{editor.headline.order}}" ng-if="!editor.headline.hideOnPrint">{{item.headline | stripHtmlTags}}</div>
                 <!-- custom media and embed fields -->
                 <div ng-repeat="field in fields track by field._id"
                     ng-if="(field.field_type === 'media' && mediaExists(item.associations, field._id) || field.field_type === 'embed' && item.extra[field._id]) && !editor[field._id].hideOnPrint"

--- a/scripts/apps/authoring/views/full-preview.html
+++ b/scripts/apps/authoring/views/full-preview.html
@@ -116,7 +116,7 @@
                     <div class="preview-data" sd-short-date ng-if="field.field_type === 'date'" data-date="item.extra[field._id]"></div>
                     <div class="preview-data preview-editor" ng-if="field.field_type === 'text'" ng-bind-html="getHtml(item.extra[field._id])"></div>
                 </div>
-                <div class="headline" order="{{editor.headline.order}}" ng-if="!editor.headline.hideOnPrint">{{item.headline | stripHtmlTags}}</div>
+                <div class="headline" order="{{editor.headline.order}}" ng-if="!editor.headline.hideOnPrint">{{item.headline}}</div>
                 <!-- custom media and embed fields -->
                 <div ng-repeat="field in fields track by field._id"
                     ng-if="(field.field_type === 'media' && mediaExists(item.associations, field._id) || field.field_type === 'embed' && item.extra[field._id]) && !editor[field._id].hideOnPrint"

--- a/scripts/core/editor3/reducers/editor3.jsx
+++ b/scripts/core/editor3/reducers/editor3.jsx
@@ -81,7 +81,9 @@ export const onChange = (state, newState, force = false) => {
     let contentChanged = state.editorState.getCurrentContent() !== newState.getCurrentContent();
 
     if (contentChanged || force) {
-        state.onChangeValue(editorState.getCurrentContent(), {plainText: !state.showToolbar});
+        const plainText = (state.editorFormat || []).length === 0;
+
+        state.onChangeValue(editorState.getCurrentContent(), {plainText});
     }
 
     if (force) {

--- a/scripts/core/editor3/reducers/editor3.jsx
+++ b/scripts/core/editor3/reducers/editor3.jsx
@@ -1,6 +1,7 @@
 import {RichUtils, EditorState, AtomicBlockUtils, SelectionState} from 'draft-js';
 import {setTansaHtml} from '../helpers/tansa';
 import {addMedia} from './toolbar';
+import {isEditorPlainText} from '../store';
 
 /**
  * @description Contains the list of editor related reducers.
@@ -81,7 +82,7 @@ export const onChange = (state, newState, force = false) => {
     let contentChanged = state.editorState.getCurrentContent() !== newState.getCurrentContent();
 
     if (contentChanged || force) {
-        const plainText = (state.editorFormat || []).length === 0;
+        const plainText = isEditorPlainText(state);
 
         state.onChangeValue(editorState.getCurrentContent(), {plainText});
     }

--- a/scripts/core/editor3/reducers/editor3.jsx
+++ b/scripts/core/editor3/reducers/editor3.jsx
@@ -81,7 +81,7 @@ export const onChange = (state, newState, force = false) => {
     let contentChanged = state.editorState.getCurrentContent() !== newState.getCurrentContent();
 
     if (contentChanged || force) {
-        state.onChangeValue(editorState.getCurrentContent());
+        state.onChangeValue(editorState.getCurrentContent(), {plainText: !state.showToolbar});
     }
 
     if (force) {

--- a/scripts/core/editor3/store/index.js
+++ b/scripts/core/editor3/store/index.js
@@ -90,7 +90,7 @@ function generateAnnotations(item, logger) {
  * current content states and updates the values of the host controller. This function
  * is bound to the controller, so 'this' points to controller attributes.
  */
-export function onChange(contentState, {plainText = false}) {
+export function onChange(contentState, {plainText = false} = {}) {
     const pathToValue = this.pathToValue;
 
     if (pathToValue == null || pathToValue.length < 1) {

--- a/scripts/core/editor3/store/index.js
+++ b/scripts/core/editor3/store/index.js
@@ -85,11 +85,12 @@ function generateAnnotations(item, logger) {
 /**
  * @name onChange
  * @params {ContentState} contentState New editor content state.
+ * @params {Boolean} plainText If this is true, the editor content will be text instead of html
  * @description Triggered whenever the state of the editor changes. It takes the
  * current content states and updates the values of the host controller. This function
  * is bound to the controller, so 'this' points to controller attributes.
  */
-export function onChange(contentState) {
+export function onChange(contentState, {plainText = false}) {
     const pathToValue = this.pathToValue;
 
     if (pathToValue == null || pathToValue.length < 1) {
@@ -124,9 +125,12 @@ export function onChange(contentState) {
     const fieldName = pathToValueArray[pathToValueArray.length - 1];
     const logger = ng.get('logger');
 
-    objectToUpdate[fieldName] = toHTML(contentStateHighlightsReadyForExport, logger);
-
-    generateAnnotations(this.item, logger);
+    if (plainText) {
+        objectToUpdate[fieldName] = contentStateHighlightsReadyForExport.getPlainText();
+    } else {
+        objectToUpdate[fieldName] = toHTML(contentStateHighlightsReadyForExport, logger);
+        generateAnnotations(this.item, logger);
+    }
 
     // call on change with scope updated
     this.$rootScope.$applyAsync(() => {

--- a/scripts/core/editor3/store/index.js
+++ b/scripts/core/editor3/store/index.js
@@ -23,6 +23,8 @@ export const ignoreInternalAnnotationFields = (annotations) =>
         (annotation) => pick(annotation, ['id', 'type', 'body'])
     );
 
+export const isEditorPlainText = (props) => props.singleLine || (props.editorFormat || []).length === 0;
+
 /**
  * @name createEditorStore
  * @description Returns a new redux store.
@@ -41,7 +43,8 @@ export default function createEditorStore(props, isReact = false) {
     const content = getInitialContent(props);
 
     const decorators = Editor3.getDecorator(props.disableSpellchecker || !spellcheck.isAutoSpellchecker);
-    const showToolbar = !props.singleLine && (props.editorFormat || []).length > 0;
+    const showToolbar = !isEditorPlainText(props);
+
     const onChangeValue = isReact ? props.onChange : _.debounce(onChange.bind(props), props.debounce);
 
     const store = createStore(reducers, {


### PR DESCRIPTION
Whenever we make changes to the headline and then we preview the item, the headline will have <p> tags around it. If we reload the page, the problem is gone (until you make changes on the headline again)

I used the same function we use to strip the tags on save so the preview is consistent with the saved item.

SDESK-2337