### PR TITLE
Drop resource intensive request that was only used as a workaround

### DIFF
--- a/scripts/apps/authoring/authoring/services/AuthoringService.ts
+++ b/scripts/apps/authoring/authoring/services/AuthoringService.ts
@@ -405,8 +405,7 @@ export function AuthoringService($q, $location, api, lock, autosave, confirm, pr
         }
 
         return api.update(endpoint, orig, extDiff, params)
-            .then(
-                (result) => lock.unlock(result).catch(() => result), // ignore unlock err
+            .catch(
                 (reason) => {
                     const issues = reason?.data?._issues;
 

--- a/scripts/apps/authoring/tests/authoring.spec.ts
+++ b/scripts/apps/authoring/tests/authoring.spec.ts
@@ -347,22 +347,6 @@ describe('authoring', () => {
         expect(error).toHaveBeenCalledWith('err');
     }));
 
-    it('can continue publishing on unlock error', inject((api, $q, $rootScope, authoring, lock) => {
-        let success = jasmine.createSpy('success');
-        let error = jasmine.createSpy('error');
-        let item = {};
-
-        spyOn(api, 'update').and.returnValue($q.when(item));
-        spyOn(lock, 'unlock').and.returnValue($q.reject({}));
-
-        authoring.publish({}, {}).then(success, error);
-        $rootScope.$digest();
-
-        expect(lock.unlock).toHaveBeenCalledWith(item);
-        expect(success).toHaveBeenCalledWith(item);
-        expect(error).not.toHaveBeenCalled();
-    }));
-
     /**
      * Start authoring ctrl for given item.
      *
@@ -508,7 +492,6 @@ describe('authoring', () => {
 
                 expect(api.update).toHaveBeenCalledWith('archive_publish', edit, {},
                     {publishing_warnings_confirmed: false});
-                expect(lock.unlock).toHaveBeenCalled();
             }));
 
         it('confirms if an item is dirty and save work in personal',

--- a/scripts/apps/monitoring/directives/MonitoringGroup.ts
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.ts
@@ -207,7 +207,6 @@ export function MonitoringGroup(
             scope.$on('item:duplicate', scheduleQuery);
             scope.$on('item:translate', scheduleQuery);
             scope.$on('item:move', scheduleQuery);
-            scope.$on('item:unlock', scheduleQuery);
             scope.$on('broadcast:created', (event, args) => {
                 scope.previewingBroadcast = true;
                 queryItems();


### PR DESCRIPTION
REQUIRES changes to unlock item after publishing on the back-end.