### PR TITLE
Fix render on items when secondLine is empty

### DIFF
--- a/scripts/apps/search/helpers.tsx
+++ b/scripts/apps/search/helpers.tsx
@@ -137,35 +137,35 @@ export function renderArea(area, itemProps, props: {className?: string}, customR
 
     /* globals __SUPERDESK_CONFIG__: true */
     const listConfig = __SUPERDESK_CONFIG__.list || DEFAULT_LIST_CONFIG;
-
-    var specs = listConfig[area] || [];
+    let specs = listConfig[area] || [];
 
     // If narrowView configuration is available and also singleline are active
     if (itemProps.scope.singleLine && itemProps.narrow && listConfig.narrowView) {
         specs = listConfig.narrowView;
     }
 
-    var elemProps = angular.extend({key: area}, props);
+    const elemProps = angular.extend({key: area}, props);
+    const components = specs.map((field, i) => {
+        if (customRender.fields && field in customRender.fields) {
+            return customRender.fields[field](itemProps);
+        }
 
-    return (
-        <div {...elemProps}>
-            {
-                specs.map((field, i) => {
-                    if (customRender.fields && field in customRender.fields) {
-                        return customRender.fields[field](itemProps);
-                    }
+        const Component = fields[field];
 
-                    const Component = fields[field];
+        if (Component != null) {
+            return <Component key={i} {...itemProps} />;
+        }
 
-                    if (Component != null) {
-                        return <Component key={i} {...itemProps} />;
-                    } else {
-                        return null;
-                    }
-                })
-            }
-        </div>
-    );
+        return null;
+    }).filter(Boolean);
+
+    if (components.length > 0) {
+        return <div {...elemProps}>
+            { components }
+        </div>;
+    }
+
+    return null;
 }
 
 /*

--- a/yarn.lock
+++ b/yarn.lock
@@ -9734,10 +9734,10 @@ superdesk-code-style@^1.1.1:
     eslint-plugin-jasmine "^2.9.1"
     eslint-plugin-react "^7.5.1"
 
-superdesk-ui-framework@2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/superdesk-ui-framework/-/superdesk-ui-framework-2.0.6.tgz#eb4f75af20f4764dc94d3a09e83231ae4261d8fe"
-  integrity sha512-trlG9V07zSQf8uKzlh5eAIInKLKlEv5MGH37w1SmUWluLVmuJg6j5jeMt24ZpdA4V9PypDJ3S9PYj+hXskPHnw==
+superdesk-ui-framework@2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/superdesk-ui-framework/-/superdesk-ui-framework-2.0.8.tgz#dbb140a69c0db3af23647c2f2b5c814607aa8db5"
+  integrity sha512-D/BCnnJ9kAp2UNi/YO4iitASwrZmKjcCRr07yPJtQGAd52scIeIECw47iHWckqD1on8yGtiTpyKUrLW5UyYOGA==
   dependencies:
     popper.js "1.14.4"
 


### PR DESCRIPTION
SDNTB-597

The bug was introduced [here](https://github.com/superdesk/superdesk-client-core/pull/3018/files#diff-f82bfbbc2c37286c0f43f8d542f07c19R150-R168) because before it could return null (line not rendered) but now it was always rendering the component even when it was empty