### PR TITLE
Fix search and edit on annotations library

### DIFF
--- a/scripts/apps/internal-destinations/InternalDestinations.tsx
+++ b/scripts/apps/internal-destinations/InternalDestinations.tsx
@@ -9,8 +9,6 @@ import {IFormField, IFormGroup} from 'superdesk-api';
 import {FormFieldType} from 'core/ui/components/generic-form/interfaces/form';
 import {gettext} from 'core/utils';
 
-const InternalDestinationsPageComponent = getGenericListPageComponent<IInternalDestination>('internal_destinations');
-
 const nameField: IFormField = {
     label: gettext('Destination name'),
     type: FormFieldType.textSingleLine,
@@ -74,6 +72,9 @@ const formConfig: IFormGroup = {
         macroField,
     ],
 };
+
+const InternalDestinationsPageComponent =
+    getGenericListPageComponent<IInternalDestination>('internal_destinations', formConfig);
 
 const renderRow = (
     key: string,

--- a/scripts/core/helpers/CrudManager.tsx
+++ b/scripts/core/helpers/CrudManager.tsx
@@ -193,7 +193,7 @@ export function connectCrudManager<Props, PropsToConnect, Entity extends IBaseRe
     WrappedComponent, // : React.ComponentType<Props & PropsToConnect>
     name: string,
     endpoint: string,
-    formatFiltersForServer: (filters: ICrudManagerFilters) => ICrudManagerFilters,
+    formatFiltersForServer?: (filters: ICrudManagerFilters) => ICrudManagerFilters,
 ): React.ComponentType<Props> {
     const component = class extends React.Component<Props, ICrudManagerState<Entity>>
         implements ICrudManagerMethods<Entity> {

--- a/scripts/core/helpers/CrudManager.tsx
+++ b/scripts/core/helpers/CrudManager.tsx
@@ -1,15 +1,23 @@
 /* eslint-disable react/display-name */
 import {appConfig} from 'appConfig';
 import ng from 'core/services/ng';
-import {generateFilterForServer} from 'core/ui/components/generic-form/generate-filter-for-server';
 import {generate} from 'json-merge-patch';
 import {isObject} from 'lodash';
 import React from 'react';
-import {IArticleQuery, IArticleQueryResult, IBaseRestApiResponse, ICrudManagerFilters, ICrudManagerMethods, ICrudManagerState, IDataApi, IQueryElasticParameters, IRestApiResponse, ISortOption, IFormGroup} from 'superdesk-api';
+import {
+    IBaseRestApiResponse,
+    ICrudManagerState,
+    ICrudManagerMethods,
+    ISortOption,
+    ICrudManagerFilters,
+    IRestApiResponse,
+    IDataApi,
+    IQueryElasticParameters,
+    IArticleQueryResult,
+    IArticleQuery,
+} from 'superdesk-api';
 import {httpRequestJsonLocal, httpRequestVoidLocal} from './network';
 import {connectServices} from './ReactRenderAsync';
-import {getFormGroupForFiltering} from 'core/ui/components/generic-form/get-form-group-for-filtering';
-import {getFormFieldsFlat} from 'core/ui/components/generic-form/get-form-fields-flat';
 
 export function queryElastic(
     parameters: IQueryElasticParameters,

--- a/scripts/core/helpers/CrudManager.tsx
+++ b/scripts/core/helpers/CrudManager.tsx
@@ -193,7 +193,7 @@ export function connectCrudManager<Props, PropsToConnect, Entity extends IBaseRe
     WrappedComponent, // : React.ComponentType<Props & PropsToConnect>
     name: string,
     endpoint: string,
-    formatFiltersForServer?: (filters: ICrudManagerFilters) => ICrudManagerFilters,
+    formatFiltersForServer: (filters: ICrudManagerFilters) => ICrudManagerFilters,
 ): React.ComponentType<Props> {
     const component = class extends React.Component<Props, ICrudManagerState<Entity>>
         implements ICrudManagerMethods<Entity> {

--- a/scripts/core/helpers/CrudManager.tsx
+++ b/scripts/core/helpers/CrudManager.tsx
@@ -1,24 +1,15 @@
 /* eslint-disable react/display-name */
-
-import React from 'react';
-import {generate} from 'json-merge-patch';
-import {connectServices} from './ReactRenderAsync';
-import {
-    IBaseRestApiResponse,
-    ICrudManagerState,
-    ICrudManagerMethods,
-    ISortOption,
-    ICrudManagerFilters,
-    IRestApiResponse,
-    IDataApi,
-    IQueryElasticParameters,
-    IArticleQueryResult,
-    IArticleQuery,
-} from 'superdesk-api';
-import {isObject} from 'lodash';
-import ng from 'core/services/ng';
-import {httpRequestJsonLocal, httpRequestVoidLocal} from './network';
 import {appConfig} from 'appConfig';
+import ng from 'core/services/ng';
+import {generateFilterForServer} from 'core/ui/components/generic-form/generate-filter-for-server';
+import {generate} from 'json-merge-patch';
+import {isObject} from 'lodash';
+import React from 'react';
+import {IArticleQuery, IArticleQueryResult, IBaseRestApiResponse, ICrudManagerFilters, ICrudManagerMethods, ICrudManagerState, IDataApi, IQueryElasticParameters, IRestApiResponse, ISortOption, IFormGroup} from 'superdesk-api';
+import {httpRequestJsonLocal, httpRequestVoidLocal} from './network';
+import {connectServices} from './ReactRenderAsync';
+import {getFormGroupForFiltering} from 'core/ui/components/generic-form/get-form-group-for-filtering';
+import {getFormFieldsFlat} from 'core/ui/components/generic-form/get-form-fields-flat';
 
 export function queryElastic(
     parameters: IQueryElasticParameters,
@@ -194,6 +185,7 @@ export function connectCrudManager<Props, PropsToConnect, Entity extends IBaseRe
     WrappedComponent, // : React.ComponentType<Props & PropsToConnect>
     name: string,
     endpoint: string,
+    formatFiltersForServer?: (filters: ICrudManagerFilters) => ICrudManagerFilters,
 ): React.ComponentType<Props> {
     const component = class extends React.Component<Props, ICrudManagerState<Entity>>
         implements ICrudManagerMethods<Entity> {
@@ -231,7 +223,6 @@ export function connectCrudManager<Props, PropsToConnect, Entity extends IBaseRe
             page: number,
             sortOption: ISortOption,
             filterValues: ICrudManagerFilters = {},
-            formatFiltersForServer?: (filters: ICrudManagerFilters) => ICrudManagerFilters,
         ): Promise<IRestApiResponse<Entity>> {
             return dataApi.query(
                 endpoint,

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -522,7 +522,6 @@ declare module 'superdesk-api' {
             page: number,
             sort: ISortOption,
             filterValues?: ICrudManagerFilters,
-            formatFiltersForServer?: (filters: ICrudManagerFilters) => ICrudManagerFilters,
         ): Promise<IRestApiResponse<Entity>>;
         update(item: Entity): Promise<Entity>;
         create(item: Entity): Promise<Entity>;
@@ -544,7 +543,7 @@ declare module 'superdesk-api' {
 
     export interface IConfigurableUiComponents {
         UserAvatar?: React.ComponentType<{user: IUser}>;
-    }    
+    }
 
     export interface IListItemProps {
         onClick?(): void;
@@ -765,11 +764,12 @@ declare module 'superdesk-api' {
         },
         components: {
             UserHtmlSingleLine: React.ComponentType<{html: string}>;
-            getGenericListPageComponent<T extends IBaseRestApiResponse>(resource: string): React.ComponentType<IPropsGenericForm<T>>;
+            getGenericListPageComponent<T extends IBaseRestApiResponse>(resource: string, formConfig?: IFormGroup): React.ComponentType<IPropsGenericForm<T>>;
             connectCrudManager<Props, PropsToConnect, Entity extends IBaseRestApiResponse>(
                 WrappedComponent: React.ComponentType<Props & PropsToConnect>,
                 name: string,
                 endpoint: string,
+                formatFiltersForServer?: (filters: ICrudManagerFilters) => ICrudManagerFilters,
             ): React.ComponentType<Props>;
             ListItem: React.ComponentType<IListItemProps>;
             ListItemColumn: React.ComponentType<IPropsListItemColumn>;
@@ -866,7 +866,7 @@ declare module 'superdesk-api' {
         saml_auth: any;
         google_auth: any;
         saml_label: any;
-        
+
 
         // FROM CLIENT
         server: {

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -764,12 +764,12 @@ declare module 'superdesk-api' {
         },
         components: {
             UserHtmlSingleLine: React.ComponentType<{html: string}>;
-            getGenericListPageComponent<T extends IBaseRestApiResponse>(resource: string, formConfig?: IFormGroup): React.ComponentType<IPropsGenericForm<T>>;
+            getGenericListPageComponent<T extends IBaseRestApiResponse>(resource: string, formConfig: IFormGroup): React.ComponentType<IPropsGenericForm<T>>;
             connectCrudManager<Props, PropsToConnect, Entity extends IBaseRestApiResponse>(
                 WrappedComponent: React.ComponentType<Props & PropsToConnect>,
                 name: string,
                 endpoint: string,
-                formatFiltersForServer?: (filters: ICrudManagerFilters) => ICrudManagerFilters,
+                formatFiltersForServer: (filters: ICrudManagerFilters) => ICrudManagerFilters,
             ): React.ComponentType<Props>;
             ListItem: React.ComponentType<IListItemProps>;
             ListItemColumn: React.ComponentType<IPropsListItemColumn>;

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -769,7 +769,7 @@ declare module 'superdesk-api' {
                 WrappedComponent: React.ComponentType<Props & PropsToConnect>,
                 name: string,
                 endpoint: string,
-                formatFiltersForServer: (filters: ICrudManagerFilters) => ICrudManagerFilters,
+                formatFiltersForServer?: (filters: ICrudManagerFilters) => ICrudManagerFilters,
             ): React.ComponentType<Props>;
             ListItem: React.ComponentType<IListItemProps>;
             ListItemColumn: React.ComponentType<IPropsListItemColumn>;

--- a/scripts/core/ui/components/ListPage/generic-list-page.tsx
+++ b/scripts/core/ui/components/ListPage/generic-list-page.tsx
@@ -602,17 +602,13 @@ export class GenericListPageComponent<T extends IBaseRestApiResponse>
 }
 
 export const getGenericListPageComponent =
-    <T extends IBaseRestApiResponse>(resource: string, formConfig?: IFormGroup) =>
+    <T extends IBaseRestApiResponse>(resource: string, formConfig: IFormGroup) =>
         connectServices<IPropsGenericForm<T>>(
             connectCrudManager<IPropsGenericForm<T>, IPropsConnected<T>, T>(
                 GenericListPageComponent,
                 'items',
                 resource,
                 (filters: IFormGroup) => {
-                    if (formConfig == null) {
-                        return filters;
-                    }
-
                     const formConfigForFilters = getFormGroupForFiltering(formConfig);
                     const fieldTypesLookup = getFormFieldsFlat(formConfigForFilters)
                         .reduce((accumulator, item) => ({...accumulator, ...{[item.field]: item.type}}), {});

--- a/scripts/core/ui/components/ListPage/generic-list-page.tsx
+++ b/scripts/core/ui/components/ListPage/generic-list-page.tsx
@@ -601,32 +601,33 @@ export class GenericListPageComponent<T extends IBaseRestApiResponse>
     }
 }
 
-export const getGenericListPageComponent = <T extends IBaseRestApiResponse>(resource: string, formConfig?: IFormGroup) =>
-    connectServices<IPropsGenericForm<T>>(
-        connectCrudManager<IPropsGenericForm<T>, IPropsConnected<T>, T>(
-            GenericListPageComponent,
-            'items',
-            resource,
-            (filters: IFormGroup) => {
-                if (formConfig == null) {
-                    return filters;
-                }
+export const getGenericListPageComponent =
+    <T extends IBaseRestApiResponse>(resource: string, formConfig?: IFormGroup) =>
+        connectServices<IPropsGenericForm<T>>(
+            connectCrudManager<IPropsGenericForm<T>, IPropsConnected<T>, T>(
+                GenericListPageComponent,
+                'items',
+                resource,
+                (filters: IFormGroup) => {
+                    if (formConfig == null) {
+                        return filters;
+                    }
 
-                const formConfigForFilters = getFormGroupForFiltering(formConfig);
-                const fieldTypesLookup = getFormFieldsFlat(formConfigForFilters)
-                    .reduce((accumulator, item) => ({...accumulator, ...{[item.field]: item.type}}), {});
+                    const formConfigForFilters = getFormGroupForFiltering(formConfig);
+                    const fieldTypesLookup = getFormFieldsFlat(formConfigForFilters)
+                        .reduce((accumulator, item) => ({...accumulator, ...{[item.field]: item.type}}), {});
 
-                let filtersFormatted = {};
+                    let filtersFormatted = {};
 
-                for (let fieldName in filters) {
-                    filtersFormatted[fieldName] = generateFilterForServer(
-                        fieldTypesLookup[fieldName],
-                        filters[fieldName],
-                    );
-                }
+                    for (let fieldName in filters) {
+                        filtersFormatted[fieldName] = generateFilterForServer(
+                            fieldTypesLookup[fieldName],
+                            filters[fieldName],
+                        );
+                    }
 
-                return filtersFormatted;
-            },
-        )
-        , ['modal', '$rootScope', 'notify'],
-    );
+                    return filtersFormatted;
+                },
+            )
+            , ['modal', '$rootScope', 'notify'],
+        );

--- a/scripts/core/ui/components/ListPage/generic-list-page.tsx
+++ b/scripts/core/ui/components/ListPage/generic-list-page.tsx
@@ -601,8 +601,8 @@ export class GenericListPageComponent<T extends IBaseRestApiResponse>
     }
 }
 
-export const getGenericListPageComponent = <T extends IBaseRestApiResponse>(resource: string, formConfig?: IFormGroup) => {
-    return connectServices<IPropsGenericForm<T>>(
+export const getGenericListPageComponent = <T extends IBaseRestApiResponse>(resource: string, formConfig?: IFormGroup) =>
+    connectServices<IPropsGenericForm<T>>(
         connectCrudManager<IPropsGenericForm<T>, IPropsConnected<T>, T>(
             GenericListPageComponent,
             'items',
@@ -630,4 +630,3 @@ export const getGenericListPageComponent = <T extends IBaseRestApiResponse>(reso
         )
         , ['modal', '$rootScope', 'notify'],
     );
-};

--- a/scripts/extensions/annotationsLibrary/src/annotations-library-page.tsx
+++ b/scripts/extensions/annotationsLibrary/src/annotations-library-page.tsx
@@ -19,8 +19,6 @@ export function getAnnotationsLibraryPage(superdesk: ISuperdesk) {
             } = superdesk.components;
             const {getFormFieldPreviewComponent} = superdesk.forms;
 
-            const AnnotationsLibraryPageComponent = getGenericListPageComponent<IKnowledgeBaseItem>('concept_items');
-
             const {
                 nameField,
                 languageField,
@@ -36,6 +34,8 @@ export function getAnnotationsLibraryPage(superdesk: ISuperdesk) {
                     definitionField,
                 ],
             };
+
+            const AnnotationsLibraryPageComponent = getGenericListPageComponent<IKnowledgeBaseItem>('concept_items', formConfig);
 
             const renderRow = (
                 key: string,

--- a/scripts/extensions/annotationsLibrary/src/annotations-library-page.tsx
+++ b/scripts/extensions/annotationsLibrary/src/annotations-library-page.tsx
@@ -35,7 +35,8 @@ export function getAnnotationsLibraryPage(superdesk: ISuperdesk) {
                 ],
             };
 
-            const AnnotationsLibraryPageComponent = getGenericListPageComponent<IKnowledgeBaseItem>('concept_items', formConfig);
+            const AnnotationsLibraryPageComponent =
+                getGenericListPageComponent<IKnowledgeBaseItem>('concept_items', formConfig);
 
             const renderRow = (
                 key: string,


### PR DESCRIPTION
SDESK-4802

There were several issues when searching & editing items inside the annotations library, caused by filters only being formatted the right way the first time the page load, not after every refresh while editing.