### PR TITLE
[SDESK-3530](fix): Picture crops should be set before saving the crops.

### DIFF
--- a/scripts/apps/authoring/authoring/controllers/AssociationController.js
+++ b/scripts/apps/authoring/authoring/controllers/AssociationController.js
@@ -213,6 +213,8 @@ export function AssociationController(config, send, api, $q, superdesk,
             return renditions.crop(item, cropOptions)
                 .then((rendition) => {
                     self.updateItemAssociation(scope, rendition, options.customRel, callback);
+                }, (error) => {
+                    notify.error(gettext('Failed to generate picture crops.'));
                 })
                 .finally(() => {
                     scope.loading = false;

--- a/scripts/apps/authoring/authoring/controllers/ChangeImageController.ts
+++ b/scripts/apps/authoring/authoring/controllers/ChangeImageController.ts
@@ -108,6 +108,10 @@ export function ChangeImageController($scope, gettext, notify, modal, _, api, $r
             };
 
             _.forEach($scope.data.cropData, (cropData, cropName) => {
+                if (!cropData || _.isEmpty(cropData)) {
+                    throw gettext('Crop coordinates are not defined for ' + cropName + ' picture crop.');
+                }
+
                 if (originalPoi.y < cropData.CropTop ||
                     originalPoi.y > cropData.CropBottom ||
                     originalPoi.x < cropData.CropLeft ||


### PR DESCRIPTION
If the user does not open the "Edit Crops" tab then corp coordinates are not set and this forces user to see the crops once before saving the changes.