### PR TITLE
display blank value when no macro is selected

### DIFF
--- a/scripts/apps/templates/views/template-editor-modal.html
+++ b/scripts/apps/templates/views/template-editor-modal.html
@@ -204,9 +204,7 @@
                                     <option
                                         ng-value="null"
                                         ng-selected="template.schedule_macro == null"
-                                    >
-                                        {{:: macro.name}}
-                                    </option>
+                                    ></option>
 
                                     <option
                                         ng-repeat="macro in macros track by macro.name"


### PR DESCRIPTION
SDNTB-660

amend #3710. `macro` variable isn't in scope here, since there's no repeater.