### PR TITLE
Fix authors field in monitoring so it does not crash when author _id is not present

### DIFF
--- a/scripts/apps/search/components/fields/authors.tsx
+++ b/scripts/apps/search/components/fields/authors.tsx
@@ -17,7 +17,9 @@ export class Authors extends SuperdeskReactComponent<IPropsItemListInfo> {
         if (item.authors == null) {
             return [];
         } else {
-            const userIds = item.authors.map((author) => ({collection: 'users', id: author._id[0]}));
+            const userIds = item.authors
+                .filter(({_id}) => _id != null) // _id is not present in ingested items
+                .map((author) => ({collection: 'users', id: author._id[0]}));
 
             return [
                 ...userIds,
@@ -52,6 +54,7 @@ export class Authors extends SuperdeskReactComponent<IPropsItemListInfo> {
         }
 
         const authors = this.props.item.authors
+            .filter(({_id}) => _id != null) // _id is not present in ingested items
             .map(({_id}) => ({userId: _id[0], roleId: _id[1]}))
             .filter(({roleId}) => options.includeRoles.includes(roleId));
 

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -157,7 +157,9 @@ declare module 'superdesk-api' {
     // ENTITIES
 
     export interface IAuthor {
-        _id: Array<string, string>; // user id, role
+        // !!! _id is optional. It will not be present in ingested items.
+        _id?: Array<string, string>; // user id, role
+
         name: string;
         scheme: any | null;
         user: IUser;


### PR DESCRIPTION
(in case an item is ingested and we don't have a local user for that author).