### PR TITLE
SDESK-3265 Wrong html conversion during saving a story.

### DIFF
--- a/scripts/core/editor3/html/tests/to-html.spec.js
+++ b/scripts/core/editor3/html/tests/to-html.spec.js
@@ -267,10 +267,10 @@ describe('core.editor3.html.to-html.BlockInlineStyleWrapper', () => {
         expect(wrapper.tags(OS([]))).toEqual('');
         expect(wrapper.tags(OS(['BOLD', 'ITALIC']))).toEqual('<b><i>');
         expect(wrapper.tags(OS(['BOLD', 'ITALIC']))).toEqual('');
-        expect(wrapper.tags(OS(['ITALIC']))).toEqual('</b>');
+        expect(wrapper.tags(OS(['ITALIC']))).toEqual('</i></b><i>');
         expect(wrapper.tags(OS(['ITALIC', 'UNDERLINE']))).toEqual('<u>');
-        expect(wrapper.tags(OS(['UNDERLINE', 'BOLD']))).toEqual('</i><b>');
-        expect(wrapper.tags(OS([]))).toEqual('</u></b>');
+        expect(wrapper.tags(OS(['UNDERLINE', 'BOLD']))).toEqual('</u></i><u><b>');
+        expect(wrapper.tags(OS([]))).toEqual('</b></u>');
         expect(wrapper.tags(OS(['ITALIC', 'UNDERLINE']))).toEqual('<i><u>');
 
         expect(wrapper.flush()).toEqual('</u></i>');

--- a/scripts/core/editor3/html/to-html/BlockInlineStyleWrapper.js
+++ b/scripts/core/editor3/html/to-html/BlockInlineStyleWrapper.js
@@ -87,8 +87,14 @@ export class BlockInlineStyleWrapper {
             return '';
         }
 
-        const noLongerApplied = this.activeStyles
+        let noLongerApplied = this.activeStyles
             .filter((s) => styles.toArray().indexOf(s) === -1);
+
+        if (noLongerApplied.length !== 0) {
+            const index = this.activeStyles.indexOf(noLongerApplied[0]);
+
+            noLongerApplied = this.activeStyles.slice(index).reverse();
+        }
 
         return noLongerApplied.map((style) => {
             const tag = this.getTag(style, 'close');


### PR DESCRIPTION
When text has multiply inline styles, editor converts editor state to html with mistakes.
Example:
![screen shot 2018-08-16 at 11 58 31](https://user-images.githubusercontent.com/4199922/44202736-157f0600-a14d-11e8-8659-f2da11a131d4.png)

Before:
```
<p>___<i>ITALIC <b>BOLD-ITALIC </i>BOLD</b>___ </p>
<p>___<i>ITALIC <b>BOLD-ITALIC </i></b>___</p>
<p>---<s>STRIKE <b>BOLD-STRIKE <u>BOLD-STRIKE-UNDERLINE</s> </b>UNDERLINE</u></p>
<p>--- X<sub>22<b>22</b>2</sub>----</p>
```

Now:
```
<p>___<i>ITALIC <b>BOLD-ITALIC </b></i><b>BOLD</b>___ </p>
<p>___<i>ITALIC <b>BOLD-ITALIC </b></i>___</p>
<p>---<s>STRIKE <b>BOLD-STRIKE <u>BOLD-STRIKE-UNDERLINE</u></b></s><u> UNDERLINE</u></p>
<p>--- X<sub>22<b>22</b>2</sub>----</p>
```