### PR TITLE
fix footer buttons not responding when clicked while select is focused

### DIFF
--- a/scripts/core/ui/components/select2.tsx
+++ b/scripts/core/ui/components/select2.tsx
@@ -139,14 +139,17 @@ export class Select2<T> extends React.Component<IProps<T>, IState> {
                         // 2. for event listeners to respond when buttons are clicked outside of a focused select
 
                         const timeout = 200; // smaller values don't work for point 2 above
-                        
+
                         setTimeout(() => {
                             if (this.wrapper != null) {
                                 const remainingAtTheBottom =
                                     window.innerHeight - this.wrapper.getBoundingClientRect().bottom - 20;
                                 const oneThirdViewportHeigh = window.innerHeight / 3;
 
-                                this.setState({isOpen, maxHeight: Math.min(remainingAtTheBottom, oneThirdViewportHeigh)});
+                                this.setState({
+                                    isOpen,
+                                    maxHeight: Math.min(remainingAtTheBottom, oneThirdViewportHeigh),
+                                });
                             }
                         }, timeout);
                     }}

--- a/scripts/core/ui/components/select2.tsx
+++ b/scripts/core/ui/components/select2.tsx
@@ -134,14 +134,21 @@ export class Select2<T> extends React.Component<IProps<T>, IState> {
                 <Autocomplete.default
                     open={this.state.isOpen}
                     onMenuVisibilityChange={(isOpen) => {
-                        // wait for wrapper ref
-                        setTimeout(() => {
-                            const remainingAtTheBottom =
-                                window.innerHeight - this.wrapper.getBoundingClientRect().bottom - 20;
-                            const oneThirdViewportHeigh = window.innerHeight / 3;
+                        // setTimeout is required for the following reasons:
+                        // 1. to wait for the wrapper to be set
+                        // 2. for event listeners to respond when buttons are clicked outside of a focused select
 
-                            this.setState({isOpen, maxHeight: Math.min(remainingAtTheBottom, oneThirdViewportHeigh)});
-                        });
+                        const timeout = 200; // smaller values don't work for point 2 above
+                        
+                        setTimeout(() => {
+                            if (this.wrapper != null) {
+                                const remainingAtTheBottom =
+                                    window.innerHeight - this.wrapper.getBoundingClientRect().bottom - 20;
+                                const oneThirdViewportHeigh = window.innerHeight / 3;
+
+                                this.setState({isOpen, maxHeight: Math.min(remainingAtTheBottom, oneThirdViewportHeigh)});
+                            }
+                        }, timeout);
                     }}
                     value={this.props.value}
                     items={Object.values(this.props.items)}

--- a/scripts/core/ui/components/select2.tsx
+++ b/scripts/core/ui/components/select2.tsx
@@ -142,8 +142,12 @@ export class Select2<T> extends React.Component<IProps<T>, IState> {
 
                         setTimeout(() => {
                             if (this.wrapper != null) {
+                                // if there's no spacing, it looks glued to the bottom
+                                // and it's not clear that the dropdown is scrolled independently from the rest of the page
+                                const spacing = 20;
+
                                 const remainingAtTheBottom =
-                                    window.innerHeight - this.wrapper.getBoundingClientRect().bottom - 20;
+                                    window.innerHeight - this.wrapper.getBoundingClientRect().bottom - spacing;
                                 const oneThirdViewportHeigh = window.innerHeight / 3;
 
                                 this.setState({

--- a/scripts/core/ui/components/select2.tsx
+++ b/scripts/core/ui/components/select2.tsx
@@ -143,7 +143,8 @@ export class Select2<T> extends React.Component<IProps<T>, IState> {
                         setTimeout(() => {
                             if (this.wrapper != null) {
                                 // if there's no spacing, it looks glued to the bottom
-                                // and it's not clear that the dropdown is scrolled independently from the rest of the page
+                                // and it's not clear that the dropdown is scrolled independently
+                                // from the rest of the page
                                 const spacing = 20;
 
                                 const remainingAtTheBottom =


### PR DESCRIPTION
SDESK-4877

This is a strange issue and I couldn't find why is it happening. Event listeners for footer buttons(when changing marked user) wouldn't respond while the select is focused. The first time you click it, blur event would be triggered on select and only future clicks would then trigger button events.