### PR TITLE
Force selection when closing popup on editor3

### DIFF
--- a/scripts/core/editor3/components/Editor3Component.tsx
+++ b/scripts/core/editor3/components/Editor3Component.tsx
@@ -469,7 +469,7 @@ export class Editor3Component extends React.Component<IProps> {
                         blockRenderMap={blockRenderMap}
                         blockRendererFn={getBlockRenderer({svc: this.props.svc})}
                         customStyleMap={{...customStyleMap, ...this.props.highlightsManager.styleMap}}
-                        onChange={(editorStateNext) => {
+                        onChange={(editorStateNext: EditorState) => {
                             // in order to position the popup component we need to know the position of editor selection
                             // even when it's not focused, or another input is focused
 

--- a/scripts/core/editor3/components/comments/CommentInput.tsx
+++ b/scripts/core/editor3/components/comments/CommentInput.tsx
@@ -24,6 +24,7 @@ class CommentInputBody extends React.Component<any, any> {
         this.state = {msg: props.data.msg || ''};
         this.onSubmit = this.onSubmit.bind(this);
         this.onChange = this.onChange.bind(this);
+        this.onCancel = this.onCancel.bind(this);
     }
 
     /**
@@ -34,7 +35,6 @@ class CommentInputBody extends React.Component<any, any> {
      */
     onSubmit() {
         const {msg} = this.state;
-        const _hidePopups = this.props.hidePopups;
         const {highlightId} = this.props.data;
 
         if (msg !== '') {
@@ -59,8 +59,12 @@ class CommentInputBody extends React.Component<any, any> {
                     {...highlightData, data: {...highlightData.data, msg, date}},
                 );
             }
-            _hidePopups();
+            this.props.hidePopups();
         }
+    }
+
+    onCancel(_ev) {
+        this.props.hidePopups();
     }
 
     /**
@@ -83,7 +87,7 @@ class CommentInputBody extends React.Component<any, any> {
                         onChange={this.onChange}
                     />
                     <div className="pull-right" style={{paddingTop: 20}}>
-                        <button className="btn btn--cancel" onClick={this.props.hidePopups}>
+                        <button className="btn btn--cancel" onClick={(ev) => this.onCancel(ev)}>
                             {gettext('Cancel')}
                         </button>
                         <button className="btn btn--primary" onClick={this.onSubmit} disabled={!msg}>

--- a/scripts/core/editor3/reducers/toolbar.tsx
+++ b/scripts/core/editor3/reducers/toolbar.tsx
@@ -224,6 +224,9 @@ const toggleInvisibles = (state) => {
  * @description Sets the toolbar popup to the given type.
  */
 const setPopup = (state: IEditorStore, {type, data}) => {
+    const {editorState} = state;
+    let newEditorState = editorState;
+
     // SDESK-3885
     // Whenever we hide a popup, the ContentState is not changed so it will
     // trigger these two DraftJS events:
@@ -235,9 +238,10 @@ const setPopup = (state: IEditorStore, {type, data}) => {
     // the selection in the first character of the first block.
     // Using `forceSelection` won't trigger those events and the selection will be correct.
     if (type === PopupTypes.Hidden) {
-        state.editorState = EditorState.forceSelection(state.editorState, state.editorState.getSelection());
+        newEditorState = EditorState.forceSelection(editorState, editorState.getSelection());
     }
-    return {...state, popup: {type, data}};
+
+    return {...state, editorState: newEditorState, popup: {type, data}};
 };
 
 export default toolbar;

--- a/scripts/core/editor3/reducers/toolbar.tsx
+++ b/scripts/core/editor3/reducers/toolbar.tsx
@@ -6,11 +6,13 @@ import * as Blocks from '../helpers/blocks';
 import * as Highlights from '../helpers/highlights';
 import {removeFormatFromState} from '../helpers/removeFormat';
 import {insertEntity} from '../helpers/draftInsertEntity';
+import {IEditorStore} from '../store';
+import {PopupTypes} from '../actions/popups';
 
 /**
  * @description Contains the list of toolbar related reducers.
  */
-const toolbar = (state = {}, action) => {
+const toolbar = (state: IEditorStore, action) => {
     switch (action.type) {
     case 'TOOLBAR_TOGGLE_BLOCK_STYLE':
         return toggleBlockStyle(state, action.payload);
@@ -221,6 +223,21 @@ const toggleInvisibles = (state) => {
  * @param {Object} data Type of popup and popup data.
  * @description Sets the toolbar popup to the given type.
  */
-const setPopup = (state, {type, data}) => ({...state, popup: {type, data}});
+const setPopup = (state: IEditorStore, {type, data}) => {
+    // SDESK-3885
+    // Whenever we hide a popup, the ContentState is not changed so it will
+    // trigger these two DraftJS events:
+    //     * editOnFocus
+    //     * editOnSelect
+    // The first one renders the right selection but the second one uses
+    // global `window.getSelection()` (which doesn't exist, as the editor lost focus)
+    // to check if the editorState selection matches that one. As it doesn't, it renders
+    // the selection in the first character of the first block.
+    // Using `forceSelection` won't trigger those events and the selection will be correct.
+    if (type === PopupTypes.Hidden) {
+        state.editorState = EditorState.forceSelection(state.editorState, state.editorState.getSelection());
+    }
+    return {...state, popup: {type, data}};
+};
 
 export default toolbar;


### PR DESCRIPTION
SDESK-3885

I put a comment on the code explaining this because it's not intuitive just by looking at it:

Whenever we hide a popup, the ContentState is not changed so it will
trigger these two DraftJS events:

* editOnFocus
* editOnSelect

The first one renders the right selection but the second one uses global `window.getSelection()` (which doesn't exist, as the editor lost focus) to check if the editorState selection matches that one. As it doesn't, it renders the selection in the first character of the first block. Using `forceSelection` won't trigger those events and the selection will be correct.

Before, clicking Submit and Cancel had different behaviours on editor rendering (cancel would trigger 2 renders, submit none). Now they are consistent.

> NOTICE

The task is only about links but this also affects other popups like comments and annotations. If you open one of those popups and then you click cancel, the error was happening before this fix.