### PR TITLE
After rearranging gallery carousel items the next or previous buttons do not function as expected

### DIFF
--- a/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts
@@ -345,6 +345,12 @@ export function ItemCarouselDirective(notify) {
                 }
             });
 
+            scope.$watch('currentIndex', () => {
+                if (scope.currentIndex != null) {
+                    carousel?.trigger('to.owl.carousel', [scope.currentIndex]);
+                }
+            });
+
             scope.$on('$destroy', () => {
                 elem.off('drop dragdrop dragover');
                 removeAddImageEventListener();


### PR DESCRIPTION
We need `scope.$watch('currentIndex')` as well so that whenever the currentIndex value is updated, it will run the carousel.