### PR TITLE
Fix ts compiler warning

### DIFF
--- a/scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx
+++ b/scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx
@@ -8,7 +8,7 @@ import {gettext} from 'core/utils';
 import {ISortOption, IVocabularyItem} from 'superdesk-api';
 import {assertNever} from 'core/helpers/typescript-helpers';
 import {Dropdown} from 'core/ui/components/Dropdown/Dropdown';
-import {Menu} from 'core/ui/components/Dropdown';
+import {Menu} from 'core/ui/components/Dropdown/Menu';
 import {Checkbox} from 'superdesk-ui-framework';
 
 interface ISchemaField {


### PR DESCRIPTION
<img width="1530" alt="Captura de pantalla 2020-03-13 a las 14 31 34" src="https://user-images.githubusercontent.com/4324982/76625358-57de1400-6537-11ea-96a5-dc81db89522c.png">

This was preventing users from creating new metadata items due to this error:

![Captura de pantalla 2020-03-13 a las 14 32 38](https://user-images.githubusercontent.com/4324982/76625432-7fcd7780-6537-11ea-8f66-a67aed579ebc.png)
