### PR TITLE
when dragging item with custom mimetype use that

### DIFF
--- a/scripts/apps/archive/services/DragItemService.ts
+++ b/scripts/apps/archive/services/DragItemService.ts
@@ -6,6 +6,11 @@
 
 const DRAG_IMAGE_HOLDER = 'drag-image-holder';
 
+/**
+ * Using div with max width/height to resize thumbnail image.
+ *
+ * link: https://stackoverflow.com/a/26347784
+ */
 const getThumbnailPlaceholder = () => {
     let div = document.getElementById(DRAG_IMAGE_HOLDER);
 

--- a/scripts/apps/archive/services/DragItemService.ts
+++ b/scripts/apps/archive/services/DragItemService.ts
@@ -1,4 +1,26 @@
 /**
+ * NOTICE:
+ * if you want to test drag image in chrome, make sure to close dev tools first,
+ * otherwise this thumbnail image might not be displayed, depends on some performance settings there.
+ */
+
+const DRAG_IMAGE_HOLDER = 'drag-image-holder';
+
+const getThumbnailPlaceholder = () => {
+    let div = document.getElementById(DRAG_IMAGE_HOLDER);
+
+    if (div == null) {
+        div = document.createElement('div');
+        div.id = DRAG_IMAGE_HOLDER;
+        document.body.appendChild(div);
+    } else {
+        div.innerHTML = ''; // removes all children
+    }
+
+    return div;
+};
+
+/**
  * Service to handle item dragging
  */
 export function DragItemService() {
@@ -9,18 +31,24 @@ export function DragItemService() {
      * @param {Object} item
      */
     this.start = function(event, item) {
-        var dt = event.dataTransfer || event.originalEvent.dataTransfer;
+        const dt = event.dataTransfer || event.originalEvent.dataTransfer;
 
-        dt.setData('application/superdesk.item.' + item.type, angular.toJson(item));
+        // search providers could specify custom mimetype
+        // which we use for filtering on drop
+        const mimetype = item.mimetype && item.mimetype.includes('application') ?
+            item.mimetype : 'application/superdesk.item.' + item.type;
+
+        dt.setData(mimetype, angular.toJson(item));
         dt.effectAllowed = 'link';
 
         if (item.renditions && item.renditions.thumbnail) {
-            var img = new Image();
-            var rendition = item.renditions.thumbnail;
+            const img = document.createElement('img');
+            const div = getThumbnailPlaceholder();
+            const rendition = item.renditions.thumbnail;
 
             img.src = rendition.href;
-            img.width = rendition.width;
-            dt.setDragImage(img, rendition.width / 2, rendition.height / 2);
+            div.appendChild(img);
+            dt.setDragImage(div, 5, 5);
         }
     };
 }

--- a/scripts/apps/archive/services/DragItemService.ts
+++ b/scripts/apps/archive/services/DragItemService.ts
@@ -33,7 +33,7 @@ export function DragItemService() {
     this.start = function(event, item) {
         const dt = event.dataTransfer || event.originalEvent.dataTransfer;
 
-        // search providers could specify custom mimetype
+        // search providers can specify custom mimetype
         // which we use for filtering on drop
         const mimetype = item.mimetype && item.mimetype.includes('application') ?
             item.mimetype : 'application/superdesk.item.' + item.type;

--- a/scripts/apps/search/styles/search.scss
+++ b/scripts/apps/search/styles/search.scss
@@ -548,10 +548,11 @@
 #drag-image-holder {
     position: absolute;
     left: -2000px;
-    float: left;
     max-width: 200px;
+    max-height: 200px;
 
     img {
         max-width: 200px;
+        max-height: 200px;
     }
 }

--- a/scripts/apps/search/styles/search.scss
+++ b/scripts/apps/search/styles/search.scss
@@ -542,3 +542,16 @@
         }
     }
 }
+
+
+// used to resize thumbnail of item while dragging it
+#drag-image-holder {
+    position: absolute;
+    left: -2000px;
+    float: left;
+    max-width: 200px;
+
+    img {
+        max-width: 200px;
+    }
+}


### PR DESCRIPTION
but only for `application/*` mimetypes, not `image/jpeg` etc.
also resize the image thumbnail when dragging

SDBELGA-325