### PR TITLE
fix product content filter field disappearing

### DIFF
--- a/scripts/apps/products/controllers/ProductsConfigController.ts
+++ b/scripts/apps/products/controllers/ProductsConfigController.ts
@@ -20,6 +20,7 @@ interface IScope {
     save: () => void;
     remove: (product: any) => void;
     test: () => void;
+    handleContentFilterChange: () => void;
     articleId: string;
     rawResults: string;
     filteredProducts: Array<any>;
@@ -136,7 +137,7 @@ export function ProductsConfigController($scope: IScope, notify, api, products, 
         $scope.modalTab = 'details';
         $scope.product = product;
         $scope.product.edit = _.create(product);
-        $scope.product.edit.content_filter = _.create(product.content_filter || {});
+        $scope.product.edit.content_filter = Object.assign({}, product.content_filter || {});
         $scope.modalActive = true;
     };
 
@@ -208,6 +209,15 @@ export function ProductsConfigController($scope: IScope, notify, api, products, 
             return remove;
         })
             .then($scope.cancel);
+    };
+
+    $scope.handleContentFilterChange = function() {
+        if ($scope.product.edit.content_filter.filter_id === '') {
+            $scope.product.edit.content_filter = null;
+        } else if ($scope.product.edit.content_filter.filter_type == null) {
+            // initialize default value
+            $scope.product.edit.content_filter.filter_type = 'permitting';
+        }
     };
 
     /**

--- a/scripts/apps/products/views/products-config-modal.html
+++ b/scripts/apps/products/views/products-config-modal.html
@@ -55,7 +55,7 @@
 
                         <div class="sd-line-input  sd-line-input--is-select">
                             <label class="sd-line-input__label" translate>Content Filter</label>
-                            <select class="sd-line-input__select" ng-model="product.edit.content_filter.filter_id">
+                            <select class="sd-line-input__select" ng-model="product.edit.content_filter.filter_id" ng-change="handleContentFilterChange()">
                                 <option value=""></option>
                                 <option value="{{filter._id}}" ng-selected="filter._id === product.edit.content_filter.filter_id" ng-repeat="filter in contentFilters track by filter._id">{{:: filter.name}}</option>
                             </select>


### PR DESCRIPTION
SDESK-5489

> $scope.product.edit.content_filter = _.create(product.content_filter || {});

The issue was the use of `_.create` to initialize a value. It creates an empty object which inherits properties, but still serializes to an empty object.

```
"content_filter": {
    "filter_id": "5f44e9b7474a0eb54142bf56",
    "filter_type": "blocking"
},
```

When `filter_type` was changed from the UI, angular model binding would then add a real property, not an inherited one, but when serialized, a patch would contain only that single property:

```
"content_filter": {
    "filter_type": "blocking"
},
```

That means `filter_id` would get dropped. It might have worked with the previous eve version, but I think now it overwrites the entire object. Anyway, after this PR it will work no matter the patching strategy used by eve.