### PR TITLE
Fix parser when html had empty characters

### DIFF
--- a/scripts/core/editor3/html/from-html/index.ts
+++ b/scripts/core/editor3/html/from-html/index.ts
@@ -168,7 +168,7 @@ class HTMLParser {
         let contentState = initialState;
 
         contentState.getBlocksAsArray().forEach((block) => {
-            block.findEntityRanges((characterMetadata) => Boolean(characterMetadata.getEntity()), (start, _end) => {
+            block.findEntityRanges((characterMetadata) => characterMetadata.getEntity() != null, (start, _end) => {
                 const key = block.getEntityAt(start);
 
                 if (key != null) {

--- a/scripts/core/editor3/html/tests/from-html.spec.ts
+++ b/scripts/core/editor3/html/tests/from-html.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 /* tslint:disable:max-line-length */
 import {getContentStateFromHtml} from '../from-html';
-import {convertFromRaw, ContentState} from 'draft-js';
+import {convertFromRaw, ContentState, ContentBlock} from 'draft-js';
 
 /**
  * @description Returns the set of blocks corresponding to the content state

--- a/scripts/core/editor3/html/tests/from-html.spec.ts
+++ b/scripts/core/editor3/html/tests/from-html.spec.ts
@@ -1,15 +1,13 @@
 /* eslint-disable max-len */
 /* tslint:disable:max-line-length */
 import {getContentStateFromHtml} from '../from-html';
-import {convertFromRaw} from 'draft-js';
+import {convertFromRaw, ContentState} from 'draft-js';
 
 /**
- * @param {string} html HTML to convert
- * @returns {Array<ContentBlock>}
  * @description Returns the set of blocks corresponding to the content state
  * resulting from the conversion of the given HTML.
  */
-function blocksFor(html) {
+function blocksFor(html: string): { contentState: ContentState, blocks: Array<ContentBlock> } {
     const contentState = getContentStateFromHtml(html);
     const blocks = contentState.getBlockMap().toArray();
 
@@ -88,6 +86,14 @@ describe('core.editor3.html.from-html', () => {
 
         expect(blocks[0].getType()).toBe('code-block');
     });
+
+    it('should create an empty content state if html contains only invisible characters', () => {
+        const {contentState} = blocksFor(`
+
+            `);
+
+        expect(contentState.getPlainText()).toEqual('');
+    }),
 
     it('should parse Google Docs special paste', () => {
         const {blocks} = blocksFor('<b style="font-weight:normal;" id="docs-internal-guid-63c0f3a6-072a-245e-c39d-3f61398cba2c"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;margin-left: 21.25984251968504pt;text-indent: 14.173228346456693pt;text-align: justify;"><span style="font-size:12pt;font-family:Roboto;color:#333333;background-color:transparent;font-weight:700;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">bold</span></p><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;margin-left: 21.25984251968504pt;text-indent: 14.173228346456693pt;text-align: justify;"><span style="font-size:12pt;font-family:Roboto;color:#333333;background-color:transparent;font-weight:400;font-style:italic;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">italic</span></p><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;margin-left: 21.25984251968504pt;text-indent: 14.173228346456693pt;text-align: justify;"><span style="font-size:12pt;font-family:Roboto;color:#333333;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:underline;-webkit-text-decoration-skip:none;text-decoration-skip-ink:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">underline</span></p><br></b>');


### PR DESCRIPTION
SDBELGA-120

There's an issue when we save empty html (not 0 length, just empty chars like line breaks) in the parser. Basically `draftjs.convertFromHTML` doesn't like that kind of input and returns a null content state instead of empty.

This issue affects templates like *article export* on planning, when the template result is empty.

Don't pay much attention to all the changes I made, I basically did some JSDoc->Typescript refactor wherever I could. The actual code is [this](https://github.com/superdesk/superdesk-client-core/pull/2990/files#diff-d36b15895cebd29622048cb16e7d1530R144) and [the test for it](https://github.com/superdesk/superdesk-client-core/pull/2990/files#diff-526d7b90caac219611fb5bb7ffd2229a)