### PR TITLE
Improve spellchecker interface

### DIFF
--- a/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
@@ -86,7 +86,8 @@ export function ItemCarouselDirective($timeout, notify) {
                         return;
                     }
 
-                    const mediaItems = carouselImages.concat(carouselAudiosAndVideos);
+                    const mediaItems: Array<HTMLAudioElement | HTMLVideoElement | HTMLImageElement> =
+                        [].concat(carouselImages).concat(carouselAudiosAndVideos);
 
                     waitForMediaToLoad(mediaItems).then(initCarousel);
                 });

--- a/scripts/apps/search/MultiImageEdit.ts
+++ b/scripts/apps/search/MultiImageEdit.ts
@@ -108,7 +108,7 @@ export function MultiImageEditController(
         }
 
         saveHandler(imagesForSaving)
-            .then((res) => {
+            .then((res: any) => {
                 if (res != null) {
                     $scope.images = angular.copy(Array.isArray(res) && res.length > 0 ? res : [res]);
                 }

--- a/scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx
+++ b/scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx
@@ -47,7 +47,7 @@ export class SpellcheckerContextMenuComponent extends React.Component<IProps> {
                                                     text: this.props.warning.text,
                                                     offset: this.props.warning.startOffset,
                                                 },
-                                                newWord: suggestion,
+                                                newWord: suggestion.text,
                                             }));
                                         }}
                                         data-test-id="spellchecker-menu--suggestion"

--- a/scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx
+++ b/scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx
@@ -52,7 +52,7 @@ export class SpellcheckerContextMenuComponent extends React.Component<IProps> {
                                         }}
                                         data-test-id="spellchecker-menu--suggestion"
                                     >
-                                        {suggestion}
+                                        {suggestion.text}
                                     </button>
                                 </li>,
                             )

--- a/scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx
+++ b/scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx
@@ -1,5 +1,5 @@
 import ng from 'core/services/ng';
-import {ISpellchecker, ISpellcheckerAction, ISpellcheckWarning} from './interfaces';
+import {ISpellchecker, ISpellcheckerAction, ISpellcheckWarning, ISpellcheckerSuggestion} from './interfaces';
 
 const actions: {[key: string]: ISpellcheckerAction} = {
     addToDictionary: {
@@ -16,10 +16,10 @@ const actions: {[key: string]: ISpellcheckerAction} = {
     },
 };
 
-function getSuggestions(text: string): Promise<Array<string>> {
+function getSuggestions(text: string): Promise<Array<ISpellcheckerSuggestion>> {
     return ng.getService('spellcheck')
         .then((spellcheck) => spellcheck.suggest(text))
-        .then((result) => result.map(({value}) => value));
+        .then((result: Array<{value: string}>) => result.map(({value}) => ({text: value})));
 }
 
 function check(str: string): Promise<Array<ISpellcheckWarning>> {

--- a/scripts/core/editor3/components/spellchecker/interfaces.ts
+++ b/scripts/core/editor3/components/spellchecker/interfaces.ts
@@ -1,3 +1,7 @@
+export interface ISpellcheckerSuggestion {
+    text: string;
+}
+
 export interface ISpellcheckWarning {
     // zero-based, line-break agnostic index
     startOffset: number;
@@ -8,7 +12,7 @@ export interface ISpellcheckWarning {
     // list of text fragments suggested to replace offending text fragment.
     // Can consist of multiple words. Can NOT span multiple paragraphs.
     // Can be omited if `ISpellchecker['getSuggestions']` method is defined.
-    suggestions?: Array<string>;
+    suggestions?: Array<ISpellcheckerSuggestion>;
 }
 
 export interface ISpellcheckerAction {
@@ -22,7 +26,7 @@ export interface ISpellchecker {
 
     // text - formatting-free text, must be single-line
     // can be ommited if suggestions are provided in `ISpellcheckWarning`s returned from the `check` method.
-    getSuggestions?(text: string): Promise<Array<string>>;
+    getSuggestions?(text: string): Promise<Array<ISpellcheckerSuggestion>>;
 
     actions: {[key: string]: ISpellcheckerAction};
 }

--- a/scripts/core/editor3/components/tests/spellchecker.spec.tsx
+++ b/scripts/core/editor3/components/tests/spellchecker.spec.tsx
@@ -7,20 +7,21 @@ import {EditorState, ContentState} from 'draft-js';
 import editorReducers from 'core/editor3/reducers';
 import {Editor3} from '..';
 import {noop} from 'lodash';
+import {ISpellchecker} from '../spellchecker/interfaces';
 
 const editorStateInitial = EditorState.createWithContent(ContentState.createFromText('This speling is not correkt.'));
 
-const testSpellchecker = {
+const testSpellchecker: ISpellchecker = {
     check: () => Promise.resolve([
         {
             startOffset: 5,
             text: 'speling',
-            suggestions: ['spelling'],
+            suggestions: [{text: 'spelling'}],
         },
         {
             startOffset: 20,
             text: 'correkt',
-            suggestions: ['correct', 'incorrect'],
+            suggestions: [{text: 'correct'}, {text: 'incorrect'}],
         },
     ]),
     actions: {

--- a/scripts/core/helpers/waitForMediaToBeReady.ts
+++ b/scripts/core/helpers/waitForMediaToBeReady.ts
@@ -1,4 +1,5 @@
 import {isImage, isAudio, isVideo} from './utils';
+import {logger} from 'core/services/logger';
 
 /**
  * @param elements An array of img, audio and video elements

--- a/scripts/core/spellcheck/spellcheck.ts
+++ b/scripts/core/spellcheck/spellcheck.ts
@@ -5,7 +5,7 @@ SpellcheckService.$inject = ['$q', 'api', 'dictionaries', '$rootScope', '$locati
 function SpellcheckService($q, api, dictionaries, $rootScope, $location, _, preferencesService) {
     var PREFERENCES_KEY = 'spellchecker:status',
         lang,
-        dict = {},
+        dict = {} as any,
         ignored = {},
         abbreviationList = [],
         self;


### PR DESCRIPTION
SDBELGA-109

Refactor spellchecker suggestion to be an object instead of a string. It will be easier to add different types of suggestions in the future.