### PR TITLE
Avoid errors when logging out

### DIFF
--- a/scripts/core/auth/auth-service.spec.ts
+++ b/scripts/core/auth/auth-service.spec.ts
@@ -23,7 +23,6 @@ describe('auth service', () => {
     });
 
     beforeEach(inject((session, preferencesService, authAdapter, urls, api, $q) => {
-        session.clear();
         spyOn(preferencesService, 'get').and.returnValue($q.when({}));
         spyOn(urls, 'resource').and.returnValue($q.when('http://localhost:5000/api/auth'));
         spyOn(session, 'start').and.returnValue(true);

--- a/scripts/core/auth/auth.ts
+++ b/scripts/core/auth/auth.ts
@@ -196,12 +196,6 @@ export default angular.module('superdesk.core.auth', [
             modal,
         ) {
             $rootScope.logout = function() {
-                function doLogout() {
-                    $rootScope.$broadcast(SESSION_EVENTS.LOGOUT);
-                    localStorage.clear();
-                    $window.location.replace('/'); // reset page for new user
-                }
-
                 var canLogout = true;
 
                 if (superdeskFlags.flags.authoring) {
@@ -216,7 +210,13 @@ export default angular.module('superdesk.core.auth', [
 
                 if (canLogout) {
                     api.auth.getById(session.sessionId).then((sessionData) => {
-                        api.auth.remove(sessionData).then(doLogout, doLogout);
+                        api.auth
+                            .remove(sessionData)
+                            .finally(() => {
+                                $rootScope.$broadcast(SESSION_EVENTS.LOGOUT);
+                                localStorage.clear();
+                                $window.location.replace('/'); // reset page for new user
+                            });
                     });
                 }
             };

--- a/scripts/core/auth/auth.ts
+++ b/scripts/core/auth/auth.ts
@@ -196,8 +196,9 @@ export default angular.module('superdesk.core.auth', [
             modal,
         ) {
             $rootScope.logout = function() {
-                function replace() {
-                    session.clear();
+                function doLogout() {
+                    $rootScope.$broadcast(SESSION_EVENTS.LOGOUT);
+                    localStorage.clear();
                     $window.location.replace('/'); // reset page for new user
                 }
 
@@ -215,7 +216,7 @@ export default angular.module('superdesk.core.auth', [
 
                 if (canLogout) {
                     api.auth.getById(session.sessionId).then((sessionData) => {
-                        api.auth.remove(sessionData).then(replace, replace);
+                        api.auth.remove(sessionData).then(doLogout, doLogout);
                     });
                 }
             };

--- a/scripts/core/auth/session-service.spec.ts
+++ b/scripts/core/auth/session-service.spec.ts
@@ -92,13 +92,6 @@ describe('session service', () => {
         expect(session.identity.allowed_actions).toBeUndefined();
     }));
 
-    it('can clear session', inject((session) => {
-        session.start(SESSION, {name: 'bar'});
-        session.clear();
-        expect(session.token).toBe(null);
-        expect(session.identity).toBe(null);
-    }));
-
     it('can persist session delete href', inject((session) => {
         session.start(SESSION, {name: 'bar'});
         expect(session.getSessionHref()).toBe(SESSION._links.self.href);

--- a/scripts/core/auth/session-service.ts
+++ b/scripts/core/auth/session-service.ts
@@ -78,7 +78,13 @@ angular.module('superdesk.core.auth.session').service('session', [
             }
         }
 
-        // SESSION_EVENTS.LOGOUT
+        this.expire = function() {
+            this.token = null;
+            this.sessionId = null;
+            setToken(null);
+            setSessionId(null);
+            $rootScope.$broadcast(SESSION_EVENTS.LOGOUT);
+        };
 
         /**
      * Return session url for delete

--- a/scripts/core/auth/session-service.ts
+++ b/scripts/core/auth/session-service.ts
@@ -78,27 +78,7 @@ angular.module('superdesk.core.auth.session').service('session', [
             }
         }
 
-        /**
-     * Set current session expired
-     */
-        this.expire = function() {
-            this.token = null;
-            this.sessionId = null;
-            setToken(null);
-            setSessionId(null);
-            $rootScope.$broadcast(SESSION_EVENTS.LOGOUT);
-        };
-
-        /**
-     * Clear session info
-     */
-        this.clear = function() {
-            this.expire();
-            this.identity = null;
-            setSessionHref(null);
-            setSessionId(null);
-            storage.clear();
-        };
+        // SESSION_EVENTS.LOGOUT
 
         /**
      * Return session url for delete


### PR DESCRIPTION
It used to set user object to `null` before logging out and cause errors in the UI. That's because when logged out, not only log-in page is rendered, but the rest application too, even if hidden. I have tried in the past not to render it at all instead of hiding it, but it's hard to do. Since we reload the page after logging out anyway, there's no benefit in clearing user object.