### PR TITLE
Fix marked for me button localStorage

### DIFF
--- a/scripts/apps/monitoring/controllers/AggregateCtrl.ts
+++ b/scripts/apps/monitoring/controllers/AggregateCtrl.ts
@@ -35,7 +35,7 @@ export function AggregateCtrl($scope, desks, workspaces, preferencesService, sto
     this.activeFilters = {
         contentProfile: $scope.type === 'monitoring' ? storage.getItem('contentProfile') || [] : [],
         fileType: $scope.type === 'monitoring' ? storage.getItem('fileType') || [] : [],
-        customFilters: $scope.type === 'monitoring' ? storage.getItem('customFilters') || [] : [],
+        customFilters: $scope.type === 'monitoring' ? storage.getItem('customFilters') || {} : {},
     };
     this.activeFilterTags = {};
 


### PR DESCRIPTION
SDESK-5187

Unlike the other filters, custom filters is an object, not an array. I introduced this issue [here](https://github.com/superdesk/superdesk-client-core/pull/3480)