### PR TITLE
Disable extensions in core in favor of enabling them on customer repositories

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -27,7 +27,11 @@ var config = {
         a: path.join(__dirname, '/spec/**/[a-f]*[Ss]pec.js'),
         b: path.join(__dirname, '/spec/**/[g-m]*[Ss]pec.js'),
         c: path.join(__dirname, '/spec/**/[n-z]*[Ss]pec.js'),
-        d: path.join(__dirname, '/scripts/extensions/*/dist/spec/*[Ss]pec.js'),
+
+        // disable running e2e tests from extensions until testing environment is reconfigured
+        // to run start client from the main repo with all extensions enabled
+
+        // d: path.join(__dirname, '/scripts/extensions/*/dist/spec/*[Ss]pec.js'),
     },
 
     framework: 'jasmine2',

--- a/superdesk.config.js
+++ b/superdesk.config.js
@@ -31,10 +31,9 @@ module.exports = function(grunt) {
             DEFAULT_IDLE_TIME: {hours: 0, minutes: 0},
         },
 
-        // enabling all extensions on master to run e2e tests from extensions
+        
         enabledExtensions: {
-            annotationsLibrary: 1,
-            markForUser: 1,
+            // helloWorld: 1,
             planning: 1,
         },
     };

--- a/superdesk.config.js
+++ b/superdesk.config.js
@@ -31,7 +31,6 @@ module.exports = function(grunt) {
             DEFAULT_IDLE_TIME: {hours: 0, minutes: 0},
         },
 
-        
         enabledExtensions: {
             // helloWorld: 1,
             planning: 1,


### PR DESCRIPTION
All extensions will be enabled on sd-master for testing.