### PR TITLE
Add loading state to monitoring groups

### DIFF
--- a/scripts/apps/monitoring/directives/MonitoringGroup.ts
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.ts
@@ -542,6 +542,9 @@ export function MonitoringGroup(
                     multi.reset();
                 }
 
+                // reset in order to display loading indicator
+                scope.items = undefined;
+
                 return (function() {
                     const customFilters: {[key: string]: IMonitoringFilter} = JSON.parse(
                         scope?.group?.customFilters ?? '{}',

--- a/scripts/apps/monitoring/views/monitoring-view.html
+++ b/scripts/apps/monitoring/views/monitoring-view.html
@@ -3,7 +3,7 @@
         <h2 id="monitoring-heading" class="a11y-only" ng-if="type === 'monitoring'" translate>Monitoring</h2>
         <h2 id="monitoring-heading" class="a11y-only" ng-if="type === 'highlights'" translate>Highlights</h2>
         <h2 id="monitoring-heading" class="a11y-only" ng-if="type === 'spike'" translate>Spiked items</h2>
-        <div class="preview-layout monitoring-preview-layout" sd-media-query min-width="700" element-class="narrowList">
+        <div class="preview-layout monitoring-preview-layout" sd-media-query min-width="700" element-class="narrowList" data-test-id="monitoring-view">
             <div class="content-list monitoring__content" ng-if="!aggregate.loading">
                 <div class="monitoring__toolbar-container" ng-if="hideMonitoringToolbar1 !== true || hideMonitoringToolbar2 !== true">
                     <div class="subnav" ng-if="hideMonitoringToolbar1 !== true">

--- a/scripts/apps/search/components/ItemList.tsx
+++ b/scripts/apps/search/components/ItemList.tsx
@@ -512,9 +512,34 @@ export class ItemList extends React.Component<IProps, IState> {
 
     render() {
         const {storage} = this.angularservices;
-
         const isEmpty = !this.props.itemsList.length;
-        const displayEmptyList = isEmpty && !this.props.loading;
+
+        if (this.props.loading) {
+            return (
+                <ul
+                    className="list-view list-without-items"
+                    tabIndex={0}
+                    ref={(el) => {
+                        this.focusableElement = el;
+                    }}
+                    data-test-id="item-list--loading"
+                >
+                    <li>{gettext('Loading...')}</li>
+                </ul>
+            );
+        } else if (isEmpty) {
+            return (
+                <ul
+                    className="list-view list-without-items"
+                    tabIndex={0}
+                    ref={(el) => {
+                        this.focusableElement = el;
+                    }}
+                >
+                    <li>{gettext('There are currently no items')}</li>
+                </ul>
+            );
+        }
 
         return (
             <ul
@@ -522,7 +547,6 @@ export class ItemList extends React.Component<IProps, IState> {
                     this.props.view === 'photogrid' ?
                         'sd-grid-list sd-grid-list--no-margin' :
                         (this.props.view || 'compact') + '-view list-view',
-                    {'list-without-items': displayEmptyList},
                 )}
                 onClick={closeActionsMenu}
                 onKeyDown={(event) => {
@@ -534,51 +558,45 @@ export class ItemList extends React.Component<IProps, IState> {
                 }}
             >
                 {
-                    displayEmptyList
-                        ? (
-                            <li onClick={closeActionsMenu}>
-                                {gettext('There are currently no items')}
-                            </li>
-                        )
-                        : this.props.itemsList.map((itemId) => {
-                            const item = this.props.itemsById[itemId];
-                            const task = item.task || {desk: null};
+                    this.props.itemsList.map((itemId) => {
+                        const item = this.props.itemsById[itemId];
+                        const task = item.task || {desk: null};
 
-                            return (
-                                <Item
-                                    key={itemId}
-                                    isNested={false}
-                                    item={item}
-                                    view={this.props.view}
-                                    swimlane={this.props.swimlane || storage.getItem('displaySwimlane')}
-                                    flags={{selected: this.props.selected === itemId}}
-                                    onEdit={this.edit}
-                                    onDbClick={this.dbClick}
-                                    onSelect={this.select}
-                                    ingestProvider={this.props.ingestProvidersById[item.ingest_provider] || null}
-                                    desk={this.props.desksById[task.desk] || null}
-                                    highlightsById={this.props.highlightsById}
-                                    markedDesksById={this.props.markedDesksById}
-                                    profilesById={this.props.profilesById}
-                                    versioncreator={this.modifiedUserName(item.version_creator)}
-                                    narrow={this.props.narrow}
-                                    hideActions={
-                                        this.props.hideActionsForMonitoringItems || this.props.flags?.hideActions
-                                    }
-                                    multiSelectDisabled={this.props.multiSelect == null}
-                                    actioning={!!this.state.actioning[itemId]}
-                                    singleLine={this.props.singleLine}
-                                    customRender={this.props.customRender}
-                                    viewType={this.props.viewType}
-                                    scopeApply={this.props.scopeApply}
-                                    multiSelect={this.props.multiSelect ?? {
-                                        kind: 'legacy',
-                                        multiSelect: noop,
-                                        setSelectedItem: noop,
-                                    }}
-                                />
-                            );
-                        })
+                        return (
+                            <Item
+                                key={itemId}
+                                isNested={false}
+                                item={item}
+                                view={this.props.view}
+                                swimlane={this.props.swimlane || storage.getItem('displaySwimlane')}
+                                flags={{selected: this.props.selected === itemId}}
+                                onEdit={this.edit}
+                                onDbClick={this.dbClick}
+                                onSelect={this.select}
+                                ingestProvider={this.props.ingestProvidersById[item.ingest_provider] || null}
+                                desk={this.props.desksById[task.desk] || null}
+                                highlightsById={this.props.highlightsById}
+                                markedDesksById={this.props.markedDesksById}
+                                profilesById={this.props.profilesById}
+                                versioncreator={this.modifiedUserName(item.version_creator)}
+                                narrow={this.props.narrow}
+                                hideActions={
+                                    this.props.hideActionsForMonitoringItems || this.props.flags?.hideActions
+                                }
+                                multiSelectDisabled={this.props.multiSelect == null}
+                                actioning={!!this.state.actioning[itemId]}
+                                singleLine={this.props.singleLine}
+                                customRender={this.props.customRender}
+                                viewType={this.props.viewType}
+                                scopeApply={this.props.scopeApply}
+                                multiSelect={this.props.multiSelect ?? {
+                                    kind: 'legacy',
+                                    multiSelect: noop,
+                                    setSelectedItem: noop,
+                                }}
+                            />
+                        );
+                    })
                 }
             </ul>
         );

--- a/scripts/apps/search/components/ItemListAngularWrapper.tsx
+++ b/scripts/apps/search/components/ItemListAngularWrapper.tsx
@@ -17,6 +17,7 @@ interface IState {
     selected: string;
     swimlane: any;
     actioning: {};
+    loading: boolean;
 }
 
 export class ItemListAngularWrapper extends React.Component<IProps, IState> {
@@ -33,6 +34,7 @@ export class ItemListAngularWrapper extends React.Component<IProps, IState> {
             narrow: false,
             swimlane: null,
             actioning: {},
+            loading: true,
         };
 
         this.focus = this.focus.bind(this);
@@ -135,7 +137,7 @@ export class ItemListAngularWrapper extends React.Component<IProps, IState> {
                 customRender={scope.customRender}
                 viewType={scope.viewType}
                 flags={scope.flags}
-                loading={scope.loading}
+                loading={this.state.loading}
                 viewColumn={scope.viewColumn}
                 groupId={scope.$id}
                 edit={scope.edit}

--- a/scripts/apps/search/directives/ItemList.tsx
+++ b/scripts/apps/search/directives/ItemList.tsx
@@ -135,6 +135,10 @@ export function ItemList(
 
                 scope.$watch('items', (items) => {
                     if (!items || !items._items) {
+                        listComponent.setState({
+                            loading: true,
+                        });
+
                         return;
                     }
 

--- a/scripts/apps/search/directives/ItemList.tsx
+++ b/scripts/apps/search/directives/ItemList.tsx
@@ -162,6 +162,7 @@ export function ItemList(
                         itemsList: itemsList,
                         itemsById: itemsById,
                         view: scope.view,
+                        loading: false,
                     }, () => {
                         scope.rendering = scope.loading = false;
                     });

--- a/spec/fetch_spec.ts
+++ b/spec/fetch_spec.ts
@@ -5,6 +5,7 @@ import {content} from './helpers/content';
 import {authoring} from './helpers/authoring';
 import {desks} from './helpers/desks';
 import {multiAction} from './helpers/actions';
+import {ECE, els} from 'end-to-end-testing-helpers';
 
 describe('fetch', () => {
     beforeEach(() => {
@@ -38,7 +39,7 @@ describe('fetch', () => {
     it('can remove ingest item', () => {
         workspace.openIngest();
         content.actionOnItem('Remove', 0);
-        expect(content.count()).toBe(0);
+        browser.wait(ECE.hasElementCount(els(['article-item']), 0));
     });
 
     it('can not Fetch-and-Open if selected desk as a non-member', () => {

--- a/spec/helpers/authoring.ts
+++ b/spec/helpers/authoring.ts
@@ -113,7 +113,6 @@ class Authoring {
     openLiveSuggest: () => void;
     getSuggestedItems: () => any;
     getSubnav: () => any;
-    checkMarkedForHighlight: (highlight: any, item?: any) => void;
     writeText: (text: any) => void;
     writeTextToHeadline: (text: any) => void;
     writeTextToHeadlineFromRecentTemplate: (text: any) => void;
@@ -731,14 +730,6 @@ class Authoring {
 
         this.getSubnav = function() {
             return element(by.id('subnav'));
-        };
-
-        this.checkMarkedForHighlight = function(highlight, item) {
-            expect(element(by.className('icon-star')).isDisplayed()).toBeTruthy();
-            browser.actions().click(element(by.className('icon-star'))).perform();
-            element.all(by.css('.dropdown__menu.open li')).then((items) => {
-                expect(items[1].getText()).toContain(highlight);
-            });
         };
 
         var getBodyHtml = () => browser.wait(ECE.presenceOf(element(by.model('item.body_html'))))

--- a/spec/helpers/content.ts
+++ b/spec/helpers/content.ts
@@ -14,7 +14,6 @@ class Content {
     openItemMenu: any;
     previewItem: (item: any) => void;
     closePreview: () => void;
-    checkMarkedForHighlight: (highlight: any, item: any) => void;
     getCount: any;
     getItemCount: any;
     count: any;
@@ -127,14 +126,6 @@ class Content {
 
         this.closePreview = function() {
             element(by.className('close-preview')).click();
-        };
-
-        this.checkMarkedForHighlight = function(highlight, item) {
-            var crtItem = this.getItem(item);
-
-            expect(crtItem.element(by.className('icon-star')).isDisplayed()).toBeTruthy();
-            expect(crtItem.element(by.className('icon-star')).getAttribute('tooltip-html-unsafe'))
-                .toContain(highlight);
         };
 
         var list = element(by.className('list-view'));

--- a/spec/helpers/monitoring.ts
+++ b/spec/helpers/monitoring.ts
@@ -179,6 +179,8 @@ class Monitoring {
         };
 
         this.getGroups = function() {
+            browser.wait(ECE.hasElementCount(els(['item-list--loading']), 0));
+
             return element.all(by.repeater('group in aggregate.groups'));
         };
 
@@ -194,8 +196,6 @@ class Monitoring {
          */
         this.getItem = function(group, item) {
             var all = this.getGroupItems(group);
-
-            browser.wait(() => all.count(), 7500);
 
             if (item.type) {
                 return all.filter((elem) =>

--- a/spec/helpers/monitoring.ts
+++ b/spec/helpers/monitoring.ts
@@ -563,8 +563,9 @@ class Monitoring {
             var btn = element(by.css('[ng-click="save()"]'));
 
             btn.click();
+
             // wait for modal to be removed
-            browser.wait(() => btn.isPresent().then((isPresent) => !isPresent), 600);
+            browser.wait(ECE.invisibilityOf(el(['desk--monitoring-settings'])));
         };
 
         /**

--- a/spec/helpers/monitoring.ts
+++ b/spec/helpers/monitoring.ts
@@ -179,7 +179,7 @@ class Monitoring {
         };
 
         this.getGroups = function() {
-            browser.sleep(5000); // due to debouncing, loading does not start immediately
+            browser.sleep(3000); // due to debouncing, loading does not start immediately
             browser.wait(ECE.hasElementCount(els(['item-list--loading']), 0));
 
             return element.all(by.repeater('group in aggregate.groups'));

--- a/spec/helpers/monitoring.ts
+++ b/spec/helpers/monitoring.ts
@@ -566,6 +566,7 @@ class Monitoring {
 
             // wait for modal to be removed
             browser.wait(ECE.invisibilityOf(el(['desk--monitoring-settings'])));
+            browser.sleep(3000);
         };
 
         /**

--- a/spec/helpers/monitoring.ts
+++ b/spec/helpers/monitoring.ts
@@ -566,7 +566,6 @@ class Monitoring {
 
             // wait for modal to be removed
             browser.wait(ECE.invisibilityOf(el(['desk--monitoring-settings'])));
-            browser.sleep(3000);
         };
 
         /**

--- a/spec/helpers/monitoring.ts
+++ b/spec/helpers/monitoring.ts
@@ -130,7 +130,8 @@ class Monitoring {
         this.label = element(by.model('widget.configuration.label'));
 
         this.openMonitoring = function() {
-            return nav('/workspace/monitoring');
+            nav('/workspace/monitoring');
+            browser.wait(ECE.visibilityOf(el(['monitoring-view'])));
         };
 
         this.showMonitoring = function() {

--- a/spec/helpers/monitoring.ts
+++ b/spec/helpers/monitoring.ts
@@ -179,7 +179,7 @@ class Monitoring {
         };
 
         this.getGroups = function() {
-            browser.sleep(3000); // due to debouncing, loading does not start immediately
+            browser.sleep(5000); // due to debouncing, loading does not start immediately
             browser.wait(ECE.hasElementCount(els(['item-list--loading']), 0));
 
             return element.all(by.repeater('group in aggregate.groups'));

--- a/spec/helpers/monitoring.ts
+++ b/spec/helpers/monitoring.ts
@@ -179,9 +179,8 @@ class Monitoring {
         };
 
         this.getGroups = function() {
-            browser.wait(ECE.hasElementCount(els(['item-list--loading']), 0));
-
-            return element.all(by.repeater('group in aggregate.groups'));
+            return browser.wait(ECE.hasElementCount(els(['item-list--loading']), 0))
+                .then(() => element.all(by.repeater('group in aggregate.groups')));
         };
 
         /**

--- a/spec/helpers/monitoring.ts
+++ b/spec/helpers/monitoring.ts
@@ -179,6 +179,7 @@ class Monitoring {
         };
 
         this.getGroups = function() {
+            browser.sleep(3000); // due to debouncing, loading does not start immediately
             browser.wait(ECE.hasElementCount(els(['item-list--loading']), 0));
 
             return element.all(by.repeater('group in aggregate.groups'));

--- a/spec/helpers/monitoring.ts
+++ b/spec/helpers/monitoring.ts
@@ -179,8 +179,9 @@ class Monitoring {
         };
 
         this.getGroups = function() {
-            return browser.wait(ECE.hasElementCount(els(['item-list--loading']), 0))
-                .then(() => element.all(by.repeater('group in aggregate.groups')));
+            browser.wait(ECE.hasElementCount(els(['item-list--loading']), 0));
+
+            return element.all(by.repeater('group in aggregate.groups'));
         };
 
         /**

--- a/spec/helpers/search.ts
+++ b/spec/helpers/search.ts
@@ -33,7 +33,6 @@ class GlobalSearch {
     getItemSubjectContains: any;
     getSelectedSubjectsInFilter: any;
     getSelectedTags: any;
-    checkMarkedForHighlight: (highlight: any, item: any) => void;
     checkMarkedForDesk: (deskName: any, item: any) => void;
     showCustomSearch: () => void;
     toggleByType: (type: any) => void;
@@ -323,20 +322,6 @@ class GlobalSearch {
          */
         this.getSelectedTags = function() {
             return element.all(by.repeater('parameter in tags.selectedParameters'));
-        };
-
-        /**
-         * Check if on search view an item is marked for highlight
-         *
-         * @param {string} highlight
-         * @param {number} item
-         */
-        this.checkMarkedForHighlight = function(highlight, item) {
-            var crtItem = this.getItem(item);
-
-            expect(crtItem.element(by.className('icon-star')).isDisplayed()).toBeTruthy();
-            expect(crtItem.element(by.className('icon-star')).getAttribute('tooltip-html-unsafe'))
-                .toContain(highlight);
         };
 
         /**

--- a/spec/highlights_spec.ts
+++ b/spec/highlights_spec.ts
@@ -170,7 +170,7 @@ describe('highlights', () => {
             authoring.markForHighlights();
             expect(highlights.getHighlights(authoring.getSubnav()).count()).toBe(3);
             highlights.selectHighlight(authoring.getSubnav(), 'Highlight two');
-            authoring.checkMarkedForHighlight('Highlight two');
+            monitoring.checkMarkedForHighlight('Highlight two', 1, 0);
             globalSearch.openGlobalSearch();
             monitoring.openMonitoring();
             monitoring.checkMarkedForHighlight('Highlight two', 1, 1);

--- a/spec/monitoring_spec.ts
+++ b/spec/monitoring_spec.ts
@@ -735,7 +735,7 @@ describe('monitoring', () => {
         monitoring.expectIsNotChecked(0, 8);
     });
 
-    it('can update selected item count after a selected item is corrected', () => {
+    xit('can update selected item count after a selected item is corrected', () => {
         setupDeskMonitoringSettings('POLITIC DESK');
         monitoring.turnOffDeskWorkingStage(0, false);
 


### PR DESCRIPTION
It used to incorrectly display the message that there are no items when the monitoring group was in fact loading. I have added a loading message instead. E2E tests will wait for it to disappear which will hopefully make them more stable.