### PR TITLE
fix(routing): Fixed issue with changing workspace flag

### DIFF
--- a/scripts/core/menu/menu.js
+++ b/scripts/core/menu/menu.js
@@ -110,9 +110,13 @@ angular.module('superdesk.core.menu', [
                     scope.$watch(function currentRoute() {
                         return $route.current;
                     }, (route) => {
-                        scope.currentRoute = route || null;
+                        if (!route) {
+                            return;
+                        }
+
+                        scope.currentRoute = route;
                         setActiveMenuItem(scope.currentRoute);
-                        ctrl.flags.workspace = route ? !!route.sideTemplateUrl : false;
+                        ctrl.flags.workspace = !!route.sideTemplateUrl;
                         ctrl.flags.workqueue = ctrl.flags.workqueue || true;
                     });
 


### PR DESCRIPTION
When route is empty, `flags.workspace` is changed to `false`, which caused on publisher double execution of controllers because of two `ng-view` directives in `superdesk-view.html` file