### PR TITLE
(fix): cloneDeep assocations so that diff is calculated on save.

### DIFF
--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.js
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.js
@@ -222,7 +222,7 @@ export function AuthoringDirective(superdesk, superdeskFlags, authoringWorkspace
                     }
 
                     // clonedeep associations so that diff can be calculated for saving next time.
-                    if (res.associations && !_.isEqual($scope.item.associations, res.associations)) {
+                    if (res.associations) {
                         $scope.item.associations = _.cloneDeep(res.associations);
                     }
 


### PR DESCRIPTION
using clonedeep for `assocations` so that diff is calculated on the `authoring.save`.

[SDESK-4104]

These [change](https://github.com/superdesk/superdesk-client-core/blob/master/scripts/apps/authoring/authoring/directives/AuthoringDirective.js#L214) was made recently but removing the change does not solve the problem.

