### PR TITLE
[SDESK-3349][SDESK-3318](fix): Fixing media metadata save issue and display fields based on validator config.

### DIFF
--- a/scripts/apps/authoring/authoring/directives/ArticleEditDirective.js
+++ b/scripts/apps/authoring/authoring/directives/ArticleEditDirective.js
@@ -133,11 +133,7 @@ export function ArticleEditDirective(
                         if (autopopulateByline && !item.byline) {
                             item.byline = session.identity.byline;
                         }
-                        if (_.includes(['picture', 'graphic'], item.type) && _.get(metadata, 'values.crop_sizes')) {
-                            item.hasCrops = metadata.values.crop_sizes.some(
-                                (crop) => item.renditions && item.renditions[crop.name]
-                            );
-                        }
+                        hasCrops(item);
                     }
                 });
 
@@ -309,10 +305,25 @@ export function ArticleEditDirective(
                             } else {
                                 scope.save();
                             }
+                            hasCrops(picture);
                         })
                         .finally(() => {
                             scope.mediaLoading = false;
                         });
+                };
+
+                /**
+                 * @ngdoc method
+                 * @name sdArticleEdit#hasCrops
+                 *
+                 * @description Checks if item has crops
+                 */
+                const hasCrops = (item) => {
+                    if (_.includes(['picture', 'graphic'], item.type) && _.get(metadata, 'values.crop_sizes')) {
+                        item.hasCrops = metadata.values.crop_sizes.some(
+                            (crop) => item.renditions && item.renditions[crop.name]
+                        );
+                    }
                 };
 
                 /**

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.js
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.js
@@ -211,8 +211,9 @@ export function AuthoringDirective(superdesk, superdeskFlags, authoringWorkspace
                         _previewHighlight(res._id);
                     }
 
-                    if (res.associations) {
-                        $scope.item.associations = res.associations;
+                    // clonedeep associations so that diff can be calculated for saving next time.
+                    if (res.associations && !_.isEqual($scope.item.associations, res.associations)) {
+                        $scope.item.associations = _.cloneDeep(res.associations);
                     }
 
                     notify.success(gettext('Item updated.'));

--- a/scripts/apps/authoring/media/MediaMetadataViewDirective.js
+++ b/scripts/apps/authoring/media/MediaMetadataViewDirective.js
@@ -1,0 +1,13 @@
+MediaMetadataViewDirective.$inject = ['deployConfig'];
+export default function MediaMetadataViewDirective(deployConfig) {
+    return {
+        scope: {
+            item: '=',
+            showAltText: '@',
+        },
+        template: require('./views/media-metadata-view-directive.html'),
+        link: (scope) => {
+            scope.validator = deployConfig.getSync('validator_media_metadata');
+        },
+    };
+}

--- a/scripts/apps/authoring/media/index.js
+++ b/scripts/apps/authoring/media/index.js
@@ -1,5 +1,7 @@
 import MediaMetadataEditorDirective from './MediaMetadataEditorDirective';
+import MediaMetadataViewDirective from './MediaMetadataViewDirective';
 
 export default angular.module('superdesk.apps.authoring.media', [])
     .directive('sdMediaMetadataEditor', MediaMetadataEditorDirective)
+    .directive('sdMediaMetadataView', MediaMetadataViewDirective)
 ;

--- a/scripts/apps/authoring/media/views/media-metadata-view-directive.html
+++ b/scripts/apps/authoring/media/views/media-metadata-view-directive.html
@@ -1,0 +1,20 @@
+<span ng-if="showAltText">
+    <em>{{:: 'Alt text:' | translate}}</em>
+    {{item.alt_text || ('[No Value]' | translate)}}
+</span>
+<span ng-if="validator.byline">
+    <em>{{:: 'Credit:' | translate}}</em>
+    {{item.byline || ('[No Value]' | translate)}}
+</span>
+<span ng-if="validator.copyrightholder">
+    <em>{{:: 'Copyright holder:' | translate}}</em>
+    {{item.copyrightholder || ('[No Value]' | translate)}}
+</span>
+<span ng-if="validator.usageterms">
+    <em>{{:: 'Assign rights:' | translate}}</em>
+    {{item.usageterms || ('[No Value]' | translate)}}
+</span>
+<span ng-if="validator.copyrightnotice">
+    <em>{{:: 'Copyright notice:' | translate}}</em>
+    {{item.copyrightnotice || ('[No Value]' | translate)}}
+</span>

--- a/scripts/apps/authoring/views/article-edit.html
+++ b/scripts/apps/authoring/views/article-edit.html
@@ -325,28 +325,12 @@
         <div class="media-item__item">
             <div sd-item-rendition data-item="item" data-rendition="baseImage" ng-click="preview(item);"></div>
             <span class="media-item__item-label" translate>Original ({{item.renditions.original.width}} x {{item.renditions.original.height}} px)</span>
-            <div class="media-container__metadata media-container__metadata--image">
-                <span>
-                    <em>{{:: 'Credit:' | translate}}</em>
-                    {{item.byline || ('[No Value]' | translate)}}
-                </span>
-                <span>
-                    <em>{{:: 'Copyright holder:' | translate}}</em>
-                    {{item.copyrightholder || ('[No Value]' | translate)}}
-                </span>
-                <span>
-                    <em>{{:: 'Assign rights:' | translate}}</em>
-                    {{item.usageterms || ('[No Value]' | translate)}}
-                </span>
-                <span>
-                    <em>{{:: 'Copyright notice:' | translate}}</em>
-                    {{item.copyrightnotice || ('[No Value]' | translate)}}
-                </span>
-            </div>
-        </div>
-        <div sd-item-crops data-item="item">
+            <div sd-media-metadata-view
+                 class="media-container__metadata media-container__metadata--image"
+                 data-item="item"></div>
 
         </div>
+        <div sd-item-crops data-item="item"></div>
         <button id="btnCrop" class="btn btn--medium pull-right" ng-click="applyCrop()" ng-if="metadata.crop_sizes && _editable">
             <span ng-if="!item.hasCrops" translate>APPLY CROPS</span>
             <span ng-if="item.hasCrops" translate>EDIT CROPS</span>
@@ -356,24 +340,9 @@
     <div ng-if="item.type == 'audio'">
         <div class="media-container">
             <audio controls="controls" sd-sources data-renditions="item.renditions"></audio>
-            <div class="media-container__metadata">
-                <span>
-                    <em>{{:: 'Credit:' | translate}}</em>
-                    {{item.byline || ('[No Value]' | translate)}}
-                </span>
-                <span>
-                    <em>{{:: 'Copyright holder:' | translate}}</em>
-                    {{item.copyrightholder || ('[No Value]' | translate)}}
-                </span>
-                <span>
-                    <em>{{:: 'Assign rights:' | translate}}</em>
-                    {{item.usageterms || ('[No Value]' | translate)}}
-                </span>
-                <span>
-                    <em>{{:: 'Copyright notice:' | translate}}</em>
-                    {{item.copyrightnotice || ('[No Value]' | translate)}}
-                </span>
-            </div>
+            <div sd-media-metadata-view
+                 class="media-container__metadata"
+                 data-item="item"></div>
             <div class="media-container__action-bar" ng-if="_editable">
                 <a class="btn btn--hollow btn--small" ng-click="editMedia()"><span translate>Edit metadata</span></a>
             </div>
@@ -382,24 +351,9 @@
     <div ng-if="item.type == 'video'">
         <div class="media-container">
             <video controls="controls" sd-sources data-renditions="item.renditions"></video>
-            <div class="media-container__metadata">
-                <span>
-                    <em>{{:: 'Credit:' | translate}}</em>
-                    {{item.byline || ('[No Value]' | translate)}}
-                </span>
-                <span>
-                    <em>{{:: 'Copyright holder:' | translate}}</em>
-                    {{item.copyrightholder || ('[No Value]' | translate)}}
-                </span>
-                <span>
-                    <em>{{:: 'Assign rights:' | translate}}</em>
-                    {{item.usageterms || ('[No Value]' | translate)}}
-                </span>
-                <span>
-                    <em>{{:: 'Copyright notice:' | translate}}</em>
-                    {{item.copyrightnotice || ('[No Value]' | translate)}}
-                </span>
-            </div>
+            <div sd-media-metadata-view
+                 class="media-container__metadata"
+                 data-item="item"></div>
             <div class="media-container__action-bar" ng-if="_editable">
                 <a class="btn btn--hollow btn--small" ng-click="editMedia()"><span translate>Edit metadata</span></a>
             </div>

--- a/scripts/apps/authoring/views/change-image.html
+++ b/scripts/apps/authoring/views/change-image.html
@@ -165,7 +165,7 @@
                             <button class="btn btn--ui-dark btn--hollow btn--icon-only btn--large" ng-click="showAreaOfInterestView()" ng-class="{'btn--active' : isAoISelectionModeEnabled}" sd-tooltip="Crop" ng-disabled="controls.isDirty"><i class="icon-crop icon--white"></i></button>
                             <button class="btn btn--ui-dark btn--hollow btn--icon-only btn--large" ng-click="rotateImage('left')" sd-tooltip="Rotate left" ng-disabled="isAoISelectionModeEnabled"><i class="icon-rotate-left icon--white"></i></button>
                             <button class="btn btn--ui-dark btn--hollow btn--icon-only btn--large" ng-click="rotateImage('right')" sd-tooltip="Rotate right" ng-disabled="isAoISelectionModeEnabled"><i class="icon-rotate-right icon--white"></i></button>
-                            <button class="btn btn--ui-dark btn--hollow btn--icon-only btn--large" ng-click="flipImage('horizontal')" sd-tooltip="Flip horizotal" ng-disabled="isAoISelectionModeEnabled"><i class="icon-flip-horizontal icon--white"></i></button>
+                            <button class="btn btn--ui-dark btn--hollow btn--icon-only btn--large" ng-click="flipImage('horizontal')" sd-tooltip="Flip horizontal" ng-disabled="isAoISelectionModeEnabled"><i class="icon-flip-horizontal icon--white"></i></button>
                             <button class="btn btn--ui-dark btn--hollow btn--icon-only btn--large" ng-click="flipImage('vertical')" sd-tooltip="Flip vertical" ng-disabled="isAoISelectionModeEnabled"><i class="icon-flip-vertical icon--white"></i></button>
                         </div>
                     </div>
@@ -199,7 +199,7 @@
                         <h3 class="sd-slide-in-panel__heading sd-slide-in-panel__heading--marg-b20" translate>Adjust colors</h3>
                         <div class="form__row form__row--small-padding">
                             <div class="form-label__container">
-                                <label class="form-label" translate>Brigtness</label>
+                                <label class="form-label" translate>Brightness</label>
                                 <span class="form-label__info-block">{{controls.brightness * 100 - 100 | number:0}}%</span>
                             </div>
                             <input type="range" class="sd-slider__range" min="0" max="2" step=".05" ng-model="controls.brightness" ng-dblclick="controls.brightness = 1" ng-change="controls.isDirty = true">

--- a/scripts/apps/authoring/views/item-association.html
+++ b/scripts/apps/authoring/views/item-association.html
@@ -22,24 +22,7 @@
                             ng-repeat="(key, rendition) in related.renditions"
                             ng-if="associations.isVideo(rendition)" html5vfix>
                 </video>
-                <div class="item-association__metadata">
-                    <span>
-                        <em>{{:: 'Credit:' | translate}}</em>
-                        {{related.byline || ('[No Value]' | translate)}}
-                    </span>
-                    <span>
-                        <em>{{:: 'Copyright holder:' | translate}}</em>
-                        {{related.copyrightholder || ('[No Value]' | translate)}}
-                    </span>
-                    <span>
-                        <em>{{:: 'Assign rights:' | translate}}</em>
-                        {{related.usageterms || ('[No Value]' | translate)}}
-                    </span>
-                    <span>
-                        <em>{{:: 'Copyright notice:' | translate}}</em>
-                        {{related.copyrightnotice || ('[No Value]' | translate)}}
-                    </span>
-                </div>
+                <div class="item-association__metadata" sd-media-metadata-view data-item="related"></div>
                 <div class="item-association__action-bar" ng-if="related && editable">
                     <a class="btn btn--hollow btn--small" ng-click="associations.isMediaEditable() && associations.edit(this, related); $event.stopPropagation()"><span translate>Edit metadata</span></a>
                 </div>
@@ -51,24 +34,7 @@
                             ng-repeat="(key, rendition) in related.renditions"
                             ng-if="associations.isAudio(rendition)" html5vfix>
                 </audio>
-                <div class="item-association__metadata">
-                    <span>
-                        <em>{{:: 'Credit:' | translate}}</em>
-                        {{related.byline || ('[No Value]' | translate)}}
-                    </span>
-                    <span>
-                        <em>{{:: 'Copyright holder:' | translate}}</em>
-                        {{related.copyrightholder || ('[No Value]' | translate)}}
-                    </span>
-                    <span>
-                        <em>{{:: 'Assign rights:' | translate}}</em>
-                        {{related.usageterms || ('[No Value]' | translate)}}
-                    </span>
-                    <span>
-                        <em>{{:: 'Copyright notice:' | translate}}</em>
-                        {{related.copyrightnotice || ('[No Value]' | translate)}}
-                    </span>
-                </div>
+                <div class="item-association__metadata" sd-media-metadata-view data-item="related"></div>
                 <div class="item-association__action-bar" ng-if="related && editable">
                     <a class="btn btn--hollow btn--small" ng-click="associations.isMediaEditable() && associations.edit(this, related); $event.stopPropagation()"><span translate>Edit metadata</span></a>
                 </div>
@@ -87,28 +53,9 @@
                         <a ng-if="related && editable" class="item-association__image-action" ng-click="associations.isMediaEditable() && associations.edit(this, related, {defaultTab: 'image-edit'}); $event.stopPropagation()" sd-tooltip="Edit image"><i class="icon-switches"></i></a>
                         <a ng-if="related && editable" class="item-association__image-action" ng-click="associations.isMediaEditable() && associations.edit(this, related, {defaultTab: 'crop', showMetadata: false}); $event.stopPropagation()" sd-tooltip="Edit crops"><i class="icon-crop"></i></a>
                     </div>
-                    <div class="item-association__metadata item-association__metadata--bottom-overlay" ng-if="related.type === 'picture' || related.type === 'graphic'">
-                        <span>
-                            <em>{{:: 'Alt text:' | translate}}</em>
-                            {{related.alt_text || ('[No Value]' | translate)}}
-                        </span>
-                        <span>
-                            <em>{{:: 'Credit:' | translate}}</em>
-                            {{related.byline || ('[No Value]' | translate)}}
-                        </span>
-                        <span>
-                            <em>{{:: 'Copyright holder:' | translate}}</em>
-                            {{related.copyrightholder || ('[No Value]' | translate)}}
-                        </span>
-                        <span>
-                            <em>{{:: 'Assign rights:' | translate}}</em>
-                            {{related.usageterms || ('[No Value]' | translate)}}
-                        </span>
-                        <span>
-                            <em>{{:: 'Copyright notice:' | translate}}</em>
-                            {{related.copyrightnotice || ('[No Value]' | translate)}}
-                        </span>
-                    </div>
+                    <div sd-media-metadata-view data-item="related" data-show-alt-text="true"
+                         class="item-association__metadata item-association__metadata--bottom-overlay"
+                         ng-if="related.type === 'picture' || related.type === 'graphic'"></div>
                 </div>
                 <img ng-src="{{ related.renditions.viewImage.href}}"
                     ng-class="{'not-editable': !associations.isMediaEditable() || !editable}"


### PR DESCRIPTION
- Associated media metadata save was working only once. After saving once, associations in `scope.item` and `scope.origItem` were pointing to same object.
- Display media metadata based on media validator config.
- set `showCrops` after renditions are created. 