### PR TITLE
fixed: Broken media gallery. (SDESK-4201)

### DIFF
--- a/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
@@ -73,8 +73,10 @@ export function ItemCarouselDirective($timeout, notify) {
                         carousel.trigger('destroy.owl.carousel');
                     }
 
-                    const carouselImages = Array.from(elem.get(0).querySelectorAll(`${carouselContainerSelector} img`));
-                    const carouselAudiosAndVideos = Array.from(
+                    const carouselImages: Array<HTMLImageElement> = Array.from(
+                        elem.get(0).querySelectorAll(`${carouselContainerSelector} img`),
+                    );
+                    const carouselAudiosAndVideos: Array<HTMLAudioElement | HTMLVideoElement> = Array.from(
                         elem.get(0).querySelectorAll(
                             `${carouselContainerSelector} video, ${carouselContainerSelector} audio`,
                         ),

--- a/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
@@ -86,10 +86,9 @@ export function ItemCarouselDirective($timeout, notify) {
                         return;
                     }
 
-                    Promise.all([
-                        waitForMediaToLoad(carouselImages),
-                        waitForMediaToLoad(carouselAudiosAndVideos),
-                    ]).then(initCarousel);
+                    const mediaItems = carouselImages.concat(carouselAudiosAndVideos);
+
+                    waitForMediaToLoad(mediaItems).then(initCarousel);
                 });
             });
             /*

--- a/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
@@ -85,10 +85,8 @@ export function ItemCarouselDirective($timeout, notify) {
                     }
 
                     Promise.all([
-                        waitForMediaToLoad(carouselImages.filter(
-                            (img: HTMLImageElement) => img.complete === false), 'load'),
-                        waitForMediaToLoad(carouselAudiosAndVideos.filter(
-                            (media: HTMLAudioElement | HTMLVideoElement) => media.readyState < 1), 'loadedmetadata'),
+                        waitForMediaToLoad(carouselImages),
+                        waitForMediaToLoad(carouselAudiosAndVideos),
                     ]).then(initCarousel);
                 });
             });

--- a/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
@@ -3,7 +3,7 @@
 import 'owl.carousel';
 import _ from 'lodash';
 import * as ctrl from '../controllers';
-import {waitForImagesToLoad, waitForAudioAndVideoToLoadMetadata} from 'core/helpers/waitForMediaToBeReady';
+import {waitForMediaToLoad} from 'core/helpers/waitForMediaToBeReady';
 import {getSuperdeskType} from 'core/utils';
 import {gettext} from 'core/utils';
 
@@ -85,8 +85,10 @@ export function ItemCarouselDirective($timeout, notify) {
                     }
 
                     Promise.all([
-                        waitForImagesToLoad(carouselImages),
-                        waitForAudioAndVideoToLoadMetadata(carouselAudiosAndVideos),
+                        waitForMediaToLoad(carouselImages.filter(
+                            (img: HTMLImageElement) => img.complete === false), 'load'),
+                        waitForMediaToLoad(carouselAudiosAndVideos.filter(
+                            (media: HTMLAudioElement | HTMLVideoElement) => media.readyState < 1), 'loadedmetadata'),
                     ]).then(initCarousel);
                 });
             });

--- a/scripts/core/helpers/utils.tsx
+++ b/scripts/core/helpers/utils.tsx
@@ -24,3 +24,15 @@ export function pick<T, K extends keyof T>(obj: T, ...keys: Array<K>): Pick<T, K
 
     return picked;
 }
+
+export function isImage(e: Element): e is HTMLImageElement {
+    return e.tagName === 'IMG';
+}
+
+export function isAudio(e: Element): e is HTMLAudioElement {
+    return e.tagName === 'AUDIO';
+}
+
+export function isVideo(e: Element): e is HTMLVideoElement {
+    return e.tagName === 'VIDEO';
+}

--- a/scripts/core/helpers/waitForMediaToBeReady.ts
+++ b/scripts/core/helpers/waitForMediaToBeReady.ts
@@ -1,9 +1,9 @@
 /**
- * @param {Array<Node>} elements
- * @param {string} eventName
+ * @param elements An array of img, audio and video elements
+ * @param eventName EventListener's name
  */
-const waitForEventToFireForAllElements = (elements, eventName) => new Promise((resolve) => {
-    let itemsLeftToLoad = elements.length;
+export const waitForMediaToLoad = (elements: Array<any>, eventName: string): Promise<void> => new Promise((resolve) => {
+    let itemsLeftToLoad: number = elements.length;
 
     if (itemsLeftToLoad === 0) {
         resolve();
@@ -32,15 +32,3 @@ const waitForEventToFireForAllElements = (elements, eventName) => new Promise((r
         element.addEventListener(eventName, eventHandler);
     });
 });
-
-/**
- * @param {Array<Node>} elements
- */
-export const waitForImagesToLoad =
-    (elements) => waitForEventToFireForAllElements(elements.filter((img) => img.complete === false), 'load');
-
-/**
- * @param {Array<Node>} elements
- */
-export const waitForAudioAndVideoToLoadMetadata =
-    (elements) => waitForEventToFireForAllElements(elements.filter((media) => media.readyState < 1), 'loadedmetadata');

--- a/scripts/core/helpers/waitForMediaToBeReady.ts
+++ b/scripts/core/helpers/waitForMediaToBeReady.ts
@@ -1,9 +1,17 @@
 /**
  * @param elements An array of img, audio and video elements
- * @param eventName EventListener's name
  */
-export const waitForMediaToLoad = (elements: Array<any>, eventName: string): Promise<void> => new Promise((resolve) => {
-    let itemsLeftToLoad: number = elements.length;
+export const waitForMediaToLoad = (elements: Array<Element>): Promise<void> => new Promise((resolve) => {
+    // EventListener's name
+    let eventName: string = 'load';
+
+    const filteredElelemnts = elements.filter((element: Element) => {
+        if (element.tagName === 'IMG') {
+            return element.complete === false;
+        }
+        return element.readyState < 1;
+    });
+    let itemsLeftToLoad: number = filteredElelemnts.length;
 
     if (itemsLeftToLoad === 0) {
         resolve();
@@ -19,11 +27,12 @@ export const waitForMediaToLoad = (elements: Array<any>, eventName: string): Pro
         }
     };
 
-    elements.forEach((element) => {
-        // check for error in image src
+    filteredElelemnts.forEach((element: Element) => {
         if (element.tagName === 'IMG') {
+            // check for error in image src
             element.addEventListener('error', eventHandler, {once: true});
         } else {
+            eventName = 'loadedmetadata';
             // for audio and video check for the error in source
             const source = element.getElementsByTagName('source')[0];
 

--- a/scripts/core/helpers/waitForMediaToBeReady.ts
+++ b/scripts/core/helpers/waitForMediaToBeReady.ts
@@ -5,11 +5,14 @@ import {isImage, isAudio, isVideo} from './utils';
  */
 export const waitForMediaToLoad = (elements: Array<HTMLImageElement | HTMLAudioElement | HTMLVideoElement>):
 Promise<void> => new Promise((resolve) => {
-    const filteredElements = elements.filter((element) => { // eslint-disable-line array-callback-return
+    const filteredElements = elements.filter((element) => {
         if (isImage(element)) {
             return element.complete === false;
         } else if (isAudio(element) || isVideo(element)) {
             return element.readyState < 1;
+        } else {
+            logger.error(new Error('Unexpected element type'));
+            return false;
         }
     });
     let itemsLeftToLoad: number = filteredElements.length;

--- a/scripts/core/helpers/waitForMediaToBeReady.ts
+++ b/scripts/core/helpers/waitForMediaToBeReady.ts
@@ -10,9 +10,9 @@ const waitForEventToFireForAllElements = (elements, eventName) => new Promise((r
         return;
     }
 
-    const onItemLoaded = (event) => {
+    const eventHandler = (event) => {
         itemsLeftToLoad--;
-        event.target.removeEventListener(eventName, onItemLoaded);
+        event.target.removeEventListener(eventName, eventHandler);
 
         if (itemsLeftToLoad === 0) {
             resolve();
@@ -20,7 +20,16 @@ const waitForEventToFireForAllElements = (elements, eventName) => new Promise((r
     };
 
     elements.forEach((element) => {
-        element.addEventListener(eventName, onItemLoaded);
+        // check for error in image src
+        if (element.tagName === 'IMG') {
+            element.addEventListener('error', eventHandler, {once: true});
+        } else {
+            // for audio and video check for the error in source
+            const source = element.getElementsByTagName('source')[0];
+
+            source.addEventListener('error', eventHandler, {once: true});
+        }
+        element.addEventListener(eventName, eventHandler);
     });
 });
 

--- a/scripts/core/helpers/waitForMediaToBeReady.ts
+++ b/scripts/core/helpers/waitForMediaToBeReady.ts
@@ -1,13 +1,16 @@
+import {isImage, isAudio, isVideo} from './utils';
+
 /**
  * @param elements An array of img, audio and video elements
  */
 export const waitForMediaToLoad = (elements: Array<HTMLImageElement | HTMLAudioElement | HTMLVideoElement>):
 Promise<void> => new Promise((resolve) => {
-    const filteredElements = elements.filter((element) => {
+    const filteredElements = elements.filter((element) => { // eslint-disable-line array-callback-return
         if (isImage(element)) {
             return element.complete === false;
+        } else if (isAudio(element) || isVideo(element)) {
+            return element.readyState < 1;
         }
-        return element.readyState < 1;
     });
     let itemsLeftToLoad: number = filteredElements.length;
 
@@ -37,15 +40,3 @@ Promise<void> => new Promise((resolve) => {
         element.addEventListener(isImage(element) ? 'load' : 'loadedmetadata', eventHandler, {once: true});
     });
 });
-
-export function isImage(e: Element): e is HTMLImageElement {
-    return e.tagName === 'IMG';
-}
-
-export function isAudio(e: Element): e is HTMLAudioElement {
-    return e.tagName === 'AUDIO';
-}
-
-export function isVideo(e: Element): e is HTMLVideoElement {
-    return e.tagName === 'VIDEO';
-}

--- a/scripts/core/helpers/waitForMediaToBeReady.ts
+++ b/scripts/core/helpers/waitForMediaToBeReady.ts
@@ -34,12 +34,13 @@ Promise<void> => new Promise((resolve) => {
         if (isImage(element)) {
             // check for error in image src
             element.addEventListener('error', eventHandler, {once: true});
+            element.addEventListener('load', eventHandler, {once: true});
         } else if (isAudio(element) || isVideo(element)) {
             // for audio and video check for the error in source
             const source = element.getElementsByTagName('source')[0];
 
             source.addEventListener('error', eventHandler, {once: true});
+            element.addEventListener('loadedmetadata', eventHandler, {once: true});
         }
-        element.addEventListener(isImage(element) ? 'load' : 'loadedmetadata', eventHandler, {once: true});
     });
 });


### PR DESCRIPTION
If the media element is not found in the source URL, the `load` and `loadedmetadata` eventListener does not fire the callback. Due to this promise never gets resolved. So, now checking for the errors in source URL, if there are any then call the same callback function.