### PR TITLE
[SDESK-5297] Contacts: Make form class optional

### DIFF
--- a/scripts/apps/contacts/components/Form/ContactFormContainer.tsx
+++ b/scripts/apps/contacts/components/Form/ContactFormContainer.tsx
@@ -29,6 +29,7 @@ interface IProps {
     onValidation(valid: boolean): void;
     triggerSave: boolean;
     hideActionBar: boolean;
+    formClass?: string;
 }
 
 interface IState {
@@ -192,7 +193,7 @@ export class ContactFormContainer extends React.PureComponent<IProps, IState> {
     }
 
     render() {
-        const {svc, contact, onCancel, hideActionBar} = this.props;
+        const {svc, contact, onCancel, hideActionBar, formClass} = this.props;
         const {
             isFormValid = false,
             dirty = false,
@@ -210,7 +211,7 @@ export class ContactFormContainer extends React.PureComponent<IProps, IState> {
         return (
             <div id={contact._id} key={contact._id} className="contact-form">
                 <form name="contactForm"
-                    className="side-panel side-panel--shadow-right"
+                    className={formClass}
                     onSubmit={(e) => e.preventDefault()}
                 >
                     {!hideActionBar && (

--- a/scripts/apps/contacts/directives/ContactEditorDirective.ts
+++ b/scripts/apps/contacts/directives/ContactEditorDirective.ts
@@ -52,6 +52,7 @@ export function ContactEditorDirective(
                     svc: services,
                     contact: scope.origContact,
                     onCancel: scope.onCancel,
+                    formClass: 'side-panel side-panel--shadow-right side-panel--bg-00',
                 }),
             );
 


### PR DESCRIPTION
This fixes the issue of using the 'side-panel' class inside a modal when used in the Planning module