### PR TITLE
(SDESK-3793) fix on creating a vocabulary having the same ID as previ…

### DIFF
--- a/scripts/apps/vocabularies/views/vocabulary-config-modal.html
+++ b/scripts/apps/vocabularies/views/vocabulary-config-modal.html
@@ -18,7 +18,7 @@
                                       ng-readonly="!!vocabulary._links"
                                       required>
                     <div class="sd-line-input__message"
-                         ng-show="issues._id.unique" translate>ID must be unique.</div>
+                         ng-show="issues._id.unique || issues._id.deleted" translate>ID must be unique.</div>
                     <div class="sd-line-input__message"
                          ng-show="issues._id.conflict" translate>ID conflicts with system field.</div>
                     <div class="sd-line-input__message"


### PR DESCRIPTION
…ously deleted one. No errors displayed to the user.
required by https://github.com/superdesk/superdesk-core/pull/1481