### PR TITLE
Fix extensions setup

### DIFF
--- a/scripts/core/register-extensions.tsx
+++ b/scripts/core/register-extensions.tsx
@@ -1,8 +1,8 @@
 import {flatMap, noop} from 'lodash';
 import {getSuperdeskApiImplementation} from './get-superdesk-api-implementation';
 import {AuthoringWorkspaceService} from 'apps/authoring/authoring/services/AuthoringWorkspaceService';
-import {IExtensions, IExtension} from 'superdesk-api';
-import {extensions as extensionsImported} from 'appConfig';
+import {IExtension} from 'superdesk-api';
+import {extensions as extensionsWithActivationResult} from 'appConfig';
 
 export function registerExtensions(
     extensions: Array<IExtension>,
@@ -15,15 +15,11 @@ export function registerExtensions(
     config,
     metadata,
 ): Promise<void> {
-    const extensionsWithActivationResult: IExtensions = {};
-
     extensions.forEach((extension) => {
         extensionsWithActivationResult[extension.id] = {
             extension,
             activationResult: {},
         };
-
-        extensionsImported[extension.id] = extensionsWithActivationResult[extension.id];
     });
 
     return Promise.all(


### PR DESCRIPTION
SDBELGA-227

The issue was that I've created another object to hold an intermediate state(which wasn't necessary) when registering extensions, and later when I was retrieving registered extensions, the wrong object would be read.

The issue was introduced in https://github.com/superdesk/superdesk-client-core/pull/3188. It only affected [internal extensions](https://github.com/superdesk/superdesk-client-core/blob/master/scripts/core/helpers/register-internal-extension.tsx#L8) which are only used for patching locked articles(local diff is getting patched instead of patching the real article on the server).