### PR TITLE
Fix annotation library breaking after editing one item

### DIFF
--- a/scripts/core/helpers/CrudManager.tsx
+++ b/scripts/core/helpers/CrudManager.tsx
@@ -266,7 +266,7 @@ export function connectCrudManager<Props, PropsToConnect, Entity extends IBaseRe
         }
 
         refresh(): Promise<IRestApiResponse<Entity>> {
-            return this.read(1, this.state.activeSortOption, this.state.activeFilters);
+            return this.read(this.state._meta.page, this.state.activeSortOption, this.state.activeFilters);
         }
 
         sort(sortOption: ISortOption): Promise<IRestApiResponse<Entity>> {


### PR DESCRIPTION
SDESK-4801

If the item was not on page 1, updating the item would cause pagination to go back to page 1 and that was making the component not find the open item inside the current fetched data (cause it was looking on page 1 instead of page X)