### PR TITLE
keep users data outside of react components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -245,6 +245,22 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag=="
     },
+    "@types/fbemitter": {
+      "version": "2.0.32",
+      "resolved": "https://registry.npmjs.org/@types/fbemitter/-/fbemitter-2.0.32.tgz",
+      "integrity": "sha1-jtIE2g9U6cjq7DGx7skeJRMtCCw=",
+      "dev": true
+    },
+    "@types/flux": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@types/flux/-/flux-3.1.9.tgz",
+      "integrity": "sha512-bSbDf4tTuN9wn3LTGPnH9wnSSLtR5rV7UPWFpM00NJ1pSTBwCzeZG07XsZ9lBkxwngrqjDtM97PLt5IuIdCQUA==",
+      "dev": true,
+      "requires": {
+        "@types/fbemitter": "*",
+        "@types/react": "*"
+      }
+    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -2804,6 +2820,21 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -5193,6 +5224,35 @@
         "websocket-driver": ">=0.5.1"
       }
     },
+    "fbemitter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-3.0.0.tgz",
+      "integrity": "sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==",
+      "requires": {
+        "fbjs": "^3.0.0"
+      },
+      "dependencies": {
+        "fbjs": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.0.tgz",
+          "integrity": "sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==",
+          "requires": {
+            "cross-fetch": "^3.0.4",
+            "fbjs-css-vars": "^1.0.0",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        }
+      }
+    },
     "fbjs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
@@ -5436,6 +5496,36 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
       "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg=="
+    },
+    "flux": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.1.tgz",
+      "integrity": "sha512-emk4RCvJ8RzNP2lNpphKnG7r18q8elDYNAPx7xn+bDeOIo9FFfxEfIQ2y6YbQNmnsGD3nH1noxtLE64Puz1bRQ==",
+      "requires": {
+        "fbemitter": "^3.0.0",
+        "fbjs": "^3.0.0"
+      },
+      "dependencies": {
+        "fbjs": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.0.tgz",
+          "integrity": "sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==",
+          "requires": {
+            "cross-fetch": "^3.0.4",
+            "fbjs-css-vars": "^1.0.0",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        }
+      }
     },
     "follow-redirects": {
       "version": "1.14.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "eslint-plugin-react": "7.16.0",
     "extract-text-webpack-plugin": "3.0.2",
     "file-loader": "1.1.11",
+    "flux": "^4.0.1",
     "gettext.js": "0.9.0",
     "git-rev-sync": "1.10.0",
     "gridster": "0.5.6",
@@ -131,6 +132,7 @@
   },
   "devDependencies": {
     "@types/classnames": "^2.2.10",
+    "@types/flux": "^3.1.9",
     "@types/moment": "^2.13.0",
     "@types/moment-timezone": "^0.5.13",
     "@types/webpack-env": "^1.13.9",

--- a/scripts/apps/desks/services/DesksFactory.ts
+++ b/scripts/apps/desks/services/DesksFactory.ts
@@ -9,6 +9,7 @@ import {
     SCHEDULED_OUTPUT,
     HIGHLIGHTS,
 } from '../constants';
+import UserActions from 'core/data/UserActions';
 
 const OUTPUT_TYPES = [
     DESK_OUTPUT,
@@ -133,6 +134,7 @@ export function DesksFactory($q, api, preferencesService, userList, notify,
                     _.each(result, (user) => {
                         self.userLookup[user._id] = user;
                     });
+                    UserActions.initUsers(self.users._items);
                 });
         },
         fetchStages: function(refresh = false) {

--- a/scripts/apps/master-desk/MasterDesk.tsx
+++ b/scripts/apps/master-desk/MasterDesk.tsx
@@ -15,6 +15,7 @@ import {gettext} from 'core/utils';
 import {appConfig} from 'appConfig';
 
 import UserActivityWidget from 'apps/dashboard/user-activity/components/UserActivityWidget';
+import {IUserMap} from 'core/data/UserStore';
 
 export enum IMasterDeskTab {
     overview = 'overview',
@@ -37,6 +38,10 @@ export function getLabelForMasterDeskTab(tab: IMasterDeskTab): string {
     }
 }
 
+interface IProps {
+    users: IUserMap;
+}
+
 interface IState {
     desks: Array<IDesk>;
     stages: Array<IStage>;
@@ -48,10 +53,10 @@ interface IState {
     filters: any;
 }
 
-export class MasterDesk extends React.Component<{}, IState> {
+export class MasterDesk extends React.Component<IProps, IState> {
     services: any;
 
-    constructor(props: {}) {
+    constructor(props) {
         super(props);
 
         this.state = {
@@ -151,6 +156,7 @@ export class MasterDesk extends React.Component<{}, IState> {
                             case IMasterDeskTab.users:
                                 return (
                                     <UsersComponent
+                                        users={this.props.users}
                                         desks={this.state.desks}
                                         onUserSelect={(user) => this.setState({activeUser: user})}
                                     />

--- a/scripts/apps/master-desk/MasterDeskContainer.tsx
+++ b/scripts/apps/master-desk/MasterDeskContainer.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import {Container} from 'flux/utils';
+import UserStore from 'core/data/UserStore';
+import {MasterDesk} from './MasterDesk';
+
+const getStores = () => ([
+    UserStore,
+]);
+
+const getState = () => ({
+    users: UserStore.getState(),
+});
+
+const MasterDeskApp = (props) => (
+    <MasterDesk {...props} />
+);
+
+export default Container.createFunctional(MasterDeskApp, getStores, getState);

--- a/scripts/apps/master-desk/index.ts
+++ b/scripts/apps/master-desk/index.ts
@@ -1,11 +1,11 @@
 import {gettext} from 'core/utils';
 import {reactToAngular1} from 'superdesk-ui-framework';
-import {MasterDesk} from './MasterDesk';
+import MasterDeskContainer from './MasterDeskContainer';
 
 const styles = 'margin-top: 48px';
 
 angular.module('superdesk.apps.master-desk', [])
-    .component('sdMasterDesk', reactToAngular1(MasterDesk, [], [], styles))
+    .component('sdMasterDesk', reactToAngular1(MasterDeskContainer, [], [], styles))
     .config(['superdeskProvider', 'workspaceMenuProvider', (superdesk, workspaceMenuProvider) => {
         superdesk
             .activity('/master-desk', {

--- a/scripts/core/data/UserActionTypes.ts
+++ b/scripts/core/data/UserActionTypes.ts
@@ -1,0 +1,6 @@
+const ActionTypes = {
+    INIT_USERS: 'INIT_USERS',
+    UPDATE_USERS: 'UPDATE_USERS',
+};
+
+export default ActionTypes;

--- a/scripts/core/data/UserActions.ts
+++ b/scripts/core/data/UserActions.ts
@@ -1,0 +1,20 @@
+import SuperdeskDispatcher from '.';
+import UserActionTypes from './UserActionTypes';
+
+const Actions = {
+    updateUser(data) {
+        SuperdeskDispatcher.dispatch({
+            type: UserActionTypes.UPDATE_USERS,
+            payload: data,
+        });
+    },
+
+    initUsers(data) {
+        SuperdeskDispatcher.dispatch({
+            type: UserActionTypes.INIT_USERS,
+            payload: data,
+        });
+    },
+};
+
+export default Actions;

--- a/scripts/core/data/UserStore.ts
+++ b/scripts/core/data/UserStore.ts
@@ -1,0 +1,31 @@
+import Immutable from 'immutable';
+import {ReduceStore} from 'flux/utils';
+import UserActionTypes from './UserActionTypes';
+import SuperdeskDispatcher, {IActionPayload} from '.';
+import {IUser} from 'superdesk-api';
+
+export type IUserMap = Immutable.Map<IUser['_id'], IUser>;
+
+class UserStore extends ReduceStore<IUserMap, IActionPayload> {
+    constructor() {
+        super(SuperdeskDispatcher);
+    }
+
+    getInitialState() {
+        return Immutable.Map<IUser['_id'], IUser>();
+    }
+
+    reduce(state, action) {
+        switch (action.type) {
+        case UserActionTypes.UPDATE_USERS:
+            return state.set(action.payload['_id'], action.payload);
+
+        case UserActionTypes.INIT_USERS:
+            return action.payload.reduce((nextState, user) => nextState.set(user._id, user), state);
+        }
+
+        return state;
+    }
+}
+
+export default new UserStore();

--- a/scripts/core/data/index.ts
+++ b/scripts/core/data/index.ts
@@ -1,0 +1,38 @@
+import {Dispatcher} from 'flux';
+import {IResourceUpdateEvent, IWebsocketMessage} from 'superdesk-api';
+import {addWebsocketEventListener} from 'core/notification/notification';
+import {dataApi} from 'core/helpers/CrudManager';
+
+export interface IActionPayload {
+    type: string;
+    payload: any;
+}
+
+const superdeskDispatcher = new Dispatcher<IActionPayload>();
+
+const RESOURCE_BLACKLIST = [
+    'auth',
+    'audit',
+];
+
+addWebsocketEventListener(
+    'resource:updated',
+    (event: IWebsocketMessage<IResourceUpdateEvent>) => {
+        const {resource, _id} = event.extra;
+
+        if (RESOURCE_BLACKLIST.includes(resource)) {
+            return;
+        }
+
+        dataApi.findOne(resource, _id).then((updated) => {
+            superdeskDispatcher.dispatch({
+                type: `UPDATE_${resource.toUpperCase()}`,
+                payload: updated,
+            });
+        }, (reason) => {
+            console.error(`got error when fetching ${resource}/${_id}: ${reason}`);
+        });
+    },
+);
+
+export default superdeskDispatcher;


### PR DESCRIPTION
SDESK-5817

built this as a POC with flux for handling users data in one place
which could be used by other components later. that seems to integrate
better into our app than redux.

this seems easier to work with than redux as it can register stores any
time rather than once at the bootstrap. we could use that for basic entities
like users/desks/roles etc and keep the rest of the state in components
which are top level views like MasterDeskApp, which could still define
its own store which would be registered when the component mounts.

what do you think @superdesk/client ?