### PR TITLE
Fix dragging text around in editor3 when media is enabled

### DIFF
--- a/scripts/core/editor3/components/Editor3Component.tsx
+++ b/scripts/core/editor3/components/Editor3Component.tsx
@@ -449,7 +449,7 @@ export class Editor3Component extends React.Component<IProps> {
             'unstyled__block--invisibles': this.props.invisibles,
         });
 
-        const mediaEnabled = this.props.editorFormat.indexOf('media') !== -1;
+        const mediaEnabled = this.props.editorFormat.includes('media');
 
         const blockRenderMap = DefaultDraftBlockRenderMap.merge(Map(
             mediaEnabled ? {

--- a/scripts/core/editor3/components/Editor3Component.tsx
+++ b/scripts/core/editor3/components/Editor3Component.tsx
@@ -8,6 +8,9 @@ import {
     getDefaultKeyBinding,
     DefaultDraftBlockRenderMap,
     KeyBindingUtil,
+    SelectionState,
+    DraftDragType,
+    DraftHandleValue,
 } from 'draft-js';
 import {getVisibleSelectionRect} from 'draft-js';
 
@@ -64,12 +67,17 @@ export function getValidMediaType(event) {
 */
 export function canDropMedia(e, editorConfig) {
     const {editorFormat, readOnly, singleLine} = editorConfig;
-    const supportsMedia = !readOnly && !singleLine && editorFormat.indexOf('media') !== -1;
+    const supportsMedia = !readOnly && !singleLine && editorFormat.includes('media');
+
+    if (!supportsMedia) {
+        return false;
+    }
+
     const mediaType = getValidMediaType(e.originalEvent);
     const dataTransfer = e.originalEvent.dataTransfer;
     let isValidMedia = !!mediaType;
 
-    if (mediaType === 'Files' && dataTransfer.files) {
+    if (mediaType === 'Files' && dataTransfer.files.length > 0) {
         // checks if files dropped from external folder are valid or not
         const isValidFileType = Object.values(dataTransfer.files).every(
             (file: File) => file.type.startsWith('audio/')
@@ -80,7 +88,7 @@ export function canDropMedia(e, editorConfig) {
         }
     }
 
-    return supportsMedia && isValidMedia;
+    return isValidMedia;
 }
 
 interface IProps {
@@ -144,6 +152,7 @@ export class Editor3Component extends React.Component<IProps> {
         this.handleKeyCommand = this.handleKeyCommand.bind(this);
         this.handleBeforeInput = this.handleBeforeInput.bind(this);
         this.keyBindingFn = this.keyBindingFn.bind(this);
+        this.handleDropOnEditor = this.handleDropOnEditor.bind(this);
         this.spellcheck = this.spellcheck.bind(this);
         this.spellcheckCancelFn = noop;
     }
@@ -201,6 +210,21 @@ export class Editor3Component extends React.Component<IProps> {
      */
     onDragOver(e) {
         return !canDropMedia(e, this.props);
+    }
+
+    handleDropOnEditor(selection: SelectionState, dataTransfer: Object, isInternal: DraftDragType): DraftHandleValue {
+        if (isInternal) {
+            const {editorState} = this.props;
+            const targetBlockKey = selection.getStartKey();
+            const block = editorState.getCurrentContent().getBlockForKey(targetBlockKey);
+
+            if (block && block.getType() === 'atomic') {
+                // Avoid dragging internal text inside an atomic block.
+                // Draft will replace the block data with the text, which
+                // will break the block until page refresh
+                return 'handled';
+            }
+        }
     }
 
     keyBindingFn(e) {
@@ -480,6 +504,7 @@ export class Editor3Component extends React.Component<IProps> {
                 />
                 <div className="focus-screen" onMouseDown={this.focus}>
                     <Editor editorState={editorState}
+                        handleDrop={this.handleDropOnEditor}
                         handleKeyCommand={this.handleKeyCommand}
                         keyBindingFn={this.keyBindingFn}
                         handleBeforeInput={this.handleBeforeInput}

--- a/scripts/core/editor3/helpers/htmlComesFromDraftjsEditor.ts
+++ b/scripts/core/editor3/helpers/htmlComesFromDraftjsEditor.ts
@@ -1,2 +1,2 @@
-export const htmlComesFromDraftjsEditor = (html) => new DOMParser().parseFromString(html, 'text/html')
+export const htmlComesFromDraftjsEditor = (html: string) => new DOMParser().parseFromString(html, 'text/html')
     .body.querySelector('[data-offset-key]') != null;


### PR DESCRIPTION
SDESK-4575

Instead of manually handling the drop event I ended up letting Draft handle it in case we can't, because it supports dragging text around natively.