### PR TITLE
fix media upload placeholder

### DIFF
--- a/scripts/apps/search/MultiImageEdit.ts
+++ b/scripts/apps/search/MultiImageEdit.ts
@@ -283,7 +283,7 @@ export function MultiImageEditController(
 
         if (values[field].length === 1) {
             extra[field] = getMetaValue(field, values[field], null);
-        } else {
+        } else if (values[field].length > 1) {
             $scope.placeholder[field] = gettext('(multiple values)');
         }
     }


### PR DESCRIPTION
it would say `multiple values` for text items
when the value is actually `undefined`

SDANSA-462