### PR TITLE
handle missing related items

### DIFF
--- a/scripts/apps/relations/directives/RelatedItemsDirective.ts
+++ b/scripts/apps/relations/directives/RelatedItemsDirective.ts
@@ -17,7 +17,7 @@ interface IScope extends IDirectiveScope<void> {
     item: IArticle;
     loading: boolean;
     reorder: (start: {index: number}, end: {index: number}) => void;
-    relatedItems: Array<IArticle>;
+    relatedItems: {[key: string]: IArticle};
     onchange: () => void;
     addRelatedItem: (item: IArticle) => void;
     isEmptyRelatedItems: (fieldId: string) => void;
@@ -239,7 +239,16 @@ export function RelatedItemsDirective(
                 scope.loading = true;
                 relationsService.getRelatedItemsForField(scope.item, scope.field._id)
                     .then((items) => {
-                        scope.relatedItems = items;
+                        scope.relatedItems = {};
+                        Object.keys(items).forEach((key) => {
+                            if (items[key] != null) {
+                                scope.relatedItems[key] = items[key];
+                            } else {
+                                scope.removeRelatedItem(key);
+                                notify.warning(gettext('Related item is not available.'));
+                            }
+                        });
+                    }).finally(() => {
                         scope.loading = false;
                     });
             };

--- a/scripts/apps/relations/services/RelationsService.ts
+++ b/scripts/apps/relations/services/RelationsService.ts
@@ -21,7 +21,14 @@ export function RelationsService(api, $q) {
 
         return $q.all(relatedItemsKeys.map((key) => {
             if (isLink(associations[key])) {
-                return api.find('archive', associations[key]._id);
+                return api.find('archive', associations[key]._id)
+                    .catch((response) => {
+                        if (response?.status === 404) {
+                            return null;
+                        }
+
+                        return Promise.reject(response);
+                    });
             }
 
             return $q.when(associations[key]);


### PR DESCRIPTION
when related item is not available anymore it was
showing the loader indefinitely. now it will remove such
item from related and show a warning to user.

SDESK-5252