### PR TITLE
Fix build fot ntb

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,15 +85,7 @@ module.exports = function makeConfig(grunt) {
         module: {
             rules: [
                 {
-                    test: /\.(ts|tsx)$/,
-                    exclude: shouldExclude,
-                    loader: 'ts-loader',
-                    options: {
-                        transpileOnly: false,
-                    },
-                },
-                {
-                    test: /\.(js|jsx)$/,
+                    test: /\.(ts|tsx|js|jsx)$/,
                     exclude: shouldExclude,
                     loader: 'ts-loader',
                     options: {


### PR DESCRIPTION
SDNTB-571

Set `transpileOnly: true` for TypeScript files. Types are checked with `tsc` in lint step so we aren't losing anything by not checking on build.

I'm still not sure why it used to get stuck when building for ntb, but not locally. My only guess is that webpack was trying to transpile typescript files in node_modules somewhere, either in ntb/client/node_modules or ntb/client/node_modules/superdesk-core/node_modules.