### PR TITLE
Fix can't remove media items from the media gallery.

### DIFF
--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -856,7 +856,7 @@ export function AuthoringDirective(
                             (result) => next($scope.origItem._autosave ?? $scope.origItem, result),
                         );
 
-                        (
+                        return (
                             onUpdateFromExtensions.length < 1
                                 ? Promise.resolve(item)
                                 : onUpdateFromExtensions


### PR DESCRIPTION
`reorderMediaItems` over [here](https://github.com/superdesk/superdesk-client-core/blob/develop/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts#L245) was being called immediately but should be called after the promise is resolved or rejected.