### PR TITLE
[SEARCH] don't split search terms with comma

### DIFF
--- a/scripts/apps/search/directives/ItemSearchbar.ts
+++ b/scripts/apps/search/directives/ItemSearchbar.ts
@@ -24,7 +24,7 @@ export function ItemSearchbar($location, $document, asset) {
 
             scope.search = function() {
                 if (scope.query) {
-                    let newQuery = _.uniq(scope.query.split(/[\s,]+/));
+                    let newQuery = _.uniq(scope.query.split(/[\s]+/));
 
                     scope.query = newQuery.join(' ');
                 }


### PR DESCRIPTION
Comma may be used in searched expression (e.g. with numbers in English,
comma is used to separate every three number).

fix SDESK-5771 (case 15b)