### PR TITLE
Keep required value of editor fields in sync with the schema fields for Content Profiles.

### DIFF
--- a/scripts/apps/workspace/content/controllers/ContentProfileFields.ts
+++ b/scripts/apps/workspace/content/controllers/ContentProfileFields.ts
@@ -117,6 +117,8 @@ export default function ContentProfileFields($scope, content, vocabularies, meta
 
                 this.sections[section].enabled.push(key);
                 this.model.editor[key].order = index + 1; // keep order in sync
+                // keep required value of editor fields in sync with the schema fields SDNTB-615
+                this.model.editor[key].required = this.model.schema[key].required;
             });
 
             Object.keys(this.model.editor)


### PR DESCRIPTION
fixes SDNTB-615

When creating a new CP or adding a new field to it the `required` field is present in schema fields but missing from the editor fields, it gets inserted only if we toggle the required checkbox in the CP.