### PR TITLE
Added background color to add suggestions

### DIFF
--- a/scripts/core/editor3/highlightsConfig.ts
+++ b/scripts/core/editor3/highlightsConfig.ts
@@ -24,6 +24,7 @@ export const highlightsConfig = {
         description: gettext('Add'),
         draftStyleMap: {
             color: 'rgba(101, 156, 8, 1.0)',
+            backgroundColor: 'rgba(101, 156, 8, 0.2))',
         },
     },
     DELETE_SUGGESTION: {


### PR DESCRIPTION
Apologies for not adding a Jira Id, I could not find out how to do that anywhere.
My news department has had issues with trying to view suggestions that are spaces. Suggestion spaces are invisible because only text is highlighted currently. My change adds a light green background to suggestions so that even spaces will be visible. I previously made this change on our local instance of Superdesk, and it has been working well for 3+ months and resolved major issues with our news process.

**Space Suggestion Without Background**
![image](https://user-images.githubusercontent.com/9011528/74058287-b271d680-49b3-11ea-8ca4-e73e782b9767.png)

**With Background**
![image](https://user-images.githubusercontent.com/9011528/74058362-d8977680-49b3-11ea-9845-df5b96ebcaf5.png)

