### PR TITLE
only update item etag in authoring if id matches

### DIFF
--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -1159,10 +1159,12 @@ export function AuthoringDirective(
 
             const removeListener = addInternalEventListener(
                 'dangerouslyOverwriteAuthoringData',
-                (partialItem) => {
-                    angular.extend($scope.item, partialItem.detail);
-                    angular.extend($scope.origItem, partialItem.detail);
-                    $scope.$apply();
+                (event) => {
+                    if (event.detail._id === $scope.item._id) {
+                        angular.extend($scope.item, event.detail);
+                        angular.extend($scope.origItem, event.detail);
+                        $scope.$apply();
+                    }
                 },
             );
 

--- a/scripts/core/get-superdesk-api-implementation.tsx
+++ b/scripts/core/get-superdesk-api-implementation.tsx
@@ -209,7 +209,7 @@ export function getSuperdeskApiImplementation(
                             if (dangerousOptions?.patchDirectlyAndOverwriteAuthoringValues === true) {
                                 dispatchInternalEvent(
                                     'dangerouslyOverwriteAuthoringData',
-                                    {...patch, _etag: res._etag},
+                                    {...patch, _etag: res._etag, _id: res._id},
                                 );
                             }
                         });


### PR DESCRIPTION
on mark user it was changing etag in authoring no matter
if the item marked/unmarked was completely different.

SDBELGA-498