### PR TITLE
feat(localisation): Add support for plural on translation(SDESK-3821)

### DIFF
--- a/scripts/apps/archive/controllers/DuplicateController.ts
+++ b/scripts/apps/archive/controllers/DuplicateController.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 DuplicateController.$inject = ['api', 'notify', '$rootScope', 'data', 'desks', '$location', 'workspaces', 'session'];
 export function DuplicateController(api, notify, $rootScope, data, desks, $location, workspaces, session) {

--- a/scripts/apps/archive/controllers/UploadController.ts
+++ b/scripts/apps/archive/controllers/UploadController.ts
@@ -1,7 +1,7 @@
 import EXIF from 'exif-js';
 import _ from 'lodash';
 import {getDataUrl} from 'core/upload/image-preview-directive';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /* eslint-disable complexity */
 

--- a/scripts/apps/archive/directives/ArchivedItemKill.js
+++ b/scripts/apps/archive/directives/ArchivedItemKill.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 ArchivedItemKill.$inject = ['authoring', 'api', 'notify'];
 

--- a/scripts/apps/archive/directives/HtmlPreview.ts
+++ b/scripts/apps/archive/directives/HtmlPreview.ts
@@ -1,7 +1,7 @@
 import {getAnnotationsFromItem} from 'core/editor3/helpers/editor3CustomData';
 import {META_FIELD_NAME} from 'core/editor3/helpers/fieldsMeta';
 import ng from 'core/services/ng';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 function getAnnotationTypesAsync(scope) {
     ng.get('metadata').initialize()

--- a/scripts/apps/archive/directives/ResendItem.js
+++ b/scripts/apps/archive/directives/ResendItem.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 ResendItem.$inject = ['subscribersService', 'authoring', 'api', 'notify'];
 

--- a/scripts/apps/archive/index.js
+++ b/scripts/apps/archive/index.js
@@ -11,7 +11,7 @@ import * as directive from './directives';
 import * as svc from './services';
 import * as ctrl from './controllers';
 
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.apps.archive.directives', [
     'superdesk.core.filters',

--- a/scripts/apps/archive/related-item-widget/relatedItem.ts
+++ b/scripts/apps/archive/related-item-widget/relatedItem.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.apps.dashboard.widgets.relatedItem', [
     'superdesk.apps.dashboard.widgets.base',

--- a/scripts/apps/archive/services/SpikeService.ts
+++ b/scripts/apps/archive/services/SpikeService.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc service

--- a/scripts/apps/authoring/attachments/attachments.js
+++ b/scripts/apps/authoring/attachments/attachments.js
@@ -1,5 +1,5 @@
 import './attachments.scss';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 class AttachmentsController {
     constructor($scope, $window, superdesk, attachments, notify, deployConfig, urls, lock) {

--- a/scripts/apps/authoring/authoring/article-url-fields.tsx
+++ b/scripts/apps/authoring/authoring/article-url-fields.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 interface IProps {
     label: string;

--- a/scripts/apps/authoring/authoring/constants.js
+++ b/scripts/apps/authoring/authoring/constants.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Menu groups for authoring

--- a/scripts/apps/authoring/authoring/controllers/AssociationController.ts
+++ b/scripts/apps/authoring/authoring/controllers/AssociationController.ts
@@ -1,5 +1,6 @@
 import {startsWith, endsWith, some, forEach, get} from 'lodash';
 import {getSuperdeskType} from 'core/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc controller

--- a/scripts/apps/authoring/authoring/controllers/ChangeImageController.ts
+++ b/scripts/apps/authoring/authoring/controllers/ChangeImageController.ts
@@ -1,5 +1,5 @@
 import {get} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc controller

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.js
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.js
@@ -1,7 +1,7 @@
 import * as helpers from 'apps/authoring/authoring/helpers';
 import _ from 'lodash';
 import postscribe from 'postscribe';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc directive

--- a/scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.js
+++ b/scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.js
@@ -1,5 +1,5 @@
 import * as helpers from 'apps/authoring/authoring/helpers';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 AuthoringEmbeddedDirective.$inject = ['api', 'notify', '$filter', 'config', 'deployConfig'];
 export function AuthoringEmbeddedDirective(api, notify, $filter, config, deployConfig) {

--- a/scripts/apps/authoring/authoring/directives/CharacterCount.ts
+++ b/scripts/apps/authoring/authoring/directives/CharacterCount.ts
@@ -1,5 +1,5 @@
 import * as helpers from 'apps/authoring/authoring/helpers';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 CharacterCount.$inject = [];
 export function CharacterCount() {

--- a/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.js
+++ b/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.js
@@ -4,7 +4,7 @@ import 'owl.carousel';
 import * as ctrl from '../controllers';
 import {waitForImagesToLoad, waitForAudioAndVideoToLoadMetadata} from 'core/helpers/waitForMediaToBeReady';
 import {getSuperdeskType} from 'core/utils';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 
 const carouselContainerSelector = '.sd-media-carousel__content';

--- a/scripts/apps/authoring/authoring/directives/PreviewFormattedDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/PreviewFormattedDirective.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 PreviewFormattedDirective.$inject = ['api', 'config', 'notify', 'storage'];
 export function PreviewFormattedDirective(api, config, notify, storage) {

--- a/scripts/apps/authoring/authoring/directives/SendItem.js
+++ b/scripts/apps/authoring/authoring/directives/SendItem.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import {PreviewModal} from '../previewModal';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 
 SendItem.$inject = ['$q', 'api', 'search', 'desks', 'notify', 'authoringWorkspace',

--- a/scripts/apps/authoring/authoring/index.ts
+++ b/scripts/apps/authoring/authoring/index.ts
@@ -11,7 +11,7 @@ import {reactToAngular1} from 'superdesk-ui-framework';
 import {ArticleUrlFields} from './article-url-fields';
 import {PopulateAuthorsController} from './controllers/PopulateAuthorsController';
 
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.apps.authoring.autosave', []).service('autosave', svc.AutosaveService);
 

--- a/scripts/apps/authoring/authoring/previewModal.tsx
+++ b/scripts/apps/authoring/authoring/previewModal.tsx
@@ -5,7 +5,7 @@ import {Modal} from 'core/ui/components/Modal/Modal';
 import {ModalHeader} from 'core/ui/components/Modal/ModalHeader';
 import {ModalBody} from 'core/ui/components/Modal/ModalBody';
 import {ModalFooter} from 'core/ui/components/Modal/ModalFooter';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 const getFormattedDocument = (url) => fetch(url).then(
     (response) => response.text()

--- a/scripts/apps/authoring/authoring/services/AuthoringService.js
+++ b/scripts/apps/authoring/authoring/services/AuthoringService.js
@@ -1,5 +1,5 @@
 import * as helpers from 'apps/authoring/authoring/helpers';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc service

--- a/scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts
+++ b/scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc service

--- a/scripts/apps/authoring/authoring/services/LockService.ts
+++ b/scripts/apps/authoring/authoring/services/LockService.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 LockService.$inject = ['$q', 'api', 'session', 'privileges', 'notify'];
 export function LockService($q, api, session, privileges, notify) {

--- a/scripts/apps/authoring/authoring/services/RenditionsService.ts
+++ b/scripts/apps/authoring/authoring/services/RenditionsService.ts
@@ -1,6 +1,6 @@
 import {isEmpty} from 'lodash';
 import {IArticle} from 'superdesk-interfaces/Article';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc service

--- a/scripts/apps/authoring/comments/comments.ts
+++ b/scripts/apps/authoring/comments/comments.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 import {each} from 'lodash';
 
 var ENTER = 13;

--- a/scripts/apps/authoring/compare-versions/index.ts
+++ b/scripts/apps/authoring/compare-versions/index.ts
@@ -3,7 +3,7 @@ import './compare-versions.scss';
 import CompareVersionsService from './CompareVersionsService';
 import CompareVersionsController from './CompareVersionsController';
 import * as directive from './directives';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/authoring/editor/find-replace.js
+++ b/scripts/apps/authoring/editor/find-replace.js
@@ -8,7 +8,7 @@
  * at https://www.sourcefabric.org/apps/license
  */
 
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 
 FindReplaceDirective.$inject = ['editorResolver', 'macros'];

--- a/scripts/apps/authoring/macros/macros.js
+++ b/scripts/apps/authoring/macros/macros.js
@@ -8,7 +8,7 @@
  * and triggering of macros to be apply on provided item
  */
 
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 MacrosService.$inject = ['api', 'notify'];
 function MacrosService(api, notify) {

--- a/scripts/apps/authoring/metadata/metadata.js
+++ b/scripts/apps/authoring/metadata/metadata.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import PreferedCvItemsConfigDirective from './PreferedCvItemsConfigDirective';
 import MetaPlaceDirective from './MetaPlaceDirective';
 import {VOCABULARY_SELECTION_TYPES} from '../../vocabularies/constants';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 const SINGLE_SELECTION = VOCABULARY_SELECTION_TYPES.SINGLE_SELECTION.id;
 

--- a/scripts/apps/authoring/multiedit/multiedit.js
+++ b/scripts/apps/authoring/multiedit/multiedit.js
@@ -8,7 +8,7 @@
  * at https://www.sourcefabric.org/superdesk/license
  */
 
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 
 MultieditService.$inject = ['storage', 'superdesk', 'authoringWorkspace', 'referrer', '$location'];

--- a/scripts/apps/authoring/packages/packages.js
+++ b/scripts/apps/authoring/packages/packages.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 PackagesCtrl.$inject = ['$scope', 'superdesk', 'api', 'search'];
 function PackagesCtrl($scope, superdesk, api, search) {

--- a/scripts/apps/authoring/tests/changeImage.spec.js
+++ b/scripts/apps/authoring/tests/changeImage.spec.js
@@ -1,5 +1,5 @@
 import {ChangeImageController} from '../authoring/controllers/ChangeImageController';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 describe('authoring ChangeImageController', () => {
     let deployConfig = {

--- a/scripts/apps/authoring/track-changes/inline-comments.ts
+++ b/scripts/apps/authoring/track-changes/inline-comments.ts
@@ -15,7 +15,7 @@ import {highlightsConfig} from 'core/editor3/highlightsConfig';
 import {getCustomMetadata} from 'core/editor3/helpers/editor3CustomData';
 import {getLabelNameResolver} from 'apps/workspace/helpers/getLabelForFieldId';
 import {get} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 function getAllUserIdsFromComments(comments) {
     const users = [];

--- a/scripts/apps/authoring/track-changes/suggestions.ts
+++ b/scripts/apps/authoring/track-changes/suggestions.ts
@@ -7,7 +7,7 @@ import * as Highlights from 'core/editor3/helpers/highlights';
 import {getLabelNameResolver} from 'apps/workspace/helpers/getLabelForFieldId';
 import {fieldsMetaKeys, META_FIELD_NAME, getFieldMetadata, getFieldId} from '../../../core/editor3/helpers/fieldsMeta';
 import {get} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 function getAllUserIdsFromSuggestions(suggestions) {
     const users = [];

--- a/scripts/apps/authoring/translations/index.js
+++ b/scripts/apps/authoring/translations/index.js
@@ -1,6 +1,6 @@
 import {reactToAngular1} from 'superdesk-ui-framework';
 import {TranslationsWidget} from './translationsWidget';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.apps.authoring.translations', [
     'superdesk.apps.authoring.widgets',

--- a/scripts/apps/authoring/translations/translationsWidget.tsx
+++ b/scripts/apps/authoring/translations/translationsWidget.tsx
@@ -3,7 +3,7 @@ import {RelativeDate} from 'core/datetime/relativeDate';
 import {state as State} from 'apps/search/components/fields/state';
 import {connectServices} from 'core/helpers/ReactRenderAsync';
 import {IArticle} from 'superdesk-interfaces/Article';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 interface IProps {
     item: IArticle;

--- a/scripts/apps/authoring/versioning/versioning.ts
+++ b/scripts/apps/authoring/versioning/versioning.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.apps.authoring.versioning', [])
     .config(['authoringWidgetsProvider', function(authoringWidgetsProvider) {

--- a/scripts/apps/authoring/widgets/widgets.ts
+++ b/scripts/apps/authoring/widgets/widgets.ts
@@ -1,7 +1,7 @@
 import {debounce} from 'lodash';
 import {IContentProfile} from "superdesk-interfaces/ContentProfile";
 import {isWidgetVisibleForContentProfile} from "apps/workspace/content/components/WidgetsConfig";
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 function AuthoringWidgetsProvider() {
     var widgets = [];

--- a/scripts/apps/contacts/components/ContactFooter.tsx
+++ b/scripts/apps/contacts/components/ContactFooter.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {VersionCreated, SocialInfo} from 'apps/contacts/components/fields';
 import {getContactType} from '../../contacts/helpers';
 import classNames from 'classnames';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Contact footer - renders footer for contact card used in grid view

--- a/scripts/apps/contacts/components/ContactHeader.tsx
+++ b/scripts/apps/contacts/components/ContactHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Contact header - renders header for contact card used in grid view

--- a/scripts/apps/contacts/components/ContactInfo.tsx
+++ b/scripts/apps/contacts/components/ContactInfo.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {ItemContainer} from 'apps/contacts/components';
 import {ContactName, Notes, JobTitle} from 'apps/contacts/components/fields';
 import {isEmpty, findKey} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Media Contact Info - renders contact's information

--- a/scripts/apps/contacts/components/Form/ActionBar.tsx
+++ b/scripts/apps/contacts/components/Form/ActionBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const ActionBar: React.StatelessComponent<any> = ({svc, readOnly, dirty, valid, onSave, onCancel}) => (
     <div className="action-bar clearfix show">

--- a/scripts/apps/contacts/components/Form/ContactFormContainer.tsx
+++ b/scripts/apps/contacts/components/Form/ContactFormContainer.tsx
@@ -5,7 +5,7 @@ import {FB_URL, IG_URL} from '../../../contacts/constants';
 import {ContactProfile} from './ContactProfile';
 import {ActionBar} from './ActionBar';
 import {get, set, isEqual, cloneDeep, some, isEmpty, extend, each, omit, isNil} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export class ContactFormContainer extends React.Component<any, any> {
     static propTypes: any;

--- a/scripts/apps/contacts/components/Form/ContactNumberInput.tsx
+++ b/scripts/apps/contacts/components/Form/ContactNumberInput.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Row, LineInput, Input, SelectInput, Toggle, Label} from './';
 import {KEYCODES} from '../../../contacts/constants';
 import {set, get, isEmpty} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export class ContactNumberInput extends React.Component<any, any> {
     static propTypes: any;

--- a/scripts/apps/contacts/components/Form/MultiTextInput.tsx
+++ b/scripts/apps/contacts/components/Form/MultiTextInput.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Row, LineInput, Input} from './';
 import {KEYCODES} from '../../../contacts/constants';
 import {isEmpty, get, set} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export class MultiTextInput extends React.Component<any, any> {
     static propTypes: any;

--- a/scripts/apps/contacts/components/Form/ProfileDetail.tsx
+++ b/scripts/apps/contacts/components/Form/ProfileDetail.tsx
@@ -5,7 +5,7 @@ import {Row, LineInput, InputArray, MultiTextInput, Input, SelectInput, Toggle, 
     ContactNumberInput, Label, SelectFieldSearchInput} from './index';
 import {get, set, isEmpty, findKey, orderBy, map} from 'lodash';
 import {validateMinRequiredField} from '../../../contacts/helpers';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export class ProfileDetail extends React.Component<any, any> {
     static propTypes: any;

--- a/scripts/apps/contacts/components/Form/ProfileHeader.tsx
+++ b/scripts/apps/contacts/components/Form/ProfileHeader.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {Toggle} from './index';
 import {get} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const ProfileHeader: React.StatelessComponent<any> = ({contact, onChange, readOnly, contactType}) => {
     const displayName = contact.first_name ? contact.first_name + ' ' + contact.last_name : contact.organisation;

--- a/scripts/apps/contacts/components/ItemContainer.tsx
+++ b/scripts/apps/contacts/components/ItemContainer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {find, join, map} from 'lodash';
 import {MAP_URL, TWITTER_URL, MAILTO_URL} from '../../contacts/constants';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export class ItemContainer extends React.Component<any, any> {
     static propTypes: any;

--- a/scripts/apps/contacts/components/ItemList.tsx
+++ b/scripts/apps/contacts/components/ItemList.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {Item} from 'apps/contacts/components';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Contact Item list component

--- a/scripts/apps/contacts/components/ListTypeIcon.tsx
+++ b/scripts/apps/contacts/components/ListTypeIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const ListTypeIcon: React.StatelessComponent<any> = ({item}) => {
     const iconClass = item.first_name ? 'icon-user' : 'icon-business';

--- a/scripts/apps/contacts/components/fields/State.tsx
+++ b/scripts/apps/contacts/components/fields/State.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const State: React.StatelessComponent<any> = ({item}) => {
     const cssClass = item.contact_state ? 'state-label' : null;

--- a/scripts/apps/contacts/constants.ts
+++ b/scripts/apps/contacts/constants.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Default list of fields

--- a/scripts/apps/contacts/controllers/ContactsController.js
+++ b/scripts/apps/contacts/controllers/ContactsController.js
@@ -1,5 +1,5 @@
 import {FILTER_FIELDS} from '../constants';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc controller

--- a/scripts/apps/contacts/directives/ContactsSearchPanelDirective.js
+++ b/scripts/apps/contacts/directives/ContactsSearchPanelDirective.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import _ from 'lodash';
 import {URL_PARAMETERS} from '../constants';
 import {SelectFieldSearchInput} from '../../contacts/components/Form';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 
 class LinkFunction {

--- a/scripts/apps/contacts/directives/ContactsSearchResultsDirective.js
+++ b/scripts/apps/contacts/directives/ContactsSearchResultsDirective.js
@@ -1,5 +1,5 @@
 import {URL_PARAMETERS} from '../constants';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 class LinkFunction {
     constructor(contacts, search, notify, $location, $timeout, scope, elem) {

--- a/scripts/apps/contacts/index.ts
+++ b/scripts/apps/contacts/index.ts
@@ -2,7 +2,7 @@ import {ContactsController} from './controllers';
 import * as directives from './directives';
 import * as services from './services';
 import './styles/contacts.scss';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/contacts/services/ContactsService.js
+++ b/scripts/apps/contacts/services/ContactsService.js
@@ -1,5 +1,5 @@
 import {FILTER_FIELDS, URL_PARAMETERS} from '../constants';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 const DEFAULT_PAGE_SIZE = 50;
 

--- a/scripts/apps/content-api/controllers/ContentAPIController.js
+++ b/scripts/apps/content-api/controllers/ContentAPIController.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc controller

--- a/scripts/apps/content-api/directives/ContentAPISearchResultsDirective.js
+++ b/scripts/apps/content-api/directives/ContentAPISearchResultsDirective.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 class LinkFunction {
     constructor(contentApiSearch, search, notify, $location, scope, elem) {

--- a/scripts/apps/content-api/index.ts
+++ b/scripts/apps/content-api/index.ts
@@ -1,7 +1,7 @@
 import {ContentAPIController} from './controllers';
 import * as directives from './directives';
 import * as services from './services';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/content-api/services/ContentAPISearchService.js
+++ b/scripts/apps/content-api/services/ContentAPISearchService.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 const DEFAULT_PAGE_SIZE = 25;
 

--- a/scripts/apps/content-filters/controllers/FilterConditionsController.js
+++ b/scripts/apps/content-filters/controllers/FilterConditionsController.js
@@ -1,5 +1,5 @@
 import {getLabelNameResolver} from 'apps/workspace/helpers/getLabelForFieldId';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc controller

--- a/scripts/apps/content-filters/controllers/FilterSearchController.ts
+++ b/scripts/apps/content-filters/controllers/FilterSearchController.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc controller

--- a/scripts/apps/content-filters/controllers/ManageContentFiltersController.js
+++ b/scripts/apps/content-filters/controllers/ManageContentFiltersController.js
@@ -1,5 +1,5 @@
 import {getLabelNameResolver} from 'apps/workspace/helpers/getLabelForFieldId';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc controller

--- a/scripts/apps/content-filters/controllers/ProductionTestController.js
+++ b/scripts/apps/content-filters/controllers/ProductionTestController.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc controller

--- a/scripts/apps/content-filters/index.ts
+++ b/scripts/apps/content-filters/index.ts
@@ -14,7 +14,7 @@ import {ManageFiltersTab} from './directives';
 import {ContentFilterSelectDirective} from './directives';
 import * as ctrl from './controllers';
 import {coreMenuGroups} from 'core/activity/activity';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 // XXX: For some reason, loading the superdesk.apps.content_filters module in
 // tests fails to load due to "Unknown provider: superdeskProvider" error.

--- a/scripts/apps/dashboard/controllers/DashboardController.js
+++ b/scripts/apps/dashboard/controllers/DashboardController.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 DashboardController.$inject = ['$scope', 'desks', 'dashboardWidgets', 'api', 'session', 'workspaces',
     'modal', 'privileges', 'pageTitle'];

--- a/scripts/apps/dashboard/index.js
+++ b/scripts/apps/dashboard/index.js
@@ -11,7 +11,7 @@ import {DashboardController} from './controllers';
 import * as directive from './directives';
 import * as svc from './services';
 
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.apps.dashboard.widgets', [])
     .provider('dashboardWidgets', svc.DashboardWidgets);

--- a/scripts/apps/dashboard/workspace-tasks/tasks.js
+++ b/scripts/apps/dashboard/workspace-tasks/tasks.js
@@ -1,5 +1,5 @@
 import './styles/tasks.scss';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 TasksService.$inject = ['desks', '$rootScope', 'api', 'datetimeHelper'];
 function TasksService(desks, $rootScope, api, datetimeHelper) {

--- a/scripts/apps/dashboard/world-clock/world-clock.js
+++ b/scripts/apps/dashboard/world-clock/world-clock.js
@@ -1,6 +1,6 @@
 import './world-clock.scss';
 import d3 from 'd3';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.apps.dashboard.world-clock', [
     'superdesk.apps.dashboard', 'superdesk.core.datetime',

--- a/scripts/apps/desks/controllers/DeskConfigController.js
+++ b/scripts/apps/desks/controllers/DeskConfigController.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 DeskConfigController.$inject = ['$scope', '$controller', 'notify', 'desks', 'WizardHandler', 'modal'];
 export function DeskConfigController($scope, $controller, notify, desks, WizardHandler, modal) {

--- a/scripts/apps/desks/directives/DeskConfigModal.ts
+++ b/scripts/apps/desks/directives/DeskConfigModal.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc directive

--- a/scripts/apps/desks/directives/DeskeditBasic.ts
+++ b/scripts/apps/desks/directives/DeskeditBasic.ts
@@ -1,6 +1,6 @@
 import {limits} from 'apps/desks/constants';
 import _ from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 DeskeditBasic.$inject = ['desks', 'WizardHandler', 'metadata', 'config',
     '$filter'];

--- a/scripts/apps/desks/directives/DeskeditPeople.js
+++ b/scripts/apps/desks/directives/DeskeditPeople.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 DeskeditPeople.$inject = ['WizardHandler', 'desks', '$rootScope'];
 export function DeskeditPeople(WizardHandler, desks, $rootScope) {

--- a/scripts/apps/desks/directives/DeskeditStages.js
+++ b/scripts/apps/desks/directives/DeskeditStages.js
@@ -1,6 +1,6 @@
 import {limits} from 'apps/desks/constants';
 import _ from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 DeskeditStages.$inject = ['api', 'WizardHandler', 'tasks', '$rootScope', 'desks', 'notify',
     'macros', 'deployConfig'];

--- a/scripts/apps/desks/directives/MarkDesksDropdown.ts
+++ b/scripts/apps/desks/directives/MarkDesksDropdown.ts
@@ -1,6 +1,6 @@
 import {DesksReactDropdown} from './DesksReactDropdown';
 import ReactDOM from 'react-dom';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc directive

--- a/scripts/apps/desks/index.ts
+++ b/scripts/apps/desks/index.ts
@@ -13,7 +13,7 @@ import * as ctrl from './controllers';
 import * as directive from './directives';
 import {DesksFactory} from './services';
 import {coreMenuGroups} from 'core/activity/activity';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/desks/services/DesksFactory.js
+++ b/scripts/apps/desks/services/DesksFactory.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc service

--- a/scripts/apps/dictionaries/controllers/DictionaryConfigController.js
+++ b/scripts/apps/dictionaries/controllers/DictionaryConfigController.js
@@ -1,3 +1,5 @@
+import {gettext} from 'core/utils';
+
 DictionaryConfigController.$inject = ['$scope', 'dictionaries', 'session', 'modal', 'notify'];
 export function DictionaryConfigController($scope, dictionaries, session, modal, notify) {
     $scope.dictionaries = null;

--- a/scripts/apps/dictionaries/controllers/DictionaryEditController.js
+++ b/scripts/apps/dictionaries/controllers/DictionaryEditController.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 DictionaryEditController.$inject = ['$scope', 'dictionaries', 'upload', 'notify',
     'modal', '$rootScope', '$q'];

--- a/scripts/apps/dictionaries/index.ts
+++ b/scripts/apps/dictionaries/index.ts
@@ -13,7 +13,7 @@ import {DictionaryService} from './services';
 import {DictionaryEditController, DictionaryConfigController} from './controllers';
 import * as directive from './directives';
 import {coreMenuGroups} from 'core/activity/activity';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/highlights/controllers/HighlightsConfig.js
+++ b/scripts/apps/highlights/controllers/HighlightsConfig.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 HighlightsConfig.$inject = ['$scope', 'highlightsService', 'desks', 'api', 'notify', 'modal'];
 export function HighlightsConfig($scope, highlightsService, desks, api, notify, modal) {

--- a/scripts/apps/highlights/index.ts
+++ b/scripts/apps/highlights/index.ts
@@ -13,7 +13,7 @@ import {HighlightsService} from './services';
 import * as ctrl from './controllers';
 import * as directive from './directives';
 import {coreMenuGroups} from 'core/activity/activity';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/highlights/services/HighlightsService.js
+++ b/scripts/apps/highlights/services/HighlightsService.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Service for highlights with caching.

--- a/scripts/apps/ingest/controllers/ExternalSourceController.ts
+++ b/scripts/apps/ingest/controllers/ExternalSourceController.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc controller

--- a/scripts/apps/ingest/controllers/IngestDashboardController.js
+++ b/scripts/apps/ingest/controllers/IngestDashboardController.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 IngestDashboardController.$inject = ['$scope', 'api', 'ingestSources', 'preferencesService',
     'notify', 'config'];

--- a/scripts/apps/ingest/directives/IngestRoutingAction.js
+++ b/scripts/apps/ingest/directives/IngestRoutingAction.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 IngestRoutingAction.$inject = ['desks', 'macros', 'subscribersService', 'metadata'];
 export function IngestRoutingAction(desks, macros, subscribersService, metadata) {

--- a/scripts/apps/ingest/directives/IngestRoutingContent.js
+++ b/scripts/apps/ingest/directives/IngestRoutingContent.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc directive

--- a/scripts/apps/ingest/directives/IngestRulesContent.js
+++ b/scripts/apps/ingest/directives/IngestRulesContent.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 IngestRulesContent.$inject = ['api', 'notify', 'modal', '$filter'];
 export function IngestRulesContent(api, notify, modal, $filter) {

--- a/scripts/apps/ingest/directives/IngestSourcesContent.js
+++ b/scripts/apps/ingest/directives/IngestSourcesContent.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import {cloneDeep} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 IngestSourcesContent.$inject = ['ingestSources', 'notify', 'api', '$location',
     'modal', '$filter', 'config', 'deployConfig', 'privileges'];

--- a/scripts/apps/ingest/index.ts
+++ b/scripts/apps/ingest/index.ts
@@ -9,7 +9,7 @@ import * as directive from './directives';
 import {InsertFilter, ScheduleFilter} from './filters';
 import _ from 'lodash';
 import {coreMenuGroups} from 'core/activity/activity';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.apps.ingest.send', ['superdesk.core.api', 'superdesk.apps.desks'])
     .service('send', svc.SendService);

--- a/scripts/apps/ingest/ingest-stats-widget/stats.ts
+++ b/scripts/apps/ingest/ingest-stats-widget/stats.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.apps.dashboard.widgets.ingeststats', [])
     .factory('colorSchemes', ['$resource', function($resource) {

--- a/scripts/apps/ingest/services/SendService.js
+++ b/scripts/apps/ingest/services/SendService.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 SendService.$inject = ['desks', 'api', '$q', 'notify', '$injector', 'multi', '$rootScope'];
 export function SendService(desks, api, $q, notify, $injector, multi, $rootScope) {

--- a/scripts/apps/internal-destinations/index.ts
+++ b/scripts/apps/internal-destinations/index.ts
@@ -1,5 +1,5 @@
 import {coreMenuGroups} from 'core/activity/activity';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 InternalDestinationsFactory.$inject = ['api'];
 function InternalDestinationsFactory(api) {

--- a/scripts/apps/legal-archive/index.ts
+++ b/scripts/apps/legal-archive/index.ts
@@ -1,6 +1,7 @@
 import {LegalArchiveService} from './services';
 import {LegalArchiveController} from './controllers';
 import {LegalItemSortbar} from './directives';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/legal-archive/services/LegalArchiveService.js
+++ b/scripts/apps/legal-archive/services/LegalArchiveService.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc service

--- a/scripts/apps/legal-archive/tests/legal.spec.ts
+++ b/scripts/apps/legal-archive/tests/legal.spec.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 describe('legal archive service', () => {
     beforeEach(window.module('superdesk.core.api'));

--- a/scripts/apps/monitoring/aggregate-widget/aggregate.ts
+++ b/scripts/apps/monitoring/aggregate-widget/aggregate.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.apps.aggregate.widgets', ['superdesk.apps.aggregate', 'superdesk.apps.dashboard.widgets'])
     .config(['dashboardWidgetsProvider', function(dashboardWidgets) {

--- a/scripts/apps/monitoring/config.ts
+++ b/scripts/apps/monitoring/config.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 Monitoring.$inject = ['superdeskProvider', 'workspaceMenuProvider'];
 export function Monitoring(superdesk, workspaceMenuProvider) {

--- a/scripts/apps/monitoring/controllers/AggregateCtrl.js
+++ b/scripts/apps/monitoring/controllers/AggregateCtrl.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 AggregateCtrl.$inject = ['$scope', 'api', 'desks', 'workspaces', 'preferencesService', 'storage',
     'multi', 'config', '$timeout', 'savedSearch', 'deployConfig'];

--- a/scripts/apps/monitoring/directives/MonitoringView.js
+++ b/scripts/apps/monitoring/directives/MonitoringView.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Main monitoring view - list + preview

--- a/scripts/apps/monitoring/index.ts
+++ b/scripts/apps/monitoring/index.ts
@@ -18,7 +18,7 @@ import * as directive from './directives';
 import * as svc from './services';
 import {SplitFilter} from './filters';
 import {MonitoringController} from './controllers/MonitoringController';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/packaging/controllers/CombinePackageCtrl.ts
+++ b/scripts/apps/packaging/controllers/CombinePackageCtrl.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 CombinePackageCtrl.$inject = ['data', 'packages', 'authoringWorkspace', 'notify'];
 export function CombinePackageCtrl(data, packages, authoringWorkspace, notify) {

--- a/scripts/apps/packaging/controllers/PackageItemCtrl.ts
+++ b/scripts/apps/packaging/controllers/PackageItemCtrl.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 PackageItemCtrl.$inject = ['data', 'packages', 'authoringWorkspace', 'notify'];
 export function PackageItemCtrl(data, packages, authoringWorkspace, notify) {

--- a/scripts/apps/packaging/directives/PackageItemsEdit.js
+++ b/scripts/apps/packaging/directives/PackageItemsEdit.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 PackageItemsEdit.$inject = ['packages', 'notify', '$rootScope'];
 export function PackageItemsEdit(packages, notify, $rootScope) {

--- a/scripts/apps/packaging/index.ts
+++ b/scripts/apps/packaging/index.ts
@@ -12,7 +12,7 @@ import './styles/packaging.scss';
 import * as ctrl from './controllers';
 import * as directive from './directives';
 import {PackagesService} from './services';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/products/controllers/ProductsConfigController.js
+++ b/scripts/apps/products/controllers/ProductsConfigController.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc controller

--- a/scripts/apps/products/index.ts
+++ b/scripts/apps/products/index.ts
@@ -4,7 +4,7 @@ import {ProductsFilter} from './filters';
 import {ProductsFactory} from './services';
 import {ProductsConfigController} from './controllers';
 import {coreMenuGroups} from 'core/activity/activity';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/profiling/index.ts
+++ b/scripts/apps/profiling/index.ts
@@ -8,7 +8,7 @@
  * at https://www.sourcefabric.org/superdesk/license
  */
 import {ProfilingController} from './controllers';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/publish/controllers/PublishQueueController.js
+++ b/scripts/apps/publish/controllers/PublishQueueController.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import {isSuperdeskContent} from 'apps/workspace/helpers/isSuperdeskContent';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 PublishQueueController.$inject = [
     '$scope',

--- a/scripts/apps/publish/directives/SubscribersDirective.js
+++ b/scripts/apps/publish/directives/SubscribersDirective.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc directive

--- a/scripts/apps/publish/index.ts
+++ b/scripts/apps/publish/index.ts
@@ -14,7 +14,7 @@ import * as ctrl from './controllers';
 import * as directive from './directives';
 import * as filter from './filters';
 import {coreMenuGroups} from 'core/activity/activity';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/relations/directives/RelatedItemsDirective.ts
+++ b/scripts/apps/relations/directives/RelatedItemsDirective.ts
@@ -1,6 +1,6 @@
 import {get} from 'lodash';
 import {getSuperdeskType} from 'core/utils';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc directive

--- a/scripts/apps/search-providers/directive.js
+++ b/scripts/apps/search-providers/directive.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export default function SearchProviderConfigDirective(searchProviderService, notify, api, modal) {
     return {

--- a/scripts/apps/search-providers/index.ts
+++ b/scripts/apps/search-providers/index.ts
@@ -11,7 +11,7 @@ import {providerTypes} from './constants';
 import SearchProviderService from './service';
 import SearchProviderConfigDirective from './directive';
 import {coreMenuGroups} from 'core/activity/activity';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 SearchProviderSettingsController.$inject = ['$scope', 'privileges'];
 function SearchProviderSettingsController($scope, privileges) { /* no-op */ }

--- a/scripts/apps/search/MultiImageEdit.ts
+++ b/scripts/apps/search/MultiImageEdit.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import {uniq, pickBy, isEmpty} from 'lodash';
 import {validateMediaFieldsThrows} from 'apps/authoring/authoring/controllers/ChangeImageController';
 import {logger} from 'core/services/logger';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 interface IScope extends ng.IScope {
     validator: any;

--- a/scripts/apps/search/components/Associations.tsx
+++ b/scripts/apps/search/components/Associations.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {TypeIcon} from './index';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc React

--- a/scripts/apps/search/components/ErrorBox.tsx
+++ b/scripts/apps/search/components/ErrorBox.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const ErrorBox: React.StatelessComponent<any> = (props) =>
     React.createElement('div', {className: 'error-box'},

--- a/scripts/apps/search/components/FetchedDesksInfo.tsx
+++ b/scripts/apps/search/components/FetchedDesksInfo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {DesksDropdown} from './index';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export class FetchedDesksInfo extends React.Component<any, any> {
     static propTypes: any;

--- a/scripts/apps/search/components/HighlightsList.tsx
+++ b/scripts/apps/search/components/HighlightsList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {closeActionsMenu} from '../helpers';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export class HighlightsList extends React.Component<any, any> {
     static propTypes: any;

--- a/scripts/apps/search/components/ItemContainer.tsx
+++ b/scripts/apps/search/components/ItemContainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const ItemContainer: React.StatelessComponent<any> = (props) => {
     const item = props.item;

--- a/scripts/apps/search/components/ItemList.tsx
+++ b/scripts/apps/search/components/ItemList.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import {Item} from './index';
 import {isCheckAllowed, closeActionsMenu, bindMarkItemShortcut} from '../helpers';
 import {querySelectorParent} from 'core/helpers/dom/querySelectorParent';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 import {IArticle} from 'superdesk-interfaces/Article';
 
 interface IState {

--- a/scripts/apps/search/components/ItemPriority.tsx
+++ b/scripts/apps/search/components/ItemPriority.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {getSpecStyle, getSpecTitle, getSpecValue} from '../helpers';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const ItemPriority: React.StatelessComponent<any> = (props) => {
     const {metadata} = props.svc;

--- a/scripts/apps/search/components/ItemUrgency.tsx
+++ b/scripts/apps/search/components/ItemUrgency.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {getSpecStyle, getSpecTitle, getSpecValue} from '../helpers';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const ItemUrgency: React.StatelessComponent<any> = (props) => {
     const {metadata} = props.svc;

--- a/scripts/apps/search/components/MarkedDesksList.tsx
+++ b/scripts/apps/search/components/MarkedDesksList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {closeActionsMenu} from '../helpers';
 import {isString, map} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc React

--- a/scripts/apps/search/components/MediaInfo.tsx
+++ b/scripts/apps/search/components/MediaInfo.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {createMarkUp} from '../helpers';
 import {FetchedDesksInfo} from './index';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Media Info - renders item metadata

--- a/scripts/apps/search/components/TypeIcon.tsx
+++ b/scripts/apps/search/components/TypeIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Type icon component

--- a/scripts/apps/search/components/WidgetItem.tsx
+++ b/scripts/apps/search/components/WidgetItem.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import {ItemUrgency, TypeIcon} from './index';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc React

--- a/scripts/apps/search/components/WidgetItemList.tsx
+++ b/scripts/apps/search/components/WidgetItemList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {WidgetItem} from './index';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc React

--- a/scripts/apps/search/components/actions-menu/Item.tsx
+++ b/scripts/apps/search/components/actions-menu/Item.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import {LEFT_SIDEBAR_WIDTH} from 'core/ui/constants';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 import {closeActionsMenu} from '../../helpers';
 

--- a/scripts/apps/search/components/actions-menu/Label.tsx
+++ b/scripts/apps/search/components/actions-menu/Label.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {closeActionsMenu} from '../../helpers';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 const Label: React.StatelessComponent<any> = (props) =>
     React.createElement(

--- a/scripts/apps/search/components/actions-menu/MenuItems.tsx
+++ b/scripts/apps/search/components/actions-menu/MenuItems.tsx
@@ -7,7 +7,7 @@ import Item from './Item';
 import SubmenuDropdown from './SubmenuDropdown';
 import {AUTHORING_MENU_GROUPS} from '../../../authoring/authoring/constants';
 import {closeActionsMenu, menuHolderElem} from '../../helpers';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export default class MenuItems extends React.Component<any, any> {
     static propTypes: any;

--- a/scripts/apps/search/components/fields/assignment.tsx
+++ b/scripts/apps/search/components/fields/assignment.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {get} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const assignment: React.StatelessComponent<any> = ({item}) => {
     if (!get(item, 'assignment_id')) {

--- a/scripts/apps/search/components/fields/embargo.tsx
+++ b/scripts/apps/search/components/fields/embargo.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const embargo: React.StatelessComponent<any> = (props) => {
     if (props.item.embargo) {

--- a/scripts/apps/search/components/fields/expiry.tsx
+++ b/scripts/apps/search/components/fields/expiry.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const expiry: React.StatelessComponent<any> = (props) => {
     const {datetime} = props.svc;

--- a/scripts/apps/search/components/fields/flags.tsx
+++ b/scripts/apps/search/components/fields/flags.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const flags: React.StatelessComponent<any> = (props) => {
     const _flags = props.item.flags || {};

--- a/scripts/apps/search/components/fields/nested-link.tsx
+++ b/scripts/apps/search/components/fields/nested-link.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {gettext} from 'core/utils';
 
 interface IProps {
     toggleNested(): void;
     showNested: boolean;
     nestedCount: number;
-    svc: {
-        gettext(message: string): string,
-    };
 }
 
 export const nestedlink: React.StatelessComponent<IProps> = (props) => (
@@ -16,8 +14,8 @@ export const nestedlink: React.StatelessComponent<IProps> = (props) => (
             <a className="text-link"
                 onClick={props.toggleNested}>
                 {props.showNested ?
-                    props.svc.gettext('Hide previous items') :
-                    props.svc.gettext('Show previous items')}
+                    gettext('Hide previous items') :
+                    gettext('Show previous items')}
             </a>
             <span className="badge badge--light">{props.nestedCount}</span>
         </div>
@@ -28,5 +26,4 @@ nestedlink.propTypes = {
     showNested: PropTypes.bool,
     nestedCount: PropTypes.number,
     toggleNested: PropTypes.func.isRequired,
-    svc: PropTypes.any.isRequired,
 };

--- a/scripts/apps/search/components/fields/state.tsx
+++ b/scripts/apps/search/components/fields/state.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {get} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const state: React.StatelessComponent<any> = (props) => {
     // support passing services as props

--- a/scripts/apps/search/components/fields/takekey.tsx
+++ b/scripts/apps/search/components/fields/takekey.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const takekey: React.StatelessComponent<any> = (props) => {
     if (props.item.anpa_take_key) {

--- a/scripts/apps/search/components/fields/update.tsx
+++ b/scripts/apps/search/components/fields/update.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const update: React.StatelessComponent<any> = (props) => {
     if (props.item.correction_sequence) {

--- a/scripts/apps/search/components/fields/updated.tsx
+++ b/scripts/apps/search/components/fields/updated.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const updated: React.StatelessComponent<any> = (props) => {
     const openItem = function(event) {

--- a/scripts/apps/search/controllers/MultiActionBarController.ts
+++ b/scripts/apps/search/controllers/MultiActionBarController.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import {IArticle} from 'superdesk-interfaces/Article';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc controller

--- a/scripts/apps/search/directives/DateFilters.ts
+++ b/scripts/apps/search/directives/DateFilters.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 interface IDateRange {
     key: string;

--- a/scripts/apps/search/directives/ItemGlobalSearch.ts
+++ b/scripts/apps/search/directives/ItemGlobalSearch.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 ItemGlobalSearch.$inject = [
     'session', 'api', 'notify', 'keyboardManager', 'asset', 'authoringWorkspace', 'authoring',

--- a/scripts/apps/search/directives/SaveSearch.ts
+++ b/scripts/apps/search/directives/SaveSearch.ts
@@ -1,6 +1,6 @@
 import {create, clone, each} from 'lodash';
 import {saveOrUpdateSavedSearch} from '../SavedSearch';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 SaveSearch.$inject = ['$location', 'asset', 'api', 'session', 'notify', '$rootScope'];
 

--- a/scripts/apps/search/directives/SavedSearchManageSubscribers.ts
+++ b/scripts/apps/search/directives/SavedSearchManageSubscribers.ts
@@ -13,7 +13,7 @@ import {CronTimeInterval} from 'types/DataStructures/TimeInterval';
 import {IDesk} from 'superdesk-interfaces/Desk';
 import {IDesksService} from 'types/Services/Desks';
 import {nameof} from 'core/helpers/typescript-helpers';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 interface IModel {
     userSubscribers: Array<IUser>;

--- a/scripts/apps/search/directives/SavedSearches.ts
+++ b/scripts/apps/search/directives/SavedSearches.ts
@@ -8,7 +8,7 @@ import {IPrivilegesService} from 'types/Services/Privileges';
 
 import {forEach, clone, filter} from 'lodash';
 import {mapPredefinedDateFiltersServerToClient} from './DateFilters';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 SavedSearches.$inject = [
     '$rootScope', 'api', 'session', 'modal', 'notify', 'asset',

--- a/scripts/apps/search/directives/SearchContainer.ts
+++ b/scripts/apps/search/directives/SearchContainer.ts
@@ -1,5 +1,5 @@
 import {isEmpty, omit} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export function SearchContainer() {
     return {

--- a/scripts/apps/search/directives/SearchResults.js
+++ b/scripts/apps/search/directives/SearchResults.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 SearchResults.$inject = [
     '$location',

--- a/scripts/apps/search/index.ts
+++ b/scripts/apps/search/index.ts
@@ -6,7 +6,7 @@ import {MultiActionBarController} from './controllers';
 import {SearchController} from './controllers';
 import SearchMenuController from './controllers/SearchMenuController';
 import {MultiImageEditDirective} from './MultiImageEdit';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.apps.search.react', [
     'superdesk.apps.highlights',

--- a/scripts/apps/search/services/SearchService.js
+++ b/scripts/apps/search/services/SearchService.js
@@ -8,7 +8,7 @@ import {
 
 import _ from 'lodash';
 import {getDateFilters, dateRangesByKey} from '../directives/DateFilters';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 const DEFAULT_REPOS = ['ingest', 'archive', 'published', 'archived'];
 

--- a/scripts/apps/search/services/TagService.js
+++ b/scripts/apps/search/services/TagService.js
@@ -1,6 +1,6 @@
 import {PARAMETERS, EXCLUDE_FACETS} from 'apps/search/constants';
 import {getDateFilters, dateRangesByKey} from '../directives/DateFilters';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc service

--- a/scripts/apps/search/tests/search.spec.js
+++ b/scripts/apps/search/tests/search.spec.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 describe('search service', () => {
     beforeEach(window.module('superdesk.templates-cache'));

--- a/scripts/apps/settings/index.ts
+++ b/scripts/apps/settings/index.ts
@@ -4,7 +4,7 @@ import './styles/settings.scss';
 import {reactToAngular1} from 'superdesk-ui-framework';
 import {Settings} from './settings';
 import * as directive from './directives';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/settings/settings.tsx
+++ b/scripts/apps/settings/settings.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {connectServices} from 'core/helpers/ReactRenderAsync';
 import {capitalize} from 'lodash';
 import {coreMenuGroups} from 'core/activity/activity';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 interface IProps {
     $route: any;

--- a/scripts/apps/stream/index.ts
+++ b/scripts/apps/stream/index.ts
@@ -1,7 +1,7 @@
 import {StreamController} from './controllers';
 import {ActivityMessageService} from './services';
 import {ActivityStream, ActivityMessage} from './directives';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export default angular.module('superdesk.apps.stream', [
     'superdesk.core.activity',

--- a/scripts/apps/stream/services/index.ts
+++ b/scripts/apps/stream/services/index.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 ActivityMessageService.$inject = [];
 export function ActivityMessageService() {

--- a/scripts/apps/templates/directives/TemplateSelectDirective.ts
+++ b/scripts/apps/templates/directives/TemplateSelectDirective.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 TemplateSelectDirective.$inject = ['api', 'desks', 'session', 'templates', 'notify'];
 export function TemplateSelectDirective(api, desks, session, templates, notify) {

--- a/scripts/apps/templates/directives/TemplatesDirective.js
+++ b/scripts/apps/templates/directives/TemplatesDirective.js
@@ -1,5 +1,5 @@
 import notifySaveError from '../helpers';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 TemplatesDirective.$inject = ['notify', 'api', 'templates', 'modal', 'desks', 'weekdays',
     'content', '$filter', 'lodash'];

--- a/scripts/apps/templates/helpers.ts
+++ b/scripts/apps/templates/helpers.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export default function notifySaveError(response, notify) {
     if (angular.isDefined(response.data._issues) &&

--- a/scripts/apps/templates/index.ts
+++ b/scripts/apps/templates/index.ts
@@ -14,7 +14,7 @@ import {FilterTemplatesFilter} from './filters';
 import * as directive from './directives';
 import * as ctrl from './controllers';
 import {coreMenuGroups} from 'core/activity/activity';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.apps.templates', [
     'superdesk.core.activity',

--- a/scripts/apps/templates/services/TemplatesService.js
+++ b/scripts/apps/templates/services/TemplatesService.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 TemplatesService.$inject = ['api', 'session', '$q', 'preferencesService', 'privileges', 'desks'];
 export function TemplatesService(api, session, $q, preferencesService, privileges, desks) {

--- a/scripts/apps/translations/index.ts
+++ b/scripts/apps/translations/index.ts
@@ -10,7 +10,7 @@
 
 import * as directive from './directives';
 import * as svc from './services';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/translations/services/TranslationService.js
+++ b/scripts/apps/translations/services/TranslationService.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc service

--- a/scripts/apps/users/config.ts
+++ b/scripts/apps/users/config.ts
@@ -9,7 +9,7 @@ import {
     SessionsDeleteCommand,
 } from './controllers';
 import {coreMenuGroups} from 'core/activity/activity';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 API.$inject = ['apiProvider'];
 export function API(apiProvider) {

--- a/scripts/apps/users/controllers/ChangeAvatarController.js
+++ b/scripts/apps/users/controllers/ChangeAvatarController.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 ChangeAvatarController.$inject = ['$scope', 'upload', 'session', 'urls', 'betaService', 'notify', 'lodash'];
 export function ChangeAvatarController($scope, upload, session, urls, beta, notify, _) {

--- a/scripts/apps/users/controllers/SessionsDeleteCommand.ts
+++ b/scripts/apps/users/controllers/SessionsDeleteCommand.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /*
  * Delete sessions of a user

--- a/scripts/apps/users/controllers/UserDeleteCommand.ts
+++ b/scripts/apps/users/controllers/UserDeleteCommand.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Disable user

--- a/scripts/apps/users/controllers/UserEnableCommand.ts
+++ b/scripts/apps/users/controllers/UserEnableCommand.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Enable user

--- a/scripts/apps/users/controllers/UserListController.js
+++ b/scripts/apps/users/controllers/UserListController.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 UserListController.$inject = ['$scope', '$location', 'api', 'lodash', 'session', 'usersService'];
 export function UserListController($scope, $location, api, _, session, usersService) {

--- a/scripts/apps/users/controllers/UserResolver.ts
+++ b/scripts/apps/users/controllers/UserResolver.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Resolve a user by route id and redirect to /users if such user does not exist

--- a/scripts/apps/users/directives/ChangePasswordDirective.ts
+++ b/scripts/apps/users/directives/ChangePasswordDirective.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 ChangePasswordDirective.$inject = ['usersService', 'notify'];
 export function ChangePasswordDirective(usersService, notify) {

--- a/scripts/apps/users/directives/ResetPasswordDirective.ts
+++ b/scripts/apps/users/directives/ResetPasswordDirective.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 ResetPasswordDirective.$inject = ['usersService', 'notify'];
 export function ResetPasswordDirective(usersService, notify) {

--- a/scripts/apps/users/directives/RolesPrivilegesDirective.js
+++ b/scripts/apps/users/directives/RolesPrivilegesDirective.js
@@ -1,5 +1,5 @@
 import handleError from '../helpers';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 RolesPrivilegesDirective.$inject = ['api', 'notify', '$q', '$filter'];
 export function RolesPrivilegesDirective(api, notify, $q, $filter) {

--- a/scripts/apps/users/directives/UserEditDirective.ts
+++ b/scripts/apps/users/directives/UserEditDirective.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 UserEditDirective.$inject = ['api', 'notify', 'usersService', 'userList', 'session', 'lodash',
     'langmap', '$location', '$route', 'superdesk', 'features', 'asset', 'privileges',

--- a/scripts/apps/users/directives/UserPreferencesDirective.ts
+++ b/scripts/apps/users/directives/UserPreferencesDirective.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc directive

--- a/scripts/apps/users/directives/UserPrivilegesDirective.js
+++ b/scripts/apps/users/directives/UserPrivilegesDirective.js
@@ -1,5 +1,5 @@
 import handleError from '../helpers';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc directive

--- a/scripts/apps/users/directives/UserRolesDirective.ts
+++ b/scripts/apps/users/directives/UserRolesDirective.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 UserRolesDirective.$inject = ['api', 'notify', 'modal', '$filter', 'lodash', 'metadata'];
 export function UserRolesDirective(api, notify, modal, $filter, _, metadata) {

--- a/scripts/apps/users/import/import.js
+++ b/scripts/apps/users/import/import.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 UserImportService.$inject = ['api', '$q'];
 function UserImportService(api, $q) {

--- a/scripts/apps/users/index.js
+++ b/scripts/apps/users/index.js
@@ -12,7 +12,7 @@ import {UserEditController} from './controllers';
 import * as svc from './services';
 import * as directive from './directives';
 import * as config from './config';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/vocabularies/components/ItemsTableComponent.tsx
+++ b/scripts/apps/vocabularies/components/ItemsTableComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ObjectEditor from './ObjectEditor';
 import {has} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export default class ItemsTableComponent extends React.Component<any, any> {
     static propTypes: any;

--- a/scripts/apps/vocabularies/constants.ts
+++ b/scripts/apps/vocabularies/constants.ts
@@ -1,5 +1,5 @@
 import {get} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const MEDIA_TYPES = {
     GALLERY: {

--- a/scripts/apps/vocabularies/controllers/VocabularyConfigController.ts
+++ b/scripts/apps/vocabularies/controllers/VocabularyConfigController.ts
@@ -2,7 +2,7 @@ import {MEDIA_TYPES, MEDIA_TYPE_KEYS, DEFAULT_SCHEMA, VOCABULARY_SELECTION_TYPES
 import {IVocabulary, IVocabularyTag} from 'superdesk-interfaces/Vocabulary';
 import {IDirectiveScope} from 'types/Angular/DirectiveScope';
 import {remove, reduce} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 const OTHER = gettext('Other');
 

--- a/scripts/apps/vocabularies/controllers/VocabularyEditController.ts
+++ b/scripts/apps/vocabularies/controllers/VocabularyEditController.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import {MEDIA_TYPES, MEDIA_TYPE_KEYS, VOCABULARY_SELECTION_TYPES} from '../constants';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 VocabularyEditController.$inject = [
     '$scope',

--- a/scripts/apps/vocabularies/index.ts
+++ b/scripts/apps/vocabularies/index.ts
@@ -13,7 +13,7 @@ import {VocabularyService, SchemaFactory} from './services';
 import * as ctrl from './controllers';
 import * as directive from './directives';
 import {coreMenuGroups} from 'core/activity/activity';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/vocabularies/services/SchemaFactory.ts
+++ b/scripts/apps/vocabularies/services/SchemaFactory.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 SchemaFactory.$inject = [];
 export function SchemaFactory() {

--- a/scripts/apps/vocabularies/services/VocabularyService.ts
+++ b/scripts/apps/vocabularies/services/VocabularyService.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const DEFAULT_DATEFIELD_SHORTCUTS = [
     {

--- a/scripts/apps/workspace/content/constants.ts
+++ b/scripts/apps/workspace/content/constants.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 // http://docs.python-cerberus.org/en/stable/usage.html
 export const DEFAULT_SCHEMA = Object.freeze({

--- a/scripts/apps/workspace/content/controllers/ContentProfilesController.ts
+++ b/scripts/apps/workspace/content/controllers/ContentProfilesController.ts
@@ -1,6 +1,6 @@
 import {cloneDeep, get, isEqual} from 'lodash';
 import {IContentProfile} from 'superdesk-interfaces/ContentProfile';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 ContentProfilesController.$inject = ['$scope', '$location', 'notify', 'content', 'modal', '$q', 'config'];
 export function ContentProfilesController($scope, $location, notify, content, modal, $q, config) {

--- a/scripts/apps/workspace/content/index.ts
+++ b/scripts/apps/workspace/content/index.ts
@@ -5,7 +5,7 @@ import * as directive from './directives';
 import * as ctrl from './controllers';
 import {coreMenuGroups} from 'core/activity/activity';
 import {WidgetsConfig} from './components/WidgetsConfig';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc module

--- a/scripts/apps/workspace/content/services/ContentService.js
+++ b/scripts/apps/workspace/content/services/ContentService.js
@@ -1,6 +1,6 @@
 import * as constant from '../constants';
 import _ from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc service

--- a/scripts/apps/workspace/helpers/getTypeForFieldId.ts
+++ b/scripts/apps/workspace/helpers/getTypeForFieldId.ts
@@ -1,5 +1,5 @@
 import {IVocabulary} from 'superdesk-interfaces/Vocabulary';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 const TYPE_LABEL = {
     text: gettext('text'),

--- a/scripts/apps/workspace/index.ts
+++ b/scripts/apps/workspace/index.ts
@@ -6,7 +6,7 @@ import './content';
 import {WorkspaceService} from './services';
 import WorkspaceMenuProvider from './services/WorkspaceMenuProvider';
 import * as directive from './directives';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.apps.workspace.menu', [])
     .provider('workspaceMenu', WorkspaceMenuProvider);

--- a/scripts/core/activity/activity-list-directive.js
+++ b/scripts/core/activity/activity-list-directive.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.core.activity.list', [])
     .directive('sdActivityList', ['superdesk', 'activityService', 'workflowService', 'asset', 'notify', 'lodash',

--- a/scripts/core/activity/activity.ts
+++ b/scripts/core/activity/activity.ts
@@ -1,6 +1,6 @@
 import {forEach} from 'lodash';
 import langmap from 'core/lang';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 interface IActivityData {
     priority: number; // priority used for ordering.

--- a/scripts/core/auth/auth.ts
+++ b/scripts/core/auth/auth.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Expire session on 401 server response

--- a/scripts/core/auth/login-modal-directive.ts
+++ b/scripts/core/auth/login-modal-directive.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Login modal is watching session token and displays modal when needed

--- a/scripts/core/datetime/absdate-directive.js
+++ b/scripts/core/datetime/absdate-directive.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Display absolute date in <time> element

--- a/scripts/core/datetime/datetime.js
+++ b/scripts/core/datetime/datetime.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 DateTimeDirective.$inject = ['datetime', 'moment'];
 function DateTimeDirective(datetime, moment) {

--- a/scripts/core/datetime/reldate-directive-complex.js
+++ b/scripts/core/datetime/reldate-directive-complex.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Display relative date in <time> element

--- a/scripts/core/directives/FiletypeIconDirective.ts
+++ b/scripts/core/directives/FiletypeIconDirective.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export default angular.module('superdesk.core.directives.filetypeIcon', [])
 /**

--- a/scripts/core/directives/PasswordStrengthDirective.ts
+++ b/scripts/core/directives/PasswordStrengthDirective.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 // config holds the default configuration for the password strength calculator.
 var config = {

--- a/scripts/core/editor2/editor.js
+++ b/scripts/core/editor2/editor.js
@@ -11,7 +11,7 @@ import MediumEditor from 'medium-editor';
 import MediumEditorTable from 'medium-editor-tables';
 import _ from 'lodash';
 import {get} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 import './customAnchor';
 

--- a/scripts/core/editor3/components/annotations/AnnotationInput.tsx
+++ b/scripts/core/editor3/components/annotations/AnnotationInput.tsx
@@ -9,7 +9,7 @@ import {getAuthorInfo} from '../../actions';
 import {connectPromiseResults} from 'core/helpers/ReactRenderAsync';
 import {hidePopups} from '../../actions';
 import ng from 'core/services/ng';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc React

--- a/scripts/core/editor3/components/annotations/AnnotationPopup.tsx
+++ b/scripts/core/editor3/components/annotations/AnnotationPopup.tsx
@@ -12,7 +12,7 @@ import {connectPromiseResults} from 'core/helpers/ReactRenderAsync';
 import {EditorHighlightsHeader} from '../../editorPopup/EditorHighlightsHeader';
 import {FluidRows} from '../../fluid-flex-rows/fluid-rows';
 import {FluidRow} from '../../fluid-flex-rows/fluid-row';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 class Annotation extends React.Component<any, any> {
     static propTypes: any;

--- a/scripts/core/editor3/components/comments/Comment.tsx
+++ b/scripts/core/editor3/components/comments/Comment.tsx
@@ -7,7 +7,7 @@ import {UserAvatar} from 'apps/users/components/UserAvatar';
 import {EditorHighlightsHeader} from 'core/editor3/editorPopup/EditorHighlightsHeader';
 import {FluidRows} from '../../fluid-flex-rows/fluid-rows';
 import {FluidRow} from '../../fluid-flex-rows/fluid-row';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc React

--- a/scripts/core/editor3/components/comments/CommentInput.tsx
+++ b/scripts/core/editor3/components/comments/CommentInput.tsx
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {getAuthorInfo, hidePopups} from '../../actions';
 import CommentTextArea from './CommentTextArea';
 import {highlightsConfig} from '../../highlightsConfig';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc React

--- a/scripts/core/editor3/components/comments/CommentPopup.tsx
+++ b/scripts/core/editor3/components/comments/CommentPopup.tsx
@@ -9,7 +9,7 @@ import {getAuthorInfo} from '../../actions';
 import {editor3DataKeys, getCustomDataFromEditor, setCustomDataForEditor} from '../../helpers/editor3CustomData';
 import * as Highlights from '../../helpers/highlights';
 import {HighlightsPopupPositioner} from '../HighlightsPopupPositioner';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc React

--- a/scripts/core/editor3/components/comments/CommentTextArea.tsx
+++ b/scripts/core/editor3/components/comments/CommentTextArea.tsx
@@ -4,7 +4,7 @@ import {Mention, MentionsInput} from 'react-mentions';
 import {UserAvatar} from 'apps/users/components';
 import mentionsStyle from './mentionsStyle';
 import ng from 'core/services/ng';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 class CommentTextArea extends React.Component<any, any> {
     static propTypes: any;

--- a/scripts/core/editor3/components/embeds/EmbedBlock.tsx
+++ b/scripts/core/editor3/components/embeds/EmbedBlock.tsx
@@ -7,7 +7,7 @@ import * as actions from '../../actions';
 import ng from 'core/services/ng';
 import {loadIframelyEmbedJs} from './loadIframely';
 import {debounce} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 // debounce to avoid multiple widget load calls on initial load
 // when it gets executed for every embed block

--- a/scripts/core/editor3/components/embeds/EmbedInput.tsx
+++ b/scripts/core/editor3/components/embeds/EmbedInput.tsx
@@ -4,7 +4,7 @@ import {loadIframelyEmbedJs} from './loadIframely';
 import ng from 'core/services/ng';
 import {connect} from 'react-redux';
 import {embed, hidePopups} from '../../actions';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 const fallbackAPIKey = '1d1728bf82b2ac8139453f'; // register to author's personal account
 const GenericError = gettext('This URL could not be embedded.');

--- a/scripts/core/editor3/components/links/AttachmentList.tsx
+++ b/scripts/core/editor3/components/links/AttachmentList.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import ng from 'core/services/ng';
 import {FileiconFilter, FilesizeFilter} from 'core/ui/ui';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export class AttachmentList extends React.Component<any, any> {
     static propTypes: any;

--- a/scripts/core/editor3/components/links/LinkInput.tsx
+++ b/scripts/core/editor3/components/links/LinkInput.tsx
@@ -8,7 +8,7 @@ import {AttachmentList} from './AttachmentList';
 import {applyLink, hidePopups, createLinkSuggestion, changeLinkSuggestion} from '../../actions';
 import {connectPromiseResults} from 'core/helpers/ReactRenderAsync';
 import ng from 'core/services/ng';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc React

--- a/scripts/core/editor3/components/links/LinkToolbar.tsx
+++ b/scripts/core/editor3/components/links/LinkToolbar.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 
 import * as actions from '../../actions';
 import {getSelectedEntityType, getSelectedEntityData} from '../links/entityUtils';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export class LinkToolbarComponent extends React.Component<any, any> {
     static propTypes: any;

--- a/scripts/core/editor3/components/media/MediaBlock.tsx
+++ b/scripts/core/editor3/components/media/MediaBlock.tsx
@@ -5,7 +5,7 @@ import ng from 'core/services/ng';
 import * as actions from '../../actions';
 import Textarea from 'react-textarea-autosize';
 import {get} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 function getTranslationForAssignRights(value) {
     if (value === 'single-usage') {

--- a/scripts/core/editor3/components/suggestions/SuggestionPopup.tsx
+++ b/scripts/core/editor3/components/suggestions/SuggestionPopup.tsx
@@ -12,7 +12,7 @@ import {UserAvatar} from 'apps/users/components/UserAvatar';
 import {FluidRows} from '../../fluid-flex-rows/fluid-rows';
 import {FluidRow} from '../../fluid-flex-rows/fluid-row';
 import {EditorHighlightsHeader} from '../../editorPopup/EditorHighlightsHeader';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc React

--- a/scripts/core/editor3/components/toolbar/StyleButton.tsx
+++ b/scripts/core/editor3/components/toolbar/StyleButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 const StyleIcons = {
     bold: 'icon-bold',

--- a/scripts/core/editor3/components/toolbar/index.tsx
+++ b/scripts/core/editor3/components/toolbar/index.tsx
@@ -13,7 +13,7 @@ import classNames from 'classnames';
 import * as actions from '../../actions';
 import {PopupTypes} from '../../actions';
 import {highlightsConfig} from '../../highlightsConfig';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc React

--- a/scripts/core/editor3/highlightsConfig.ts
+++ b/scripts/core/editor3/highlightsConfig.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 const ENTITY_STYLE_MAP = {
     backgroundColor: 'rgba(100, 235, 59, 0.2)',

--- a/scripts/core/itemList/itemList.ts
+++ b/scripts/core/itemList/itemList.ts
@@ -1,3 +1,4 @@
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.core.itemList', ['superdesk.apps.search'])
 /**
@@ -10,8 +11,8 @@ angular.module('superdesk.core.itemList', ['superdesk.apps.search'])
  * @param {object} loading
  * @description Creates a list of stories to appear in related items widget.
  */
-    .directive('sdRelatedItemListWidget', ['notify', 'gettext', 'familyService', 'desks',
-        function(notify, gettext, familyService, desks) {
+    .directive('sdRelatedItemListWidget', ['notify', 'familyService', 'desks',
+        function(notify, familyService, desks) {
             return {
                 scope: {
                     options: '=',

--- a/scripts/core/keyboard/keyboard.js
+++ b/scripts/core/keyboard/keyboard.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export default angular.module('superdesk.core.keyboard', [])
 

--- a/scripts/core/menu/notifications/notifications.js
+++ b/scripts/core/menu/notifications/notifications.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 UserNotificationsService.$inject = [
     '$rootScope',

--- a/scripts/core/notification/notification.js
+++ b/scripts/core/notification/notification.js
@@ -8,7 +8,7 @@
 * at https://www.sourcefabric.org/superdesk/license
 */
 
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 WebSocketProxy.$inject = ['$rootScope', 'config', '$interval', 'session', 'SESSION_EVENTS'];
 function WebSocketProxy($rootScope, config, $interval, session, SESSION_EVENTS) {

--- a/scripts/core/notify/notify.tsx
+++ b/scripts/core/notify/notify.tsx
@@ -1,7 +1,7 @@
 import ReactDOM from 'react-dom';
 import React from 'react';
 import {find, matches} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 interface IMessageDisplayDurationByType {
     info: number;

--- a/scripts/core/services/modalService.tsx
+++ b/scripts/core/services/modalService.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import {ModalPrompt} from 'core/ui/components/Modal/ModalPrompt';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export default angular.module('superdesk.core.services.modal', ['superdesk-ui', 'superdesk.core.services.asset'])
     .service('modal', ['$q', '$modal', '$sce', 'asset', function($q, $modal, $sce, asset) {

--- a/scripts/core/ui/components/Form/ColouredValueInput/ColouredValuePopup.tsx
+++ b/scripts/core/ui/components/Form/ColouredValueInput/ColouredValuePopup.tsx
@@ -7,7 +7,7 @@ import {onEventCapture} from '../../utils';
 import {KEYCODES} from '../../constants';
 
 import {Popup, Header, Content, Label} from '../../Popup';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 import './style.scss';
 

--- a/scripts/core/ui/components/Form/ColouredValueInput/index.tsx
+++ b/scripts/core/ui/components/Form/ColouredValueInput/index.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {get} from 'lodash';
 
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 import {LineInput, Label} from '../';
 import {ColouredValuePopup} from './ColouredValuePopup';

--- a/scripts/core/ui/components/Form/DateInput/DateInputPopup.tsx
+++ b/scripts/core/ui/components/Form/DateInput/DateInputPopup.tsx
@@ -9,7 +9,7 @@ import {YearPicker} from './YearPicker';
 
 const moment: any = momentAlias;
 
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 import './style.scss';
 

--- a/scripts/core/ui/components/Form/DateTimeInput/index.tsx
+++ b/scripts/core/ui/components/Form/DateTimeInput/index.tsx
@@ -4,7 +4,7 @@ import * as momentAlias from 'moment';
 import {Row, DateInput, TimeInput, Field} from '..';
 import './style.scss';
 import Button from '../../Button';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 const moment: any = momentAlias;
 

--- a/scripts/core/ui/components/Form/FileInput.tsx
+++ b/scripts/core/ui/components/Form/FileInput.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Row, LineInput, Label, Input, TextArea} from './';
 import {IconButton} from '../';
 import {onEventCapture} from '../utils';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 import {get} from 'lodash';
 import './style.scss';
 

--- a/scripts/core/ui/components/Form/SelectUserInput/SelectUserPopup.tsx
+++ b/scripts/core/ui/components/Form/SelectUserInput/SelectUserPopup.tsx
@@ -5,7 +5,7 @@ import {get} from 'lodash';
 
 import {KEYCODES} from '../../constants';
 import {scrollListItemIfNeeded, onEventCapture} from '../../utils';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 import {Popup, Content} from '../../Popup';
 import {UserAvatar} from 'apps/users/components/UserAvatar';

--- a/scripts/core/ui/components/Form/TimeInput/TimeInputPopup.tsx
+++ b/scripts/core/ui/components/Form/TimeInput/TimeInputPopup.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import {range} from 'lodash';
 
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 import {Popup, Content, Header, Footer} from '../../Popup';
 import {Button} from '../../';

--- a/scripts/core/ui/components/List/PubStatus.tsx
+++ b/scripts/core/ui/components/List/PubStatus.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import {Column} from './Column';
 import {isNotForPublication} from '../utils';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc react

--- a/scripts/core/ui/components/Modal/ModalPrompt.tsx
+++ b/scripts/core/ui/components/Modal/ModalPrompt.tsx
@@ -7,7 +7,7 @@ import {Modal} from './Modal';
 import {ModalHeader} from './ModalHeader';
 import {ModalBody} from './ModalBody';
 import {ModalFooter} from './ModalFooter';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export class ModalPrompt extends React.Component<any, any> {
     static propTypes: any;

--- a/scripts/core/ui/components/Popup/Label.tsx
+++ b/scripts/core/ui/components/Popup/Label.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc react

--- a/scripts/core/ui/components/SearchBox.tsx
+++ b/scripts/core/ui/components/SearchBox.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {KEYCODES} from './constants';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc react

--- a/scripts/core/ui/components/SubNav/SlidingToolBar.tsx
+++ b/scripts/core/ui/components/SubNav/SlidingToolBar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {Button} from '../index';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 import './style.scss';
 
 /**

--- a/scripts/core/ui/components/ToggleBox/index.tsx
+++ b/scripts/core/ui/components/ToggleBox/index.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {onEventCapture} from '../utils';
 import {KEYCODES} from '../constants';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 import './style.scss';
 

--- a/scripts/core/ui/components/utils.ts
+++ b/scripts/core/ui/components/utils.ts
@@ -40,12 +40,14 @@ export const gettext = (text, params = null) => {
 
 /**
  * @ngdoc method
- * @name gettextCatalog
+ * @name gettextPlural
+ * @param {Number} count
  * @param {String} text
+ * @param {String} pluralText
  * @param {Object} params
- * @description Used angular gettext service for displaying localised text on Browser
+ * @description Used angular gettext service for displaying plural localised text on Browser
  */
-export const gettextCatalog = (text, params = null) => {
+const gettextPlural = (count, text, pluralText, params) => {
     if (!text) {
         return '';
     }
@@ -53,12 +55,15 @@ export const gettextCatalog = (text, params = null) => {
     const injector = angular.element(document.body).injector();
 
     if (injector) { // in tests this will be empty
-        const translated = injector.get('gettextCatalog').getString(text);
-
-        return params ? injector.get('$interpolate')(translated)(params) : translated;
+        return injector.get('gettextCatalog').getPlural(count, text, pluralText, params);
     }
 
     return text;
+};
+
+export const gettextCatalog = {
+    getString: gettext,
+    getPlural: gettextPlural,
 };
 
 /**

--- a/scripts/core/ui/components/utils.ts
+++ b/scripts/core/ui/components/utils.ts
@@ -16,58 +16,6 @@ export const onEventCapture = (event) => {
 
 /**
  * @ngdoc method
- * @name gettext
- * @param {String} text - the text that will be translated, it supports parameters (see the example)
- * @param {Object} params - dictionary of parameters used in text and their value (see the example)
- * @description Used angular gettext service for displaying localised text on Browser
- *
- * gettext('This item was locked by {{username}}.', {username: 'John'});
- * result -> 'This item was locked by John'
- */
-export const gettext = (text, params = null) => {
-    if (!text) {
-        return '';
-    }
-
-    const injector = angular.element(document.body).injector();
-
-    if (injector) { // in tests this will be empty
-        return injector.get('gettextCatalog').getString(text, params || {});
-    }
-
-    return text;
-};
-
-/**
- * @ngdoc method
- * @name gettextPlural
- * @param {Number} count
- * @param {String} text
- * @param {String} pluralText
- * @param {Object} params
- * @description Used angular gettext service for displaying plural localised text on Browser
- */
-const gettextPlural = (count, text, pluralText, params) => {
-    if (!text) {
-        return '';
-    }
-
-    const injector = angular.element(document.body).injector();
-
-    if (injector) { // in tests this will be empty
-        return injector.get('gettextCatalog').getPlural(count, text, pluralText, params);
-    }
-
-    return text;
-};
-
-export const gettextCatalog = {
-    getString: gettext,
-    getPlural: gettextPlural,
-};
-
-/**
- * @ngdoc method
  * @name scrollListItemIfNeeded
  * @param {number} selectedIndex
  * @param {Object} listRefElement

--- a/scripts/core/ui/constants.ts
+++ b/scripts/core/ui/constants.ts
@@ -1,5 +1,5 @@
 export const LEFT_SIDEBAR_WIDTH = 48;
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export const getGenericErrorMessage = () =>
     gettext('Unknow error occured. Try repeating the action or reloading the page.');

--- a/scripts/core/ui/ui.js
+++ b/scripts/core/ui/ui.js
@@ -1,5 +1,5 @@
 import {mapValues} from 'lodash';
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 /**
  * Gives top shadow for scroll elements

--- a/scripts/core/upload/crop-directive.js
+++ b/scripts/core/upload/crop-directive.js
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 angular.module('superdesk.core.upload.crop', [])
     .directive('sdCrop', ['notify', function(notify) {

--- a/scripts/core/upload/image-crop-directive.ts
+++ b/scripts/core/upload/image-crop-directive.ts
@@ -1,4 +1,4 @@
-import {gettext} from 'core/ui/components/utils';
+import {gettext} from 'core/utils';
 
 export default angular.module('superdesk.core.upload.imagecrop', [
     'superdesk.core.translate',

--- a/scripts/core/utils.ts
+++ b/scripts/core/utils.ts
@@ -32,3 +32,54 @@ export const getSuperdeskType = (event, supportExternalFiles = true) =>
     event.originalEvent.dataTransfer.types.find((name) =>
         name.includes('application/superdesk') || supportExternalFiles && name === 'Files',
     );
+
+    /**
+ * @ngdoc method
+ * @name gettext
+ * @param {String} text - the text that will be translated, it supports parameters (see the example)
+ * @param {Object} params - dictionary of parameters used in text and their value (see the example)
+ * @description Used angular gettext service for displaying localised text on Browser
+ *
+ * gettext('This item was locked by {{username}}.', {username: 'John'});
+ * result -> 'This item was locked by John'
+ */
+export const gettext = (text, params = null) => {
+    if (!text) {
+        return '';
+    }
+
+    const injector = angular.element(document.body).injector();
+
+    if (injector) { // in tests this will be empty
+        return injector.get('gettextCatalog').getString(text, params || {});
+    }
+
+    return text;
+};
+
+/**
+ * @ngdoc method
+ * @name gettextPlural
+ * @param {Number} count
+ * @param {String} text
+ * @param {String} pluralText
+ * @param {Object} params
+ * @description Used angular gettext service for displaying plural localised text on Browser
+ */
+const gettextPlural = (count, text, pluralText, params) => {
+    if (!text) {
+        return '';
+    }
+
+    const injector = angular.element(document.body).injector();
+
+    if (injector) { // in tests this will be empty
+        return injector.get('gettextCatalog').getPlural(count, text, pluralText, params);
+    }
+
+    return text;
+};
+
+export const gettextCatalog = {
+    getPlural: gettextPlural,
+};

--- a/scripts/core/utils.ts
+++ b/scripts/core/utils.ts
@@ -66,7 +66,7 @@ export const gettext = (text, params = null) => {
  * @param {Object} params
  * @description Used angular gettext service for displaying plural localised text on Browser
  */
-const gettextPlural = (count, text, pluralText, params) => {
+const gettextPlural = (count, text, pluralText, params = {}) => {
     if (!text) {
         return '';
     }


### PR DESCRIPTION
Example:

import {gettextCatalog} from 'core/ui/components/utils';

console.log(
gettextCatalog.getPlural(2, "One {{size}} Bird", "{{$count}} {{size}}
Birds", {size: 'large'})
);

Console:
2 large Birds

console.log(
gettextCatalog.getPlural(1, "One {{size}} Bird", "{{$count}} {{size}}
Birds", {size: 'large'})
);

Console:
One large Bird

superdesk.po
msgid "One {{size}} Bird"
msgid_plural "{{$count}} {{size}} Birds"
msgstr[0] ""
msgstr[1] ""