### PR TITLE
Activate save button on drag&drop feature media

### DIFF
--- a/scripts/apps/authoring/authoring/controllers/AssociationController.ts
+++ b/scripts/apps/authoring/authoring/controllers/AssociationController.ts
@@ -232,7 +232,9 @@ export function AssociationController(config, send, api, $q, superdesk,
      * @param {Object} event Drop event
      */
     this.initializeUploadOnDrop = function(scope, event) {
-        if (getSuperdeskType(event) === 'Files') {
+        const superdeskType = getSuperdeskType(event);
+
+        if (superdeskType === 'Files') {
             if (self.isMediaEditable()) {
                 const files = event.originalEvent.dataTransfer.files;
 
@@ -241,7 +243,7 @@ export function AssociationController(config, send, api, $q, superdesk,
             return;
         }
 
-        self.getItem(event, getSuperdeskType(event)).then((item) => {
+        self.getItem(event, superdeskType).then((item) => {
             if (!scope.editable) {
                 return;
             }

--- a/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts
@@ -31,7 +31,7 @@ export function ItemAssociationDirective(renditions) {
             allowPicture: '<',
             allowVideo: '<',
             allowAudio: '<',
-            _onchange: '&onchange',
+            onchange: '&',
             showTitle: '<',
             save: '&',
             maxUploads: '=',
@@ -122,9 +122,9 @@ export function ItemAssociationDirective(renditions) {
                 }
             };
 
-            scope.onchange = (field) => {
+            scope.onMetadataChange = (field) => {
                 scope.related[field] = stripHtmlTags(scope.related[field]);
-                scope._onchange();
+                scope.onchange();
             };
         },
     };

--- a/scripts/apps/authoring/views/item-association.html
+++ b/scripts/apps/authoring/views/item-association.html
@@ -74,7 +74,7 @@
         tansa-scope-sync
         ng-model="related.headline"
         ng-model-options="{debounce: 1000}"
-        ng-change="onchange('headline')"
+        ng-change="onMetadataChange('headline')"
         sd-placeholder="{{:: 'Add title' | translate}}"
         ng-if="related && showTitle"
         class="sd-media-carousel__media-title">
@@ -84,7 +84,7 @@
         tansa-scope-sync
         ng-model="related.description_text"
         ng-model-options="{debounce: 1000}"
-        ng-change="onchange('description_text')"
+        ng-change="onMetadataChange('description_text')"
         sd-placeholder="{{:: 'Add caption' | translate}}"
         ng-if="related"
         class="sd-media-carousel__media-caption">

--- a/scripts/core/index.js
+++ b/scripts/core/index.js
@@ -80,7 +80,7 @@ core.config(['$routeProvider', ($routeProvider) => {
 
 // due to angular 1.6
 core.config(['$locationProvider', ($locationProvider) => $locationProvider.hashPrefix('')]);
-core.config(['$qProvider', ($qProvider) => $qProvider.errorOnUnhandledRejections(false)]);
+core.config(['$qProvider', ($qProvider) => $qProvider.errorOnUnhandledRejections(true)]);
 core.config(['$compileProvider', ($compileProvider) => $compileProvider.preAssignBindingsEnabled(true)]);
 
 core.run(['$injector', ng.register]);


### PR DESCRIPTION
SDESK-3798

The issue is that https://github.com/superdesk/superdesk-client-core/pull/2532 introduced a new `onchange` function for metadata and `scope.onchange` was now calling that one instead (with wrong arguments). The error was not shown because angularJS had "show unhandled errors" disabled so I also enabled that (as it caused us some other issues in the past)