### PR TITLE
Configure source maps to work with sentry (SDESK 3663)

### DIFF
--- a/tasks/options/webpack.js
+++ b/tasks/options/webpack.js
@@ -4,7 +4,7 @@ module.exports = function(grunt) {
     var config = require('../../webpack.config.js')(grunt);
 
     config.progress = !grunt.option('webpack-no-progress');
-    config.devtool = grunt.option('webpack-devtool') || 'cheap-source-map';
+    config.devtool = grunt.option('webpack-devtool') || 'source-map';
 
     config.module.rules = config.module.rules.map((rule) => {
         if (rule.loader === 'ts-loader') {


### PR DESCRIPTION
SDESK-3663

Before / after:

![sentry-before-after](https://user-images.githubusercontent.com/2076953/49783318-1b16e200-fd22-11e8-993b-08e659dea35e.png)
