### PR TITLE
Make editor3 fields html if they are not single line

### DIFF
--- a/scripts/apps/archive/directives/HtmlPreview.ts
+++ b/scripts/apps/archive/directives/HtmlPreview.ts
@@ -2,7 +2,6 @@ import {getAnnotationsFromItem} from 'core/editor3/helpers/editor3CustomData';
 import {META_FIELD_NAME} from 'core/editor3/helpers/fieldsMeta';
 import ng from 'core/services/ng';
 import {gettext} from 'core/utils';
-import {isStringHtml, plainTextToHtml} from 'core/editor3/html/to-html/plainTextToHtml';
 
 function getAnnotationTypesAsync(scope) {
     ng.get('metadata').initialize()
@@ -52,11 +51,7 @@ export function HtmlPreview($sce, $timeout) {
         templateUrl: 'scripts/apps/archive/views/html-preview.html',
         link: function(scope, elem, attrs) {
             scope.$watch('sdHtmlPreview', (html) => {
-                if (typeof html === 'string') {
-                    scope.html = isStringHtml(html)
-                        ? $sce.trustAsHtml(html)
-                        : $sce.trustAsHtml(plainTextToHtml(html));
-                }
+                scope.html = $sce.trustAsHtml(html);
 
                 if (window.hasOwnProperty('instgrm')) {
                     window.instgrm.Embeds.process();

--- a/scripts/core/editor3/reducers/editor3.tsx
+++ b/scripts/core/editor3/reducers/editor3.tsx
@@ -7,8 +7,6 @@ import {DELETE_SUGGESTION} from '../highlightsConfig';
 import {moveBlockWithoutDispatching} from '../helpers/draftMoveBlockWithoutDispatching';
 import {insertEntity} from '../helpers/draftInsertEntity';
 
-const isEditorPlainText = (props) => props.singleLine || (props.editorFormat || []).length === 0;
-
 /**
  * @description Contains the list of editor related reducers.
  */
@@ -132,7 +130,7 @@ export const onChange = (
     const contentChanged = state.editorState.getCurrentContent() !== editorStateNext.getCurrentContent();
 
     if (!skipOnChange && (contentChanged || force)) {
-        const plainText = isEditorPlainText(state);
+        const plainText = state.singleLine === true;
 
         state.onChangeValue(editorStateNext.getCurrentContent(), {plainText});
     }


### PR DESCRIPTION
SDESK-5113

This will also revert the changes in https://github.com/superdesk/superdesk-client-core/pull/3351 as they are not needed anymore (because that issue was caused by body_html not being really html)