### PR TITLE
Avoid extending inline styles when pressing space at end of block

### DIFF
--- a/scripts/core/editor3/helpers/getDraftCharacterListForSelection.ts
+++ b/scripts/core/editor3/helpers/getDraftCharacterListForSelection.ts
@@ -1,3 +1,4 @@
+import {EditorState, SelectionState, ContentBlock, CharacterMetadata} from 'draft-js';
 import {List} from 'immutable';
 
 /**
@@ -27,12 +28,10 @@ function orderedMapGetRange(orderedMap, fromKey, toKey) {
     });
 }
 
-/**
- * @ngdoc method
- * @name getDraftCharacterListForSelection
- * @returns {List<CharacterMetadata>}
- */
-export function getDraftCharacterListForSelection(editorState, selection) {
+export function getDraftCharacterListForSelection(
+    editorState: EditorState,
+    selection: SelectionState,
+): List<CharacterMetadata> {
     // including all blocks
 
     if (selection.isCollapsed()) {
@@ -49,15 +48,27 @@ export function getDraftCharacterListForSelection(editorState, selection) {
     );
 
     const selectedCharacters = selectedBlocks
-        .map((block) => {
+        .map((block: ContentBlock) => {
             const blockKey = block.getKey();
 
-            if (selectionStartKey === selectionEndKey && selectionStartKey === blockKey) {
-                return block.getCharacterList().slice(selection.getStartOffset(), selection.getEndOffset());
+            if (
+                selectionStartKey === selectionEndKey &&
+                selectionStartKey === blockKey
+            ) {
+                return block
+                    .getCharacterList()
+                    .slice(
+                        selection.getStartOffset(),
+                        selection.getEndOffset(),
+                    );
             } else if (blockKey === selectionStartKey) {
-                return block.getCharacterList().slice(selection.getStartOffset(), block.getLength());
+                return block
+                    .getCharacterList()
+                    .slice(selection.getStartOffset(), block.getLength());
             } else if (blockKey === selectionEndKey) {
-                return block.getCharacterList().slice(0, selection.getEndOffset());
+                return block
+                    .getCharacterList()
+                    .slice(0, selection.getEndOffset());
             } else {
                 return block.getCharacterList();
             }

--- a/scripts/core/editor3/helpers/handleBeforeInputHighlights.ts
+++ b/scripts/core/editor3/helpers/handleBeforeInputHighlights.ts
@@ -1,4 +1,10 @@
-import {EditorState, Modifier, CharacterMetadata, DraftHandleValue} from 'draft-js';
+import {
+    EditorState,
+    Modifier,
+    CharacterMetadata,
+    SelectionState,
+    DraftHandleValue
+} from 'draft-js';
 import {List, OrderedSet} from 'immutable';
 import {uniq} from 'lodash';
 
@@ -15,28 +21,40 @@ function isSelectionAtEndOfBlock(editorState: EditorState): boolean {
 }
 
 /**
- * @ngdoc method
- * @name addCommentsForServer
- * @param {EditorState} editorState
- * @param {SelectionState} collapsedSelection
- * @return {List<CharacterMetadata>}
+ * Returns the characters before and after the cursor.
  */
-function getRelevantCharactersForCollapsedSelection(editorState, collapsedSelection) {
-    let characters: any = List();
-    const selectionAtTheStartOfTheLine = editorState.getSelection().getStartOffset() === 0;
+function getRelevantCharactersForCollapsedSelection(
+    editorState: EditorState,
+    collapsedSelection: SelectionState,
+): List<CharacterMetadata> {
+    let characters = List<CharacterMetadata>();
+    const selectionAtTheStartOfTheLine =
+        editorState.getSelection().getStartOffset() === 0;
     const selectionAtTheEndOfTheBlock = isSelectionAtEndOfBlock(editorState);
     const resizeLeft = selectionAtTheStartOfTheLine ? 2 : 1; // SDESK-2861
-    const resizedSelection = resizeDraftSelection(resizeLeft, 1, collapsedSelection, editorState, false);
-    const resizeLeftFailed = collapsedSelection.getStartOffset() === resizedSelection.getStartOffset();
-    const resizeRightFailed = collapsedSelection.getEndOffset() === resizedSelection.getEndOffset();
+    const resizeRight = selectionAtTheEndOfTheBlock ? 2 : 1; // SDESK-4335
+    const resizedSelection = resizeDraftSelection(
+        resizeLeft,
+        resizeRight,
+        collapsedSelection,
+        editorState,
+        false,
+    );
+    const resizeLeftFailed =
+        collapsedSelection.getStartOffset() ===
+        resizedSelection.getStartOffset();
+    const resizeRightFailed =
+        collapsedSelection.getEndOffset() === resizedSelection.getEndOffset();
 
     if (resizeLeftFailed === true) {
         characters = characters.push(CharacterMetadata.create());
     }
 
-    characters = characters.concat(getDraftCharacterListForSelection(editorState, resizedSelection));
+    characters = characters.merge(
+        getDraftCharacterListForSelection(editorState, resizedSelection),
+    );
 
-    if (resizeRightFailed === true || selectionAtTheEndOfTheBlock) {
+    if (resizeRightFailed === true) {
         characters = characters.push(CharacterMetadata.create());
     }
 
@@ -48,35 +66,53 @@ function getRelevantCharactersForCollapsedSelection(editorState, collapsedSelect
  * @name handleBeforeInputHighlights
  * @description prevents inheriting of highlight styles
  */
-export function handleBeforeInputHighlights(onChange, chars: string, editorState: EditorState): DraftHandleValue {
+export function handleBeforeInputHighlights(
+    onChange,
+    chars: string,
+    editorState: EditorState,
+): DraftHandleValue {
     // see handleBeforeInputHighlights.spec.gif
 
     const selection = editorState.getSelection();
     const characterList = selection.isCollapsed()
         ? getRelevantCharactersForCollapsedSelection(editorState, selection)
         : getDraftCharacterListForSelection(editorState, selection);
-    const characterStyles = characterList.map((character) => character.getStyle()).toJS();
-    const allHighlightStyles = uniq(characterStyles.reduce((a, b) => a.concat(b)))
-        .filter(styleNameBelongsToHighlight);
+    const characterStyles = characterList
+        .map((character) => character.getStyle())
+        .toJS();
+    const allHighlightStyles = uniq(
+        characterStyles.reduce((a, b) => a.concat(b)),
+    ).filter(styleNameBelongsToHighlight);
 
     if (allHighlightStyles.length < 1) {
         return 'not-handled';
     }
 
-    const commonHighlightStyles = allHighlightStyles.filter(
-        (styleName) => characterStyles.every((stylesAtPosition) => stylesAtPosition.includes(styleName)),
+    const commonHighlightStyles = allHighlightStyles.filter((styleName) =>
+        characterStyles.every((stylesAtPosition) =>
+            stylesAtPosition.includes(styleName),
+        ),
     );
 
-    const nextInlineStyles = OrderedSet<string>(editorState.getCurrentInlineStyle()
-        .filter((styleName) => styleNameBelongsToHighlight(styleName) === false)
-        .concat(commonHighlightStyles));
+    const nextInlineStyles = OrderedSet<string>(
+        editorState
+            .getCurrentInlineStyle()
+            .filter(
+                (styleName) => styleNameBelongsToHighlight(styleName) === false,
+            )
+            .concat(commonHighlightStyles),
+    );
     const nextContentState = Modifier.replaceText(
         editorState.getCurrentContent(),
         editorState.getSelection(),
         chars,
         nextInlineStyles,
     );
-    const nextEditorState = EditorState.push(editorState, nextContentState, 'insert-characters');
+    const nextEditorState = EditorState.push(
+        editorState,
+        nextContentState,
+        'insert-characters',
+    );
 
     onChange(nextEditorState);
 

--- a/scripts/core/editor3/helpers/handleBeforeInputHighlights.ts
+++ b/scripts/core/editor3/helpers/handleBeforeInputHighlights.ts
@@ -74,9 +74,9 @@ export function handleBeforeInputHighlights(onChange, chars: string, editorState
             (styleName) => characterStyles.every((stylesAtPosition) => stylesAtPosition.includes(styleName)),
         );
 
-        nextInlineStyles = editorState.getCurrentInlineStyle()
-            .filter((styleName: string) => styleNameBelongsToHighlight(styleName) === false)
-            .concat(commonHighlightStyles);
+        nextInlineStyles = OrderedSet<string>(editorState.getCurrentInlineStyle()
+            .filter((styleName) => styleNameBelongsToHighlight(styleName) === false)
+            .concat(commonHighlightStyles));
     }
 
     const nextContentState = Modifier.replaceText(

--- a/scripts/core/editor3/helpers/handleBeforeInputHighlights.ts
+++ b/scripts/core/editor3/helpers/handleBeforeInputHighlights.ts
@@ -22,6 +22,8 @@ function isSelectionAtEndOfBlock(editorState: EditorState): boolean {
 
 /**
  * Returns the characters before and after the cursor.
+ *   If it fails resizing the selection to the right, it will push a character with an empty style on the left.
+ *   If it fails resizing the selection to the left, it will also push a character with an empty style on the right.
  */
 function getRelevantCharactersForCollapsedSelection(
     editorState: EditorState,

--- a/scripts/extensions/helloWorld/package.json
+++ b/scripts/extensions/helloWorld/package.json
@@ -9,6 +9,8 @@
     "typescript": "3.4.4"
   },
   "superdeskExtension": {
-    "dependencies": ["other-extension"]
+    "dependencies": [
+      "other-extension"
+    ]
   }
 }


### PR DESCRIPTION
SDESK-4335

This includes all styles (annotations, comments, italic...)

![pressing space](https://user-images.githubusercontent.com/4324982/60893211-ca884880-a260-11e9-95ac-7484fceeccfc.gif)
