### PR TITLE
Improve authors dropdown performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "react-bootstrap": "0.32.1",
     "react-debounce-input": "3.2.0",
     "react-dom": "16.9.0",
+    "react-lazyload": "^3.0.0",
     "react-mentions": "1.2.2",
     "react-paginate": "6.3.0",
     "react-portal": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "start-client-server": "http-server dist -p 9000 -s &",
     "stop-client-server": "fuser -k 9000/tcp",
     "protractor": "protractor protractor.conf.js",
-    "webdriver-manager": "webdriver-manager update --gecko false --standalone false --versions.chrome=84.0.4147.30",
+    "webdriver-manager": "webdriver-manager update --gecko false --standalone false --versions.chrome=86.0.4240.75",
     "server": "grunt server",
     "dev": "npm run server"
   }

--- a/scripts/apps/authoring/metadata/views/metadata-dropdown.html
+++ b/scripts/apps/authoring/metadata/views/metadata-dropdown.html
@@ -23,7 +23,7 @@
         <li ng-if="label"><div class="dropdown__menu-label">{{ label }}</div></li>
         <li ng-click="select()"><button ng-disabled="disabled" translate>None</button></li>
 
-        <li ng-repeat="term in list" ng-click="select(term)" ng-if="field !== 'place'">
+        <li ng-repeat="term in list" ng-click="select(term)" ng-if="field !== 'place'" data-test-id="dropdown__item">
             <button ng-disabled="disabled">
                 <span ng-if="icon"
                     class="{{icon}}-{{term.name}}"

--- a/scripts/apps/authoring/metadata/views/metadata-terms.html
+++ b/scripts/apps/authoring/metadata/views/metadata-terms.html
@@ -69,7 +69,7 @@
                 </li>
             </ul>
             <ul ng-if="!preferredView">
-                <li ng-repeat="term in activeTree track by term[uniqueField]">
+                <li ng-repeat="term in activeTree track by term[uniqueField]" data-test-id="dropdown__item">
                     <button
                         ng-if="tree[term[uniqueField]]"
                         class="nested-toggle flex-row sibling-spacer-10"

--- a/scripts/apps/authoring/metadata/views/metadata-terms.html
+++ b/scripts/apps/authoring/metadata/views/metadata-terms.html
@@ -11,7 +11,7 @@
     <button class="dropdown__toggle" dropdown__toggle tabindex="{{tabindex}}" ng-disabled="disabled" ng-if="header && !disabled">
         <i class="icon--white icon-plus-large"></i>
     </button>
-    <ul class="dropdown__menu nested-menu pull-right" style="{{ cv.popup_width ? 'min-width: 0; width: ' + cv.popup_width + 'px' : ''}}">
+    <ul class="dropdown__menu nested-menu pull-right" style="{{ cv.popup_width ? 'min-width: 0; width: ' + cv.popup_width + 'px' : ''}}" id="metadata-terms-dropdown-users">
         <li ng-show="!activeTerm && header">
             <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="selectTerm(item, $event)" always-visible="header" data-disabled="disabled || allSelected">
                 <ul class="item-list" vs-repeat ng-if="!activeTree.length || activeList">
@@ -21,7 +21,7 @@
                             style="display: flex;"
                             ng-click="selectTerm(t, $event)"
                         >
-                            <sd-user-avatar ng-if="t.user != null" data-user="t.user"></sd-user-avatar>
+                            <sd-user-avatar ng-if="t.user != null" data-user="t.user" scroll-container="'#metadata-terms-dropdown-users'"></sd-user-avatar>
                             <span>{{getLocaleName(t, item)}}</span>
                         </button>
                     </li>
@@ -68,7 +68,7 @@
                     </button>
                 </li>
             </ul>
-            <ul vs-repeat ng-if="!preferredView">
+            <ul ng-if="!preferredView">
                 <li ng-repeat="term in activeTree track by term[uniqueField]">
                     <button
                         ng-if="tree[term[uniqueField]]"
@@ -78,7 +78,7 @@
                         title="{{getLocaleName(term, item)}}"
                     >
                         <span ng-if="term.user">
-                            <sd-user-avatar data-user="term.user"></sd-user-avatar>
+                            <sd-user-avatar data-user="term.user" scroll-container="'#metadata-terms-dropdown-users'"></sd-user-avatar>
                         </span>
                         <span>{{getLocaleName(term, item)}}</span>
                         <i class="icon-chevron-right-thin"></i></button>

--- a/scripts/apps/users/components/UserAvatar.tsx
+++ b/scripts/apps/users/components/UserAvatar.tsx
@@ -8,6 +8,12 @@ import {gettext} from 'core/utils';
 import {AvatarWrapper, AvatarContentText, AvatarContentImage} from 'superdesk-ui-framework/react';
 import LazyLoad, {forceVisible} from 'react-lazyload';
 
+export enum AvatarSize {
+    small = 24,
+    medium = 30,
+    large = 48,
+}
+
 class DefaultAvatarDisplay extends React.PureComponent<{user: Partial<IUser>}> {
     render() {
         const {user} = this.props;
@@ -62,6 +68,7 @@ const LazyOrNot = ({children, ...rest}) => {
                 once
                 overflow
                 scrollContainer={props.scrollContainer}
+                height={props.size ? AvatarSize[props.size] : AvatarSize.medium}
             >
                 {children}
             </LazyLoad>

--- a/scripts/apps/users/components/UserAvatar.tsx
+++ b/scripts/apps/users/components/UserAvatar.tsx
@@ -68,7 +68,7 @@ const LazyOrNot = ({children, ...rest}) => {
         );
     }
 
-    return <>{children}</>;
+    return children;
 };
 
 export class UserAvatar extends React.PureComponent<IProps> {

--- a/scripts/apps/users/components/UserAvatar.tsx
+++ b/scripts/apps/users/components/UserAvatar.tsx
@@ -60,8 +60,8 @@ const LazyOrNot = ({children, ...rest}) => {
         return (
             <LazyLoad
                 once
-                overflow={Boolean(props.scrollContainer)}
-                scrollContainer={props.scrollContainer ? props.scrollContainer : undefined}
+                overflow
+                scrollContainer={props.scrollContainer}
             >
                 {children}
             </LazyLoad>

--- a/scripts/apps/users/views/user-list-item.html
+++ b/scripts/apps/users/views/user-list-item.html
@@ -5,7 +5,7 @@
     data-test-id="users-list-item"
 >
     <div style="height: auto">
-        <sd-user-avatar data-user="user" data-display-status="true" display-administrator-indicator="true"></sd-user-avatar>
+        <sd-user-avatar data-user="user" data-display-status="true" display-administrator-indicator="true" scroll-container="'.content'"></sd-user-avatar>
     </div>
 
     <div class="row-wrapper" sd-col-width>

--- a/scripts/core/directives/index.ts
+++ b/scripts/core/directives/index.ts
@@ -28,32 +28,38 @@ import {UserOrganisationAvatar} from 'apps/users/components/OrganisationAvatar';
  * @description Superdesk core directives collection. Contains a set of modules
  *  that implement various UI components and helpers.
  */
-export default angular.module('superdesk.core.directives', [
-    'superdesk.core.directives.autofocus',
-    'superdesk.core.directives.sort',
-    'superdesk.core.directives.passwordStrength',
-    'superdesk.core.directives.searchList',
-    'superdesk.core.directives.filetypeIcon',
-    'superdesk.core.directives.checkAll',
-    'superdesk.core.directives.switchInverted',
-    'superdesk.core.directives.select',
-    'superdesk.core.directives.selectPopup',
-    'superdesk.core.directives.permissions',
-    'superdesk.core.directives.sortable',
-    'superdesk.core.directives.draggable',
-    'superdesk.core.directives.droppable',
-    'superdesk.core.directives.typeahead',
-    'superdesk.core.directives.slider',
-    'superdesk.core.directives.withParams',
-])
+export default angular
+    .module('superdesk.core.directives', [
+        'superdesk.core.directives.autofocus',
+        'superdesk.core.directives.sort',
+        'superdesk.core.directives.passwordStrength',
+        'superdesk.core.directives.searchList',
+        'superdesk.core.directives.filetypeIcon',
+        'superdesk.core.directives.checkAll',
+        'superdesk.core.directives.switchInverted',
+        'superdesk.core.directives.select',
+        'superdesk.core.directives.selectPopup',
+        'superdesk.core.directives.permissions',
+        'superdesk.core.directives.sortable',
+        'superdesk.core.directives.draggable',
+        'superdesk.core.directives.droppable',
+        'superdesk.core.directives.typeahead',
+        'superdesk.core.directives.slider',
+        'superdesk.core.directives.withParams',
+    ])
 
     .directive('sdPhoneHomeModal', PhoneHomeModalDirective)
     .component(
         'sdUserAvatar',
-        reactToAngular1(UserAvatar, ['user', 'size', 'displayStatus', 'displayAdministratorIndicator', 'scrollContainer']),
+        reactToAngular1(UserAvatar, [
+            'user',
+            'size',
+            'displayStatus',
+            'displayAdministratorIndicator',
+            'scrollContainer',
+        ]),
     )
     .component(
         'sdOrganisationAvatar',
         reactToAngular1(UserOrganisationAvatar, ['size']),
-    )
-;
+    );

--- a/scripts/core/directives/index.ts
+++ b/scripts/core/directives/index.ts
@@ -50,7 +50,7 @@ export default angular.module('superdesk.core.directives', [
     .directive('sdPhoneHomeModal', PhoneHomeModalDirective)
     .component(
         'sdUserAvatar',
-        reactToAngular1(UserAvatar, ['user', 'size', 'displayStatus', 'displayAdministratorIndicator']),
+        reactToAngular1(UserAvatar, ['user', 'size', 'displayStatus', 'displayAdministratorIndicator', 'scrollContainer']),
     )
     .component(
         'sdOrganisationAvatar',

--- a/spec/helpers/authoring.ts
+++ b/spec/helpers/authoring.ts
@@ -216,7 +216,7 @@ class Authoring {
             .element(by.tagName('button'));
 
         this.getCategoryListItems = element(by.id('category-setting'))
-            .all(by.repeater('term in $vs_collection track by term[uniqueField]'));
+            .all(el(['dropdown__item']).locator());
 
         this.sendItemContainer = element(by.id('send-item-container'));
         this.linkToMasterButton = element(by.id('preview-master'));

--- a/spec/helpers/search.ts
+++ b/spec/helpers/search.ts
@@ -429,7 +429,7 @@ class GlobalSearch {
             scrollRelative(advancedSearchPanel, 'up', 60); // account for sticky tabs
 
             toggleButton.click();
-            markedDesks.all(by.repeater('term in $vs_collection track by term[uniqueField]')).get(index).click();
+            markedDesks.all(el(['dropdown__item']).locator()).get(index).click();
         };
 
         /**


### PR DESCRIPTION
SDESK-5595

This solution is not perfect but the performance is a bit better. Old dropdowns still need to be replaced with the new ones to prevent issues like this one.

* Lazy load avatars inside scroll elements
* Removed vs-repeat from loop: Recalculating DOM styles takes a huge amount of time but this seems to help.

### Before

![bad blurred gif](https://user-images.githubusercontent.com/4324982/95197670-3c3fa100-07da-11eb-86f3-5807048ad994.gif)

### After

![good blurred gif](https://user-images.githubusercontent.com/4324982/95197700-4b265380-07da-11eb-97a9-2515f50e7005.gif)
