### PR TITLE
fix(authoring): Issue pressing Save button twice

### DIFF
--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -211,7 +211,7 @@ export function AuthoringDirective(superdesk, superdeskFlags, authoringWorkspace
             $scope.save = function() {
                 return authoring.save($scope.origItem, $scope.item).then((res) => {
                     $scope.dirty = false;
-                    angular.extend($scope.item, res);
+                    $scope.item = _.merge($scope.item, res);
 
                     if (res.cropData) {
                         $scope.item.hasCrops = true;

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -211,7 +211,7 @@ export function AuthoringDirective(superdesk, superdeskFlags, authoringWorkspace
             $scope.save = function() {
                 return authoring.save($scope.origItem, $scope.item).then((res) => {
                     $scope.dirty = false;
-                    $scope.item = _.merge($scope.item, res);
+                    _.merge($scope.item, res);
 
                     if (res.cropData) {
                         $scope.item.hasCrops = true;


### PR DESCRIPTION
SDESK-4123

Basically once the Save button was pressed, it wouldn't function
properly the following times. It wouldn't save the next changes you
made.

The issue was caused by the `angular.extend` function that was keeping
`origItem` and `item` the same object, and that was making the save
function not see the differences being saved (after you saved once).

`angular.merge` did solve the issue but [it's deprecated](https://docs.angularjs.org/api/ng/function/angular.merge)
and they recommend using `lodash.merge`, which basically does the same
thing (deep copy of properties).