### PR TITLE
sync item associations on client

### DIFF
--- a/scripts/core/editor3/store/index.js
+++ b/scripts/core/editor3/store/index.js
@@ -1,7 +1,7 @@
 import {EditorState, convertFromRaw, convertToRaw, ContentState} from 'draft-js';
 import {createStore, applyMiddleware} from 'redux';
 import thunk from 'redux-thunk';
-import {pick} from 'lodash';
+import {pick, get} from 'lodash';
 
 import {toHTML} from 'core/editor3/html';
 import ng from 'core/services/ng';
@@ -110,13 +110,18 @@ export function onChange(contentState, {plainText = false} = {}) {
     const contentStateHighlightsReadyForExport = prepareHighlightsForExport(
         EditorState.createWithContent(contentStateCleaned)
     ).getCurrentContent();
+    const rawState = convertToRaw(contentStateHighlightsReadyForExport);
 
     setFieldMetadata(
         this.item,
         pathToValue,
         fieldsMetaKeys.draftjsState,
-        convertToRaw(contentStateHighlightsReadyForExport)
+        rawState
     );
+
+    if (pathToValue === 'body_html') {
+        syncAssociations(this.item, rawState);
+    }
 
     // example: "extra.customField"
     const pathToValueArray = pathToValue.split(FIELD_KEY_SEPARATOR);
@@ -180,4 +185,26 @@ export function getInitialContent(props) {
     }
 
     return ContentState.createFromText('');
+}
+
+/**
+ * Sync editor embeds in item.associations
+ *
+ * @param {Object} item
+ * @param {RawDraftContentState} rawState
+ */
+function syncAssociations(item, rawState) {
+    const associations = Object.assign({}, item.associations);
+
+    Object.keys(associations).forEach((key) => {
+        if (key.startsWith('editor_')) {
+            associations[key] = null;
+        }
+    });
+
+    Object.keys(rawState.entityMap).forEach((key) => {
+        associations['editor_' + key] = get(rawState.entityMap[key], 'data.media');
+    });
+
+    item.associations = associations;
 }


### PR DESCRIPTION
atm it's done on server on save, but if user publishes without
saving first associations data is missing or incomplete

SDESK-4015