### PR TITLE
Use correct content profile data for description text

### DIFF
--- a/scripts/apps/authoring/views/article-edit.html
+++ b/scripts/apps/authoring/views/article-edit.html
@@ -423,12 +423,12 @@
 
 <div ng-if="isMediaType && !(features.onlyEditor3 || editor.body_html.editor3)"
      class="field abstract"
-     order="{{editor.media_description.order}}"
+     order="{{editor.description_text.order}}"
      sd-validation-error="error.description_text"
-     sd-width="{{editor.media_description.sdWidth|| 'full'}}"
-     ng-attr-title="{{schema.media_description.readonly === true ? readOnlyLabel : ''}}"
-     data-required="schema.media_description.required">
-    <label for="title" class="field__label" translate>Caption</label>
+     sd-width="{{editor.description_text.sdWidth|| 'full'}}"
+     ng-attr-title="{{schema.description_text.readonly === true ? readOnlyLabel : ''}}"
+     data-required="schema.description_text.required">
+    <label for="title" class="field__label">{{label('description_text')}}</label>
     <span ng-if="validator.description_text.maxlength" sd-character-count data-item="item.description_text" data-html="true" data-limit="validator.description_text.maxlength"></span>
     <div id="title" class="abstract"
          sd-text-editor
@@ -437,19 +437,19 @@
          data-language="item.language"
          ng-model="item.description_text"
          ng-change="autosave(item)"
-         data-read-only="!_editable || schema.media_description.readonly === true"
+         data-read-only="!_editable || schema.description_text.readonly === true"
          ng-trim="false"></div>
     <div class="abstract" ng-if="!_editable">{{item.description_text}}</div>
 </div>
 
 <div ng-if="isMediaType && (features.onlyEditor3 || editor.body_html.editor3)"
      class="field abstract"
-     order="{{editor.media_description.order}}"
+     order="{{editor.description_text.order}}"
      sd-validation-error="error.description_text"
-     sd-width="{{editor.media_description.sdWidth|| 'full'}}"
-     ng-attr-title="{{schema.media_description.readonly === true ? readOnlyLabel : ''}}"
-     data-required="schema.media_description.required">
-    <label for="title" class="field__label" translate>Caption</label>
+     sd-width="{{editor.description_text.sdWidth|| 'full'}}"
+     ng-attr-title="{{schema.description_text.readonly === true ? readOnlyLabel : ''}}"
+     data-required="schema.description_text.required">
+    <label for="title" class="field__label">{{label('description_text')}}</label>
     <span ng-if="validator.description_text.maxlength" sd-character-count data-item="item.description_text" data-html="true" data-limit="validator.description_text.maxlength"></span>
     <div id="title" class="abstract"
          sd-editor3
@@ -458,12 +458,12 @@
          data-scroll-container=".page-content-container"
          data-bind-to-value="compareView"
          data-value="item.description_text"
-         data-read-only="!_editable || schema.media_description.readonly === true"
+         data-read-only="!_editable || schema.description_text.readonly === true"
          data-on-change="autosave(item)"
          data-language="item.language"
          data-item="item"
          data-refresh-trigger="refreshTrigger"
-         data-tabindex="editor.media_description.order"
+         data-tabindex="editor.description_text.order"
          data-clean-pasted-html="editor.description_text.cleanPastedHTML"
     ></div>
 </div>
@@ -474,7 +474,7 @@
      data-required="schema.footer.required"
      order="{{editor.footer.order}}"
      ng-attr-title="{{schema.footer.readonly === true ? readOnlyLabel : ''}}"
-     sd-width="{{editor.media_description.sdWidth|| 'full'}}">
+     sd-width="{{editor.footer.sdWidth|| 'full'}}">
     <label class="field__label"translate>Helplines/Contact Information</label>
     <select class="field__select" id="helplines"
             ng-model="extra.body_footer_value"


### PR DESCRIPTION
SDESK-5624

Field order was incorrect because it was accessing `editor.media_description`(which was undefined) instead of `editor.description_text`.