### PR TITLE
fix npm install when package.json is missing for extension

### DIFF
--- a/tasks/get-extension-directories-sync.js
+++ b/tasks/get-extension-directories-sync.js
@@ -2,8 +2,6 @@
 
 var fs = require('fs');
 var path = require('path');
-var lstatSync = fs.lstatSync;
-
 var flatMap = require('lodash/flatMap');
 
 function getExtensionDirectoriesSync() {
@@ -16,7 +14,7 @@ function getExtensionDirectoriesSync() {
         return (fs.existsSync(absolutePath) ? fs.readdirSync(absolutePath) : [])
             .map((extensionName) => ({extensionName, relativePath, absolutePath}))
             .filter(
-                ({absolutePath, extensionName}) => lstatSync(absolutePath + '/' + extensionName).isDirectory()
+                ({absolutePath, extensionName}) => fs.existsSync(path.join(absolutePath, extensionName, 'package.json'))
             );
     });
 }

--- a/tasks/install-extensions.js
+++ b/tasks/install-extensions.js
@@ -8,7 +8,7 @@ directories.forEach(({extensionName, absolutePath}) => {
     const extensionPath = path.resolve(`${absolutePath}/${extensionName}`);
 
     execSync(
-        `cd ${extensionPath} && npm install && npm run compile`,
+        `cd ${extensionPath} && npm install && npm run compile --if-present`,
         {stdio: 'inherit'}
     );
 });


### PR DESCRIPTION
when you switch to different version or different branch
in superdesk the extension folder stays there with node_modules
but without package.json and install fails then.