### PR TITLE
fix(monitoring): Fixed issue with infinite scroll on single stage

### DIFF
--- a/scripts/apps/monitoring/controllers/MonitoringController.ts
+++ b/scripts/apps/monitoring/controllers/MonitoringController.ts
@@ -97,6 +97,7 @@ export function MonitoringController($rootScope, $scope, $location, desks, confi
     function viewSingleGroup(group, type) {
         group.singleViewType = type;
         self.singleGroup = group;
+        $rootScope.$broadcast('stage:single');
     }
 
     function viewMonitoringHome() {

--- a/scripts/apps/monitoring/directives/MonitoringView.ts
+++ b/scripts/apps/monitoring/directives/MonitoringView.ts
@@ -25,7 +25,16 @@ export function MonitoringView($rootScope, authoringWorkspace, pageTitle, $timeo
             hideMonitoringToolbar2: '=?',
         },
         link: function(scope, elem) {
-            const containerElem = elem.find('.content-list');
+            let containerElem = elem.find('.sd-column-box__main-column');
+
+            /**
+             * Issue here is that sd-column-box__main-column element is not visible on initializing sd-monitoring-view.
+             * So I added $broadcast and listener for updating onScroll binding and containerElem for it.
+            */
+            $rootScope.$on('stage:single', () => {
+                containerElem = elem.find('.sd-column-box__main-column');
+                containerElem.on('scroll', handleContainerScroll);
+            });
 
             pageTitle.setUrl(_.capitalize(gettext(scope.type)));
 
@@ -108,7 +117,7 @@ export function MonitoringView($rootScope, authoringWorkspace, pageTitle, $timeo
              * Trigger render in case user scrolls to the very end of list
              */
             function renderIfNeeded() {
-                if (scope.monitoring.viewColumn && isListEnd(containerElem[0])) {
+                if (isListEnd(containerElem[0])) {
                     scheduleFetchNext();
                 }
             }


### PR DESCRIPTION
- [SDANSA-273] BUG: infinite scroll

Issue here is that `sd-column-box__main-column` element is not visible on initializing `sd-monitoring-view`. So I added `$broadcast` and listener for updating onScroll binding and `containerElem` for it.

In some cases, like on spike and personal view element is visible without problem. Because of that, I left old settings.