### PR TITLE
Duplicated description field is presented when uploading a media to authoring item (SDESK 3271)

### DIFF
--- a/scripts/apps/archive/controllers/UploadController.js
+++ b/scripts/apps/archive/controllers/UploadController.js
@@ -14,7 +14,6 @@ export function UploadController($scope, $q, upload, api, archiveService, sessio
     $scope.allowPicture = !($scope.locals && $scope.locals.data && $scope.locals.data.allowPicture === false);
     $scope.allowVideo = !($scope.locals && $scope.locals.data && $scope.locals.data.allowVideo === false);
     $scope.allowAudio = !($scope.locals && $scope.locals.data && $scope.locals.data.allowAudio === false);
-
     $scope.validator = _.omit(deployConfig.getSync('validator_media_metadata'), ['archive_description']);
 
     var uploadFile = function(item) {

--- a/scripts/apps/archive/controllers/UploadController.js
+++ b/scripts/apps/archive/controllers/UploadController.js
@@ -14,7 +14,8 @@ export function UploadController($scope, $q, upload, api, archiveService, sessio
     $scope.allowPicture = !($scope.locals && $scope.locals.data && $scope.locals.data.allowPicture === false);
     $scope.allowVideo = !($scope.locals && $scope.locals.data && $scope.locals.data.allowVideo === false);
     $scope.allowAudio = !($scope.locals && $scope.locals.data && $scope.locals.data.allowAudio === false);
-    $scope.validator = deployConfig.getSync('validator_media_metadata');
+
+    $scope.validator = _.omit(deployConfig.getSync('validator_media_metadata'), ['archive_description']);
 
     var uploadFile = function(item) {
         var handleError = function(reason) {

--- a/scripts/apps/authoring/media/views/media-metadata-editor-directive.html
+++ b/scripts/apps/authoring/media/views/media-metadata-editor-directive.html
@@ -36,7 +36,7 @@
         data-boxed="boxed"
         data-textarea="true"
         data-required="validator.archive_description.required"
-        data-label="{{:: 'Description' | translate}}"
+        data-label="{{:: 'Caption' | translate}}"
         data-disabled="disabled || associated"
         data-onblur="onBlur()"
         data-onchange="onChange({key: 'archive_description'})"

--- a/scripts/apps/authoring/media/views/media-metadata-editor-directive.html
+++ b/scripts/apps/authoring/media/views/media-metadata-editor-directive.html
@@ -29,22 +29,6 @@
     </sd-line-input>
 </div>
 
-<div class="form__row" ng-if="validator.archive_description">
-    <sd-line-input
-        ng-model="item.archive_description"
-        data-dark="dark"
-        data-boxed="boxed"
-        data-textarea="true"
-        data-required="validator.archive_description.required"
-        data-label="{{:: 'Description' | translate}}"
-        data-disabled="disabled || associated"
-        data-onblur="onBlur()"
-        data-onchange="onChange({key: 'archive_description'})"
-        data-maxlength="validator.archive_description.maxlength"
-        data-placeholder="{{ placeholder.archive_description }}">
-    </sd-line-input>
-</div>
-
 <div class="form__row" ng-if="validator.alt_text">
     <sd-line-input
         ng-model="item.alt_text"

--- a/scripts/apps/authoring/media/views/media-metadata-editor-directive.html
+++ b/scripts/apps/authoring/media/views/media-metadata-editor-directive.html
@@ -29,6 +29,22 @@
     </sd-line-input>
 </div>
 
+<div class="form__row" ng-if="validator.archive_description">
+    <sd-line-input
+        ng-model="item.archive_description"
+        data-dark="dark"
+        data-boxed="boxed"
+        data-textarea="true"
+        data-required="validator.archive_description.required"
+        data-label="{{:: 'Description' | translate}}"
+        data-disabled="disabled || associated"
+        data-onblur="onBlur()"
+        data-onchange="onChange({key: 'archive_description'})"
+        data-maxlength="validator.archive_description.maxlength"
+        data-placeholder="{{ placeholder.archive_description }}">
+    </sd-line-input>
+</div>
+
 <div class="form__row" ng-if="validator.alt_text">
     <sd-line-input
         ng-model="item.alt_text"


### PR DESCRIPTION
SDESK-3271

`archive_description` is read-only, but AAP still wants to see it in the metadata editor for reference, so I'm only hiding it when uploading.