### PR TITLE
build fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,13 +21,6 @@ module.exports = Object.assign({}, sharedConfigs, {
         // but keep internal properties unquoted unless required
         'quote-props': 0,
 
-        "comma-dangle": ["error", {
-            "arrays": "always-multiline",
-            "objects": "always-multiline",
-            "imports": "always-multiline",
-            "exports": "always-multiline",
-            "functions": "always-multiline"
-        }],
         'newline-per-chained-call': ["error", {"ignoreChainWithDepth": 3}],
     }),
     parser: 'typescript-eslint-parser',
@@ -46,6 +39,14 @@ module.exports = Object.assign({}, sharedConfigs, {
                 'quote-props': 0,
                 'arrow-body-style': 0,
                 'max-len': 0, // handled by tslint
+
+                "comma-dangle": ["error", {
+                    "arrays": "always-multiline",
+                    "objects": "always-multiline",
+                    "imports": "always-multiline",
+                    "exports": "always-multiline",
+                    "functions": "always-multiline"
+                }],
             },
         },
     ],

--- a/scripts/apps/authoring/authoring/preview-test-server/server.js
+++ b/scripts/apps/authoring/authoring/preview-test-server/server.js
@@ -38,7 +38,7 @@ app.post('/preview', (req, res) => {
         ${getContent(req.headers['content-type'], req.body)}
     </div>
 </body>
-</html>`,
+</html>`
     );
 });
 

--- a/scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx
+++ b/scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx
@@ -5,7 +5,7 @@ import {StickElementsWithTracking} from 'core/helpers/dom/stickElementsWithTrack
 import {
     ISpellcheckWarning,
     ISpellchecker,
-    ISpellcheckerSuggestion
+    ISpellcheckerSuggestion,
 } from './interfaces';
 import {reloadSpellcheckerWarnings} from '../../actions';
 

--- a/tasks/options/webpack.js
+++ b/tasks/options/webpack.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
         build: {
             plugins: config.plugins.concat(
                 new webpack.DefinePlugin({'process.env': {NODE_ENV: JSON.stringify('production')}}),
-                new webpack.optimize.UglifyJsPlugin({sourceMap: true})
+                new webpack.optimize.UglifyJsPlugin({sourceMap: false})
             ),
         },
     };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,10 @@ var path = require('path');
 var webpack = require('webpack');
 var lodash = require('lodash');
 
+function countOccurences(_string, substring) {
+    return _string.split(substring).length - 1;
+}
+
 // makeConfig creates a new configuration file based on the passed options.
 module.exports = function makeConfig(grunt) {
     var appConfigPath = path.join(process.cwd(), 'superdesk.config.js');
@@ -15,26 +19,10 @@ module.exports = function makeConfig(grunt) {
 
     const sdConfig = lodash.defaultsDeep(require(appConfigPath)(grunt), getDefaults(grunt));
 
-    // shouldExclude returns true if the path p should be excluded from loaders
-    // such as 'babel' or 'eslint'. This is to avoid including node_modules into
-    // these loaders, but not node modules that are superdesk apps.
-    const shouldExclude = function(p) {
-        if (p.includes('WEBPACK_IGNORE')) {
-            return true;
-        }
+    const apps = sdConfig.importApps || [];
 
-        // don't exclude anything outside node_modules
-        if (p.indexOf('node_modules') === -1) {
-            return false;
-        }
-
-        const apps = sdConfig.importApps || sdConfig.apps || [];
-
-        // include only 'superdesk-core' and valid modules inside node_modules
-        let validModules = ['superdesk-core'].concat(apps);
-
-        return !validModules.some((app) => p.indexOf(app) > -1);
-    };
+    // include only 'superdesk-core' and valid modules inside node_modules
+    let validModules = ['superdesk-core'].concat(apps);
 
     return {
         entry: {
@@ -86,7 +74,26 @@ module.exports = function makeConfig(grunt) {
             rules: [
                 {
                     test: /\.(ts|tsx|js|jsx)$/,
-                    exclude: shouldExclude,
+                    exclude: function(absolutePath) {
+                        // Exclude files inside `WEBPACK_IGNORE` folder.
+                        // This is only relevant in development.
+                        // It was added to enable linking ui-framework.
+                        if (absolutePath.includes('WEBPACK_IGNORE')) {
+                            return true;
+                        }
+                
+                        // don't exclude anything outside node_modules
+                        if (absolutePath.indexOf('node_modules') === -1) {
+                            return false;
+                        }
+                
+                        // exclude everything else, unless it's a part of a superdesk app like superdesk-planning
+                        // but is not its dependency.
+                        // For example, `superdesk-planning/node_modules/**/*` will be excluded.
+                        return !validModules.some(
+                            (app) => absolutePath.indexOf(app) !== -1 && countOccurences(absolutePath, '/node_modules/') === 1,
+                        );
+                    },
                     loader: 'ts-loader',
                     options: {
                         transpileOnly: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,17 +81,18 @@ module.exports = function makeConfig(grunt) {
                         if (absolutePath.includes('WEBPACK_IGNORE')) {
                             return true;
                         }
-                
+
                         // don't exclude anything outside node_modules
                         if (absolutePath.indexOf('node_modules') === -1) {
                             return false;
                         }
-                
+
                         // exclude everything else, unless it's a part of a superdesk app like superdesk-planning
                         // but is not its dependency.
                         // For example, `superdesk-planning/node_modules/**/*` will be excluded.
                         return !validModules.some(
-                            (app) => absolutePath.indexOf(app) !== -1 && countOccurences(absolutePath, '/node_modules/') === 1,
+                            (app) =>
+                                absolutePath.includes(app) && countOccurences(absolutePath, '/node_modules/') === 1,
                         );
                     },
                     loader: 'ts-loader',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -92,7 +92,7 @@ module.exports = function makeConfig(grunt) {
                         // For example, `superdesk-planning/node_modules/**/*` will be excluded.
                         return !validModules.some(
                             (app) =>
-                                absolutePath.includes(app) && countOccurences(absolutePath, '/node_modules/') === 1,
+                                absolutePath.includes(app) && countOccurences(absolutePath, '/node_modules/') === 1
                         );
                     },
                     loader: 'ts-loader',


### PR DESCRIPTION
```
Running "webpack:build" (webpack) task
 92% chunk asset optimization                                                             
<--- Last few GCs --->

  193642 ms: Mark-sweep 1322.5 (1434.6) -> 1321.3 (1434.6) MB, 844.4 / 0.0 ms [allocation failure] [GC in old space requested].
  194546 ms: Mark-sweep 1321.3 (1434.6) -> 1321.3 (1434.6) MB, 903.6 / 0.0 ms [allocation failure] [GC in old space requested].
  195422 ms: Mark-sweep 1321.3 (1434.6) -> 1327.1 (1418.6) MB, 875.1 / 0.0 ms [last resort gc].
  196319 ms: Mark-sweep 1327.1 (1418.6) -> 1333.1 (1418.6) MB, 897.2 / 0.0 ms [last resort gc].


<--- JS stacktrace --->

==== JS stack trace =========================================

Security context: 0x3a4d7accf781 <JS Object>
    1: slice [native string.js:~246] [pc=0x2cbd96643803] (this=0x422f411c81 <String[157]:             return (react_1.default.createElement("div", { key: file._id, className: className, onClick: function () { return _this.props.onClick(file); } },>,R=58,S=69)
    2: /* anonymous */(aka /* anonymous */) [/home/tomas/DevTools/superdesk-repos/superdesk-client-core/node_modules/webpack-sources/lib/...

FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
 1: node::Abort() [grunt]
 2: 0x7d027c [grunt]
 3: v8::Utils::ReportApiFailure(char const*, char const*) [grunt]
 4: v8::internal::V8::FatalProcessOutOfMemory(char const*, bool) [grunt]
 5: v8::internal::Factory::NewCode(v8::internal::CodeDesc const&, unsigned int, v8::internal::Handle<v8::internal::Object>, bool, bool, int, bool) [grunt]
 6: v8::internal::CodeGenerator::MakeCodeEpilogue(v8::internal::MacroAssembler*, v8::internal::CompilationInfo*) [grunt]
 7: v8::internal::LChunk::Codegen() [grunt]
 8: v8::internal::OptimizedCompileJob::GenerateCode() [grunt]
 9: v8::internal::Compiler::FinalizeOptimizedCompileJob(v8::internal::OptimizedCompileJob*) [grunt]
10: v8::internal::OptimizingCompileDispatcher::InstallOptimizedFunctions() [grunt]
11: v8::internal::StackGuard::HandleInterrupts() [grunt]
12: v8::internal::Runtime_StackGuard(int, v8::internal::Object**, v8::internal::Isolate*) [grunt]
13: 0x2cbd90f092a7
Aborted (core dumped)
```

Sometimes the client would not build and throw an out of memory error(nodejs). I've noticed that the typescript loader was handling files that it shouldn't like `superdesk/client/node_modules/react/*`. I suspected that it might be the reason for the crashes and fixed it, but the issue persisted.

I later found that excluding `superdesk-planning` also fixes the issue. I don't know why that it is, but I suspect that it either increases the amount of code webpack has to handle or there are some circular imports.

I finally found that the build starts working again when source maps are disabled when uglifying(even with planning enabled). I'd like to maintain the source maps, but I can't find a better solution at the moment.

