### PR TITLE
[SDCP-6] - Users should send only to member desks if no privilege

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log
 *.swm
 
 .vscode
+.idea

--- a/scripts/apps/authoring/authoring/directives/SendItem.tsx
+++ b/scripts/apps/authoring/authoring/directives/SendItem.tsx
@@ -816,8 +816,12 @@ export function SendItem($q,
             }
 
             /**
-             * Set the last selected desk based on the user action.
-             * To be called after currentUserAction is set
+             * Sets the desk and stage list for user to move the story to.
+             * Also sets the last selected desk based on the user action.
+             * if user has the move privilege and if the story is not published she can send the story to any desk.
+             * if user doesn't have the move privilege or if the story is published
+             * then story can be sent only to member desks.
+             * This function to be called after currentUserAction is set
              */
             function setDesksAndStages() {
                 if (!scope.currentUserAction) {
@@ -832,8 +836,6 @@ export function SendItem($q,
                     } else {
                         scope.selectedDesk = null;
                     }
-
-                    return;
                 } else {
                     scope.desks = scope.allDesks;
                 }

--- a/scripts/apps/authoring/authoring/directives/SendItem.tsx
+++ b/scripts/apps/authoring/authoring/directives/SendItem.tsx
@@ -824,8 +824,16 @@ export function SendItem($q,
                     return;
                 }
                 // set the desks for desk filter
-                if (scope.currentUserAction === ctrl.userActions.publish) {
+                if (scope.currentUserAction === ctrl.userActions.publish || !privileges.privileges.move) {
                     scope.desks = scope.userDesks;
+
+                    if (!_.isEmpty(scope.desks)) {
+                        scope.selectDesk(scope.desks[0]);
+                    } else {
+                        scope.selectedDesk = null;
+                    }
+
+                    return;
                 } else {
                     scope.desks = scope.allDesks;
                 }

--- a/scripts/apps/authoring/authoring/services/AuthoringService.ts
+++ b/scripts/apps/authoring/authoring/services/AuthoringService.ts
@@ -528,7 +528,7 @@ export function AuthoringService($q, $location, api, lock, autosave, confirm, pr
 
         action.spike = currentItem.state !== ITEM_STATE.SPIKED && userPrivileges.spike;
 
-        action.send = currentItem._current_version > 0 && userPrivileges.move && lockedByMe;
+        action.send = currentItem._current_version > 0 && lockedByMe;
     };
 
     this._getCurrentItem = function(item) {

--- a/scripts/apps/authoring/tests/authoring.spec.ts
+++ b/scripts/apps/authoring/tests/authoring.spec.ts
@@ -902,7 +902,7 @@ describe('authoring actions', () => {
 
             allowedActions(itemActions, ['save', 'edit', 'duplicate', 'spike', 're_write',
                 'mark_item_for_highlight', 'mark_item_for_desks',
-                'package_item', 'multi_edit', 'publish', 'add_to_current', 'export', 'set_label']);
+                'package_item', 'multi_edit', 'publish', 'add_to_current', 'export', 'set_label', 'send']);
         }));
 
     it('cannot perform publish if the item is marked for not publication',
@@ -934,7 +934,7 @@ describe('authoring actions', () => {
 
             allowedActions(itemActions, ['save', 'edit', 'duplicate', 'spike', 're_write',
                 'mark_item_for_highlight', 'package_item', 'multi_edit', 'add_to_current',
-                'export', 'set_label']);
+                'export', 'set_label', 'send']);
         }));
 
     it('cannot perform publish if the item is highlight package',
@@ -965,7 +965,7 @@ describe('authoring actions', () => {
             var itemActions = authoring.itemActions(item);
 
             allowedActions(itemActions, ['save', 'edit', 'duplicate', 'spike',
-                'package_item', 'multi_edit', 'add_to_current', 'set_label']);
+                'package_item', 'multi_edit', 'add_to_current', 'set_label', 'send']);
         }));
 
     it('cannot publish if user does not have publish privileges on the desk',
@@ -997,7 +997,7 @@ describe('authoring actions', () => {
 
             allowedActions(itemActions, ['save', 'edit', 'duplicate', 'spike', 're_write',
                 'mark_item_for_highlight', 'package_item', 'multi_edit', 'add_to_current',
-                'export', 'set_label']);
+                'export', 'set_label', 'send']);
         }));
 
     it('can only view the item if the user does not have desk membership',
@@ -1442,7 +1442,7 @@ describe('authoring actions', () => {
                 're_write', 'set_label']);
         }));
 
-    it('Cannot send item if the no move privileges',
+    it('Can send item even if there is no move privileges',
         inject((privileges, desks, authoring, $q, $rootScope) => {
             var item = {
                 _id: 'test',
@@ -1475,7 +1475,7 @@ describe('authoring actions', () => {
 
             allowedActions(itemActions, ['save', 'edit', 'duplicate', 'spike', 'add_to_current',
                 're_write', 'mark_item_for_highlight', 'package_item', 'multi_edit', 'publish',
-                'export', 'set_label']);
+                'export', 'set_label', 'send']);
         }));
 
     it('Can send item if the version greater then zero',


### PR DESCRIPTION
- users with `move` privilege can send content to any desk (no change)
- users with no `move` privilege can send still send content but only to member desks