### PR TITLE
[INGEST][SEARCH]use `ingest_provider` instead of source for `go to items

### DIFF
--- a/scripts/apps/ingest/directives/IngestSourcesContent.js
+++ b/scripts/apps/ingest/directives/IngestSourcesContent.js
@@ -494,7 +494,7 @@ export function IngestSourcesContent(ingestSources, notify, api, $location,
                         });
                     } else {
                         $location.path('/search').search(
-                            {repo: 'ingest', source: angular.toJson([provider.source])}
+                            {repo: 'ingest', ingest_provider: provider._id}
                         );
                     }
                 };


### PR DESCRIPTION
`go to items` button shown in ingest settings was using `source` to
filter on ingest. This is not correct, as the source may be modified.
This patch fixes it by using `ingest_provider` which is the stable id of
the provider.

fixes SDESK-3928