### PR TITLE
Fix item preview when modifying tables

### DIFF
--- a/scripts/core/editor3/reducers/table.tsx
+++ b/scripts/core/editor3/reducers/table.tsx
@@ -3,7 +3,7 @@ import {Map} from 'immutable';
 import {onChange} from './editor3';
 import insertAtomicBlockWithoutEmptyLines from '../helpers/insertAtomicBlockWithoutEmptyLines';
 import {createBlockSelection} from '../helpers/selection';
-import {getCell, setCell, getData} from '../helpers/table';
+import {getCell, setCell, getData, setData} from '../helpers/table';
 
 /**
  * @description Contains the list of table related reducers.
@@ -163,9 +163,7 @@ const processCells = (state, fn) => {
     const block = contentState.getBlockForKey(key);
     const {cells, numRows, numCols, withHeader} = getData(editorState, block);
     const {data, newCurrentStyle} = fn(cells, numCols, numRows, i, j, withHeader, currentStyle, selection);
-    const blockSelection = createBlockSelection(editorState, block);
-    const newContentState = Modifier.setBlockData(contentState, blockSelection, Map({data: JSON.stringify(data)}));
-    const newEditorState = EditorState.push(editorState, newContentState, 'change-block-data');
+    const newEditorState = setData(editorState, block, data, 'change-block-data');
     const entityDataHasChanged = true;
 
     if (newCurrentStyle != null) {

--- a/scripts/core/editor3/store/index.js
+++ b/scripts/core/editor3/store/index.js
@@ -111,7 +111,6 @@ export function onChange(contentState, {plainText = false} = {}) {
         EditorState.createWithContent(contentStateCleaned)
     ).getCurrentContent();
 
-
     setFieldMetadata(
         this.item,
         pathToValue,


### PR DESCRIPTION
SDESK-3248 

## Issue

Right now if you delete a row from table inside an article, if you go to preview that article you will still see the deleted row. Then if you undo the change (getting the row back), the preview will not show it.

## Solution

The way we were storing the entity data was okay for draft-js rendering but html conversion (for preview purposes) was getting always the previous editor state. I use a custom function we had to set the entity data for tables within the entity and not the block like before.