### PR TITLE
The description line for custom vocabulary has drifted from the parent control in authoring ui (SDESK 3192)

### DIFF
--- a/scripts/apps/authoring/styles/authoring.scss
+++ b/scripts/apps/authoring/styles/authoring.scss
@@ -735,7 +735,7 @@
     font-size: 12px;
     color: #747474;
     float: left;
-    margin-bottom: -16px;
+    margin-bottom: -2px;
     margin-left: 0;
 }
 


### PR DESCRIPTION
SDESK-3192