### PR TITLE
fix the order of fields displayed when uploading media

### DIFF
--- a/scripts/apps/authoring/media/media-fields-controller.ts
+++ b/scripts/apps/authoring/media/media-fields-controller.ts
@@ -1,4 +1,4 @@
-import {max, sortBy, get} from 'lodash';
+import {sortBy, get} from 'lodash';
 import {getLabelNameResolver} from 'apps/workspace/helpers/getLabelForFieldId';
 import {appConfig} from 'appConfig';
 
@@ -33,7 +33,7 @@ export default function MediaFieldsController($q, metadata) {
         const validator = appConfig.validator_media_metadata;
 
         // get last order
-        let nextOrder = max(Object.keys(editor).map((field) => get(editor, `${field}.order`, 0))) + 1;
+        let nextOrder = Math.max(0, ...Object.keys(editor).map((field) => editor?.[field]?.order ?? 0)) + 1;
 
         // add missing fields from validator to editor/schema
         Object.keys(validator || {}).forEach((field) => {


### PR DESCRIPTION
SDESK-4711

When `editor` was empty, `max` function was called with an empty array, which used to return `undefined` and order of all fields would become `NaN`(`undefined + 1`).

I've added a zero to the call so it would never return undefined.