### PR TITLE
fix(editor3) dragging text on chrome

### DIFF
--- a/scripts/core/editor3/components/BaseUnstyledComponent.tsx
+++ b/scripts/core/editor3/components/BaseUnstyledComponent.tsx
@@ -5,6 +5,7 @@ import {getValidMediaType, canDropMedia} from './Editor3Component';
 import {moveBlock, dragDrop, embed} from '../actions/editor3';
 import {getEmbedObject} from './embeds/EmbedInput';
 import {htmlComesFromDraftjsEditor} from 'core/editor3/helpers/htmlComesFromDraftjsEditor';
+import {htmlIsPlainTextDragged} from 'core/editor3/helpers/htmlIsPlainTextDragged';
 
 const EDITOR_BLOCK_TYPE = 'superdesk/editor3-block';
 
@@ -14,17 +15,6 @@ export function isEditorBlockEvent(event) {
 
 export function getEditorBlock(event) {
     return event.originalEvent.dataTransfer.getData(EDITOR_BLOCK_TYPE);
-}
-
-// Dragging a single line in chrome removes DraftJS's data
-// and only sends a <span> containing the dragged text next
-// to a <meta> tag
-function htmlIsPlainTextDragged(html: string): boolean {
-    const parser = new DOMParser().parseFromString(html, 'text/html');
-
-    return parser.querySelectorAll('span').length === 1 &&
-        parser.querySelectorAll('meta').length === 1 &&
-        parser.querySelectorAll(':not(span):not(meta):not(html):not(head):not(body)').length === 0;
 }
 
 class BaseUnstyledComponent extends React.Component<any, any> {

--- a/scripts/core/editor3/helpers/htmlComesFromDraftjsEditor.ts
+++ b/scripts/core/editor3/helpers/htmlComesFromDraftjsEditor.ts
@@ -1,18 +1,1 @@
-export const htmlComesFromDraftjsEditor = (html: string) => {
-    const parser = new DOMParser().parseFromString(html, 'text/html');
-    const comesFromeditor = parser.querySelector('[data-offset-key]') != null;
-
-    if (comesFromeditor) {
-        return true;
-    }
-
-    // Dragging a single line in chrome removes DraftJS's data
-    // and only sends a <span> containing the dragged text next
-    // to a <meta> tag
-    const chromeDraggedText =
-        parser.querySelectorAll('span').length === 1 &&
-        parser.querySelectorAll('meta').length === 1 &&
-        parser.querySelectorAll(':not(span):not(meta):not(html):not(head):not(body)').length === 0;
-
-    return chromeDraggedText;
-};
+export const htmlComesFromDraftjsEditor = (html: string) => new DOMParser().parseFromString(html, 'text/html').querySelector('[data-offset-key]') != null;

--- a/scripts/core/editor3/helpers/htmlComesFromDraftjsEditor.ts
+++ b/scripts/core/editor3/helpers/htmlComesFromDraftjsEditor.ts
@@ -1,1 +1,2 @@
-export const htmlComesFromDraftjsEditor = (html: string) => new DOMParser().parseFromString(html, 'text/html').querySelector('[data-offset-key]') != null;
+export const htmlComesFromDraftjsEditor = (html: string) =>
+    new DOMParser().parseFromString(html, 'text/html').querySelector('[data-offset-key]') != null;

--- a/scripts/core/editor3/helpers/htmlComesFromDraftjsEditor.ts
+++ b/scripts/core/editor3/helpers/htmlComesFromDraftjsEditor.ts
@@ -1,2 +1,18 @@
-export const htmlComesFromDraftjsEditor = (html: string) => new DOMParser().parseFromString(html, 'text/html')
-    .body.querySelector('[data-offset-key]') != null;
+export const htmlComesFromDraftjsEditor = (html: string) => {
+    const parser = new DOMParser().parseFromString(html, 'text/html');
+    const comesFromeditor = parser.querySelector('[data-offset-key]') != null;
+
+    if (comesFromeditor) {
+        return true;
+    }
+
+    // Dragging a single line in chrome removes DraftJS's data
+    // and only sends a <span> containing the dragged text next
+    // to a <meta> tag
+    const chromeDraggedText =
+        parser.querySelectorAll('span').length === 1 &&
+        parser.querySelectorAll('meta').length === 1 &&
+        parser.querySelectorAll(':not(span):not(meta):not(html):not(head):not(body)').length === 0;
+
+    return chromeDraggedText;
+};

--- a/scripts/core/editor3/helpers/htmlIsPlainTextDragged.spec.ts
+++ b/scripts/core/editor3/helpers/htmlIsPlainTextDragged.spec.ts
@@ -1,6 +1,6 @@
 import {htmlIsPlainTextDragged} from './htmlIsPlainTextDragged';
 
-fit('should detect plain text dragged from browser', () => {
+it('should detect plain text dragged from browser', () => {
     const html = `
     <meta charset="utf-8">
     <span>Plain text dragged</span>
@@ -9,7 +9,7 @@ fit('should detect plain text dragged from browser', () => {
     expect(htmlIsPlainTextDragged(html)).toBe(true);
 });
 
-fit('should not detect plain text if it contains a link', () => {
+it('should not detect plain text if it contains a link', () => {
     const html = `
     <meta charset="utf-8">
     <span>

--- a/scripts/core/editor3/helpers/htmlIsPlainTextDragged.spec.ts
+++ b/scripts/core/editor3/helpers/htmlIsPlainTextDragged.spec.ts
@@ -1,0 +1,21 @@
+import {htmlIsPlainTextDragged} from './htmlIsPlainTextDragged';
+
+fit('should detect plain text dragged from browser', () => {
+    const html = `
+    <meta charset="utf-8">
+    <span>Plain text dragged</span>
+    `;
+
+    expect(htmlIsPlainTextDragged(html)).toBe(true);
+});
+
+fit('should not detect plain text if it contains a link', () => {
+    const html = `
+    <meta charset="utf-8">
+    <span>
+    <a href="">link</a>
+    </span>
+    `;
+
+    expect(htmlIsPlainTextDragged(html)).toBe(false);
+});

--- a/scripts/core/editor3/helpers/htmlIsPlainTextDragged.ts
+++ b/scripts/core/editor3/helpers/htmlIsPlainTextDragged.ts
@@ -2,9 +2,13 @@
 // and only sends a <span> containing the dragged text next
 // to a <meta> tag
 export function htmlIsPlainTextDragged(html: string): boolean {
-    const parser = new DOMParser().parseFromString(html, 'text/html');
+    const doc = new DOMParser().parseFromString(html, 'text/html');
 
-    return parser.querySelectorAll('span').length === 1 &&
-        parser.querySelectorAll('meta').length === 1 &&
-        parser.querySelectorAll(':not(span):not(meta):not(html):not(head):not(body)').length === 0;
+    if (doc.body.childElementCount !== 1) {
+        return false;
+    }
+
+    const span = doc.body.childNodes[0] as HTMLElement;
+
+    return span.tagName === 'SPAN' && span.innerHTML === span.innerText;
 }

--- a/scripts/core/editor3/helpers/htmlIsPlainTextDragged.ts
+++ b/scripts/core/editor3/helpers/htmlIsPlainTextDragged.ts
@@ -1,0 +1,10 @@
+// Dragging a single line in chrome removes DraftJS's data
+// and only sends a <span> containing the dragged text next
+// to a <meta> tag
+export function htmlIsPlainTextDragged(html: string): boolean {
+    const parser = new DOMParser().parseFromString(html, 'text/html');
+
+    return parser.querySelectorAll('span').length === 1 &&
+        parser.querySelectorAll('meta').length === 1 &&
+        parser.querySelectorAll(':not(span):not(meta):not(html):not(head):not(body)').length === 0;
+}


### PR DESCRIPTION
SDESK-4575

htmlComesFromDraftjsEditor was not working when manually selecting
one/more words on the same line on chrome, as it removed all html
references of draft-js