### PR TITLE
Custom script tags on index.html

### DIFF
--- a/index.html.js
+++ b/index.html.js
@@ -1,7 +1,4 @@
-module.exports = function buildIndex(features) {
-    const scriptTags = features.scriptTags || [];
-
-    return `
+const buildIndex = ({scriptTags}) => `
         <!doctype html>
         <html class="no-js">
           <head>
@@ -20,4 +17,5 @@ module.exports = function buildIndex(features) {
           </body>
         </html>
     `;
-};
+
+module.exports = buildIndex;

--- a/index.html.js
+++ b/index.html.js
@@ -1,4 +1,6 @@
-module.exports = function buildIndex(o) {
+module.exports = function buildIndex(features) {
+    const scriptTags = features.scriptTags || [];
+
     return `
         <!doctype html>
         <html class="no-js">
@@ -8,7 +10,7 @@ module.exports = function buildIndex(o) {
             <meta name="description" content="">
             <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
             <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-            ${o.qumu ? '<script src="https://video.fidelity.tv/widgets/1/application.js"></script>' : ''}
+            ${scriptTags.map((script) => `<script src="${script}"></script>`)}
             <link rel="icon" type="image/x-icon" href="images/favicon.ico" />
           </head>
           <body ng-class="config.bodyClass">

--- a/scripts/superdesk-interfaces/SuperdeskGlobalConfig.d.ts
+++ b/scripts/superdesk-interfaces/SuperdeskGlobalConfig.d.ts
@@ -6,6 +6,7 @@ export interface ISuperdeskGlobalConfig {
         };
         editor3: boolean;
         qumu: boolean;
+        scriptTags?: Array<string>;
         editorAttachments: boolean;
         editorInlineComments: boolean;
         editorSuggestions: boolean;

--- a/tasks/options/ngtemplates.js
+++ b/tasks/options/ngtemplates.js
@@ -1,5 +1,3 @@
-
-
 var path = require('path');
 var rootDir = path.dirname(path.dirname(__dirname));
 
@@ -54,10 +52,10 @@ module.exports = {
         src: __filename, // hack to make ngtemplate work
         options: {
             bootstrap: () => {
-                const features = getConfig().features || {};
+                const scriptTags = getConfig().scriptTags || [];
                 const buildIndex = require('../../index.html.js');
 
-                return buildIndex(features);
+                return buildIndex({scriptTags});
             },
         },
     },


### PR DESCRIPTION
SDESK-3781

We have a custom script on `index.html` only if `qumu` feature is enabled. As this is specific to fidelity, I created `features.scriptTags` field to inject custom scripts on superdesk.

In repos like `superdesk-fi` we can put:

```js
features: {
   ...,
   scriptTags: [ 'https://video.fidelity.tv/widgets/1/application.js' ]
}
```

Thoughts on this? @hlmnrmr @petrjasek  @tomaskikutis 