### PR TITLE
Fix errors when removing carousel items

### DIFF
--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -889,7 +889,7 @@ export function AuthoringDirective(
                 return authoring.autosave(
                     $scope.item,
                     $scope.origItem,
-                    timeout
+                    timeout,
                 ).then(
                     () => {
                         $scope.$applyAsync(() => {
@@ -898,7 +898,7 @@ export function AuthoringDirective(
                             updateSchema();
                         });
                     },
-                ));
+                );
             };
 
             $scope.sendToNextStage = function() {

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -889,7 +889,8 @@ export function AuthoringDirective(
                 return authoring.autosave(
                     $scope.item,
                     $scope.origItem,
-                    timeout,
+                    timeout
+                ).then(
                     () => {
                         $scope.$applyAsync(() => {
                             authoringWorkspace.addAutosave();
@@ -897,7 +898,7 @@ export function AuthoringDirective(
                             updateSchema();
                         });
                     },
-                );
+                ));
             };
 
             $scope.sendToNextStage = function() {

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -886,7 +886,7 @@ export function AuthoringDirective(
                 $scope.dirty = true;
                 angular.extend($scope.item, item); // make sure all changes are available
 
-                authoring.autosave(
+                return authoring.autosave(
                     $scope.item,
                     $scope.origItem,
                     timeout,

--- a/scripts/apps/authoring/tests/authoring.spec.ts
+++ b/scripts/apps/authoring/tests/authoring.spec.ts
@@ -274,7 +274,7 @@ describe('authoring', () => {
 
             spyOn(api, 'find').and.returnValue($q.when(rewriteOf));
             spyOn(confirm, 'confirmFeatureMedia').and.returnValue(defered.promise);
-            spyOn(authoring, 'autosave').and.returnValue(item);
+            spyOn(authoring, 'autosave').and.returnValue(Promise.resolve(item));
             spyOn(authoring, 'publish').and.returnValue(item);
             let scope = startAuthoring(item, 'edit');
 


### PR DESCRIPTION
SDESK-5379

The issue was caused by a backend error that is now fixed, but there
were still some issues in the console. This error was being caused by
an undefined promise being returned from autosave