### PR TITLE
fetch deploy config immediatelly

### DIFF
--- a/scripts/core/config.ts
+++ b/scripts/core/config.ts
@@ -85,12 +85,16 @@ function DeployConfigFactory(api, $q) {
         }
     }
 
-    return new DeployConfig();
+    const deployConfig = new DeployConfig();
+
+    deployConfig.fetch();
+
+    return deployConfig;
 }
 
 angular.module('superdesk.config', ['superdesk.core.api'])
     .factory('deployConfig', DeployConfigFactory)
 
-    .run(['$rootScope', 'deployConfig', function($rootScope, deployConfig) {
+    .run(['$rootScope', 'deployConfig', function($rootScope) {
         $rootScope.config = appConfig || {};
     }]);


### PR DESCRIPTION
After refactoring configs in https://github.com/superdesk/superdesk-client-core/pull/3170 NTB instance crashes due to not having configs already loaded. It shouldn't have relied on it being loaded in the first place and should have used `deployConfig.get` instead which takes care of the loading. I'm adding immediate loading to maintain old behavior in case other instances depend on it. In the long run, `deployConfig` service will be removed in favor of retrieving configs from extensions API where configs are preloaded and synchronous.