### PR TITLE
fix e2e test

### DIFF
--- a/spec/editor3_spec.ts
+++ b/spec/editor3_spec.ts
@@ -152,7 +152,9 @@ describe('editor3', () => {
     });
 
     function getPreviewBody() {
+        browser.sleep(1000); // wait for autosave (input is debounced)
         authoring.save();
+        browser.sleep(500); // wait for saving to complete
         monitoring.previewAction(0, 0);
         return monitoring.getPreviewBody();
     }


### PR DESCRIPTION
It wasn't waiting for debouncing to finish which was causing old data to be saved and "save" button to get re-enabled a few seconds after the clicking "save".