### PR TITLE
Allow duplicated text annotations

### DIFF
--- a/scripts/core/editor3/components/annotations/AnnotationInput.tsx
+++ b/scripts/core/editor3/components/annotations/AnnotationInput.tsx
@@ -119,7 +119,7 @@ class AnnotationInputBody extends React.Component<IProps, IState> {
      * @description onSubmit is called when the user clicks the Submit button in the UI.
      * Consequently, it calls the `onSubmit` prop, passing it the value of the text input.
      */
-    onSubmit() {
+    onSubmit(_event, reusingAnnotationFromExtensions = false) {
         const {body, type} = this.state;
         const _hidePopups = this.props.hidePopups;
         const {highlightId} = this.props.data;
@@ -129,13 +129,15 @@ class AnnotationInputBody extends React.Component<IProps, IState> {
             const annotationType = type;
 
             if (highlightId === undefined) {
-                this.annotationInputTabsFromExtensions.forEach((tab) => {
-                    tab.onAnnotationCreate(
-                        this.props.language,
-                        this.getAnnotatedText(),
-                        stateToHTML(convertFromRaw(body)),
-                    );
-                });
+                if (!reusingAnnotationFromExtensions) {
+                    this.annotationInputTabsFromExtensions.forEach((tab) => {
+                        tab.onAnnotationCreate(
+                            this.props.language,
+                            this.getAnnotatedText(),
+                            stateToHTML(convertFromRaw(body)),
+                        );
+                    });
+                }
 
                 this.props.highlightsManager.addHighlight(
                     highlightsConfig.ANNOTATION.type,
@@ -307,7 +309,7 @@ class AnnotationInputBody extends React.Component<IProps, IState> {
                                                         onApplyAnnotation={(html: string) => {
                                                             this.onChange(
                                                                 convertToRaw(getContentStateFromHtml(html)),
-                                                                this.onSubmit,
+                                                                (ev) => this.onSubmit(ev, true),
                                                             );
                                                         }}
                                                     />

--- a/scripts/core/editor3/components/annotations/AnnotationInput.tsx
+++ b/scripts/core/editor3/components/annotations/AnnotationInput.tsx
@@ -119,7 +119,7 @@ class AnnotationInputBody extends React.Component<IProps, IState> {
      * @description onSubmit is called when the user clicks the Submit button in the UI.
      * Consequently, it calls the `onSubmit` prop, passing it the value of the text input.
      */
-    onSubmit(_event, reusingAnnotationFromExtensions = false) {
+    onSubmit(_event) {
         const {body, type} = this.state;
         const _hidePopups = this.props.hidePopups;
         const {highlightId} = this.props.data;
@@ -129,15 +129,13 @@ class AnnotationInputBody extends React.Component<IProps, IState> {
             const annotationType = type;
 
             if (highlightId === undefined) {
-                if (!reusingAnnotationFromExtensions) {
-                    this.annotationInputTabsFromExtensions.forEach((tab) => {
-                        tab.onAnnotationCreate(
-                            this.props.language,
-                            this.getAnnotatedText(),
-                            stateToHTML(convertFromRaw(body)),
-                        );
-                    });
-                }
+                this.annotationInputTabsFromExtensions.forEach((tab) => {
+                    tab.onAnnotationCreate(
+                        this.props.language,
+                        this.getAnnotatedText(),
+                        stateToHTML(convertFromRaw(body)),
+                    );
+                });
 
                 this.props.highlightsManager.addHighlight(
                     highlightsConfig.ANNOTATION.type,
@@ -309,7 +307,7 @@ class AnnotationInputBody extends React.Component<IProps, IState> {
                                                         onApplyAnnotation={(html: string) => {
                                                             this.onChange(
                                                                 convertToRaw(getContentStateFromHtml(html)),
-                                                                (ev) => this.onSubmit(ev, true),
+                                                                (ev) => this.onSubmit(ev),
                                                             );
                                                         }}
                                                     />

--- a/scripts/core/editor3/components/annotations/AnnotationInput.tsx
+++ b/scripts/core/editor3/components/annotations/AnnotationInput.tsx
@@ -119,7 +119,7 @@ class AnnotationInputBody extends React.Component<IProps, IState> {
      * @description onSubmit is called when the user clicks the Submit button in the UI.
      * Consequently, it calls the `onSubmit` prop, passing it the value of the text input.
      */
-    onSubmit(_event) {
+    onSubmit() {
         const {body, type} = this.state;
         const _hidePopups = this.props.hidePopups;
         const {highlightId} = this.props.data;
@@ -307,7 +307,7 @@ class AnnotationInputBody extends React.Component<IProps, IState> {
                                                         onApplyAnnotation={(html: string) => {
                                                             this.onChange(
                                                                 convertToRaw(getContentStateFromHtml(html)),
-                                                                (ev) => this.onSubmit(ev),
+                                                                this.onSubmit,
                                                             );
                                                         }}
                                                     />

--- a/scripts/extensions/annotationsLibrary/src/extension.tsx
+++ b/scripts/extensions/annotationsLibrary/src/extension.tsx
@@ -6,7 +6,10 @@ import {IKnowledgeBaseItem} from './interfaces';
 
 const RESOURCE = 'concept_items';
 
-function annotationExistsInKnowledgeBase(superdesk: ISuperdesk, annotationText: string) {
+function getAnnotationsInKnowledgeBase(
+    superdesk: ISuperdesk,
+    annotationText: string,
+): Promise<IRestApiResponse<IKnowledgeBaseItem>> {
     const {dataApi} = superdesk;
     const {nameField} = getFields(superdesk);
     const {generateFilterForServer} = superdesk.forms;
@@ -16,7 +19,26 @@ function annotationExistsInKnowledgeBase(superdesk: ISuperdesk, annotationText: 
         1,
         {field: 'name', direction: 'ascending'},
         {name: generateFilterForServer(nameField.type, annotationText)},
-    ).then((res: IRestApiResponse<IKnowledgeBaseItem>) => res._items.length > 0);
+    );
+}
+
+function annotationExistsInKnowledgeBase(
+    superdesk: ISuperdesk,
+    annotationText: string,
+    definitionHtml?: string,
+): Promise<boolean> {
+    return getAnnotationsInKnowledgeBase(superdesk, annotationText)
+        .then((res: IRestApiResponse<IKnowledgeBaseItem>) => {
+            if (definitionHtml == null) {
+                // just searching for annotationText
+                return res._items.length > 0;
+            }
+
+            // searching for exact match (text + definition)
+            const matches = res._items.filter((item) => item.definition_html === definitionHtml);
+
+            return matches.length > 0;
+        });
 }
 
 function annotationFromLibraryTabSelectedByDefault(
@@ -35,13 +57,24 @@ function annotationFromLibraryTabSelectedByDefault(
     }
 }
 
-function onAnnotationCreate(superdesk: ISuperdesk, language: string, annotationText: string, definitionHtml: string) {
-    superdesk.dataApi.create(RESOURCE, {
-        language: language,
-        name: annotationText,
-        definition_html: definitionHtml,
-        cpnat_type: 'cpnat:abstract',
-    });
+function onAnnotationCreate(
+    superdesk: ISuperdesk,
+    language: string,
+    annotationText: string,
+    definitionHtml: string,
+) {
+    annotationExistsInKnowledgeBase(superdesk, annotationText, definitionHtml)
+        .then((exists) => {
+            // Don't create another annotation with the same text + definition
+            if (!exists) {
+                superdesk.dataApi.create(RESOURCE, {
+                    language: language,
+                    name: annotationText,
+                    definition_html: definitionHtml,
+                    cpnat_type: 'cpnat:abstract',
+                });
+            }
+        });
 }
 
 var extension: IExtension = {

--- a/scripts/extensions/annotationsLibrary/src/extension.tsx
+++ b/scripts/extensions/annotationsLibrary/src/extension.tsx
@@ -36,18 +36,12 @@ function annotationFromLibraryTabSelectedByDefault(
 }
 
 function onAnnotationCreate(superdesk: ISuperdesk, language: string, annotationText: string, definitionHtml: string) {
-    annotationExistsInKnowledgeBase(superdesk, annotationText)
-        .then((exists) => {
-            // Don't create a knowledge base item for that annotation if it already exists
-            if (!exists) {
-                superdesk.dataApi.create(RESOURCE, {
-                    language: language,
-                    name: annotationText,
-                    definition_html: definitionHtml,
-                    cpnat_type: 'cpnat:abstract',
-                });
-            }
-        });
+    superdesk.dataApi.create(RESOURCE, {
+        language: language,
+        name: annotationText,
+        definition_html: definitionHtml,
+        cpnat_type: 'cpnat:abstract',
+    });
 }
 
 var extension: IExtension = {


### PR DESCRIPTION
SDESK-4836

Fixes an issue where the user wasn't allowed to create an annotation if another one existed in the database for the same text