### PR TITLE
Apply local client configs before fetching server configs

### DIFF
--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -43,16 +43,16 @@ export function startApp(
         }
     }
 
+    // update config via config.js
+    if (window.superdeskConfig) {
+        angular.merge(appConfig, window.superdeskConfig);
+    }
+
+    // non-mock app configuration must live here to allow tests to override
+    // since tests do not import this file.
+    angular.module('superdesk.config').constant('config', appConfig);
+
     loadConfigs().then(() => {
-        // update config via config.js
-        if (window.superdeskConfig) {
-            angular.merge(appConfig, window.superdeskConfig);
-        }
-
-        // non-mock app configuration must live here to allow tests to override
-        // since tests do not import this file.
-        angular.module('superdesk.config').constant('config', appConfig);
-
         /**
          * @ngdoc module
          * @name superdesk-client


### PR DESCRIPTION
Server URL is in local configs. Configs from the server can't be fetched until a server URL is set.