### PR TITLE
fix lock detection

### DIFF
--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -984,9 +984,17 @@ export function AuthoringDirective(
             });
 
             $scope.$on('item:lock', (_e, data) => {
-                if ($scope.item._id === data.item && !_closing &&
-                    session.sessionId !== data.lock_session) {
-                    authoring.lock($scope.item, data.user);
+                if ($scope.item._id === data.item
+                    && !_closing
+                    && session.sessionId !== data.lock_session
+                ) {
+                    const {
+                        user,
+                        lock_time,
+                        lock_session,
+                    } = data;
+
+                    authoring.lock($scope.item, {user, lock_time, lock_session});
                 }
             });
 

--- a/scripts/apps/authoring/authoring/services/AuthoringService.ts
+++ b/scripts/apps/authoring/authoring/services/AuthoringService.ts
@@ -9,7 +9,7 @@ import {getUnpublishConfirmModal} from '../components/unpublish-confirm-modal';
 import {ITEM_STATE, CANCELED_STATES, READONLY_STATES} from 'apps/archive/constants';
 import {AuthoringWorkspaceService} from './AuthoringWorkspaceService';
 import {appConfig} from 'appConfig';
-import {IPublishedArticle} from 'superdesk-api';
+import {IPublishedArticle, IArticle} from 'superdesk-api';
 
 interface IPublishOptions {
     notifyErrors: boolean;
@@ -426,18 +426,21 @@ export function AuthoringService($q, $location, api, lock, autosave, confirm, pr
 
     /**
      * Lock an item - callback for item:lock event
-     *
-     * @param {Object} item
-     * @param {string} userId
      */
-    this.lock = function(item, userId) {
+    this.lock = function(
+        item: IArticle,
+        data: {
+            user: string;
+            lock_time: string;
+            lock_session: string;
+        },
+    ) {
         autosave.stop(item);
-        api.find('users', userId).then((user) => {
+        api.find('users', data.user).then((user) => {
             item.lock_user = user;
-        }, (rejection) => {
-            item.lock_user = userId;
+            item.lock_session = data.lock_session;
+            item._locked = true;
         });
-        item._locked = true;
     };
 
     /**

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -368,6 +368,7 @@ declare module 'superdesk-api' {
             archive?: boolean;
             externalsource: boolean;
         };
+        _locked?: boolean;
     }
 
     export interface IPublishedArticle extends IArticle {


### PR DESCRIPTION
SDESK-4878

When force unlocked by another user, the item becomes locked for the current user, but due to missing `lock_session` property, lock service used to report that the item is not locked at all.