### PR TITLE
SDFID-516 Adjust style for relative date buttons in the datepicker

### DIFF
--- a/styles/sass/sf-additional.scss
+++ b/styles/sass/sf-additional.scss
@@ -624,6 +624,7 @@
         padding: 4px 6px;
         font-size: 11px;
         line-height: 11px!important;
+        height: auto;
     }
     table {
         width: 100%;


### PR DESCRIPTION
Each relative date button now has it's own height according to text inside.
Example:
<img width="392" alt="screenshot 2019-01-07 at 12 01 27" src="https://user-images.githubusercontent.com/4199922/50761831-0b80af80-1274-11e9-9ee2-d962c6ccbb87.png">
