### PR TITLE
read-only fields - cursor fix

### DIFF
--- a/scripts/apps/authoring/styles/themes.scss
+++ b/scripts/apps/authoring/styles/themes.scss
@@ -360,8 +360,14 @@ body, html {
     }
     .text-editor:hover, .headline:hover, .abstract:hover, .field__select:hover {
         border-bottom-color: rgba(123, 123, 123, 0.60) !important;
-        cursor: text;
     }
+
+    .text-editor, .headline, .abstract {
+        &:not([disabled]) {
+            cursor: text;
+        }
+    }
+
     .field__select:hover {
         -moz-appearance: menulist-button;
         -webkit-appearance: menulist-button;


### PR DESCRIPTION
Don't set cursor:text for disabled fields. Don't set cursor:text for dropdowns at all.

SDESK-5202