### PR TITLE
Fix attachments/related-items colors in alternative themes

### DIFF
--- a/scripts/apps/authoring/attachments/attachments.scss
+++ b/scripts/apps/authoring/attachments/attachments.scss
@@ -1,5 +1,12 @@
 @import '~variables.scss';
 
+
+.field .attachments-pane {
+    .attachments-list {
+        color: $grayDark;
+    }
+}
+
 .sd-widget.attachments {
 	.attachments-pane {
 
@@ -38,7 +45,7 @@
 				border-radius: 50%;
 				margin: 0 auto;
 				box-shadow: 0 0 6px 1px rgba(0,0,0,0.08);
-				
+
 				i.icon {
 					display: block;
 					width: 56px;

--- a/scripts/apps/authoring/styles/authoring.scss
+++ b/scripts/apps/authoring/styles/authoring.scss
@@ -1584,6 +1584,7 @@ feature-image {
     padding: 1rem 1rem 0;
     background-color: rgba(150, 150, 150, 0.075);
     border: 1px solid rgba(150, 150, 150, 0.2);
+    color: $grayDark;
     .draggable-list {
         .placeholder {
             border: 2px dotted $sd-blue;

--- a/scripts/apps/authoring/views/article-edit.html
+++ b/scripts/apps/authoring/views/article-edit.html
@@ -705,7 +705,7 @@
     <div ng-if="!_editable">
         <label class="field__label">{{field.display_name}}</label>
 
-        <div 
+        <div
             sd-related-items-preview
             data-item="item"
             data-field="field">


### PR DESCRIPTION
SDESK-5028

### Before

![Captura de pantalla 2020-02-13 a las 15 34 09](https://user-images.githubusercontent.com/4324982/74445284-6ffa3f00-4e76-11ea-88c5-2bf4051cb42c.png)

### After

![Captura de pantalla 2020-02-13 a las 15 34 54](https://user-images.githubusercontent.com/4324982/74445298-74265c80-4e76-11ea-9c84-74a6ed53ece7.png)
