### PR TITLE
feat(iMatrics): Added ability to configure fields and order of fields in superdesk.config.js

### DIFF
--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -1793,6 +1793,13 @@ declare module 'superdesk-api' {
         }>;
 
         userOnlineMinutes: number;
+
+        iMatricsFields: {
+            [key: string]: {
+                name: string;
+                order: number;
+            };
+        };
     }
 
 

--- a/scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx
+++ b/scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx
@@ -406,12 +406,13 @@ export function getAutoTaggingComponent(superdesk: ISuperdesk, label: string) {
                                 );
 
                                 const othersGroupedAndSortedNotInConfig = othersGrouped
-                                    .filter(item => !othersGroupedAndSortedByConfig.includes(item))
+                                    .filter((item) => !othersGroupedAndSortedByConfig.includes(item))
                                     .sortBy((_, key) => key!.toString().toLocaleLowerCase(),
-                                        (a, b) => a.localeCompare(b)
+                                        (a, b) => a.localeCompare(b),
                                 );
 
-                                const othersGroupedAndSorted = othersGroupedAndSortedByConfig.concat(othersGroupedAndSortedNotInConfig);
+                                const othersGroupedAndSorted = othersGroupedAndSortedByConfig
+                                    .concat(othersGroupedAndSortedNotInConfig);
 
                                 return (
                                     <React.Fragment>

--- a/scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx
+++ b/scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx
@@ -422,7 +422,11 @@ export function getAutoTaggingComponent(superdesk: ISuperdesk, label: string) {
                                                 return (
                                                     <ToggleBoxNext
                                                         key={groupId}
-                                                        title={this.iMatricsFields[groupId].name ?? vocabularyLabels.get(groupId) ?? groupId}
+                                                        title={
+                                                            this.iMatricsFields[groupId].name ??
+                                                            vocabularyLabels.get(groupId) ??
+                                                            groupId
+                                                        }
                                                         style="circle"
                                                         isOpen={true}
                                                     >

--- a/scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx
+++ b/scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx
@@ -402,14 +402,12 @@ export function getAutoTaggingComponent(superdesk: ISuperdesk, label: string) {
 
                                 const othersGroupedAndSortedByConfig = othersGrouped
                                     .filter((_, key) => !!this.iMatricsFields[key])
-                                    .sortBy((_, key) => this.iMatricsFields[key].order,
-                                );
+                                    .sortBy((_, key) => this.iMatricsFields[key].order);
 
                                 const othersGroupedAndSortedNotInConfig = othersGrouped
                                     .filter((item) => !othersGroupedAndSortedByConfig.includes(item))
                                     .sortBy((_, key) => key!.toString().toLocaleLowerCase(),
-                                        (a, b) => a.localeCompare(b),
-                                );
+                                        (a, b) => a.localeCompare(b));
 
                                 const othersGroupedAndSorted = othersGroupedAndSortedByConfig
                                     .concat(othersGroupedAndSortedNotInConfig);

--- a/scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx
+++ b/scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx
@@ -61,6 +61,7 @@ export function getAutoTaggingComponent(superdesk: ISuperdesk, label: string) {
     return class AutoTagging extends React.PureComponent<IProps, IState> {
         private isDirty: (a: IAutoTaggingResponse, b: Partial<IAutoTaggingResponse>) => boolean;
         private _mounted: boolean;
+        private iMatricsFields = superdesk.instance.config.iMatricsFields ?? [];
 
         constructor(props: IProps) {
             super(props);
@@ -388,8 +389,7 @@ export function getAutoTaggingComponent(superdesk: ISuperdesk, label: string) {
                                 const others = items.filter((tag) => isEntity(tag) === false);
                                 const othersGrouped = others.groupBy((tag) => tag.group.value);
                                 const othersGroupedAndSorted = othersGrouped.sortBy(
-                                    (_, key) => key!.toString().toLocaleLowerCase(),
-                                    (a, b) => a.localeCompare(b),
+                                    (_, key) => this.iMatricsFields[key].order ?? -1,
                                 );
 
                                 return (
@@ -422,7 +422,7 @@ export function getAutoTaggingComponent(superdesk: ISuperdesk, label: string) {
                                                 return (
                                                     <ToggleBoxNext
                                                         key={groupId}
-                                                        title={vocabularyLabels.get(groupId) ?? groupId}
+                                                        title={this.iMatricsFields[groupId].name ?? vocabularyLabels.get(groupId) ?? groupId}
                                                         style="circle"
                                                         isOpen={true}
                                                     >


### PR DESCRIPTION
Example configuration in superdesk.config.js:
```
iMatricsFields: {
    imatrics_category: {
        name: 'Category',
        order: 1,
    },
    imatrics_topic: {
        name: 'Topics',
        order: 2,
    },
    topics: {
        name: 'Media topics',
        order: 3,
    }
}
```