### PR TITLE
Fix string type dropdown

### DIFF
--- a/scripts/apps/authoring/metadata/metadata.ts
+++ b/scripts/apps/authoring/metadata/metadata.ts
@@ -366,6 +366,7 @@ function MetaDropdownDirective($filter) {
                 if (item) {
                     if (!scope.multiInputFields.includes(scope.field)) {
                         // single input field
+                        // we use 'name' attribute for string fields and the whole object for other fields
                         fieldObject[scope.field] = item.name || item;
                     } else if (scope.cv && scope.cv._id != null) {
                         // if there is cv as well as field, store cv._id as scheme

--- a/scripts/apps/authoring/metadata/metadata.ts
+++ b/scripts/apps/authoring/metadata/metadata.ts
@@ -366,7 +366,7 @@ function MetaDropdownDirective($filter) {
                 if (item) {
                     if (!scope.multiInputFields.includes(scope.field)) {
                         // single input field
-                        fieldObject[scope.field] = item;
+                        fieldObject[scope.field] = item.name || item;
                     } else if (scope.cv && scope.cv._id != null) {
                         // if there is cv as well as field, store cv._id as scheme
                         // so that it can be differentiated from another cv inside same parent field(subject).


### PR DESCRIPTION
SDESK-4815

Server was throwing errors for some fields like 'usageterms' because we were saving the object instead of the string.