### PR TITLE
Update node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "moment": "2.20.1",
     "moment-timezone": "0.5.14",
     "ng-file-upload": "12.2.13",
-    "node-sass": "4.12.0",
+    "node-sass": "4.14.0",
     "owl.carousel": "2.2.0",
     "postscribe": "2.0.8",
     "prop-types": "15.6.1",


### PR DESCRIPTION
There's a new LTS version of node (which we use on travis) and node-sass needs to be updated to support it.

Builds are failing on PRs because of this.