### PR TITLE
prevent http request when template is not executed

### DIFF
--- a/scripts/apps/archive/views/preview.html
+++ b/scripts/apps/archive/views/preview.html
@@ -173,7 +173,7 @@
                 </div>
                 <div ng-if="field.field_type === 'media'" class="association">
                     <div ng-repeat="(mediaId, media) in getAssociatedItems(item.associations, field._id) track by mediaId">
-                        <img src="{{media.renditions.viewImage.href}}" ng-if="media.type === 'picture'">
+                        <img ng-src="{{media.renditions.viewImage.href}}" ng-if="media.type === 'picture'">
                         <sd-video ng-if="media.type === 'video'" item="media"></sd-video>
                         <audio controls="controls" ng-if="media.type === 'audio'">
                             <source vsrc="{{rendition.href}}"


### PR DESCRIPTION
SDESK-5528

`http://localhost:9000/%7B%7Bmedia.renditions.viewImage.href%7D%7D 404 (Not Found)`

The error used to be displayed even when `ng-if` wasn't resolving to true. I suspect that's because angular first renders the template as is and only after that populates placeholders with values and does other modifications to templates.

It wasn't causing any real error in the app, just initializing a faulty request.