### PR TITLE
fix: render null in AvatarDisplay if user is not defined

### DIFF
--- a/scripts/apps/users/components/UserAvatar.tsx
+++ b/scripts/apps/users/components/UserAvatar.tsx
@@ -10,6 +10,11 @@ import {AvatarWrapper, AvatarContentText, AvatarContentImage} from 'superdesk-ui
 class DefaultAvatarDisplay extends React.PureComponent<{user: Partial<IUser>}> {
     render() {
         const {user} = this.props;
+
+        if (user == null) {
+            return null;
+        }
+
         const tooltipText = user?.display_name ?? null;
 
         if (user.picture_url == null) {


### PR DESCRIPTION
This should never happen in production, but is sometimes happening in the Planning e2e tests on initial load of the page