### PR TITLE
fix user management diffs

### DIFF
--- a/scripts/apps/users/directives/UserEditDirective.ts
+++ b/scripts/apps/users/directives/UserEditDirective.ts
@@ -10,6 +10,10 @@ import {noop} from 'lodash';
 // according to the latest data on the server
 let clearOrigUserWatcher = noop;
 
+// only initialize after selecting a user for editing/creation
+// having it running when switcing between users can cause fields to be modified or produce an incorrect dirtiness value
+let clearUserWatcher = noop;
+
 UserEditDirective.$inject = ['api', 'notify', 'usersService', 'userList', 'session', 'lodash',
     'langmap', '$location', '$route', 'superdesk', 'features', 'asset', 'privileges',
     'desks', 'keyboardManager', 'gettextCatalog', 'metadata', 'modal', '$q'];
@@ -56,27 +60,6 @@ export function UserEditDirective(api, notify, usersService, userList, session, 
 
             scope.isNetworkSubscription = () =>
                 ['solo', 'team'].indexOf(appConfig.subscriptionLevel) === -1;
-
-            let userWatchInitialized = false;
-
-            scope.$watchCollection('user', (user) => {
-                if (userWatchInitialized) { // avoid incorrect dirty check when user is undefined and not initialized
-                    scope.userImmutable = {...user};
-
-                    _.each(user, (value, key) => {
-                        if (value === '') {
-                            if (key !== 'phone' || key !== 'byline') {
-                                user[key] = null;
-                            } else {
-                                delete user[key];
-                            }
-                        }
-                    });
-                    scope.dirty = JSON.stringify(user) !== JSON.stringify(scope.origUser);
-                } else {
-                    userWatchInitialized = true;
-                }
-            });
 
             api('roles').query()
                 .then((result) => {
@@ -218,14 +201,15 @@ export function UserEditDirective(api, notify, usersService, userList, session, 
 
             function resetUser() {
                 clearOrigUserWatcher();
+                clearUserWatcher();
 
                 scope.dirty = false;
                 scope.loading = true;
 
-                const user = scope.origUser;
-
                 return $q.when()
                     .then(() => {
+                        const user = scope.origUser;
+
                         if (angular.isDefined(user._id)) {
                             return userList.getUser(user._id, true)
                                 .then((u) => {
@@ -258,6 +242,28 @@ export function UserEditDirective(api, notify, usersService, userList, session, 
                         clearOrigUserWatcher = scope.$watch('origUser', (newVal, oldVal) => {
                             if (newVal !== oldVal) {
                                 resetUser();
+                            }
+                        });
+
+                        let userWatchInitialized = false;
+
+                        clearUserWatcher = scope.$watchCollection('user', (user) => {
+                            // avoid incorrect dirty check when user is undefined and not initialized
+                            if (userWatchInitialized) {
+                                scope.userImmutable = {...user};
+
+                                _.each(user, (value, key) => {
+                                    if (scope.origUser[key] !== '' && value === '') {
+                                        if (key !== 'phone' || key !== 'byline') {
+                                            user[key] = null;
+                                        } else {
+                                            delete user[key];
+                                        }
+                                    }
+                                });
+                                scope.dirty = JSON.stringify(user) !== JSON.stringify(scope.origUser);
+                            } else {
+                                userWatchInitialized = true;
                             }
                         });
 

--- a/scripts/apps/users/directives/UserEditDirective.ts
+++ b/scripts/apps/users/directives/UserEditDirective.ts
@@ -5,15 +5,6 @@ import {CC} from 'core/ui/configurable-ui-components';
 import {generate} from 'json-merge-patch';
 import {noop} from 'lodash';
 
-// origUser is set by parent scope when selecting users from GUI
-// but it also needs to be updated before editing so dirtiness can be computed correctly
-// according to the latest data on the server
-let clearOrigUserWatcher = noop;
-
-// only initialize after selecting a user for editing/creation
-// having it running when switcing between users can cause fields to be modified or produce an incorrect dirtiness value
-let clearUserWatcher = noop;
-
 UserEditDirective.$inject = ['api', 'notify', 'usersService', 'userList', 'session', 'lodash',
     'langmap', '$location', '$route', 'superdesk', 'features', 'asset', 'privileges',
     'desks', 'keyboardManager', 'gettextCatalog', 'metadata', 'modal', '$q'];
@@ -29,6 +20,16 @@ export function UserEditDirective(api, notify, usersService, userList, session, 
             onupdate: '&',
         },
         link: function(scope, elem) {
+            // origUser is set by parent scope when selecting users from GUI
+            // but it also needs to be updated before editing so dirtiness can be computed correctly
+            // according to the latest data on the server
+            let clearOrigUserWatcher = noop;
+
+            // only initialize after selecting a user for editing/creation
+            // having it running when switcing between users can cause fields to be modified
+            // or produce an incorrect dirtiness value
+            let clearUserWatcher = noop;
+
             metadata.initialize().then(() => {
                 scope.metadata = metadata.values;
             });


### PR DESCRIPTION
SDESK-5145

the problem was partially in the database since it had `dateline_source` set to an empty string when in theory it should only be a non-empty string or `null`. I've adjusted the code to only write `null` if it wasn't an empty string originally and was changed by a user to an empty string.