### PR TITLE
Insert embed before block if cursor is at the beginning

### DIFF
--- a/scripts/core/editor3/helpers/handleBeforeInputHighlights.ts
+++ b/scripts/core/editor3/helpers/handleBeforeInputHighlights.ts
@@ -11,14 +11,7 @@ import {uniq} from 'lodash';
 import {getDraftCharacterListForSelection} from './getDraftCharacterListForSelection';
 import {resizeDraftSelection} from './resizeDraftSelection';
 import {styleNameBelongsToHighlight} from './highlights';
-
-function isSelectionAtEndOfBlock(editorState: EditorState): boolean {
-    const selection = editorState.getSelection();
-    const endBlockKey = selection.getEndKey();
-    const block = editorState.getCurrentContent().getBlockForKey(endBlockKey);
-
-    return block.getLength() === selection.getEndOffset();
-}
+import {isSelectionAtEndOfBlock} from './selectionPositionInBlock';
 
 /**
  * Returns the characters before and after the cursor.

--- a/scripts/core/editor3/helpers/selectionPositionInBlock.ts
+++ b/scripts/core/editor3/helpers/selectionPositionInBlock.ts
@@ -1,0 +1,13 @@
+import {EditorState} from 'draft-js';
+
+export function isSelectionAtEndOfBlock(editorState: EditorState): boolean {
+    const selection = editorState.getSelection();
+    const endBlockKey = selection.getEndKey();
+    const block = editorState.getCurrentContent().getBlockForKey(endBlockKey);
+
+    return block.getLength() === selection.getEndOffset();
+}
+
+export function isSelectionAtStartOfBlock(editorState: EditorState): boolean {
+    return editorState.getSelection().getStartOffset() === 0;
+}


### PR DESCRIPTION
SDESK-4640

If the cursor is at the beginning of the block when the *embed* button is pressed, the embed will appear before that block.

I modified the `insertBlocksAfter` function to allow inserting content before or after an specific block