### PR TITLE
fix(editor3): fix typo in generated html

### DIFF
--- a/scripts/core/editor3/html/tests/to-html.spec.ts
+++ b/scripts/core/editor3/html/tests/to-html.spec.ts
@@ -89,7 +89,7 @@ describe('core.editor3.html.to-html snapshots', () => {
 `<!-- EMBED START Image {id: "editor_0"} -->
 <figure>
     <img src="http://localhost:5000/api/upload-raw/5c9d03dd149f116747b6730f.jpg" alt="pin alt" />
-    <figcatpion>pin dec</figcaption>
+    <figcaption>pin dec</figcaption>
 </figure>
 <!-- EMBED END Image {id: "editor_0"} -->`
         );
@@ -334,7 +334,7 @@ describe('core.editor3.html.to-html.AtomicBlockParser', () => {
 `<!-- EMBED START Image {id: "editor_0"} -->
 <figure>
     <img src="image_href" alt="image_alt_text" />
-    <figcatpion>image_description</figcaption>
+    <figcaption>image_description</figcaption>
 </figure>
 <!-- EMBED END Image {id: "editor_0"} -->`);
     });

--- a/scripts/core/editor3/html/to-html/AtomicBlockParser.ts
+++ b/scripts/core/editor3/html/to-html/AtomicBlockParser.ts
@@ -121,7 +121,7 @@ export class AtomicBlockParser {
 
         if (desc) {
             // eslint-disable-next-line
-            content += `\n    <figcatpion>${desc}</figcaption>`;
+            content += `\n    <figcaption>${desc}</figcaption>`;
         }
 
         return `


### PR DESCRIPTION
change `<figcatpion>` to `<figcaption>`