### PR TITLE
fix(search): Fix issue saving changes on search after updating subscriptions

### DIFF
--- a/scripts/apps/search/SavedSearch.ts
+++ b/scripts/apps/search/SavedSearch.ts
@@ -74,7 +74,7 @@ export const updateSubscribers = (
     savedSearch: ISavedSearch,
     nextSubscribers: ISavedSearch['subscribers'],
     api: any,
-): Promise<void> => {
+): Promise<ISavedSearch> => {
     const savedSearchNext: ISavedSearch = {
         ...savedSearch,
         subscribers: nextSubscribers,
@@ -87,7 +87,7 @@ export const unsubscribeUser = (
     savedSearch: ISavedSearch,
     userId: IUser['_id'],
     api: any,
-): Promise<void> => {
+): Promise<ISavedSearch> => {
     const nextSubscribers: ISavedSearch['subscribers'] = {
         ...savedSearch.subscribers,
         user_subscriptions: savedSearch.subscribers.user_subscriptions.filter(
@@ -102,7 +102,7 @@ export const unsubscribeDesk = (
     savedSearch: ISavedSearch,
     deskId: IDesk['_id'],
     api: any,
-): Promise<void> => {
+): Promise<ISavedSearch> => {
     const nextSubscribers: ISavedSearch['subscribers'] = {
         ...savedSearch.subscribers,
         desk_subscriptions: savedSearch.subscribers.desk_subscriptions.filter(

--- a/scripts/apps/search/directives/SaveSearch.ts
+++ b/scripts/apps/search/directives/SaveSearch.ts
@@ -2,19 +2,19 @@ import {create, clone, each} from 'lodash';
 import {saveOrUpdateSavedSearch} from '../SavedSearch';
 import {gettext} from 'core/utils';
 import {isEmptyString} from 'core/helpers/utils';
-SaveSearch.$inject = ['$location', 'asset', 'api', 'session', 'notify', '$rootScope'];
+SaveSearch.$inject = ['$location', 'asset', 'api', 'notify', '$rootScope'];
 
 /**
  * Opens and manages save search panel
  */
-export function SaveSearch($location, asset, api, session, notify, $rootScope) {
+export function SaveSearch($location, asset, api, notify, $rootScope) {
     return {
         templateUrl: asset.templateUrl('apps/search/views/save-search.html'),
-        link: function(scope, elem) {
+        link: function(scope, _elem) {
             scope.edit = null;
             scope.activateSearchPane = false;
 
-            scope.$on('edit:search', (event, args) => {
+            scope.$on('edit:search', (_event, args) => {
                 scope.activateSearchPane = false;
                 scope.editingSearch = args;
                 scope.edit = create(scope.editingSearch) || {};
@@ -51,7 +51,7 @@ export function SaveSearch($location, asset, api, session, notify, $rootScope) {
             scope.clear = function() {
                 scope.editingSearch = false;
                 scope.edit = null;
-                each($location.search(), (item, key) => {
+                each($location.search(), (_item, key) => {
                     if (key !== 'repo') {
                         $location.search(key, null);
                     }

--- a/scripts/apps/search/directives/SavedSearchManageSubscribers.ts
+++ b/scripts/apps/search/directives/SavedSearchManageSubscribers.ts
@@ -227,12 +227,13 @@ export function SavedSearchManageSubscribers(asset, userList, api, modal, desks)
                 modal.confirm(
                     gettext('Are you sure to remove this subscription?'),
                     gettext('Unsubscribe desk'),
-                ).then(() => {
-                    unsubscribeDesk(
+                ).then(async () => {
+                    const updatedSearch = await unsubscribeDesk(
                         scope.savedSearch,
                         desk._id,
                         api,
                     );
+                    scope.onSubscriptionsChange(updatedSearch);
                 });
 
             scope.editUserSubscription = (user: IUser) => {

--- a/scripts/apps/search/directives/SavedSearchManageSubscribers.ts
+++ b/scripts/apps/search/directives/SavedSearchManageSubscribers.ts
@@ -36,7 +36,8 @@ function isDeskSubscription(x: IModel['subscriptionInCreateOrEditMode']): x is I
 
 interface IScope extends IDirectiveScope<IModel> {
     savedSearch: ISavedSearch;
-    manageSubscriptions(active: boolean): void;
+    setIsManagingSubscriptions(active: boolean): void;
+    onSubscriptionsChange(nextValue: ISavedSearch): void;
     unsubscribeUser(user: IUser): Promise<void>;
     unsubscribeDesk(desk: IDesk): Promise<void>;
     editUserSubscription(user: IUser): void;
@@ -60,7 +61,8 @@ export function SavedSearchManageSubscribers(asset, userList, api, modal, desks)
     return {
         scope: {
             savedSearch: '=',
-            manageSubscriptions: '=',
+            setIsManagingSubscriptions: '=',
+            onSubscriptionsChange: '=',
         },
         templateUrl: asset.templateUrl('apps/search/views/saved-search-manage-subscribers.html'),
         link: function(scope: IScope) {
@@ -194,7 +196,11 @@ export function SavedSearchManageSubscribers(asset, userList, api, modal, desks)
                     desk_subscriptions: nextDeskSubscriptions,
                 };
 
-                updateSubscribers(scope.savedSearch, nextSubscribers, api).then(scope.backToList);
+                updateSubscribers(scope.savedSearch, nextSubscribers, api)
+                    .then((newSavedSearch: ISavedSearch) => {
+                        scope.onSubscriptionsChange(newSavedSearch)
+                        scope.backToList()
+                    });
             };
 
             scope.handleIntervalChange = (cronExpression: CronTimeInterval) => {
@@ -279,7 +285,7 @@ export function SavedSearchManageSubscribers(asset, userList, api, modal, desks)
                 () => {
                     // when modal is closed via ESC key, stop managing subscription so it can be started again.
                     if (!scope.wrapper.modalOpen) {
-                        scope.manageSubscriptions(false);
+                        scope.setIsManagingSubscriptions(false);
                     }
                 },
             );

--- a/scripts/apps/search/directives/SavedSearchManageSubscribers.ts
+++ b/scripts/apps/search/directives/SavedSearchManageSubscribers.ts
@@ -214,12 +214,13 @@ export function SavedSearchManageSubscribers(asset, userList, api, modal, desks)
                 modal.confirm(
                     gettext('Are you sure to remove this subscription?'),
                     gettext('Unsubscribe user'),
-                ).then(() => {
-                    unsubscribeUser(
+                ).then(async () => {
+                    const updatedSearch = await unsubscribeUser(
                         scope.savedSearch,
                         user._id,
                         api,
                     );
+                    scope.onSubscriptionsChange(updatedSearch);
                 });
 
             scope.unsubscribeDesk = (desk: IDesk) =>

--- a/scripts/apps/search/directives/SavedSearchManageSubscribers.ts
+++ b/scripts/apps/search/directives/SavedSearchManageSubscribers.ts
@@ -214,27 +214,21 @@ export function SavedSearchManageSubscribers(asset, userList, api, modal, desks)
                 modal.confirm(
                     gettext('Are you sure to remove this subscription?'),
                     gettext('Unsubscribe user'),
-                ).then(async () => {
-                    const updatedSearch = await unsubscribeUser(
-                        scope.savedSearch,
-                        user._id,
-                        api,
-                    );
-                    scope.onSubscriptionsChange(updatedSearch);
-                });
+                ).then(() =>
+                    unsubscribeUser(scope.savedSearch, user._id, api),
+                ).then((updatedSearch: ISavedSearch) =>
+                    scope.onSubscriptionsChange(updatedSearch),
+                );
 
             scope.unsubscribeDesk = (desk: IDesk) =>
                 modal.confirm(
                     gettext('Are you sure to remove this subscription?'),
                     gettext('Unsubscribe desk'),
-                ).then(async () => {
-                    const updatedSearch = await unsubscribeDesk(
-                        scope.savedSearch,
-                        desk._id,
-                        api,
-                    );
-                    scope.onSubscriptionsChange(updatedSearch);
-                });
+                ).then(() =>
+                    unsubscribeDesk(scope.savedSearch, desk._id, api),
+                ).then((updatedSearch) =>
+                    scope.onSubscriptionsChange(updatedSearch),
+                );
 
             scope.editUserSubscription = (user: IUser) => {
                 scope.wrapper.subscriptionInCreateOrEditMode = scope.savedSearch.subscribers.user_subscriptions.find(

--- a/scripts/apps/search/directives/SavedSearchManageSubscribers.ts
+++ b/scripts/apps/search/directives/SavedSearchManageSubscribers.ts
@@ -198,8 +198,8 @@ export function SavedSearchManageSubscribers(asset, userList, api, modal, desks)
 
                 updateSubscribers(scope.savedSearch, nextSubscribers, api)
                     .then((newSavedSearch: ISavedSearch) => {
-                        scope.onSubscriptionsChange(newSavedSearch)
-                        scope.backToList()
+                        scope.onSubscriptionsChange(newSavedSearch);
+                        scope.backToList();
                     });
             };
 

--- a/scripts/apps/search/directives/SavedSearches.ts
+++ b/scripts/apps/search/directives/SavedSearches.ts
@@ -12,7 +12,7 @@ import {gettext} from 'core/utils';
 
 SavedSearches.$inject = [
     '$rootScope', 'api', 'session', 'modal', 'notify', 'asset',
-    '$location', 'desks', 'privileges', 'search', 'savedSearch', 'config',
+    '$location', 'desks', 'privileges', 'savedSearch', 'config',
 ];
 
 interface ISavedSearchesScope extends ng.IScope {
@@ -39,7 +39,7 @@ interface ISavedSearchesScope extends ng.IScope {
 }
 
 export function SavedSearches($rootScope, api, session, modal, notify, asset, $location,
-    desks, privileges, search, savedSearch, config): ng.IDirective {
+    desks, privileges, savedSearch, config): ng.IDirective {
     return {
         templateUrl: asset.templateUrl('apps/search/views/saved-searches.html'),
         scope: {},

--- a/scripts/apps/search/directives/SearchPanel.ts
+++ b/scripts/apps/search/directives/SearchPanel.ts
@@ -68,7 +68,7 @@ export function SearchPanel($location,
             scope.onSubscriptionsChange = (udpatedSavedSearch) => {
                 // subscriptions were updated via API so the etag has changed
                 scope.editingSearch._etag = udpatedSavedSearch._etag;
-            }
+            };
 
             scope.aggregations = {};
             scope.privileges = privileges.privileges;

--- a/scripts/apps/search/directives/SearchPanel.ts
+++ b/scripts/apps/search/directives/SearchPanel.ts
@@ -66,7 +66,7 @@ export function SearchPanel($location,
 
             // called after changing the subscriptions for current search
             scope.onSubscriptionsChange = (updatedSavedSearch) => {
-                // subscriptions were updated via API so the etag has changed
+                // subscriptions were updated via API so the object has changed
                 for (const key in updatedSavedSearch) {
                     scope.editingSearch[key] = updatedSavedSearch[key]
                 }

--- a/scripts/apps/search/directives/SearchPanel.ts
+++ b/scripts/apps/search/directives/SearchPanel.ts
@@ -65,9 +65,11 @@ export function SearchPanel($location,
             };
 
             // called after changing the subscriptions for current search
-            scope.onSubscriptionsChange = (udpatedSavedSearch) => {
+            scope.onSubscriptionsChange = (updatedSavedSearch) => {
                 // subscriptions were updated via API so the etag has changed
-                scope.editingSearch._etag = udpatedSavedSearch._etag;
+                for (const key in updatedSavedSearch) {
+                    scope.editingSearch[key] = updatedSavedSearch[key]
+                }
             };
 
             scope.aggregations = {};

--- a/scripts/apps/search/directives/SearchPanel.ts
+++ b/scripts/apps/search/directives/SearchPanel.ts
@@ -68,7 +68,7 @@ export function SearchPanel($location,
             scope.onSubscriptionsChange = (updatedSavedSearch) => {
                 // subscriptions were updated via API so the object has changed
                 for (const key in updatedSavedSearch) {
-                    scope.editingSearch[key] = updatedSavedSearch[key]
+                    scope.editingSearch[key] = updatedSavedSearch[key];
                 }
             };
 

--- a/scripts/apps/search/directives/SearchPanel.ts
+++ b/scripts/apps/search/directives/SearchPanel.ts
@@ -8,7 +8,6 @@ import _, {cloneDeep} from 'lodash';
  * @requires $location
  * @requires desks
  * @requires privileges
- * @requires tags
  * @requires asset
  * @requires metadata
  * @requires $rootScope
@@ -23,7 +22,6 @@ SearchPanel.$inject = [
     '$location',
     'desks',
     'privileges',
-    'tags',
     'asset',
     'metadata',
     '$rootScope',
@@ -34,7 +32,6 @@ SearchPanel.$inject = [
 export function SearchPanel($location,
     desks,
     privileges,
-    tags,
     asset,
     metadata,
     $rootScope,
@@ -63,16 +60,22 @@ export function SearchPanel($location,
             scope.isManagingSubscriptions = false;
             scope.wrapper = {};
 
-            scope.manageSubscriptions = (nextValue) => {
+            scope.setIsManagingSubscriptions = (nextValue: boolean) => {
                 scope.isManagingSubscriptions = nextValue;
             };
+
+            // called after changing the subscriptions for current search
+            scope.onSubscriptionsChange = (udpatedSavedSearch) => {
+                // subscriptions were updated via API so the etag has changed
+                scope.editingSearch._etag = udpatedSavedSearch._etag;
+            }
 
             scope.aggregations = {};
             scope.privileges = privileges.privileges;
             scope.userHasPrivileges = privileges.userHasPrivileges;
             scope.search_config = metadata.search_config;
 
-            scope.$on('edit:search', (event, args) => {
+            scope.$on('edit:search', (_event, args) => {
                 scope.sTab = 'advancedSearch';
                 scope.innerTab = 'parameters';
                 scope.activateSearchPane = false;

--- a/scripts/apps/search/views/saved-search-manage-subscribers.html
+++ b/scripts/apps/search/views/saved-search-manage-subscribers.html
@@ -1,6 +1,6 @@
 <div sd-modal class="modal" data-model="wrapper.modalOpen" on-modal-close="onInternalModalClose">
     <div class="modal__header">
-        <a href="" class="close" ng-click="manageSubscriptions(false)"><i class="icon-close-small"></i></a>
+        <a href="" class="close" ng-click="setIsManagingSubscriptions(false)"><i class="icon-close-small"></i></a>
         <h3 class="modal__heading">
             <span translate>Manage: </span>
             <strong>{{savedSearch.name}}</strong>

--- a/scripts/apps/search/views/search-panel.html
+++ b/scripts/apps/search/views/search-panel.html
@@ -5,13 +5,13 @@
       </div>
         <ul ng-show="!editingSearch || activateSearchPane">
             <li ng-class="{active: sTab === 'advancedSearch'}" ng-click="changeTab('advancedSearch')" translate>Advanced Search</li>
-            <li id="saved_searches_tab" 
-                ng-show="privileges.saved_searches == 1" 
-                ng-class="{active: sTab === 'savedSearches'}" 
+            <li id="saved_searches_tab"
+                ng-show="privileges.saved_searches == 1"
+                ng-class="{active: sTab === 'savedSearches'}"
                 ng-click="changeTab('savedSearches')" translate>Saved
             </li>
             <li id="raw_search_tab"
-                ng-if="isAdmin()" 
+                ng-if="isAdmin()"
                 ng-class="{active: sTab === 'rawSearch'}"
                 ng-click="changeTab('rawSearch')"
                 translate>Raw</li>
@@ -31,12 +31,13 @@
                     </strong>
                     <span translate>subscriptions</span>
                 </span>
-                <button class="btn btn--small btn--hollow" ng-click="manageSubscriptions(true)" translate>Manage</button>
+                <button class="btn btn--small btn--hollow" ng-click="setIsManagingSubscriptions(true)" translate>Manage</button>
             </div>
 
             <div
                 ng-if="isManagingSubscriptions"
-                manage-subscriptions="manageSubscriptions"
+                set-is-managing-subscriptions="setIsManagingSubscriptions"
+                on-subscriptions-change="onSubscriptionsChange"
                 sd-saved-search-manage-subscribers data-saved-search="wrapper.edit"></div>
 
             <form name="viewsForm">


### PR DESCRIPTION
SDESK-4183

Pressing 'Save changes' was causing an error only after user had changed
subscriptions for the current search. The issue was that saving the
subscriptions was changing the `etag` in the server but the current search
on the client was not being udpated.

As you can see in the code I didn't replace the whole object with the
updated one as the user might lose any changes to the current search
that's being edited, so I just udpated the `etag`.