### PR TITLE
fixed: once an improper configuration is introduced, 'Add New source'…

### DIFF
--- a/scripts/apps/ingest/directives/IngestSourcesContent.js
+++ b/scripts/apps/ingest/directives/IngestSourcesContent.js
@@ -341,6 +341,7 @@ export function IngestSourcesContent(ingestSources, notify, api, $location,
 
                 $scope.cancel = function() {
                     $scope.provider = null;
+                    $scope.error = null;
                 };
 
                 $scope.setConfig = function(provider) {


### PR DESCRIPTION
… will display warning on reopening a brand new dialogue (SDESK-1248)