### PR TITLE
let user skip ingest config test if needed

### DIFF
--- a/scripts/apps/ingest/views/settings/ingest-sources-content.html
+++ b/scripts/apps/ingest/views/settings/ingest-sources-content.html
@@ -193,6 +193,11 @@
                         <div class="sd-alert sd-alert--hollow sd-alert--alert sd-alert--small" ng-show="error" translate>
                             An error occured when testing config.
                         </div>
+
+                        <div class="form__row" ng-show="error || provider.skip_config_test != null">
+                            <span sd-switch ng-model="provider.skip_config_test"></span><label translate>Skip config test</label>
+                        </div>
+
                         <div sd-ingest-provider-config></div>
                     </div>
 

--- a/scripts/apps/ingest/views/settings/ingest-sources-content.html
+++ b/scripts/apps/ingest/views/settings/ingest-sources-content.html
@@ -194,11 +194,12 @@
                             An error occured when testing config.
                         </div>
 
-                        <div class="form__row" ng-show="error || provider.skip_config_test != null">
-                            <span sd-switch ng-model="provider.skip_config_test"></span><label translate>Skip config test</label>
-                        </div>
-
                         <div sd-ingest-provider-config></div>
+
+                        <div class="sd-line-input">
+                            <span sd-switch ng-model="provider.skip_config_test"></span><label translate>Skip config test</label>
+                            <p class="sd-line-input__hint" translate>Enable if config can't be tested on REST server.</p>
+                        </div>
                     </div>
 
                     <div class="form__row form__row--s-padding">


### PR DESCRIPTION
by default the switch is not visible, but once there is
an error or it was set it stays there.

SDESK-4853