### PR TITLE
Show linebreaks in preview when html is plain text

### DIFF
--- a/scripts/apps/archive/directives/HtmlPreview.ts
+++ b/scripts/apps/archive/directives/HtmlPreview.ts
@@ -52,9 +52,11 @@ export function HtmlPreview($sce, $timeout) {
         templateUrl: 'scripts/apps/archive/views/html-preview.html',
         link: function(scope, elem, attrs) {
             scope.$watch('sdHtmlPreview', (html) => {
-                scope.html = stringIsHtml(html)
-                    ? $sce.trustAsHtml(html)
-                    : $sce.trustAsHtml(plainTextToHtml(html));
+                if (html && typeof html === 'string') {
+                    scope.html = stringIsHtml(html)
+                        ? $sce.trustAsHtml(html)
+                        : $sce.trustAsHtml(plainTextToHtml(html));
+                }
 
                 if (window.hasOwnProperty('instgrm')) {
                     window.instgrm.Embeds.process();

--- a/scripts/apps/archive/directives/HtmlPreview.ts
+++ b/scripts/apps/archive/directives/HtmlPreview.ts
@@ -52,7 +52,7 @@ export function HtmlPreview($sce, $timeout) {
         templateUrl: 'scripts/apps/archive/views/html-preview.html',
         link: function(scope, elem, attrs) {
             scope.$watch('sdHtmlPreview', (html) => {
-                if (html && typeof html === 'string') {
+                if (typeof html === 'string') {
                     scope.html = stringIsHtml(html)
                         ? $sce.trustAsHtml(html)
                         : $sce.trustAsHtml(plainTextToHtml(html));

--- a/scripts/apps/archive/directives/HtmlPreview.ts
+++ b/scripts/apps/archive/directives/HtmlPreview.ts
@@ -2,6 +2,7 @@ import {getAnnotationsFromItem} from 'core/editor3/helpers/editor3CustomData';
 import {META_FIELD_NAME} from 'core/editor3/helpers/fieldsMeta';
 import ng from 'core/services/ng';
 import {gettext} from 'core/utils';
+import {stringIsHtml, plainTextToHtml} from 'core/editor3/html/to-html/plainTextToHtml';
 
 function getAnnotationTypesAsync(scope) {
     ng.get('metadata').initialize()
@@ -51,7 +52,9 @@ export function HtmlPreview($sce, $timeout) {
         templateUrl: 'scripts/apps/archive/views/html-preview.html',
         link: function(scope, elem, attrs) {
             scope.$watch('sdHtmlPreview', (html) => {
-                scope.html = $sce.trustAsHtml(html);
+                scope.html = stringIsHtml(html)
+                    ? $sce.trustAsHtml(html)
+                    : $sce.trustAsHtml(plainTextToHtml(html));
 
                 if (window.hasOwnProperty('instgrm')) {
                     window.instgrm.Embeds.process();

--- a/scripts/apps/archive/directives/HtmlPreview.ts
+++ b/scripts/apps/archive/directives/HtmlPreview.ts
@@ -2,7 +2,7 @@ import {getAnnotationsFromItem} from 'core/editor3/helpers/editor3CustomData';
 import {META_FIELD_NAME} from 'core/editor3/helpers/fieldsMeta';
 import ng from 'core/services/ng';
 import {gettext} from 'core/utils';
-import {stringIsHtml, plainTextToHtml} from 'core/editor3/html/to-html/plainTextToHtml';
+import {isStringHtml, plainTextToHtml} from 'core/editor3/html/to-html/plainTextToHtml';
 
 function getAnnotationTypesAsync(scope) {
     ng.get('metadata').initialize()
@@ -53,7 +53,7 @@ export function HtmlPreview($sce, $timeout) {
         link: function(scope, elem, attrs) {
             scope.$watch('sdHtmlPreview', (html) => {
                 if (typeof html === 'string') {
-                    scope.html = stringIsHtml(html)
+                    scope.html = isStringHtml(html)
                         ? $sce.trustAsHtml(html)
                         : $sce.trustAsHtml(plainTextToHtml(html));
                 }

--- a/scripts/core/editor3/html/to-html/plainTextToHtml.ts
+++ b/scripts/core/editor3/html/to-html/plainTextToHtml.ts
@@ -2,7 +2,7 @@
 export const plainTextToHtml = (text: string) =>
     text.replace(/.*[^\n]/g, '<p>$&</p>');
 
-export const stringIsHtml = (text: string) => {
+export const isStringHtml = (text: string) => {
     const doc = (new DOMParser()).parseFromString(text, 'text/html');
 
     return Array.from(doc.body.childNodes).some((node) => node.nodeType === 1);

--- a/scripts/core/editor3/html/to-html/plainTextToHtml.ts
+++ b/scripts/core/editor3/html/to-html/plainTextToHtml.ts
@@ -2,5 +2,8 @@
 export const plainTextToHtml = (text: string) =>
     text.replace(/.*[^\n]/g, '<p>$&</p>');
 
-export const stringIsHtml = (text: string) =>
-    /<\/?[a-z][\s\S]*>/i.test(text);
+export const stringIsHtml = (text: string) => {
+    const doc = (new DOMParser()).parseFromString(text, 'text/html');
+
+    return Array.from(doc.body.childNodes).some((node) => node.nodeType === 1);
+};

--- a/scripts/core/editor3/html/to-html/plainTextToHtml.ts
+++ b/scripts/core/editor3/html/to-html/plainTextToHtml.ts
@@ -1,0 +1,6 @@
+// converts linebreaks in paragraphs
+export const plainTextToHtml = (text: string) =>
+    text.replace(/.*[^\n]/g, '<p>$&</p>');
+
+export const stringIsHtml = (text: string) =>
+    /<\/?[a-z][\s\S]*>/i.test(text);

--- a/scripts/core/editor3/html/to-html/plainTextToHtml.ts
+++ b/scripts/core/editor3/html/to-html/plainTextToHtml.ts
@@ -1,6 +1,6 @@
 // converts linebreaks in paragraphs
 export const plainTextToHtml = (text: string) =>
-    text.replace(/.*[^\n]/g, '<p>$&</p>');
+    text.split('\n').map((line) => `<p>${line}</p>`).join('');
 
 export const isStringHtml = (text: string) => {
     const doc = (new DOMParser()).parseFromString(text, 'text/html');


### PR DESCRIPTION
SDBELGA-284

If CP has no formatting options for BODY_HTML, then it will be saved as plain text, which makes it not show linebreaks on the html preview (as linebreaks don't really mean anything in html).