### PR TITLE
Allow date ranges in custom fields

### DIFF
--- a/scripts/apps/search/services/SearchService.js
+++ b/scripts/apps/search/services/SearchService.js
@@ -338,6 +338,15 @@ export function SearchService($location, gettext, config, session, multi,
             // date filters start
             var facetrange = {};
 
+            // inject custom field filters { fieldname: 'string(IDateRange)' }
+            if (typeof params.customFields !== 'undefined') {
+                for (let [fieldname, range] of Object.entries(params.customFields)) {
+                    if (typeof dateRangesByKey[range] !== 'undefined') {
+                        facetrange[fieldname] = dateRangesByKey[range].elasticSearchDateRange;
+                    }
+                }
+            }
+
             getDateFilters(gettext).forEach(({fieldname}) => {
                 const dateRangeKey = params[fieldname];
 


### PR DESCRIPTION
SDFID-520

Compliance Review uses 2 filters but the search service doesn't know
about `compliantlifetime` field (and it shouldn't) since https://github.com/superdesk/superdesk-client-core/pull/2696