### PR TITLE
Character count issues

### DIFF
--- a/scripts/apps/authoring/views/article-edit.html
+++ b/scripts/apps/authoring/views/article-edit.html
@@ -632,7 +632,12 @@
     <label class="field__label">{{field.display_name}}</label>
     <span ng-if="schema[field._id].maxlength || schema[field._id].minlength">
         <sd-character-count-config-button data-field="field._id"></sd-character-count-config-button>
-        <sd-character-count data-item="item.extra[field._id]" data-html="true" data-limit="schema[field._id].maxlength"></sd-character-count>
+
+        <sd-character-count
+            data-item="item.extra[field._id]"
+            data-html="field.field_options != null && field.field_options.single === true ? false: true"
+            data-limit="schema[field._id].maxlength"
+        ></sd-character-count>
     </span>
     <sd-validate-characters ng-if="schema[field._id].validate_characters"
         class="disallowed-char-error" item="item.extra[field._id]" field="field.display_name"></sd-validate-characters>

--- a/scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.ts
+++ b/scripts/apps/workspace/content/directives/ContentProfileSchemaEditor.ts
@@ -133,6 +133,21 @@ export type RICH_FORMATTING_OPTION =
     'undo' |
     'redo';
 
+export const formattingOptionsUnsafeToParseFromHTML: Array<RICH_FORMATTING_OPTION> = [
+    // these aren't outputted to HTML at all
+    'comments',
+    'suggestions',
+
+    // no standard in HTML, parsing according to our output format is not implemented
+    'annotation',
+
+    // may not be parsed well
+    'pre',
+    'embed',
+    'media',
+    'table',
+];
+
 const EDITOR3_RICH_FORMATTING_OPTIONS: Array<RICH_FORMATTING_OPTION> = [
     ...EDITOR3_PLAINTEXT_FORMATTING_OPTIONS,
     'h1',

--- a/scripts/core/editor3/components/Editor3Component.tsx
+++ b/scripts/core/editor3/components/Editor3Component.tsx
@@ -34,7 +34,7 @@ import {IEditorStore} from '../store';
 import {appConfig} from 'appConfig';
 import {EDITOR_BLOCK_TYPE} from '../constants';
 import {RICH_FORMATTING_OPTION} from 'apps/workspace/content/directives/ContentProfileSchemaEditor';
-import {preventInputWhenLimitIsPassed, handleOverflowHighlights} from '../helpers/characters-limit';
+import {preventInputWhenLimitIsPassed} from '../helpers/characters-limit';
 import {handleBeforeInputHighlights} from '../helpers/handleBeforeInputHighlights';
 import {CharacterLimitUiBehavior} from 'apps/authoring/authoring/components/CharacterCountConfigButton';
 

--- a/scripts/core/editor3/reducers/editor3.tsx
+++ b/scripts/core/editor3/reducers/editor3.tsx
@@ -104,7 +104,7 @@ function clearSpellcheckInfo(editorStateCurrent: EditorState, editorStateNext: E
     }
 }
 
-function editorStateChangeMiddlewares(state, editorState: EditorState, contentChanged: boolean) {
+export function editorStateChangeMiddlewares(state, editorState: EditorState, contentChanged: boolean) {
     let newState = state;
 
     newState = applyAbbreviations({

--- a/scripts/core/editor3/store/index.ts
+++ b/scripts/core/editor3/store/index.ts
@@ -42,6 +42,7 @@ import {
     CharacterLimitUiBehavior,
     DEFAULT_UI_FOR_EDITOR_LIMIT,
 } from 'apps/authoring/authoring/components/CharacterCountConfigButton';
+import {handleOverflowHighlights} from '../helpers/characters-limit';
 
 export const ignoreInternalAnnotationFields = (annotations) =>
     annotations.map((annotation) => pick(annotation, ['id', 'type', 'body']));
@@ -151,13 +152,24 @@ export default function createEditorStore(
         middlewares.push(createLogger());
     }
 
+    const limitConfig: EditorLimit | null = !props.limit
+        ? null
+        : {
+            ui: props.limitBehavior || DEFAULT_UI_FOR_EDITOR_LIMIT,
+            chars: props.limit,
+        };
+
+    let editorState = EditorState.createWithContent(
+        content,
+        getCustomDecorator(),
+    );
+
+    editorState = handleOverflowHighlights(editorState, limitConfig?.chars);
+
     const store = createStore<IEditorStore, any, any, any>(
         reducers,
         {
-            editorState: EditorState.createWithContent(
-                content,
-                getCustomDecorator(),
-            ),
+            editorState,
             searchTerm: {pattern: '', index: -1, caseSensitive: false},
             popup: {type: PopupTypes.Hidden},
             readOnly: props.readOnly,
@@ -184,12 +196,7 @@ export default function createEditorStore(
             svc: props.svc,
             abbreviations: {},
             loading: false,
-            limitConfig: !props.limit
-                ? null
-                : {
-                    ui: props.limitBehavior || DEFAULT_UI_FOR_EDITOR_LIMIT,
-                    chars: props.limit,
-                },
+            limitConfig,
         },
         applyMiddleware(...middlewares),
     );
@@ -289,12 +296,11 @@ export function onChange(contentState, {plainText = false} = {}) {
 /**
  * @name getInitialContent
  * @param {Object} props Controller hosting the editor
- * @returns {ContentState} DraftJS ContentState object.
  * @description Gets the initial content state of the editor based on available information.
  * If an editor state is available as saved in the DB, we use that, otherwise we attempt to
  * use available HTML. If none are available, an empty ContentState is created.
  */
-export function getInitialContent(props) {
+export function getInitialContent(props): ContentState {
     // support standalone instance of editor3 which is not connected to item field
     if (props.editorState != null) {
         var contentState = convertFromRaw(

--- a/scripts/core/register-extensions.tsx
+++ b/scripts/core/register-extensions.tsx
@@ -30,7 +30,7 @@ export function registerExtensions(
         };
 
         if (page.addToMainMenu ?? true) {
-            params.category = superdesk.MAIN_MENU;
+            params.category = superdesk.MENU_MAIN;
         }
 
         if (page.showTopMenu === true) {


### PR DESCRIPTION
SDCP-509

When draftjs is used, there are 2 sources of truth - draftjs object and generated text/html. If one is updated by a macro or other automatic process, but not another, there will be issues, like word count not matching.

The editor will now try to initialize from text/html field by default unless there are formatting options enabled that don't parse well from HTML.