### PR TITLE
Make mediablock usageterms consistent with galleries

### DIFF
--- a/scripts/core/editor3/components/media/MediaBlock.tsx
+++ b/scripts/core/editor3/components/media/MediaBlock.tsx
@@ -15,8 +15,10 @@ function getTranslationForAssignRights(value) {
         return gettext('Time Restricted');
     } else if (value === 'indefinite-usage') {
         return gettext('Indefinite Usage');
+    } else if (typeof value === 'string') {
+        return value;
     } else {
-        return '';
+        return null;
     }
 }
 


### PR DESCRIPTION
SDESK-5423

Usageterms were only being shown on a media block for "single selection"
fields (so only these values: 'Single Usage', 'Time Restricted' and
'Indefinite Usage'). When the field is a simple input, other places like
galleries and feature media shows the actual string value, while the
media block just shows "[No value]".