### PR TITLE
Improve extensions loading

### DIFF
--- a/scripts/apps/archive/tests/archive.spec.ts
+++ b/scripts/apps/archive/tests/archive.spec.ts
@@ -81,15 +81,17 @@ describe('content', () => {
                 [
                     {
                         id: 'test-extension',
-                        activate: () => {
-                            return Promise.resolve({
-                                contributions: {
-                                    entities: {
-                                        article: articleEntities,
+                        load: () => Promise.resolve({
+                            activate: () => {
+                                return Promise.resolve({
+                                    contributions: {
+                                        entities: {
+                                            article: articleEntities,
+                                        },
                                     },
-                                },
-                            });
-                        },
+                                });
+                            },
+                        }),
                     },
                 ],
                 superdesk,

--- a/scripts/apps/search/tests/MultiActionController.spec.ts
+++ b/scripts/apps/search/tests/MultiActionController.spec.ts
@@ -107,15 +107,19 @@ describe('Multi Action Bar', () => {
                 [
                     {
                         id: 'test-extension',
-                        activate: () => {
-                            return Promise.resolve({
-                                contributions: {
-                                    entities: {
-                                        article: articleEntities,
-                                    },
+                        load: () => Promise.resolve(
+                            {
+                                activate: () => {
+                                    return Promise.resolve({
+                                        contributions: {
+                                            entities: {
+                                                article: articleEntities,
+                                            },
+                                        },
+                                    });
                                 },
-                            });
-                        },
+                            },
+                        ),
                     },
                 ],
                 superdesk,

--- a/scripts/core/helpers/register-internal-extension.tsx
+++ b/scripts/core/helpers/register-internal-extension.tsx
@@ -7,7 +7,7 @@ const prefix = '__internal__';
 
 export function registerInternalExtension(name: string, activationResult: IExtensionActivationResult) {
     extensions[prefix + name] = {
-        extension: {id: prefix + name, activate: () => Promise.resolve({})},
+        extension: {activate: () => Promise.resolve({})},
         activationResult,
     };
 }

--- a/scripts/core/register-extensions.tsx
+++ b/scripts/core/register-extensions.tsx
@@ -1,11 +1,11 @@
 import {flatMap, noop} from 'lodash';
 import {getSuperdeskApiImplementation} from './get-superdesk-api-implementation';
 import {AuthoringWorkspaceService} from 'apps/authoring/authoring/services/AuthoringWorkspaceService';
-import {IExtension} from 'superdesk-api';
+import {IExtension, ISuperdesk} from 'superdesk-api';
 import {extensions as extensionsWithActivationResult} from 'appConfig';
 
 export function registerExtensions(
-    extensions: Array<IExtension>,
+    extensionLoaders: Array<{id: string; load(): Promise<IExtension>}>,
     superdesk,
     modal,
     privileges,
@@ -16,54 +16,67 @@ export function registerExtensions(
     metadata,
     preferencesService,
 ): Promise<void> {
-    extensions.forEach((extension) => {
-        extensionsWithActivationResult[extension.id] = {
-            extension,
-            activationResult: {},
-        };
-    });
-
     return Promise.all(
-        Object.keys(extensionsWithActivationResult).map((extensionId) => {
-            const extensionObject = extensionsWithActivationResult[extensionId];
+        extensionLoaders.map(
+            ({id, load}) => {
+                const apiInstance: ISuperdesk = getSuperdeskApiImplementation(
+                    id,
+                    extensionsWithActivationResult,
+                    modal,
+                    privileges,
+                    lock,
+                    session,
+                    authoringWorkspace,
+                    config,
+                    metadata,
+                    preferencesService,
+                );
 
-            const superdeskApi = getSuperdeskApiImplementation(
-                extensionId,
-                extensionsWithActivationResult,
-                modal,
-                privileges,
-                lock,
-                session,
-                authoringWorkspace,
-                config,
-                metadata,
-                preferencesService,
+                return load().then((extension) => {
+                    extensionsWithActivationResult[id] = {
+                        extension,
+                        activationResult: {},
+                        apiInstance,
+                    };
+                });
+            },
+        ),
+    ).then(() => {
+        return Promise.all(
+            Object.keys(extensionsWithActivationResult).map((extensionId) => {
+                const extensionObject = extensionsWithActivationResult[extensionId];
+
+                // USE EXTENSION ID TO GET IMPLEMENTATION
+                // SET IMPLEMENTATION AS A GLOBAL OR IN A MODULE
+                // LOAD EXTENSION
+                // ACTIVATE EXTENSION
+                // SAVE ACTIVATION RESULT
+
+                return extensionObject.extension.activate(extensionObject.apiInstance).then((activationResult) => {
+                    extensionObject.activationResult = activationResult;
+
+                    return activationResult;
+                });
+            }),
+        ).then((activationResults) => {
+            const pages = flatMap(activationResults, (activationResult) =>
+                activationResult.contributions != null
+                && activationResult.contributions.pages != null
+                    ? activationResult.contributions.pages
+                    : [],
             );
 
-            return extensionObject.extension.activate(superdeskApi).then((activationResult) => {
-                extensionObject.activationResult = activationResult;
-
-                return activationResult;
+            pages.forEach((page) => {
+                superdesk
+                    .activity(page.url, {
+                        label: page.title,
+                        priority: 100,
+                        category: superdesk.MENU_MAIN,
+                        adminTools: false,
+                        controller: noop,
+                        template: '<sd-extension-page></<sd-extension-page>',
+                    });
             });
-        }),
-    ).then((activationResults) => {
-        const pages = flatMap(activationResults, (activationResult) =>
-            activationResult.contributions != null
-            && activationResult.contributions.pages != null
-                ? activationResult.contributions.pages
-                : [],
-        );
-
-        pages.forEach((page) => {
-            superdesk
-                .activity(page.url, {
-                    label: page.title,
-                    priority: 100,
-                    category: superdesk.MENU_MAIN,
-                    adminTools: false,
-                    controller: noop,
-                    template: '<sd-extension-page></<sd-extension-page>',
-                });
         });
     });
 }

--- a/scripts/core/register-extensions.tsx
+++ b/scripts/core/register-extensions.tsx
@@ -16,6 +16,8 @@ export function registerExtensions(
     metadata,
     preferencesService,
 ): Promise<void> {
+    window['extensionsApiInstances'] = {};
+
     return Promise.all(
         extensionLoaders.map(
             ({id, load}) => {
@@ -32,11 +34,12 @@ export function registerExtensions(
                     preferencesService,
                 );
 
+                window['extensionsApiInstances'][id] = apiInstance;
+
                 return load().then((extension) => {
                     extensionsWithActivationResult[id] = {
                         extension,
                         activationResult: {},
-                        apiInstance,
                     };
                 });
             },
@@ -52,11 +55,12 @@ export function registerExtensions(
                 // ACTIVATE EXTENSION
                 // SAVE ACTIVATION RESULT
 
-                return extensionObject.extension.activate(extensionObject.apiInstance).then((activationResult) => {
-                    extensionObject.activationResult = activationResult;
+                return extensionObject.extension.activate(window['extensionsApiInstances'][extensionId])
+                    .then((activationResult) => {
+                        extensionObject.activationResult = activationResult;
 
-                    return activationResult;
-                });
+                        return activationResult;
+                    });
             }),
         ).then((activationResults) => {
             const pages = flatMap(activationResults, (activationResult) =>

--- a/scripts/core/register-extensions.tsx
+++ b/scripts/core/register-extensions.tsx
@@ -72,7 +72,7 @@ export function registerExtensions(
                         category: superdesk.MENU_MAIN,
                         adminTools: false,
                         controller: noop,
-                        template: '<sd-extension-page></<sd-extension-page>',
+                        template: '<sd-extension-page></sd-extension-page>',
                     });
             });
         });

--- a/scripts/core/register-extensions.tsx
+++ b/scripts/core/register-extensions.tsx
@@ -49,12 +49,6 @@ export function registerExtensions(
             Object.keys(extensionsWithActivationResult).map((extensionId) => {
                 const extensionObject = extensionsWithActivationResult[extensionId];
 
-                // USE EXTENSION ID TO GET IMPLEMENTATION
-                // SET IMPLEMENTATION AS A GLOBAL OR IN A MODULE
-                // LOAD EXTENSION
-                // ACTIVATE EXTENSION
-                // SAVE ACTIVATION RESULT
-
                 return extensionObject.extension.activate(window['extensionsApiInstances'][extensionId])
                     .then((activationResult) => {
                         extensionObject.activationResult = activationResult;

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -133,7 +133,6 @@ declare module 'superdesk-api' {
     export type IExtensionObject = {
         extension: IExtension;
         activationResult: IExtensionActivationResult;
-        apiInstance: ISuperdesk;
     };
 
     export type IExtensions = {[key: string]: IExtensionObject};

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -126,7 +126,6 @@ declare module 'superdesk-api' {
     };
 
     export type IExtension = DeepReadonly<{
-        id: string;
         activate: (superdesk: ISuperdesk) => Promise<IExtensionActivationResult>;
         exposes?: {[key: string]: any};
     }>;
@@ -134,6 +133,7 @@ declare module 'superdesk-api' {
     export type IExtensionObject = {
         extension: IExtension;
         activationResult: IExtensionActivationResult;
+        apiInstance: ISuperdesk;
     };
 
     export type IExtensions = {[key: string]: IExtensionObject};

--- a/scripts/extensions/annotationsLibrary/src/extension.tsx
+++ b/scripts/extensions/annotationsLibrary/src/extension.tsx
@@ -78,7 +78,6 @@ function onAnnotationCreate(
 }
 
 var extension: IExtension = {
-    id: 'annotationsLibrary',
     activate: (superdesk: ISuperdesk) => {
         const {gettext} = superdesk.localization;
 

--- a/scripts/extensions/auto-tagging-widget/src/extension.tsx
+++ b/scripts/extensions/auto-tagging-widget/src/extension.tsx
@@ -2,7 +2,6 @@ import {ISuperdesk, IExtension, IExtensionActivationResult, IArticle} from 'supe
 import {getAutoTaggingComponent} from './auto-tagging';
 
 const extension: IExtension = {
-    id: 'autoTagging',
     activate: (superdesk: ISuperdesk) => {
         const {gettext} = superdesk.localization;
 

--- a/scripts/extensions/datetimeField/src/extension.tsx
+++ b/scripts/extensions/datetimeField/src/extension.tsx
@@ -34,7 +34,6 @@ export const defaultDateTimeConfig: IDateTimeFieldConfig = {
 };
 
 const extension: IExtension = {
-    id: 'datetimeField',
     activate: (superdesk: ISuperdesk) => {
         const gettext = superdesk.localization.gettext;
 

--- a/scripts/extensions/helloWorld/src/extension.ts
+++ b/scripts/extensions/helloWorld/src/extension.ts
@@ -1,7 +1,6 @@
 import {ISuperdesk, IExtension} from 'superdesk-api';
 
 const extension: IExtension = {
-    id: 'helloWorld',
     activate: (superdesk: ISuperdesk) => {
         const {gettext} = superdesk.localization;
 

--- a/scripts/extensions/helloWorld/src/extension.ts
+++ b/scripts/extensions/helloWorld/src/extension.ts
@@ -1,10 +1,13 @@
-import {ISuperdesk, IExtension} from 'superdesk-api';
+import {IExtension} from 'superdesk-api';
+import {superdesk} from './superdesk';
+
+const {gettext} = superdesk.localization;
+
+const str = gettext('Hello world');
 
 const extension: IExtension = {
-    activate: (superdesk: ISuperdesk) => {
-        const {gettext} = superdesk.localization;
-
-        superdesk.ui.alert(gettext('Hello world'));
+    activate: () => {
+        superdesk.ui.alert(str);
 
         return Promise.resolve({});
     },

--- a/scripts/extensions/helloWorld/src/superdesk.ts
+++ b/scripts/extensions/helloWorld/src/superdesk.ts
@@ -1,0 +1,4 @@
+import {ISuperdesk} from 'superdesk-api';
+
+// @ts-ignore
+export const superdesk = window['extensionsApiInstances']['helloWorld'] as ISuperdesk;

--- a/scripts/extensions/markForUser/src/extension.tsx
+++ b/scripts/extensions/markForUser/src/extension.tsx
@@ -11,7 +11,6 @@ interface IMarkForUserNotification {
 }
 
 const extension: IExtension = {
-    id: 'markForUser',
     exposes: {
         getQueryNotMarkedForAnyoneOrMarkedForMe,
         getQueryMarkedForUser,

--- a/scripts/extensions/videoEditor/src/extension.tsx
+++ b/scripts/extensions/videoEditor/src/extension.tsx
@@ -30,7 +30,6 @@ function getEditVideoAction(superdesk: ISuperdesk) {
 }
 
 const extension: IExtension = {
-    id: 'videoEditor',
     activate: (superdesk: ISuperdesk) => {
         const result: IExtensionActivationResult = {
             contributions: {

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -110,7 +110,7 @@ function isDateFormatValid() {
 }
 
 export function startApp(
-    extensions: Array<IExtension>,
+    extensions: Array<{id: string; load(): Promise<IExtension>}>,
     customUiComponents: IConfigurableUiComponents,
     customAlgorithms: IConfigurableAlgorithms = {},
 ) {


### PR DESCRIPTION
Enables importing superdesk api from extensions synchronously, without having to pass it from `activate` method through factory functions.

Loading from the parent repository would look like this:

```
startApp(
    [
        {
            id: 'helloWorld',
            load: () => import('superdesk-core/scripts/extensions/helloWorld/dist/src/extension').then((res) => res.default),
        }
    ],
    {},
    {},
);
 ```