### PR TITLE
Fix overlapping text when printing

### DIFF
--- a/styles/sass/layouts.scss
+++ b/styles/sass/layouts.scss
@@ -1470,6 +1470,10 @@ body.prepare-print {
             font-size: 16pt !important;
             margin-bottom: 16px !important;
         }
+        .modal__body {
+            display: block !important;
+            padding: 0 !important;
+        }
         .modal-content {
             display: block !important;
             > * {


### PR DESCRIPTION
There is no ticket regarding this. I was refactoring monitoring view and found that when printing, sometimes multiple items are rendered [on top of one another](https://user-images.githubusercontent.com/2076953/99285801-4f617a00-2838-11eb-92c9-91ad9524afb2.png).

I have fixed it for the scenario I was testing, but the code is quite fragile and doesn't work on firefox. I have created SDESK-5662 to refactor the code so print preview isn't rendered inside a modal.