### PR TITLE
Copy and paste only metadata fields that are shown

### DIFF
--- a/scripts/apps/authoring/media/index.ts
+++ b/scripts/apps/authoring/media/index.ts
@@ -1,6 +1,6 @@
-import MediaMetadataEditorDirective from './MediaMetadataEditorDirective';
-import MediaMetadataViewDirective from './MediaMetadataViewDirective';
-import MediaCopyMetadataDirective from './MediaCopyMetadataDirective';
+import MediaMetadataEditorDirective from './metadata/MediaMetadataEditorDirective';
+import MediaMetadataViewDirective from './metadata/MediaMetadataViewDirective';
+import MediaCopyMetadataDirective from './metadata/MediaCopyMetadataDirective';
 
 export default angular.module('superdesk.apps.authoring.media', [])
     .directive('sdMediaMetadataEditor', MediaMetadataEditorDirective)

--- a/scripts/apps/authoring/media/metadata/MediaCopyMetadataDirective.ts
+++ b/scripts/apps/authoring/media/metadata/MediaCopyMetadataDirective.ts
@@ -5,7 +5,7 @@ export default function MediaCopyMetadataDirective() {
             metadata: '=',
             onChange: '&',
         },
-        template: require('./views/media-copy-metadata-directive.html'),
+        template: require('../views/media-copy-metadata-directive.html'),
         link: (scope) => {
             const METADATA_ITEMS = 'metadata:items';
 

--- a/scripts/apps/authoring/media/metadata/MediaMetadataEditorDirective.ts
+++ b/scripts/apps/authoring/media/metadata/MediaMetadataEditorDirective.ts
@@ -34,7 +34,7 @@ export default function MediaMetadataEditorDirective(metadata, deployConfig, fea
             boxed: '@',
             associated: '=',
         },
-        template: require('./views/media-metadata-editor-directive.html'),
+        template: require('../views/media-metadata-editor-directive.html'),
         link: (scope) => {
             scope.features = features;
             scope.metadata = metadata;

--- a/scripts/apps/authoring/media/metadata/MediaMetadataViewDirective.ts
+++ b/scripts/apps/authoring/media/metadata/MediaMetadataViewDirective.ts
@@ -5,7 +5,7 @@ export default function MediaMetadataViewDirective(deployConfig) {
             item: '=',
             showAltText: '@',
         },
-        template: require('./views/media-metadata-view-directive.html'),
+        template: require('../views/media-metadata-view-directive.html'),
         link: (scope) => {
             scope.validator = deployConfig.getSync('validator_media_metadata');
         },


### PR DESCRIPTION
SDESK-4502

Centralize fields building on a service and only use those fields to copy&paste the metadata.

Before, all the object was being copied which resulted in the image being overwritten.