### PR TITLE
Fix editor2 focus when clicking on placeholder

### DIFF
--- a/scripts/core/editor2/styles/editor.scss
+++ b/scripts/core/editor2/styles/editor.scss
@@ -8,6 +8,7 @@
     }
     &:empty:before{
           content: attr(placeholder);
+          pointer-events: none;
           display: block; /* For Firefox */
           color: rgba(150, 150, 150, 0.5)
     }
@@ -21,16 +22,16 @@
     }
 
     span, h3 {
-        font-size: inherit; 
+        font-size: inherit;
         line-height: 150%;
     }
 
     pre {
-        font-size: inherit; 
+        font-size: inherit;
         line-height: 150%;
 
         span, h3 {
-            font-size: inherit; 
+            font-size: inherit;
             line-height: 150%;
         }
     }


### PR DESCRIPTION
SDNTB-631

I tested on chrome and edge and they both have the following issue:

When you have a contenteditable element with a `:before` pseudo-element (which is what we use to display the placeholder) then when you click on that placeholder, the `focus` event fires but medium-editor doesn't show the caret nor allows you to write until you focus/click again.

On firefox, it works.

Solution: Preventing mouse events on that pseudo-element.