### PR TITLE
Fix timing issue in monitoring groups

### DIFF
--- a/scripts/apps/monitoring/directives/MonitoringGroup.ts
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.ts
@@ -145,7 +145,7 @@ export function MonitoringGroup(
             function scheduleQueryFn(event, data) {
                 queryItems(event, data, {auto: (data && data.force) ? 0 : 1})
                     .finally(() => {
-                        scope.$apply();
+                        scope.$applyAsync();
                     });
             }
 

--- a/scripts/apps/monitoring/directives/MonitoringGroup.ts
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.ts
@@ -1,5 +1,5 @@
 /* eslint-disable complexity */
-import _ from 'lodash';
+import _, {throttle} from 'lodash';
 import getCustomSortForGroup, {GroupSortOptions} from '../helpers/CustomSortOfGroups';
 import {GET_LABEL_MAP, getLabelForStage} from '../../workspace/content/constants';
 import {isPublished} from 'apps/archive/utils';
@@ -142,6 +142,15 @@ export function MonitoringGroup(
                 );
             }
 
+            function scheduleQueryFn(event, data) {
+                queryItems(event, data, {auto: (data && data.force) ? 0 : 1})
+                    .finally(() => {
+                        scope.$apply();
+                    });
+            }
+
+            const scheduleQuery = throttle(scheduleQueryFn, 1000);
+
             var monitoring = ctrls[0];
             var projections = search.getProjectedFields();
 
@@ -199,6 +208,7 @@ export function MonitoringGroup(
             scope.$on('item:duplicate', scheduleQuery);
             scope.$on('item:translate', scheduleQuery);
             scope.$on('item:move', scheduleQuery);
+            scope.$on('item:unlock', scheduleQuery);
             scope.$on('broadcast:created', (event, args) => {
                 scope.previewingBroadcast = true;
                 queryItems();
@@ -404,25 +414,6 @@ export function MonitoringGroup(
                     }
 
                     scope.styleProperties.maxHeight = groupItems * ITEM_HEIGHT - scrollOffset;
-                }
-            }
-
-            var queryTimeout;
-
-            /**
-             * Schedule content reload after some delay
-             */
-            function scheduleQuery(event, data) {
-                if (!queryTimeout) {
-                    queryTimeout = $timeout(() => {
-                        queryItems(event, data, {auto: (data && data.force) ? 0 : 1})
-                            .finally(() => {
-                                scope.$applyAsync(() => {
-                                    // ignore any updates requested in current $digest
-                                    queryTimeout = null;
-                                });
-                            });
-                    }, 1000, false);
                 }
             }
 

--- a/scripts/apps/monitoring/tests/monitoring.spec.ts
+++ b/scripts/apps/monitoring/tests/monitoring.spec.ts
@@ -295,7 +295,7 @@ describe('monitoring', () => {
             }));
 
         it('updates custom search on item preview',
-            inject(($rootScope, $compile, search, api, session, $q, $timeout, $templateCache) => {
+            (done) => inject(($rootScope, $compile, search, api, session, $q, $timeout, $templateCache) => {
                 $templateCache.put('scripts/apps/monitoring/views/monitoring-view.html',
                     '<div id="group" sd-monitoring-group ' +
                     'data-group="{type: \'search\', search: {filter: {query: \'\'}}}"></div>');
@@ -306,16 +306,20 @@ describe('monitoring', () => {
 
                 session.identity = {_id: 'foo'};
                 scope.$digest();
-                $timeout.flush(2000);
 
                 spyOn(api, 'query').and.returnValue($q.when({_items: [], _meta: {total: 0}}));
                 spyOn(search, 'mergeItems');
 
                 session.identity = {_id: 'foo'};
                 scope.$broadcast('ingest:update', {});
-                scope.$digest();
-                $timeout.flush(2000);
-                expect(search.mergeItems).toHaveBeenCalled();
+
+                setTimeout(() => {
+                    scope.$digest();
+
+                    expect(search.mergeItems).toHaveBeenCalled();
+
+                    done();
+                }, 2000);
             }),
         );
 

--- a/scripts/apps/monitoring/tests/monitoring.spec.ts
+++ b/scripts/apps/monitoring/tests/monitoring.spec.ts
@@ -271,7 +271,7 @@ describe('monitoring', () => {
 
     describe('monitoring group directive', () => {
         it('can update items on item:move event',
-            inject(($rootScope, $compile, $q, api, $timeout, session) => {
+            (done) => inject(($rootScope, $compile, $q, api, $timeout, session) => {
                 session.identity = {_id: 'foo'};
                 var scope = $rootScope.$new();
 
@@ -282,13 +282,16 @@ describe('monitoring', () => {
 
                 scope.$broadcast('item:move', {from_stage: 'bar', to_stage: 'bar'});
                 scope.$digest();
-                $timeout.flush(500);
+
                 expect(api.query).not.toHaveBeenCalled();
 
                 scope.$broadcast('item:move', {from_stage: 'bar', to_stage: 'foo'});
                 scope.$digest();
-                $timeout.flush(2000);
-                expect(api.query).toHaveBeenCalled();
+
+                setTimeout(() => {
+                    expect(api.query).toHaveBeenCalled();
+                    done();
+                }, 2000);
             }));
 
         it('updates custom search on item preview',

--- a/scripts/apps/search/components/ItemListAngularWrapper.tsx
+++ b/scripts/apps/search/components/ItemListAngularWrapper.tsx
@@ -250,9 +250,15 @@ export class ItemListAngularWrapper extends React.Component<IProps, IState> {
     render() {
         const {scope, monitoringState} = this.props;
 
+        const style = scope.styleProperties == null
+            ? null
+
+            // styleProperties will be modified on the angular side so it can not be directly used as a react prop.
+            : Object.assign({}, scope.styleProperties);
+
         return (
             <SmoothLoader loading={this.state.loading}>
-                <div style={scope.styleProperties ?? {}}>
+                <div style={style}>
                     <ItemList
                         itemsList={this.state.itemsList}
                         itemsById={this.state.itemsById}

--- a/spec/monitoring_spec.ts
+++ b/spec/monitoring_spec.ts
@@ -395,7 +395,7 @@ describe('monitoring', () => {
         el(['content-profile-dropdown']).click();
         browser.wait(ECE.hasElementCount(els(['content-profiles']), 2));
         el(['content-profile-dropdown'], by.buttonText('testing')).click();
-        expect(monitoring.getAllItems().count()).toBe(1);
+        browser.wait(ECE.hasElementCount(els(['article-item']), 1));
         expect(monitoring.getTextItemBySlugline(0, 0)).toBe('TESTING1 SLUGLINE');
         expect(monitoring.isGroupEmpty(2)).toBe(true);
         expect(monitoring.isGroupEmpty(4)).toBe(true);

--- a/spec/monitoring_spec.ts
+++ b/spec/monitoring_spec.ts
@@ -391,7 +391,7 @@ describe('monitoring', () => {
             .perform();
         authoring.save();
         authoring.close();
-        expect(monitoring.getAllItems().count()).toBe(3);
+        browser.wait(ECE.hasElementCount(els(['article-item']), 3));
         el(['content-profile-dropdown']).click();
         browser.wait(ECE.hasElementCount(els(['content-profiles']), 2));
         el(['content-profile-dropdown'], by.buttonText('testing')).click();


### PR DESCRIPTION
SDCP-502

Use throttle.
Previous implementation used to not make a request if one was already in progress. Old data was received because of this.