### PR TITLE
After rearranging gallery carousel items the next or previous buttons do not function as expected. [SDESK-5540]

### DIFF
--- a/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
@@ -331,6 +331,10 @@ export function ItemCarouselDirective(notify) {
                         updated = true;
                     },
                 });
+
+                if (scope.currentIndex != null) {
+                    carousel?.trigger('to.owl.carousel', [scope.currentIndex]);
+                }
             }
 
             const removeAddImageEventListener = addInternalEventListener('addImage', (event) => {
@@ -338,12 +342,6 @@ export function ItemCarouselDirective(notify) {
 
                 if (scope.field._id === field) {
                     controller.addAssociation(scope, image);
-                }
-            });
-
-            scope.$watch('currentIndex', () => {
-                if (scope.currentIndex != null) {
-                    carousel?.trigger('to.owl.carousel', [scope.currentIndex]);
                 }
             });
 

--- a/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
@@ -333,7 +333,7 @@ export function ItemCarouselDirective(notify) {
                 });
 
                 if (scope.currentIndex != null) {
-                    carousel?.trigger('to.owl.carousel', [scope.currentIndex]);
+                    carousel.trigger('to.owl.carousel', [scope.currentIndex]);
                 }
             }
 


### PR DESCRIPTION
When we rearrange the images, the carousel is not updated because the scope.$watch('currentIndex') is not called.