### PR TITLE
Add Save event for superdesk api

### DIFF
--- a/scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts
@@ -7,7 +7,6 @@ import {isPublished} from 'apps/archive/utils';
 import {resetFieldMetadata} from 'core/editor3/helpers/fieldsMeta';
 import {appConfig} from 'appConfig';
 import {gettext} from 'core/utils';
-import {addInternalEventListener} from 'core/internal-events';
 
 interface IScope extends ng.IScope {
     readOnlyLabel: string;
@@ -88,8 +87,6 @@ ArticleEditDirective.$inject = [
     '$interpolate',
     'suggest',
     'renditions',
-    'authoring',
-    'notify',
 ];
 export function ArticleEditDirective(
     autosave,
@@ -101,8 +98,6 @@ export function ArticleEditDirective(
     $interpolate,
     suggest,
     renditions,
-    authoring,
-    notify,
 ) {
     return {
         templateUrl: 'scripts/apps/authoring/views/article-edit.html',
@@ -460,19 +455,8 @@ export function ArticleEditDirective(
                 scope.extra = {}; // placeholder for fields not part of item
             });
 
-            const removeSaveEventListener = addInternalEventListener('save', () => {
-                authoring.saveAuthoring(scope.origItem, scope.item).then((res) => {
-                    const mainEditScope: any = scope.$parent.$parent;
-
-                    mainEditScope.dirty = false;
-                    _.merge(scope.item, res);
-                    notify.success(gettext('Item updated.'));
-                });
-            });
-
             scope.$on('$destroy', () => {
                 elem.off('drop dragdrop');
-                removeSaveEventListener();
             });
         },
     };

--- a/scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts
@@ -7,6 +7,7 @@ import {isPublished} from 'apps/archive/utils';
 import {resetFieldMetadata} from 'core/editor3/helpers/fieldsMeta';
 import {appConfig} from 'appConfig';
 import {gettext} from 'core/utils';
+import {addInternalEventListener} from 'core/internal-events';
 
 interface IScope extends ng.IScope {
     readOnlyLabel: string;
@@ -87,6 +88,8 @@ ArticleEditDirective.$inject = [
     '$interpolate',
     'suggest',
     'renditions',
+    'authoring',
+    'notify',
 ];
 export function ArticleEditDirective(
     autosave,
@@ -98,6 +101,8 @@ export function ArticleEditDirective(
     $interpolate,
     suggest,
     renditions,
+    authoring,
+    notify,
 ) {
     return {
         templateUrl: 'scripts/apps/authoring/views/article-edit.html',
@@ -455,8 +460,19 @@ export function ArticleEditDirective(
                 scope.extra = {}; // placeholder for fields not part of item
             });
 
+            const removeSaveEventListener = addInternalEventListener('save', () => {
+                authoring.saveAuthoring(scope.origItem, scope.item).then((res) => {
+                    const mainEditScope: any = scope.$parent.$parent;
+
+                    mainEditScope.dirty = false;
+                    _.merge(scope.item, res);
+                    notify.success(gettext('Item updated.'));
+                });
+            });
+
             scope.$on('$destroy', () => {
                 elem.off('drop dragdrop');
+                removeSaveEventListener();
             });
         },
     };

--- a/scripts/apps/authoring/authoring/directives/AuthoringTopbarDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringTopbarDirective.ts
@@ -2,6 +2,7 @@ import {AuthoringWorkspaceService} from '../services/AuthoringWorkspaceService';
 import {getSpellchecker} from 'core/editor3/components/spellchecker/default-spellcheckers';
 import {IArticleAction} from 'superdesk-api';
 import {getArticleActionsFromExtensions} from 'core/superdesk-api-helpers';
+import {addInternalEventListener} from 'core/internal-events';
 
 /**
  * @ngdoc directive
@@ -86,6 +87,14 @@ export function AuthoringTopbarDirective(
             scope.$watch('item', () => {
                 setActionsFromExtensions();
             }, true);
+
+            const removeSaveEventListener = addInternalEventListener('saveArticleInEditMode', () => {
+                scope.saveTopbar();
+            });
+
+            scope.$on('$destroy', () => {
+                removeSaveEventListener();
+            });
         },
     };
 }

--- a/scripts/apps/authoring/authoring/services/AuthoringService.ts
+++ b/scripts/apps/authoring/authoring/services/AuthoringService.ts
@@ -18,7 +18,7 @@ export function runBeforeUpdateMiddlware(item: IArticle, orig: IArticle): Promis
     return coreApplyMiddleware(onChangeMiddleware, {item: item, original: orig}, 'item')
         .then(() => {
             const onUpdateFromExtensions = Object.values(extensions).map(
-                (extension) => extension.activationResult?.contributions?.authoring?.onUpdate,
+                (extension) => extension.activationResult?.contributions?.authoring?.onUpdateBefore,
             ).filter((updateFn) => updateFn != null);
 
             return (
@@ -34,6 +34,16 @@ export function runBeforeUpdateMiddlware(item: IArticle, orig: IArticle): Promis
                         .then((nextItem) => angular.extend(item, nextItem))
             );
         });
+}
+
+export function runAfterUpdateEvent(previous: IArticle, current: IArticle) {
+    const onUpdateAfterFromExtensions = Object.values(extensions).map(
+        (extension) => extension.activationResult?.contributions?.authoring?.onUpdateAfter,
+    ).filter((fn) => fn != null);
+
+    onUpdateAfterFromExtensions.forEach((fn) => {
+        fn(previous, current);
+    });
 }
 
 function isReadOnly(item: IArticle) {
@@ -488,6 +498,8 @@ export function AuthoringService($q, $location, api, lock, autosave, confirm, pr
 
             if (_.size(diff) > 0) {
                 return api.save('archive', origItem, diff).then((__item) => {
+                    runAfterUpdateEvent(origItem, __item);
+
                     if (origItem.type === 'picture') {
                         item._etag = __item._etag;
                     }

--- a/scripts/apps/authoring/authoring/services/AuthoringService.ts
+++ b/scripts/apps/authoring/authoring/services/AuthoringService.ts
@@ -457,59 +457,61 @@ export function AuthoringService($q, $location, api, lock, autosave, confirm, pr
      * @param {Object} origItem
      * @param {Object} item
      */
-    this.save = function saveAuthoring(origItem, _item) {
-        return runBeforeUpdateMiddlware(_item, origItem).then((item: IArticle) => {
-            var diff = helpers.extendItem({}, item);
-            // Finding if all the keys are dirty for real
+    this.save = function save(origItem, _item) {
+        return runBeforeUpdateMiddlware(_item, origItem).then((item: IArticle) => this.saveAuthoring(origItem, item));
+    };
 
-            if (angular.isDefined(origItem)) {
-                angular.forEach(_.keys(diff), (key) => {
-                    if (_.isEqual(diff[key], origItem[key])) {
-                        delete diff[key];
-                    }
-                });
-            }
+    this.saveAuthoring = function saveAuthoring(origItem, item) {
+        var diff = helpers.extendItem({}, item);
+        // Finding if all the keys are dirty for real
 
-            helpers.stripHtml(diff);
-            helpers.stripWhitespaces(diff);
-            helpers.cutoffPreviousRenditions(diff, origItem);
-            autosave.stop(item);
+        if (angular.isDefined(origItem)) {
+            angular.forEach(_.keys(diff), (key) => {
+                if (_.isEqual(diff[key], origItem[key])) {
+                    delete diff[key];
+                }
+            });
+        }
 
-            if (diff._etag) { // make sure we use orig item etag
-                delete diff._etag;
-            }
+        helpers.stripHtml(diff);
+        helpers.stripWhitespaces(diff);
+        helpers.cutoffPreviousRenditions(diff, origItem);
+        autosave.stop(item);
 
-            // if current document is image and it has been changed on 'media edit' we have to update the etag
-            if (origItem.type === 'picture' && item._etag != null) {
-                diff._etag = item._etag;
-            }
+        if (diff._etag) { // make sure we use orig item etag
+            delete diff._etag;
+        }
 
-            helpers.filterDefaultValues(diff, origItem);
+        // if current document is image and it has been changed on 'media edit' we have to update the etag
+        if (origItem.type === 'picture' && item._etag != null) {
+            diff._etag = item._etag;
+        }
 
-            if (_.size(diff) > 0) {
-                return api.save('archive', origItem, diff).then((__item) => {
-                    if (origItem.type === 'picture') {
-                        item._etag = __item._etag;
-                    }
-                    origItem._autosave = null;
-                    origItem._autosaved = false;
-                    origItem._locked = lock.isLockedInCurrentSession(item);
+        helpers.filterDefaultValues(diff, origItem);
 
-                    const authoringWorkspace: AuthoringWorkspaceService = $injector.get('authoringWorkspace');
-
-                    authoringWorkspace.update(origItem);
-                    return origItem;
-                });
-            }
-
-            if (origItem) {
-                // if there is nothing to save. No diff.
+        if (_.size(diff) > 0) {
+            return api.save('archive', origItem, diff).then((__item) => {
+                if (origItem.type === 'picture') {
+                    item._etag = __item._etag;
+                }
                 origItem._autosave = null;
                 origItem._autosaved = false;
-            }
+                origItem._locked = lock.isLockedInCurrentSession(item);
 
-            return Promise.resolve(origItem);
-        });
+                const authoringWorkspace: AuthoringWorkspaceService = $injector.get('authoringWorkspace');
+
+                authoringWorkspace.update(origItem);
+                return origItem;
+            });
+        }
+
+        if (origItem) {
+            // if there is nothing to save. No diff.
+            origItem._autosave = null;
+            origItem._autosaved = false;
+        }
+
+        return Promise.resolve(origItem);
     };
 
     /**

--- a/scripts/apps/authoring/authoring/services/AutosaveService.ts
+++ b/scripts/apps/authoring/authoring/services/AutosaveService.ts
@@ -1,6 +1,6 @@
 import * as helpers from 'apps/authoring/authoring/helpers';
 import {IArticle} from 'superdesk-api';
-import {runBeforeUpdateMiddlware} from './AuthoringService';
+import {runBeforeUpdateMiddlware, runAfterUpdateEvent} from './AuthoringService';
 
 const RESOURCE = 'archive_autosave';
 const AUTOSAVE_TIMEOUT = 3000;
@@ -59,7 +59,9 @@ export class AutosaveService {
 
                     helpers.filterDefaultValues(diff, orig);
 
-                    return api.save(RESOURCE, {}, diff).then((_autosave) => {
+                    return api.save(RESOURCE, {}, diff).then((_autosave: IArticle) => {
+                        runAfterUpdateEvent(orig, _autosave);
+
                         orig._autosave = _autosave;
 
                         if (typeof callback === 'function') {

--- a/scripts/core/get-superdesk-api-implementation.tsx
+++ b/scripts/core/get-superdesk-api-implementation.tsx
@@ -200,6 +200,9 @@ export function getSuperdeskApiImplementation(
                 addImage: (field: string, image: IArticle) => {
                     dispatchInternalEvent('addImage', {field, image});
                 },
+                save: () => {
+                    dispatchInternalEvent('save', null);
+                },
             },
             alert: (message: string) => modal.alert({bodyText: message}),
             confirm: (message: string) => new Promise((resolve) => {

--- a/scripts/core/get-superdesk-api-implementation.tsx
+++ b/scripts/core/get-superdesk-api-implementation.tsx
@@ -201,7 +201,7 @@ export function getSuperdeskApiImplementation(
                     dispatchInternalEvent('addImage', {field, image});
                 },
                 save: () => {
-                    dispatchInternalEvent('save', null);
+                    dispatchInternalEvent('saveArticleInEditMode', null);
                 },
             },
             alert: (message: string) => modal.alert({bodyText: message}),

--- a/scripts/core/internal-events.ts
+++ b/scripts/core/internal-events.ts
@@ -5,7 +5,7 @@ interface IInternalEvents {
         field: string;
         image: IArticle;
     };
-    save: void;
+    saveArticleInEditMode: void;
     dangerouslyOverwriteAuthoringData: Partial<IArticle>;
 }
 

--- a/scripts/core/internal-events.ts
+++ b/scripts/core/internal-events.ts
@@ -5,6 +5,7 @@ interface IInternalEvents {
         field: string;
         image: IArticle;
     };
+    save: void;
     dangerouslyOverwriteAuthoringData: Partial<IArticle>;
 }
 

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -90,7 +90,15 @@ declare module 'superdesk-api' {
             iptcMapping?(data: Partial<IPTCMetadata>, item: Partial<IArticle>, parent?: IArticle): Promise<Partial<IArticle>>;
             searchPanelWidgets?: Array<React.ComponentType<ISearchPanelWidgetProps>>;
             authoring?: {
-                onUpdate?(current: IArticle, next: IArticle): Promise<IArticle>;
+                /**
+                 * Updates can be intercepted and modified. Return value will be used to compute a patch.
+                 * 
+                 * Example: onUpdateBefore = (current, next) => ({...next, priority: next.headline.includes('important') ? 10 : 1})
+                */
+                onUpdateBefore?(current: IArticle, next: IArticle): Promise<IArticle>;
+
+                /** Called after the update. */
+                onUpdateAfter?(previous: IArticle, current: IArticle): void;
             };
             monitoring?: {
                 getFilteringButtons?(): Promise<Array<IMonitoringFilter>>;

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -964,6 +964,7 @@ declare module 'superdesk-api' {
 
                 // This isn't implemented for all fields accepting images.
                 addImage(field: string, image: IArticle): void;
+                save(): void;
             };
             alert(message: string): Promise<void>;
             confirm(message: string): Promise<boolean>;

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -964,6 +964,11 @@ declare module 'superdesk-api' {
 
                 // This isn't implemented for all fields accepting images.
                 addImage(field: string, image: IArticle): void;
+
+                /**
+                 * Programatically triggers saving of an article in edit mode.
+                 * Runs the same code as if "save" button was clicked manually.
+                */
                 save(): void;
             };
             alert(message: string): Promise<void>;


### PR DESCRIPTION
This event is similar to click Save button on the UI by calling `save` function in `AuthoringEditDirective` (as requested in https://github.com/superdesk/superdesk-belga/pull/228)

- Move `saveAuthoring` to separate function, otherwise, calling `save` will cause infinite loop because: `runBeforeUpdateMiddlware` => Run Extension => Trigger Save => Run `runBeforeUpdateMiddlware`
- If multiple extensions trigger `save` event, it will run `save` only once (`saveAuthoring` already do the diff comparison)
