### PR TITLE
Fix scrolling issue in ingest list

### DIFF
--- a/scripts/apps/archive/controllers/ArchiveListController.ts
+++ b/scripts/apps/archive/controllers/ArchiveListController.ts
@@ -6,6 +6,8 @@ export class ArchiveListController extends BaseListController {
         StagesCtrl, notify, multi, search) {
         super($scope, $location, search, desks);
 
+        const setTotalCount = super.setTotalCount.bind(this);
+
         var resource,
             self = this;
 
@@ -68,6 +70,8 @@ export class ArchiveListController extends BaseListController {
                 $scope.loading = false;
                 $scope.items = search.mergeItems(items, $scope.items, next);
                 $scope.total = items._meta.total;
+
+                setTotalCount(items._meta.total);
             }, () => {
                 $scope.loading = false;
             });

--- a/scripts/apps/archive/controllers/BaseListController.ts
+++ b/scripts/apps/archive/controllers/BaseListController.ts
@@ -5,6 +5,7 @@ export class BaseListController {
     $location: any;
     search: any;
     desks: any;
+    totalCount: number;
 
     constructor($scope, $location, search, desks) {
         this.lastQueryParams = {};
@@ -14,7 +15,14 @@ export class BaseListController {
 
         $scope.selected = {};
 
+        this.totalCount = Infinity;
+
         $scope.fetchNext = (from) => {
+            if (from >= this.totalCount) {
+                // no more items to fetch
+                return;
+            }
+
             const source = this.getQuery(null, $scope.repo.archive || false);
 
             source.from = from;
@@ -81,6 +89,10 @@ export class BaseListController {
         const params = this.$location.search().params ? JSON.parse(this.$location.search().params) : {};
 
         return {source, params};
+    }
+
+    setTotalCount(n: number) {
+        this.totalCount = n;
     }
 }
 

--- a/scripts/apps/ingest/controllers/IngestListController.ts
+++ b/scripts/apps/ingest/controllers/IngestListController.ts
@@ -5,6 +5,8 @@ export class IngestListController extends BaseListController {
     constructor($scope, $injector, $location, api, $rootScope, search, desks) {
         super($scope, $location, search, desks);
 
+        const setTotalCount = super.setTotalCount.bind(this);
+
         $scope.type = 'ingest';
         $scope.loading = false;
         $scope.repo = {
@@ -22,6 +24,8 @@ export class IngestListController extends BaseListController {
             api.query('ingest', criteria).then((items) => {
                 $scope.items = search.mergeItems(items, $scope.items, next);
                 $scope.total = items._meta.total;
+
+                setTotalCount(items._meta.total);
             })
                 .finally(() => {
                     $scope.loading = false;


### PR DESCRIPTION
SDANSA-412

The scroll was "jumping to the top", because after the last page of items has been loaded, another request was sent to fetch more, which would always return zero. The list would be re-rendered to display 0 items and then the first page would get loaded again which made it look like the scroll position was jumping.