### PR TITLE
fix(metadata): Fixed issue with coping subject fields

### DIFF
--- a/scripts/apps/authoring/media/MediaCopyMetadataDirective.ts
+++ b/scripts/apps/authoring/media/MediaCopyMetadataDirective.ts
@@ -13,11 +13,15 @@ export default function MediaCopyMetadataDirective() {
             const METADATA_ITEMS = 'metadata:items';
             const FIELD_KEYS = keys(scope.validator);
 
+            const METADATA_FIELDS = [
+                'subject',
+            ].concat(FIELD_KEYS);
+
             scope.metadataFromStorage = !!localStorage.getItem(METADATA_ITEMS);
 
             scope.copyMetadata = (metadata) => {
                 scope.metadataFromStorage = true;
-                localStorage.setItem(METADATA_ITEMS, JSON.stringify(pick(metadata, FIELD_KEYS)));
+                localStorage.setItem(METADATA_ITEMS, JSON.stringify(pick(metadata, METADATA_FIELDS)));
             };
 
             scope.pasteMetadata = () => {

--- a/scripts/apps/authoring/metadata/metadata.ts
+++ b/scripts/apps/authoring/metadata/metadata.ts
@@ -707,7 +707,7 @@ function MetaTermsDirective(metadata, $filter, $timeout, preferencesService, des
                 } else {
                     scope.selectedItems = selected.filter((term) => !term.scheme || term.scheme === scope.field);
                 }
-            });
+            }, true);
 
             scope.$on('$destroy', () => {
                 metadata.subjectScope = null;

--- a/scripts/apps/search/views/multi-image-edit.html
+++ b/scripts/apps/search/views/multi-image-edit.html
@@ -86,6 +86,7 @@
                     </div>
                 </div>
                 <div sd-media-copy-metadata
+                    ng-if="getSelectedImages().length"
                     class="sd-slide-in-panel__footer"
                     data-metadata="metadata"
                     data-validator="validator"


### PR DESCRIPTION
[SDESK-4543] - Usage terms are not remembered when copy pasting media metadata
[SDESK-4364] - Copy/paste metadata in media edit should not be active if no items are selected