### PR TITLE
[SDESK-3392](fix): Not updating association if media is editable.

### DIFF
--- a/scripts/apps/authoring/authoring/controllers/AssociationController.js
+++ b/scripts/apps/authoring/authoring/controllers/AssociationController.js
@@ -250,18 +250,20 @@ export function AssociationController(config, send, api, $q, superdesk,
                 return;
             }
 
-            self.updateItemAssociation(scope, item, null, null, true);
-
             // save generated association id in order to be able to update the same item after editing.
             const originalRel = scope.rel;
 
             if (self.isMediaEditable()) {
+                // if media is editable then association will be updated by self.edit method
                 scope.loading = true;
                 renditions.ingest(item)
                     .then((item) => self.edit(scope, item, {customRel: originalRel}))
                     .finally(() => {
                         scope.loading = false;
                     });
+            } else {
+                // Update the association is media is not editable.
+                self.updateItemAssociation(scope, item, null, null, true);
             }
         });
     };

--- a/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.spec.js
+++ b/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.spec.js
@@ -61,7 +61,7 @@ describe('item association directive', () => {
         $rootScope.$digest();
         expect(renditions.ingest).toHaveBeenCalled();
         expect(renditions.crop).toHaveBeenCalled();
-        expect(scope.onChange).toHaveBeenCalled();
+        expect(scope.onChange).not.toHaveBeenCalled();
         expect(scope.save).toHaveBeenCalled();
         expect(event.preventDefault).toHaveBeenCalled();
         expect(event.stopPropagation).toHaveBeenCalled();


### PR DESCRIPTION
In case of media is editable, if the `updateItemAssociation` is called before downloading the item then the item is saved 2 twice:
1) Image as part of the drag-drop event (in our case watermark image).
2) On "Save and Close" of the `ChangeImageController`.
