### PR TITLE
Hide edit/crop tabs when editing single video/audio item

### DIFF
--- a/scripts/apps/authoring/authoring/controllers/AssociationController.js
+++ b/scripts/apps/authoring/authoring/controllers/AssociationController.js
@@ -202,7 +202,6 @@ export function AssociationController(config, send, api, $q, superdesk,
 
         const cropOptions = {
             isNew: 'isNew' in options ? options.isNew : false,
-            hideTabs: isImage ? [] : ['crop', 'image-edit'],
             editable: !!scope.editable,
             isAssociated: true,
             defaultTab: 'defaultTab' in options ? options.defaultTab : defaultTab,

--- a/scripts/apps/authoring/authoring/directives/ArticleEditDirective.js
+++ b/scripts/apps/authoring/authoring/directives/ArticleEditDirective.js
@@ -285,11 +285,6 @@ export function ArticleEditDirective(
                     scope.mediaLoading = true;
 
                     const defaultTab = crop ? 'crop' : 'view';
-                    let hideTabs = [];
-
-                    if (scope.item.type !== 'picture') {
-                        hideTabs = ['image-edit', 'crop'];
-                    }
 
                     return renditions.crop(
                         scope.item,
@@ -299,7 +294,6 @@ export function ArticleEditDirective(
                             isAssociated: false,
                             defaultTab: defaultTab,
                             showMetadata: true,
-                            hideTabs: hideTabs,
                         }
                     )
                         .then((picture) => {

--- a/scripts/apps/authoring/authoring/directives/ArticleEditDirective.js
+++ b/scripts/apps/authoring/authoring/directives/ArticleEditDirective.js
@@ -285,9 +285,14 @@ export function ArticleEditDirective(
                     scope.mediaLoading = true;
 
                     const defaultTab = crop ? 'crop' : 'view';
+                    let hideTabs = [];
+
+                    if (scope.item.type !== 'picture') {
+                        hideTabs = ['image-edit', 'crop'];
+                    }
 
                     return renditions.crop(scope.item,
-                        {isNew: false, editable: true, isAssociated: false, defaultTab: defaultTab, showMetadata: true})
+                        {isNew: false, editable: true, isAssociated: false, defaultTab: defaultTab, showMetadata: true, hideTabs: hideTabs})
                         .then((picture) => {
                             scope.item._etag = picture._etag;
 

--- a/scripts/apps/authoring/authoring/directives/ArticleEditDirective.js
+++ b/scripts/apps/authoring/authoring/directives/ArticleEditDirective.js
@@ -291,8 +291,17 @@ export function ArticleEditDirective(
                         hideTabs = ['image-edit', 'crop'];
                     }
 
-                    return renditions.crop(scope.item,
-                        {isNew: false, editable: true, isAssociated: false, defaultTab: defaultTab, showMetadata: true, hideTabs: hideTabs})
+                    return renditions.crop(
+                        scope.item,
+                        {
+                            isNew: false,
+                            editable: true,
+                            isAssociated: false,
+                            defaultTab: defaultTab,
+                            showMetadata: true,
+                            hideTabs: hideTabs,
+                        }
+                    )
                         .then((picture) => {
                             scope.item._etag = picture._etag;
 

--- a/scripts/apps/authoring/authoring/services/RenditionsService.js
+++ b/scripts/apps/authoring/authoring/services/RenditionsService.js
@@ -55,16 +55,16 @@ export function RenditionsService(metadata, $q, api, superdesk, _) {
      *  @public
      *  @description Crop the images.
      *
-     *  @param {Object} picture Picture item
+     *  @param {Object} item Media item
      *  @param {boolean} isNew to indicate if picture is new or not
      *  @param {boolean} editable to indicate if picture is editable or not
      *  @param {boolean} isAssociated to indicate if picture is isAssociated or not
      *  @return {promise} returns the modified picture item
      */
-    this.crop = function(picture, options) {
-        let clonedPicture = _.extend({}, picture);
+    this.crop = function(item, options) {
+        let clonedItem = _.extend({}, item);
 
-        clonedPicture.renditions = _.cloneDeep(clonedPicture.renditions);
+        clonedItem.renditions = _.cloneDeep(clonedItem.renditions);
 
         return self.get().then((renditions) => {
             // we want to crop only renditions that change the ratio
@@ -80,15 +80,15 @@ export function RenditionsService(metadata, $q, api, superdesk, _) {
                 isAssociated: false,
                 editable: true,
                 defaultTab: false,
-                hideTabs: [],
+                hideTabs: item.type === 'picture' ? [] : ['image-edit', 'crop'],
                 showMetadata: false,
                 ...options,
             };
 
             return superdesk.intent('edit', 'crop', {
-                item: clonedPicture,
+                item: clonedItem,
                 renditions: withRatio,
-                poi: clonedPicture.poi || {x: 0.5, y: 0.5},
+                poi: clonedItem.poi || {x: 0.5, y: 0.5},
                 showAoISelectionButton: true,
                 showMetadataEditor: true,
                 ...cropOptions,
@@ -103,8 +103,8 @@ export function RenditionsService(metadata, $q, api, superdesk, _) {
                         const keys = ['CropLeft', 'CropTop', 'CropBottom', 'CropRight'];
 
                         let canAdd = !keys.every((key) => {
-                            let sameCoords = angular.isDefined(picture.renditions[renditionName]) &&
-                            picture.renditions[renditionName][key] === croppingData[key];
+                            let sameCoords = angular.isDefined(item.renditions[renditionName]) &&
+                            item.renditions[renditionName][key] === croppingData[key];
 
                             return sameCoords;
                         });
@@ -116,9 +116,9 @@ export function RenditionsService(metadata, $q, api, superdesk, _) {
 
                     // perform the request to make the cropped images
                     renditionNames.forEach((renditionName) => {
-                        if (picture.renditions[renditionName] !== result.cropData[renditionName]) {
+                        if (item.renditions[renditionName] !== result.cropData[renditionName]) {
                             savingImagePromises.push(
-                                api.save('picture_crop', {item: clonedPicture, crop: result.cropData[renditionName]})
+                                api.save('picture_crop', {item: clonedItem, crop: result.cropData[renditionName]})
                             );
                         }
                     });
@@ -144,8 +144,8 @@ export function RenditionsService(metadata, $q, api, superdesk, _) {
                             });
 
                             // apply the metadata changes
-                            angular.extend(picture, result.metadata);
-                            return picture;
+                            angular.extend(item, result.metadata);
+                            return item;
                         });
                 });
         });

--- a/scripts/core/editor3/components/media/MediaBlock.tsx
+++ b/scripts/core/editor3/components/media/MediaBlock.tsx
@@ -74,16 +74,10 @@ export class MediaBlockComponent extends React.Component<any, any> {
         const entityKey = block.getEntityAt(0);
         const entity = contentState.getEntity(entityKey);
         const data = entity.getData();
-        const isImage = data.media.type === 'picture';
         const isNew = false;
         const showMetadata = true;
-        let hideTabs = [];
 
-        if (!isImage) {
-            hideTabs = ['crop', 'image-edit'];
-        }
-
-        cropImage(entityKey, data, {isNew, hideTabs, showMetadata});
+        cropImage(entityKey, data, {isNew, showMetadata});
     }
 
     /**

--- a/scripts/core/editor3/components/tests/media.spec.tsx
+++ b/scripts/core/editor3/components/tests/media.spec.tsx
@@ -47,6 +47,6 @@ describe('editor3.components.media-block', () => {
         const entity = contentState.getEntity(entityKey);
 
         expect(cropImage).toHaveBeenCalledWith(entityKey, entity.getData(),
-            {isNew: false, hideTabs: [], showMetadata: true});
+            {isNew: false, showMetadata: true});
     });
 });


### PR DESCRIPTION
SDESK-3204

When editing a single media item, the "edit metadata" button will only show the Details tab for video and audio files