### PR TITLE
Fix copy-paste from MS Word on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "d3": "3.5.17",
     "diff-match-patch": "1.0.0",
     "docs-soap": "github:tomaskikutis/docs-soap#convert-tables",
-    "draft-js": "github:pablopunk/draft-js#add-subscript-superscript",
+    "draft-js": "github:superdesk/draft-js#master",
     "draft-js-export-html": "1.3.3",
     "end-to-end-testing-helpers": "1.0.6",
     "eslint": "6.6.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "d3": "3.5.17",
     "diff-match-patch": "1.0.0",
     "docs-soap": "github:tomaskikutis/docs-soap#convert-tables",
-    "draft-js": "github:tomaskikutis/draft-js#add-subscript-superscript",
+    "draft-js": "github:pablopunk/draft-js#add-subscript-superscript",
     "draft-js-export-html": "1.3.3",
     "end-to-end-testing-helpers": "1.0.6",
     "eslint": "6.6.0",


### PR DESCRIPTION
SDESK-5530

There's an issue on draft-js that I [explain here](https://github.com/facebook/draft-js/commit/5081c872304384d3a213159bd8cc16e164bdf85a#r42395763) where copy & pasting from certain documents in Word won't paste spaces after links.

The actual fix is here https://github.com/pablopunk/draft-js/commit/df890ab9570dcb20a6e287116abdd9c247e510c2