### PR TITLE
fix(authoring): add missing error indicator on custom required fields

### DIFF
--- a/scripts/apps/authoring/authoring/article-url-fields.tsx
+++ b/scripts/apps/authoring/authoring/article-url-fields.tsx
@@ -13,6 +13,7 @@ interface IProps {
     fieldId: string;
     onChange: (fieldId: string, urls: Array<IUrl>) => void;
     editable: boolean;
+    required: boolean;
 }
 
 interface IState {
@@ -58,11 +59,14 @@ export class ArticleUrlFields extends React.Component<IProps, IState> {
         });
     }
     render() {
-        const {label, helperText, editable} = this.props;
+        const {label, helperText, editable, required} = this.props;
 
         return (
             <div>
                 <label className="field__label">{label}</label>
+                {editable && required && (
+                    <span className="sd-required">{gettext('Required')}</span>
+                )}
 
                 {this.state.urls.map((item, i) => (
                     <div key={i}>

--- a/scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts
@@ -395,6 +395,7 @@ export function ArticleEditDirective(
                                 scope.editor = authoring.editor = content.editor(type, scope.item.type);
                                 scope.schema = authoring.schema = content.schema(type, scope.item.type);
                                 scope.fields = content.fields(type);
+                                console.info('schema', scope.schema, scope.editor);
                             });
                     } else {
                         scope.editor = authoring.editor = content.editor(null, scope.item.type);

--- a/scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts
@@ -395,7 +395,6 @@ export function ArticleEditDirective(
                                 scope.editor = authoring.editor = content.editor(type, scope.item.type);
                                 scope.schema = authoring.schema = content.schema(type, scope.item.type);
                                 scope.fields = content.fields(type);
-                                console.info('schema', scope.schema, scope.editor);
                             });
                     } else {
                         scope.editor = authoring.editor = content.editor(null, scope.item.type);

--- a/scripts/apps/authoring/authoring/index.ts
+++ b/scripts/apps/authoring/authoring/index.ts
@@ -82,7 +82,10 @@ angular.module('superdesk.apps.authoring', [
     .directive('tansaScopeSync', directive.TansaScopeSyncDirective)
     .directive('sdItemActionByIntent', directive.ItemActionsByIntentDirective)
     .component('sdArticleUrlFields',
-        reactToAngular1(ArticleUrlFields, ['label', 'urls', 'helperText', 'onChange', 'fieldId', 'editable']),
+        reactToAngular1(
+            ArticleUrlFields,
+            ['label', 'urls', 'helperText', 'onChange', 'fieldId', 'editable', 'required'],
+        ),
     )
 
     .controller('PopulateAuthorsController', PopulateAuthorsController)

--- a/scripts/apps/authoring/views/article-edit.html
+++ b/scripts/apps/authoring/views/article-edit.html
@@ -550,7 +550,7 @@
     sd-width="{{ editor[field._id].sdWidth || 'full' }}"
     data-required="schema[field._id].required"
     order="{{ editor[field._id].order }}"
-    sd-validation-error="error[field._id.toLowerCase()]">
+    sd-validation-error="error[field.display_name.toLowerCase()]">
 
     <label class="field__label">{{field.display_name}}</label>
     <span ng-if="schema[field._id].maxlength || schema[field._id].minlength" sd-character-count
@@ -678,7 +678,7 @@
 <div class="field" ng-repeat="field in fields track by field._id"
     ng-if="field.field_type === 'urls'"
     sd-width="{{editor[field._id].sdWidth || 'full'}}"
-    sd-validation-error="error[field._id.toLowerCase()]"
+    sd-validation-error="error[field.display_name.toLowerCase()]"
     order="{{editor[field._id].order}}"
     data-required="schema[field._id].required">
 
@@ -688,7 +688,9 @@
         helper-text="helper_text[field._id]"
         field-id="field._id"
         urls="item.extra[field._id]"
-        on-change="handleUrlsChange"></sd-article-url-fields>
+        on-change="handleUrlsChange"
+        required="schema[field._id].required"
+        ></sd-article-url-fields>
 </div>
 
 <div class="field"


### PR DESCRIPTION
it was using _id to find out if there is an error, but server sends
display name instead for custom fields.

SDESK-2390