### PR TITLE
Fix metaterms search when disabled category selection

### DIFF
--- a/scripts/apps/authoring/metadata/metadata.ts
+++ b/scripts/apps/authoring/metadata/metadata.ts
@@ -778,13 +778,7 @@ function MetaTermsDirective(metadata, $filter, $timeout, preferencesService, des
                     scope.terms = filterSelected(scope.list);
                     scope.activeList = false;
                 } else {
-                    var searchList;
-
-                    if (!scope.allowEntireCat) {
-                        searchList = _.filter(scope.list, (item) => !item.parent);
-                    } else {
-                        searchList = reloadList ? scope.list : scope.combinedList;
-                    }
+                    const searchList = reloadList ? scope.list : scope.combinedList;
 
                     scope.terms = $filter('sortByName')(_.filter(filterSelected(searchList), (t) => {
                         var searchObj = {};


### PR DESCRIPTION
SDANSA-396

Dropdown search was not working when "entire category selection" was disabled