### PR TITLE
Add default option to custom sort of groups

### DIFF
--- a/scripts/apps/monitoring/directives/MonitoringGroup.ts
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.ts
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 import _ from 'lodash';
-import getCustomSortForGroup, {GroupSortOptions, getDefaultFieldForConfig} from '../helpers/CustomSortOfGroups';
+import getCustomSortForGroup, {GroupSortOptions} from '../helpers/CustomSortOfGroups';
 import {GET_LABEL_MAP} from '../../workspace/content/constants';
 
 const translatedFields = GET_LABEL_MAP();
@@ -138,13 +138,11 @@ export function MonitoringGroup(cards, api, authoringWorkspace, $timeout, superd
             const customSorts = getCustomSortForGroup(config, scope.group);
 
             if (customSorts != null) {
-                scope.customSortOptions = translateCustomSorts(customSorts.options);
+                scope.customSortOptions = translateCustomSorts(customSorts.allowed_fields_to_sort);
                 if (customSorts.default) {
-                    const defaultOption = getDefaultFieldForConfig(customSorts);
-
                     scope.customSortOptionActive = {
-                        field: defaultOption.field,
-                        order: defaultOption.order,
+                        field: customSorts.default.field,
+                        order: customSorts.default.order,
                     };
                 } else {
                     scope.customSortOptionActive = null;

--- a/scripts/apps/monitoring/directives/MonitoringGroup.ts
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.ts
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 import _ from 'lodash';
-import getCustomSortForGroup, {GroupSortOptions} from '../helpers/CustomSortOfGroups';
+import getCustomSortForGroup, {GroupSortOptions, getDefaultFieldForConfig} from '../helpers/CustomSortOfGroups';
 import {GET_LABEL_MAP} from '../../workspace/content/constants';
 
 const translatedFields = GET_LABEL_MAP();
@@ -137,9 +137,18 @@ export function MonitoringGroup(cards, api, authoringWorkspace, $timeout, superd
 
             const customSorts = getCustomSortForGroup(config, scope.group);
 
-            if (customSorts.length > 0) {
-                scope.customSortOptions = translateCustomSorts(customSorts);
-                scope.customSortOptionActive = null; // default
+            if (customSorts != null) {
+                scope.customSortOptions = translateCustomSorts(customSorts.options);
+                if (customSorts.default) {
+                    const defaultOption = getDefaultFieldForConfig(customSorts);
+
+                    scope.customSortOptionActive = {
+                        field: defaultOption.field,
+                        order: defaultOption.order,
+                    };
+                } else {
+                    scope.customSortOptionActive = null;
+                }
             }
 
             scope.page = 1;

--- a/scripts/apps/monitoring/helpers/CustomSortOfGroups.ts
+++ b/scripts/apps/monitoring/helpers/CustomSortOfGroups.ts
@@ -1,7 +1,7 @@
 import {get} from 'lodash';
 import {StageGroup} from '../directives/MonitoringGroup';
 
-type OrderType = 'desc' | 'asc';
+type OrderType = 'desc' | 'asc';
 
 export type GroupSortOptions = Array<string>;
 

--- a/scripts/apps/monitoring/helpers/CustomSortOfGroups.ts
+++ b/scripts/apps/monitoring/helpers/CustomSortOfGroups.ts
@@ -1,13 +1,13 @@
 import {get} from 'lodash';
 import {StageGroup} from '../directives/MonitoringGroup';
 
-type OrderType = 'desc' | 'asc';
-
 export type GroupSortOptions = Array<string>;
 
+type OrderType = 'desc' | 'asc';
+
 export type GroupSortConfig = {
-    default?: string, // field:order (publish_schedule:asc)
-    options: GroupSortOptions
+    default?: { field: string, order: OrderType },
+    allowed_fields_to_sort: GroupSortOptions
 };
 
 function isOrderType(o: string): o is OrderType {
@@ -32,30 +32,10 @@ export default function getCustomSortForGroup(config: any, group: StageGroup): G
     const configForGroup = matchGroupToOrderConfig(group);
     const customConfig: GroupSortConfig = get(config, configForGroup, null);
 
-    if (customConfig != null && customConfig.default) {
-        const {field, order} = getDefaultFieldForConfig(customConfig);
-
-        customConfig.default = `${field}:${order}`;
+    if (customConfig && customConfig.default && !isOrderType(customConfig.default.order)) {
+        console.warn(`Default sort order is not a valid string '${customConfig.default.order}'. Use 'asc' or 'desc'`);
+        customConfig.default.order = 'asc';
     }
 
     return customConfig;
-}
-
-export function getDefaultFieldForConfig(config: GroupSortConfig):
-    {field: string, order: OrderType} | null {
-    let [field, order] = config.default.split(':');
-
-    if (!order || !isOrderType(order)) {
-        order = 'asc';
-    }
-
-    // make sure default field exists in options
-    if (!config.options.includes(field)) {
-        return null;
-    }
-
-    return {
-        field,
-        order: order as OrderType,
-    };
 }

--- a/scripts/apps/monitoring/helpers/CustomSortOfGroups.ts
+++ b/scripts/apps/monitoring/helpers/CustomSortOfGroups.ts
@@ -1,7 +1,18 @@
 import {get} from 'lodash';
 import {StageGroup} from '../directives/MonitoringGroup';
 
+type OrderType = 'desc' | 'asc';
+
 export type GroupSortOptions = Array<string>;
+
+export type GroupSortConfig = {
+    default?: string, // field:order (publish_schedule:asc)
+    options: GroupSortOptions
+};
+
+function isOrderType(o: string): o is OrderType {
+    return ['desc', 'asc'].includes(o);
+}
 
 export function matchGroupToOrderConfig(group: StageGroup) {
     if (group._id.endsWith(':output')) {
@@ -13,13 +24,38 @@ export function matchGroupToOrderConfig(group: StageGroup) {
     return 'monitoring.stage.sort';
 }
 
-export default function getCustomSortForGroup(config: any, group: StageGroup): GroupSortOptions {
+export default function getCustomSortForGroup(config: any, group: StageGroup): GroupSortConfig | null {
     if (!group || !group._id || !group.type) {
-        return [];
+        return null;
     }
 
     const configForGroup = matchGroupToOrderConfig(group);
-    const customConfig = get(config, configForGroup, []);
+    const customConfig: GroupSortConfig = get(config, configForGroup, null);
+
+    if (customConfig != null && customConfig.default) {
+        const {field, order} = getDefaultFieldForConfig(customConfig);
+
+        customConfig.default = `${field}:${order}`;
+    }
 
     return customConfig;
+}
+
+export function getDefaultFieldForConfig(config: GroupSortConfig):
+    {field: string, order: OrderType} | null {
+    let [field, order] = config.default.split(':');
+
+    if (!order || !isOrderType(order)) {
+        order = 'asc';
+    }
+
+    // make sure default field exists in options
+    if (!config.options.includes(field)) {
+        return null;
+    }
+
+    return {
+        field,
+        order: order as OrderType,
+    };
 }

--- a/scripts/apps/monitoring/styles/monitoring.scss
+++ b/scripts/apps/monitoring/styles/monitoring.scss
@@ -8,6 +8,23 @@
     right: 0;
     bottom: 0;
 
+    .sortbar.sortbar-custom-sort-groups {
+        .dropdown {
+            vertical-align: middle;
+
+            .dropdown__menu li small {
+                font-weight: 300;
+                font-style: italic;
+                color: $grayLight;
+                margin-left: 1em;
+            }
+        }
+
+        .direction {
+            display: inline-block !important; // take up space when it's hidden
+        }
+    }
+
     .subnav {
         top: 0;
         .sortbar-container {
@@ -126,7 +143,7 @@
             position: relative;
             flex-grow: 1;
             display: flex;
-            overflow-y: auto;   
+            overflow-y: auto;
         }
     }
 }
@@ -241,7 +258,7 @@
         opacity: 1;
         background-color: $sd-blue;
         i { color: $white; }
-    }          
+    }
     &.shift {
         top: 1px;
         @include border-radius(2px 0 0 2px);
@@ -280,7 +297,7 @@
 .monitoring {
     .sd-grid-group:not(.refresh) {
         box-shadow: none !important;
-        
+
         .sd-grid-list {
             margin: 1.4rem;
         }
@@ -307,7 +324,7 @@
 .monitoring-dropdown {
     .dropdown__menu {
         margin-top: 5px;
-        max-width: 220px !important;        
+        max-width: 220px !important;
     }
 
     a {
@@ -344,7 +361,7 @@
         display: block;
         padding: 5px 15px 5px 20px;
         border-bottom: 1px solid #ddd;
-        
+
         .slugline {
             font-weight: 500;
             color: #216278;

--- a/scripts/apps/monitoring/views/monitoring-group-header.html
+++ b/scripts/apps/monitoring/views/monitoring-group-header.html
@@ -24,23 +24,32 @@
         <button ng-if="showRefresh" class="btn btn--primary btn--icon-only-circle btn--small" ng-click="refreshGroup(group)" tooltip="{{:: 'Refresh' | translate}}" tooltip-placement="left">
             <i class="icon-repeat"></i>
         </button>
-        <div class="sortbar" ng-show="customSortOptions">
-            <div class="dropdown dropdown--align-right dropdown--hover" dropdown__toggle>
-                <button id="order_button" class="dropdown__toggle" dropdown__toggle>
+        <div class="sortbar sortbar-custom-sort-groups" ng-show="customSortOptions">
+            <span translate>Sorting:</span>
+            <div class="dropdown dropdown--align-right" dropdown>
+                <button class="dropdown__toggle" dropdown__toggle>
                     <span ng-if="!customSortOptionActive" translate>Default</span>
                     <span ng-if="customSortOptionActive">{{ customSortOptions[customSortOptionActive.field].label }}</span>
                     <span class="dropdown__caret"></span>
                 </button>
                 <ul class="dropdown__menu">
                     <li>
-                        <button ng-click="selectDefaultSortOption()" translate>Default</button>
+                        <div class="dropdown__menu-label" translate>
+                            Sort by
+                        </div>
+                    </li>
+                    <li>
+                        <button ng-click="selectDefaultSortOption()">
+                            <span translate>Default</span>
+                            <small translate>(as defined for all groups)</small>
+                        </button>
                     </li>
                     <li ng-repeat="(field, option) in customSortOptions">
                         <button ng-click="selectCustomSortOption(field)">{{ option.label }}</button>
                     </li>
                 </ul>
             </div>
-            <button ng-click="toggleCustomSortOrder()" class="icn-btn direction" title="{{customSortOptionActive.order}}" ng-if="customSortOptionActive">
+            <button ng-click="toggleCustomSortOrder()" class="icn-btn direction" title="{{customSortOptionActive.order}}" ng-show="customSortOptionActive">
                 <i class="icon-ascending" ng-if="customSortOptionActive.order === 'asc'"></i>
                 <i class="icon-descending" ng-if="customSortOptionActive.order === 'desc'"></i>
             </button>


### PR DESCRIPTION
SDNTB-545

Adds `default` option to custom sort config.
If present, this will sort the stage by default without the user having to select it in the dropdown.

```js
        monitoring: {
            scheduled: {
                sort: {
                    default: { field: 'publish_schedule', order: 'asc' },
                    allowed_fields_to_sort: [ 'publish_schedule' ]
                }
            },
        }
```

If `default` is not present, the dropdown will contain `allowed_fields_to_sort` but without sorting the stage until the users wants to.

Also, I made some UI fixes to make it look like the proposal (see task)