### PR TITLE
Fix dragging text on editor3

### DIFF
--- a/scripts/core/editor3/components/toolbar/index.tsx
+++ b/scripts/core/editor3/components/toolbar/index.tsx
@@ -57,7 +57,7 @@ class ToolbarComponent extends React.Component<any, IState> {
             width: 'auto',
         };
 
-        if (!this.props.editorNode) {
+        if (!this.props.editorNode || !this.toolbarNode) {
             return defaultState;
         }
 


### PR DESCRIPTION
SDESK-4956

Toolbar component state was not being computed properly due to toolbar ref being null.