### PR TITLE
[INGEST] [SETTINGS] Use Object ID instead of provider name to identit…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15440,6 +15440,11 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
       "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
     },
+    "uuid": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+    },
     "uws": {
       "version": "9.14.0",
       "resolved": "https://registry.npmjs.org/uws/-/uws-9.14.0.tgz",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "ts-loader": "3.5.0",
     "tslint": "5.11.0",
     "typescript": "3.9.7",
-    "uuid": "<9.0.0",
+    "uuid": "8.3.1",
     "webdriver-manager": "12.1.7",
     "webpack": "3.11.0",
     "webpack-dev-server": "2.11.1"

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "ts-loader": "3.5.0",
     "tslint": "5.11.0",
     "typescript": "3.9.7",
+    "uuid": "<9.0.0",
     "webdriver-manager": "12.1.7",
     "webpack": "3.11.0",
     "webpack-dev-server": "2.11.1"

--- a/scripts/apps/ingest/directives/IngestSourcesContent.ts
+++ b/scripts/apps/ingest/directives/IngestSourcesContent.ts
@@ -638,7 +638,6 @@ export function IngestSourcesContent(ingestSources, notify, api, $location,
                  * @param field url_request field metadata
                  */
                 $scope.doUrlRequest = (provider: IProvider, field: IFeedingServiceField): void => {
-                    let provider_name = encodeURIComponent(provider.name);
                     provider.url_id = mongoDBObjectId();
 
                     window.open(field.url.replace('{OID}', provider.url_id));

--- a/scripts/apps/ingest/directives/IngestSourcesContent.ts
+++ b/scripts/apps/ingest/directives/IngestSourcesContent.ts
@@ -40,6 +40,7 @@ interface IProvider {
     last_opened?: {};
     critical_errors?: {};
     skip_config_test?: boolean;
+    url_id?: string;
 }
 
 IngestSourcesContent.$inject = ['ingestSources', 'notify', 'api', '$location',
@@ -620,14 +621,27 @@ export function IngestSourcesContent(ingestSources, notify, api, $location,
                 };
 
                 /**
+                 * Generates ID compatible with MongoDB's ObjectID
+                 */
+                function mongoDBObjectId(): str {
+                    let oid = Math.floor(Date.now()/1000).toString(16);
+                    for (let i = 0; i < 16; i++) {
+                        oid += Math.floor(Math.random()*16).toString(16);
+                    }
+                    return oid;
+                }
+
+
+                /**
                  * Do URL request specified in url_request field
                  * @param provider ingest provider metadata
                  * @param field url_request field metadata
                  */
                 $scope.doUrlRequest = (provider: IProvider, field: IFeedingServiceField): void => {
                     let provider_name = encodeURIComponent(provider.name);
+                    provider.url_id = mongoDBObjectId();
 
-                    window.open(field.url.replace('{PROVIDER_NAME}', provider_name));
+                    window.open(field.url.replace('{OID}', provider.url_id));
                 };
 
                 function getCurrentService() {

--- a/scripts/apps/ingest/directives/IngestSourcesContent.ts
+++ b/scripts/apps/ingest/directives/IngestSourcesContent.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import {cloneDeep} from 'lodash';
 import {gettext} from 'core/utils';
 import {appConfig} from 'appConfig';
-import { v4 as uuidv4 } from 'uuid';
+import {v4 as uuidv4} from 'uuid';
 
 interface IFeedingServiceField {
     id?: string;
@@ -620,7 +620,6 @@ export function IngestSourcesContent(ingestSources, notify, api, $location,
 
                     return feedingService ? feedingService.templateUrl : '';
                 };
-
 
                 /**
                  * Do URL request specified in url_request field

--- a/scripts/apps/ingest/directives/IngestSourcesContent.ts
+++ b/scripts/apps/ingest/directives/IngestSourcesContent.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import {cloneDeep} from 'lodash';
 import {gettext} from 'core/utils';
 import {appConfig} from 'appConfig';
+import { v4 as uuidv4 } from 'uuid';
 
 interface IFeedingServiceField {
     id?: string;
@@ -620,17 +621,6 @@ export function IngestSourcesContent(ingestSources, notify, api, $location,
                     return feedingService ? feedingService.templateUrl : '';
                 };
 
-                /**
-                 * Generates ID compatible with MongoDB's ObjectID
-                 */
-                function mongoDBObjectId(): str {
-                    let oid = Math.floor(Date.now()/1000).toString(16);
-                    for (let i = 0; i < 16; i++) {
-                        oid += Math.floor(Math.random()*16).toString(16);
-                    }
-                    return oid;
-                }
-
 
                 /**
                  * Do URL request specified in url_request field
@@ -638,9 +628,9 @@ export function IngestSourcesContent(ingestSources, notify, api, $location,
                  * @param field url_request field metadata
                  */
                 $scope.doUrlRequest = (provider: IProvider, field: IFeedingServiceField): void => {
-                    provider.url_id = mongoDBObjectId();
+                    provider.url_id = uuidv4();
 
-                    window.open(field.url.replace('{OID}', provider.url_id));
+                    window.open(field.url.replace('{URL_ID}', provider.url_id));
                 };
 
                 function getCurrentService() {


### PR DESCRIPTION
…y provider

Provider name was used to identify the requesting provider when doing
URL request, but the provider name may not be set yet at this point.
This has been replaced by a generated ID which is compatible with
MongoDB. This way it can be used in the backend in the `_id` field.

SDESK-5342