### PR TITLE
[AUTHORING] update item.associations on "save"

### DIFF
--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.js
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.js
@@ -211,6 +211,10 @@ export function AuthoringDirective(superdesk, superdeskFlags, authoringWorkspace
                         _previewHighlight(res._id);
                     }
 
+                    if (res.associations) {
+                        $scope.item.associations = res.associations;
+                    }
+
                     notify.success(gettext('Item updated.'));
 
                     initMedia();


### PR DESCRIPTION
When user push the save button, $scope.item is not updated correctly,
resulting in validation issues when publishing ($scope.item is used in the
HTTP PATCH request).

This patch fixes this.
SDESK-3274