### PR TITLE
enable aggragations for listing items marked for current user

### DIFF
--- a/scripts/core/helpers/CrudManager.tsx
+++ b/scripts/core/helpers/CrudManager.tsx
@@ -22,7 +22,7 @@ import {httpRequestJsonLocal, httpRequestVoidLocal} from './network';
 export function queryElastic(
     parameters: IQueryElasticParameters,
 ) {
-    const {endpoint, page, sort, filterValues} = parameters;
+    const {endpoint, page, sort, filterValues, aggregations} = parameters;
 
     return ng.getServices(['config', 'session', 'api'])
         .then((res: any) => {
@@ -66,7 +66,7 @@ export function queryElastic(
             };
 
             const query = {
-                aggregations: 0,
+                aggregations: aggregations === true ? 1 : 0,
                 es_highlight: 0,
                 // projections: [],
                 source,

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -420,6 +420,8 @@ declare module 'superdesk-api' {
 
         // can use deep references like {'a.b.c': []}
         filterValues: {[fieldName: string]: Array<string>};
+
+        aggregations: boolean;
     }
 
     interface IElasticSearchAggregationResult {

--- a/scripts/extensions/markForUser/src/get-marked-for-me-component.tsx
+++ b/scripts/extensions/markForUser/src/get-marked-for-me-component.tsx
@@ -40,6 +40,7 @@ export function getMarkedForMeComponent(superdesk: ISuperdesk) {
                     page: {from: 0, size: 300},
                     sort: [{'_updated': 'desc'}],
                     filterValues: {marked_for_user: [user._id]},
+                    aggregations: true,
                 }).then((articles) => {
                     this.setState({articles});
                 });


### PR DESCRIPTION
SDNTB-612

Mark for user feature was crashing for ntb because they have [ELASTICSEARCH_AUTO_AGGREGATIONS](https://github.com/superdesk/superdesk-ntb/blob/master/server/settings.py#L177) disabled.