### PR TITLE
FIX: Strange behavior (double blinking) observed when removing gallery items. [SDESK-5262]

### DIFF
--- a/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
@@ -267,7 +267,6 @@ export function ItemCarouselDirective(notify) {
                     data[item.fieldId] = item[item.fieldId];
                     scope.item.associations = angular.extend({}, scope.item.associations, data);
                 });
-                scope.onchange();
             }
 
             scope.handleInputChange = (value: string, onChangeData) => {


### PR DESCRIPTION
Calling the onchange [here](https://github.com/superdesk/superdesk-client-core/blob/develop/scripts/apps/authoring/authoring/controllers/AssociationController.ts#L157) and once again [here]( https://github.com/superdesk/superdesk-client-core/blob/develop/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts#L270)