### PR TITLE
Increase the limit of displayed marked items

### DIFF
--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -414,7 +414,7 @@ declare module 'superdesk-api' {
         endpoint: string;
         page: {
             from: number;
-            size?: number;
+            size: number;
         };
         sort: Array<{[field: string]: 'asc' | 'desc'}>;
 

--- a/scripts/extensions/markForUser/src/get-marked-for-me-component.tsx
+++ b/scripts/extensions/markForUser/src/get-marked-for-me-component.tsx
@@ -37,7 +37,7 @@ export function getMarkedForMeComponent(superdesk: ISuperdesk) {
 
             if (user != null) {
                 superdesk.dataApiByEntity.article.query({
-                    page: {from: 0},
+                    page: {from: 0, size: 300},
                     sort: [{'_updated': 'desc'}],
                     filterValues: {marked_for_user: [user._id]},
                 }).then((articles) => {


### PR DESCRIPTION
SDBELGA-123

I've increased the limit to 300. It should be enough for most use cases given that items would be unmarked upon publishing.

To fix it properly we would need to implement a lazy loadable tree view which would take a lot of time. I think the best trade-off would be to ditch the tree view and display the items in a flat list sorted by last updated date. The desk label would still be visible except it wouldn't be grouped. Implementation of a lazy loadable list would be required, but it's much simpler than a tree and would be more reusable across superdesk.