### PR TITLE
Bring old ranges back

### DIFF
--- a/scripts/apps/search/directives/DateFilters.ts
+++ b/scripts/apps/search/directives/DateFilters.ts
@@ -7,6 +7,22 @@ interface IDateRange {
     };
 }
 
+const before1MonthFilter: IDateRange = {
+    key: 'before_next_month',
+    label: gettext('Next Month'),
+    elasticSearchDateRange: {
+        lte: 'now+1M/d',
+    },
+};
+
+const before3MonthsFilter: IDateRange = {
+    key: 'before_3_months_ahead',
+    label: gettext('Next 3 Months'),
+    elasticSearchDateRange: {
+        lte: 'now+3M/d',
+    },
+};
+
 const last30daysFilter: IDateRange = {
     key: 'last_30_days',
     label: gettext('Last 30 Days'),
@@ -40,6 +56,8 @@ const last8hoursFilter: IDateRange = {
 };
 
 export const dateRangesByKey: Dictionary<string, IDateRange> = {
+    before_next_month: before1MonthFilter,
+    before_3_months_ahead: before3MonthsFilter,
     last_30_days: last30daysFilter,
     last_7_days: last7daysFilter,
     last_24_hours: last24hoursFilter,


### PR DESCRIPTION
[This PR](https://github.com/superdesk/superdesk-client-core/pull/2696) should have only deleted the specific filter, and not the date ranges.