### PR TITLE
SDBELGA-370 Image upload window is stuck

### DIFF
--- a/scripts/apps/authoring/media/views/media-metadata-editor-directive.html
+++ b/scripts/apps/authoring/media/views/media-metadata-editor-directive.html
@@ -51,7 +51,7 @@
             class="data sd-terms--boxed sd-line-input--dark-ui sd-line-input--boxed"
             data-item="item"
             data-field="keywords"
-            data-change="onChange({key: field})"
+            data-change="onChange({key: field.field})"
             data-list="field.cv.items"
             data-disabled="isDisabled(field)"
             data-style="sd-line-input__input"


### PR DESCRIPTION
The reason is that we send a wrong payload to the server, more concrete example:
```
{
    "language": "nl",
    "source": "Belga",
    "subject": [
        ...
    ],
    "extra": {
        "city": "Brussels"
    },
    "[object Object]": ""
}
```
it should be `keywords`  instead of `[object Object]`