### PR TITLE
Build extensions from client repositories

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "typescript-eslint-parser": "^18.0.0"
   },
   "scripts": {
-    "setup-extensions": "if test -d ../../extensions; then cp -a ../../extensions/. scripts/extensions/; fi && node ./tasks/install-extensions.js && node ./tasks/generate-extension-imports.js",
+    "setup-extensions": "node ./tasks/install-extensions.js && node ./tasks/generate-extension-imports.js",
     "postinstall": "npm run setup-extensions",
     "test": "grunt ci:travis",
     "debug-unit-tests": "karma start karma.conf.js --browsers=Chrome",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "typescript-eslint-parser": "^18.0.0"
   },
   "scripts": {
-    "setup-extensions": "node ./tasks/install-extensions.js && node ./tasks/generate-extension-imports.js",
+    "setup-extensions": "if test -d ../../extensions; then cp -a ../../extensions/. scripts/extensions/; fi && node ./tasks/install-extensions.js && node ./tasks/generate-extension-imports.js",
     "postinstall": "npm run setup-extensions",
     "test": "grunt ci:travis",
     "debug-unit-tests": "karma start karma.conf.js --browsers=Chrome",

--- a/tasks/generate-extension-imports.js
+++ b/tasks/generate-extension-imports.js
@@ -8,7 +8,7 @@ var merge = require('lodash/object').merge;
 var getExtensionDirectoriesSync = require('./get-extension-directories-sync');
 
 const directories = getExtensionDirectoriesSync();
-const directoryNamingViolation = directories.find((name) => name.match(/^\w+$/g) == null);
+const directoryNamingViolation = directories.find(({extensionName}) => extensionName.match(/^\w+$/g) == null);
 
 if (directoryNamingViolation != null) {
     console.error(`"${directoryNamingViolation}" - extension directory names \
@@ -47,15 +47,13 @@ for (const key in mergedConfig.enabledExtensions) {
 }
 
 directories
-    .filter((extensionName) => enabledExtensions.includes(extensionName))
-    .forEach((extensionName) => {
+    .filter(({extensionName}) => enabledExtensions.includes(extensionName))
+    .forEach(({extensionName, relativePath, absolutePath}) => {
         const manifestFile = JSON.parse(
-            fs.readFileSync(
-                path.resolve(`${__dirname}/../scripts/extensions/${extensionName}/package.json`)
-            ).toString()
+            fs.readFileSync(`${absolutePath}/${extensionName}/package.json`).toString()
         );
 
-        importStatements.push(`import * as ${extensionName} from '../extensions/${extensionName}/${manifestFile.main}';`);
+        importStatements.push(`import * as ${extensionName} from '../${relativePath}/${extensionName}/${manifestFile.main}';`);
 
         insertIntoObjectStatements.push(
             `extensions['${extensionName}'] = {extension: ${extensionName}.default, manifest: ${JSON.stringify(manifestFile)}, activationResult: {}}`

--- a/tasks/get-extension-directories-sync.js
+++ b/tasks/get-extension-directories-sync.js
@@ -2,10 +2,21 @@ var fs = require('fs');
 var path = require('path');
 var lstatSync = fs.lstatSync;
 
+var flatMap = require('lodash/flatMap');
+
 function getExtensionDirectoriesSync() {
-    return fs.readdirSync(path.resolve(`${__dirname}/../scripts/extensions`)).filter(
-        (name) => lstatSync(path.resolve(`${__dirname}/../scripts/extensions/${name}`)).isDirectory()
-    );
+    return flatMap([
+        '../scripts/extensions', // extensions from core
+        '../../../extensions', // extensions from parent repository
+    ], (relativePath) => {
+        const absolutePath = path.resolve(__dirname + '/' + relativePath);
+
+        return (fs.existsSync(absolutePath) ? fs.readdirSync(absolutePath) : [])
+            .map((extensionName) => ({extensionName, relativePath, absolutePath}))
+            .filter(
+                ({absolutePath, extensionName}) => lstatSync(absolutePath + '/' + extensionName).isDirectory()
+            );
+    });
 }
 
 module.exports = getExtensionDirectoriesSync;

--- a/tasks/install-extensions.js
+++ b/tasks/install-extensions.js
@@ -4,8 +4,8 @@ var getExtensionDirectoriesSync = require('./get-extension-directories-sync');
 const execSync = require('child_process').execSync;
 const directories = getExtensionDirectoriesSync();
 
-directories.forEach((extensionName) => {
-    const extensionPath = path.resolve(`${__dirname}/../scripts/extensions/${extensionName}`);
+directories.forEach(({extensionName, absolutePath}) => {
+    const extensionPath = path.resolve(`${absolutePath}/${extensionName}`);
 
     execSync(`cd ${extensionPath} && npm install && npm run compile`);
 });


### PR DESCRIPTION
Extensions are now first-class citizens in client repositories. Everything that works in client core will work from client repositories as well, including webpack dev server and live reload :tada: 

Extensions should be placed at `superdesk/client/extensions/myExtension`

The only difference is the path to api typings which will be
```
/// <reference path='../../../../node_modules/superdesk-core/scripts/core/superdesk-api.d.ts' />
```

assuming the line above is located in `superdesk/client/extensions/myExtension/src/typings/refs.d.ts`