### PR TITLE
Add support for 'application/x-mpegurl' HLS video stream for the built-in video player.

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "grunt-filerev": "2.3.1",
     "grunt-usemin": "3.1.1",
     "grunt-webpack": "3.0.2",
+    "hls.js": "0.12.4",
     "html-loader": "0.5.5",
     "immutable": "3.8.2",
     "jquery": "3.3.1",

--- a/scripts/core/ui/components/video-hls.tsx
+++ b/scripts/core/ui/components/video-hls.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import Hls from 'hls.js';
 
-
 interface IProps {
     poster: string;
-    streamUrl: string
+    streamUrl: string;
 }
-
 
 export class HLSVideoComponent extends React.PureComponent<IProps> {
     videoElement: HTMLElement;

--- a/scripts/core/ui/components/video-hls.tsx
+++ b/scripts/core/ui/components/video-hls.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import Hls from 'hls.js';
+
+
+interface IProps {
+    poster: string;
+    streamUrl: string
+}
+
+
+export class HLSVideoComponent extends React.PureComponent<IProps> {
+    videoElement: HTMLElement;
+    hls: Hls;
+
+    _initHLS = () => {
+        if (Hls.isSupported() && this.videoElement) {
+            this.hls = new Hls();
+            this.hls.loadSource(this.props.streamUrl);
+            this.hls.attachMedia(this.videoElement);
+        }
+    };
+
+    _destroyHLS = () => {
+        this.hls.stopLoad();
+        this.hls.destroy();
+    };
+
+    componentDidUpdate(prevProps: Readonly<IProps>, prevState: Readonly<{}>, snapshot?: any): void {
+        if (this.props.streamUrl !== prevProps.streamUrl) {
+            this._destroyHLS();
+            this._initHLS();
+        }
+    }
+
+    componentDidMount(): void {
+        this._initHLS();
+    }
+
+    componentWillUnmount(): void {
+        this._destroyHLS();
+    }
+
+    render() {
+        return (
+            <video controls
+                preload="metadata"
+                ref={(el) => this.videoElement = el}
+                poster={this.props.poster}
+            />
+        );
+    }
+}

--- a/scripts/core/ui/components/video-hls.tsx
+++ b/scripts/core/ui/components/video-hls.tsx
@@ -8,6 +8,10 @@ interface IProps {
     height?: string;
 }
 
+/**
+ * HLSVideoComponent is rendered by VideoComponent when item's rendition has an 'application/x-mpegurl' mimetype.
+ * NOTE: It can handle only one stream url.
+ */
 export class HLSVideoComponent extends React.PureComponent<IProps> {
     videoElement: HTMLElement;
     hls: Hls;

--- a/scripts/core/ui/components/video-hls.tsx
+++ b/scripts/core/ui/components/video-hls.tsx
@@ -4,6 +4,8 @@ import Hls from 'hls.js';
 interface IProps {
     poster: string;
     streamUrl: string;
+    width?: string;
+    height?: string;
 }
 
 export class HLSVideoComponent extends React.PureComponent<IProps> {
@@ -39,6 +41,8 @@ export class HLSVideoComponent extends React.PureComponent<IProps> {
                 preload="metadata"
                 ref={(el) => this.videoElement = el}
                 poster={this.props.poster}
+                width={this.props.width}
+                height={this.props.height}
             />
         );
     }

--- a/scripts/core/ui/components/video-hls.tsx
+++ b/scripts/core/ui/components/video-hls.tsx
@@ -12,32 +12,27 @@ export class HLSVideoComponent extends React.PureComponent<IProps> {
     videoElement: HTMLElement;
     hls: Hls;
 
-    _initHLS = () => {
+    private initHLS = () => {
         if (Hls.isSupported() && this.videoElement) {
             this.hls = new Hls();
             this.hls.loadSource(this.props.streamUrl);
             this.hls.attachMedia(this.videoElement);
         }
-    };
+    }
 
-    _destroyHLS = () => {
-        this.hls.stopLoad();
-        this.hls.destroy();
-    };
-
-    componentDidUpdate(prevProps: Readonly<IProps>, prevState: Readonly<{}>, snapshot?: any): void {
-        if (this.props.streamUrl !== prevProps.streamUrl) {
-            this._destroyHLS();
-            this._initHLS();
+    private destroyHLS = () => {
+        if (this.hls) {
+            this.hls.stopLoad();
+            this.hls.destroy();
         }
     }
 
     componentDidMount(): void {
-        this._initHLS();
+        this.initHLS();
     }
 
     componentWillUnmount(): void {
-        this._destroyHLS();
+        this.destroyHLS();
     }
 
     render() {

--- a/scripts/core/ui/components/video.tsx
+++ b/scripts/core/ui/components/video.tsx
@@ -32,6 +32,7 @@ export class VideoComponent extends React.PureComponent<IProps> {
             if (rend.mimetype == null) {
                 continue;
             } else if (rend.mimetype.toLowerCase() === 'application/x-mpegurl') {
+                // HLSVideoComponent can handle only one stream url
                 return <HLSVideoComponent
                     poster={poster}
                     streamUrl={rend.href}

--- a/scripts/core/ui/components/video.tsx
+++ b/scripts/core/ui/components/video.tsx
@@ -25,7 +25,11 @@ export class VideoComponent extends React.PureComponent<IProps> {
             );
 
         if (videoRenditions.length > 0 && videoRenditions[0].mimetype === 'application/x-mpegurl') {
-            return <HLSVideoComponent poster={poster} streamUrl={videoRenditions[0].href}/>;
+            return <HLSVideoComponent
+                poster={poster}
+                streamUrl={videoRenditions[0].href}
+                key={videoRenditions[0].href}
+            />;
         }
 
         return (

--- a/scripts/core/ui/components/video.tsx
+++ b/scripts/core/ui/components/video.tsx
@@ -21,7 +21,8 @@ export class VideoComponent extends React.PureComponent<IProps> {
 
         const videoRenditions = Object.values(item.renditions)
             .filter(
-                (rend) => rend.mimetype != null && (rend.mimetype.startsWith('video') || rend.mimetype.startsWith('application/x-mpegurl')),
+                (rend) => rend.mimetype != null && (rend.mimetype.startsWith('video') ||
+                                                    rend.mimetype.startsWith('application/x-mpegurl')),
             );
 
         if (videoRenditions.length > 0 && videoRenditions[0].mimetype === 'application/x-mpegurl') {

--- a/scripts/core/ui/components/video.tsx
+++ b/scripts/core/ui/components/video.tsx
@@ -32,7 +32,13 @@ export class VideoComponent extends React.PureComponent<IProps> {
             if (rend.mimetype == null) {
                 continue;
             } else if (rend.mimetype.toLowerCase() === 'application/x-mpegurl') {
-                return <HLSVideoComponent poster={poster} streamUrl={rend.href} key={rend.href}/>;
+                return <HLSVideoComponent
+                    poster={poster}
+                    streamUrl={rend.href}
+                    key={rend.href}
+                    width={this.props.width}
+                    height={this.props.height}
+                />;
             } else if (rend.mimetype.startsWith('video')) {
                 videoRenditions.push(rend);
             }

--- a/scripts/core/ui/components/video.tsx
+++ b/scripts/core/ui/components/video.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {IArticle} from 'superdesk-api';
+import {HLSVideoComponent} from './video-hls';
 
 interface IProps {
     item: IArticle;
@@ -19,12 +20,18 @@ export class VideoComponent extends React.PureComponent<IProps> {
         }
 
         const videoRenditions = Object.values(item.renditions)
-            .filter((rendition) => rendition.mimetype != null && rendition.mimetype.startsWith('video'));
+            .filter(
+                (rend) => rend.mimetype != null && (rend.mimetype.startsWith('video') || rend.mimetype.startsWith('application/x-mpegurl')),
+            );
+
+        if (videoRenditions.length > 0 && videoRenditions[0].mimetype === 'application/x-mpegurl') {
+            return <HLSVideoComponent poster={poster} streamUrl={videoRenditions[0].href}/>;
+        }
 
         return (
             <video controls preload="metadata" poster={poster}>
                 {videoRenditions.map((rendition) => (
-                    <source key={rendition.href} src={rendition.href} type={rendition.mimetype} />
+                    <source key={rendition.href} src={rendition.href} type={rendition.mimetype}/>
                 ))}
             </video>
         );

--- a/scripts/core/ui/components/video.tsx
+++ b/scripts/core/ui/components/video.tsx
@@ -6,6 +6,11 @@ interface IProps {
     item: IArticle;
 }
 
+interface IVideoRenditionItem {
+    mimetype: string;
+    href: string;
+}
+
 export class VideoComponent extends React.PureComponent<IProps> {
     render() {
         const {item} = this.props;
@@ -19,18 +24,16 @@ export class VideoComponent extends React.PureComponent<IProps> {
             poster = item.renditions.viewImage.href;
         }
 
-        const videoRenditions = Object.values(item.renditions)
-            .filter(
-                (rend) => rend.mimetype != null && (rend.mimetype.startsWith('video') ||
-                                                    rend.mimetype.startsWith('application/x-mpegurl')),
-            );
+        let videoRenditions: Array<IVideoRenditionItem> = [];
 
-        if (videoRenditions.length > 0 && videoRenditions[0].mimetype === 'application/x-mpegurl') {
-            return <HLSVideoComponent
-                poster={poster}
-                streamUrl={videoRenditions[0].href}
-                key={videoRenditions[0].href}
-            />;
+        for (const rend of Object.values(item.renditions)) {
+            if (rend.mimetype == null) {
+                continue;
+            } else if (rend.mimetype.toLowerCase() === 'application/x-mpegurl') {
+                return <HLSVideoComponent poster={poster} streamUrl={rend.href} key={rend.href}/>;
+            } else if (rend.mimetype.startsWith('video')) {
+                videoRenditions.push(rend);
+            }
         }
 
         return (

--- a/scripts/core/ui/components/video.tsx
+++ b/scripts/core/ui/components/video.tsx
@@ -13,6 +13,9 @@ interface IVideoRenditionItem {
     href: string;
 }
 
+/**
+ * VideoComponent is used to render a player for an item with type video.
+ */
 export class VideoComponent extends React.PureComponent<IProps> {
     render() {
         const {item} = this.props;


### PR DESCRIPTION
This PR adds the ability to render an enhanced `video` element for `VideoComponent` if item has an `application/x-mpegurl` mime-type. 
In most cases it will stream video in [m3u8](https://en.wikipedia.org/wiki/M3U)
