### PR TITLE
[ABOUT] Remove obsolet code/HTML

### DIFF
--- a/scripts/core/menu/menu.ts
+++ b/scripts/core/menu/menu.ts
@@ -235,7 +235,6 @@ angular.module('superdesk.core.menu', [
             link: function(scope) {
                 api.query('backend_meta', {}).then(
                     (metadata) => {
-                        scope.build_rev = appConfig.version || metadata.meta_rev;
                         scope.modules = metadata.modules;
                     });
                 scope.version = appConfig.version;

--- a/scripts/core/menu/views/about.html
+++ b/scripts/core/menu/views/about.html
@@ -10,7 +10,6 @@
     <div class="about-content">
       <span class="sf-logo"></span>
       <h4>Superdesk {{ :: version }}</span></h4>
-      <h5 ng-if="build_rev && build_rev !== ''">Superdesk rev. <a href="https://github.com/superdesk/superdesk/tree/{{ :: build_rev }}" rel="noopener noreferrer">{{ :: build_rev }}</a></h5>
 
       <h5 ng-repeat="module in modules track by module.name">
         {{ module.name }}: <a ng-href="{{ module.href }}" rel="noopener noreferrer">{{ module.version }}</a>


### PR DESCRIPTION
Following change in backend at
https://github.com/superdesk/superdesk-core/pull/2072, `build_rev` and
`Superdesk rev.` line are not needed anymore

SDESK-3632