### PR TITLE
support installing extensions outside of client core repository using build tools

### DIFF
--- a/build-tools/package-lock.json
+++ b/build-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13,6 +13,20 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "chalk": {
       "version": "0.4.0",
@@ -28,6 +42,11 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "css": {
       "version": "2.2.4",
@@ -73,6 +92,11 @@
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
       "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
     "gettext-parser": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.0.tgz",
@@ -89,6 +113,19 @@
         "po2json": "^0.4.0"
       }
     },
+    "glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
     "has-color": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
@@ -100,6 +137,15 @@
       "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -117,6 +163,14 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
     "nomnom": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
@@ -125,6 +179,19 @@
         "chalk": "~0.4.0",
         "underscore": "~1.6.0"
       }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "po2json": {
       "version": "0.4.5",
@@ -209,6 +276,11 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }
 }

--- a/build-tools/package-lock.json
+++ b/build-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/build-tools/package-lock.json
+++ b/build-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/build-tools/package-lock.json
+++ b/build-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/build-tools/package-lock.json
+++ b/build-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/build-tools/package-lock.json
+++ b/build-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/build-tools/package-lock.json
+++ b/build-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/build-tools/package-lock.json
+++ b/build-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/build-tools/package-lock.json
+++ b/build-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "publishConfig": {
     "access": "public"
   },

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "publishConfig": {
     "access": "public"
   },

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "publishConfig": {
     "access": "public"
   },
@@ -12,6 +12,7 @@
     "css": "2.2.4",
     "css-selector-tokenizer": "0.7.1",
     "gettext.js": "^0.9.0",
+    "glob": "^7.1.7",
     "lodash": "^4.17.19"
   }
 }

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "publishConfig": {
     "access": "public"
   },

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "publishConfig": {
     "access": "public"
   },

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "publishConfig": {
     "access": "public"
   },

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "publishConfig": {
     "access": "public"
   },

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "publishConfig": {
     "access": "public"
   },

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "publishConfig": {
     "access": "public"
   },

--- a/build-tools/src/extensions/get-extension-directories-sync.js
+++ b/build-tools/src/extensions/get-extension-directories-sync.js
@@ -6,7 +6,15 @@ const _ = require('lodash');
 const {trimEnd} = _;
 
 function getAbsoluteModuleDirectory(clientPath, modulePathRelative) {
-    return path.join(require.resolve(path.join(`${clientPath}/node_modules`, modulePathRelative, 'package.json')), '../');
+    // if module path starts with a dot, don't look into node_modules
+    if (modulePathRelative.startsWith('.')) {
+        return path.join(clientPath, modulePathRelative);
+    } else {
+        return path.join(
+            require.resolve(path.join(`${clientPath}/node_modules`, modulePathRelative, 'package.json')),
+            '../'
+        );
+    }
 }
 
 function getPaths(clientPath, extensionRootRelative) {
@@ -108,7 +116,7 @@ function getExtensionDirectoriesSync(clientPath) {
 
     while ((_match = extensionRegistrationPattern.exec(indexFile)) !== null) {
         const extensionName = _match[1];
-        const {extensionRootPath, extensionSrcPath, extensionCssFilePath} = getPaths(clientPath ,_match[2]);
+        const {extensionRootPath, extensionSrcPath, extensionCssFilePath} = getPaths(clientPath, _match[2]);
 
         matches.push({extensionName, extensionRootPath, extensionSrcPath, extensionCssFilePath});
     }

--- a/build-tools/src/extensions/install-extensions.js
+++ b/build-tools/src/extensions/install-extensions.js
@@ -51,19 +51,30 @@ function correctMainPathInPackageJson(extensionRootPath) {
  * that relative path is no longer correct, so it's overwritten here.
  */
 function correctApiDefinitionsPath(extensionRootPath, clientDir) {
+    const apiDefinitionsDestDir = path.join(extensionRootPath, 'src/typings');
     const apiDefinitionsDestPath = path.join(extensionRootPath, 'src/typings/refs.d.ts');
+
+    if (fs.existsSync(apiDefinitionsDestPath) !== true) {
+        return;
+    }
+
+    const definitionsFileContents = fs.readFileSync(apiDefinitionsDestPath, 'utf-8');
+    const referencePath = definitionsFileContents.match(/reference path=("|')(.+?)("|')/)[2];
+    const definitionsExistAtSpecifiedPath = fs.existsSync(path.join(apiDefinitionsDestDir, referencePath));
+
+    if (definitionsExistAtSpecifiedPath) {
+        return;
+    }
 
     const apiDefinitionsSrcPath = require.resolve(
         path.join(clientDir, 'node_modules/superdesk-core/scripts/core/superdesk-api.d.ts')
     );
 
-    if (fs.existsSync(apiDefinitionsDestPath)) {
-        fs.writeFileSync(
-            apiDefinitionsDestPath,
-            `/// <reference path='${apiDefinitionsSrcPath}' />`,
-            'utf-8'
-        );
-    }
+    fs.writeFileSync(
+        apiDefinitionsDestPath,
+        `/// <reference path='${apiDefinitionsSrcPath}' />`,
+        'utf-8'
+    );
 }
 
 module.exports = function installExtensions(clientDir) {

--- a/build-tools/src/extensions/install-extensions.js
+++ b/build-tools/src/extensions/install-extensions.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var path = require('path');
 var getExtensionDirectoriesSync = require('./get-extension-directories-sync');
 
 const execSync = require('child_process').execSync;
@@ -6,8 +7,29 @@ const execSync = require('child_process').execSync;
 module.exports = function installExtensions(clientDir) {
     const directories = getExtensionDirectoriesSync(clientDir);
 
+    const apiDefinitionsSrcPath = require.resolve(
+        path.join(clientDir, 'node_modules/superdesk-core/scripts/core/superdesk-api.d.ts')
+    );
+
     directories.forEach(({extensionRootPath, extensionSrcPath}) => {
-        if (fs.existsSync(extensionSrcPath)) { // if src dir doesn't exist, assume that the extension is already build
+        // if src dir doesn't exist, assume that the extension is already built (e.g. when installed from npm)
+        if (fs.existsSync(extensionSrcPath)) {
+            const apiDefinitionsDestPath = path.join(extensionRootPath, 'src/typings/refs.d.ts');
+
+            /**
+             * Extensions that are located outside of superdesk-client-core repository,
+             * can't reference API definitions relatively. They can in development,
+             * but if the extension is installed using build-tools rather than from npm,
+             * that relative path is no longer correct, so it's overwritten here.
+             */
+            if (fs.existsSync(apiDefinitionsDestPath)) {
+                fs.writeFileSync(
+                    apiDefinitionsDestPath,
+                    `/// <reference path='${apiDefinitionsSrcPath}' />`,
+                    'utf-8'
+                );
+            }
+
             execSync(
                 `cd ${extensionRootPath} && npm install --no-audit && npm run compile --if-present`,
                 {stdio: 'inherit'}

--- a/build-tools/src/extensions/install-extensions.js
+++ b/build-tools/src/extensions/install-extensions.js
@@ -1,8 +1,66 @@
 var fs = require('fs');
 var path = require('path');
+var glob = require('glob');
+var _ = require('lodash');
 var getExtensionDirectoriesSync = require('./get-extension-directories-sync');
 
 const execSync = require('child_process').execSync;
+
+/**
+ * When TypeScript is compiling an extension,
+ * the directory structure in resulting dist folder is sometimes different,
+ * even when the same files are used.
+ * The main file sometimes ends up in dist/extension.js
+ * and other times in dist/planning-extension/src/extension.js
+ * The only difference is the location of the extension.
+ * If it's inside node_modules, extra directories are not getting generated.
+ */
+function correctMainPathInPackageJson(extensionRootPath) {
+    const packageJsonPath = path.join(extensionRootPath, 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+    const mainFile = path.join(extensionRootPath, packageJson.main);
+
+    if (fs.existsSync(mainFile) !== true) {
+        const result = glob.sync(`${path.join(extensionRootPath, 'dist')}/**/extension.js`, {});
+
+        if (result != null && result[0] != null) {
+            const relativeToPackage = _.trimStart(
+                result[0].replace(extensionRootPath, ''),
+                '/'
+            );
+
+            const packageJsonUpdated = {
+                ...packageJson,
+                main: relativeToPackage,
+            };
+
+            fs.writeFileSync(
+                packageJsonPath,
+                JSON.stringify(packageJsonUpdated),
+                'utf-8'
+            );
+        }
+    }
+}
+
+
+/**
+ * Extensions that are located outside of superdesk-client-core repository,
+ * can't reference API definitions relatively. They can in development,
+ * but if the extension is installed using build-tools rather than from npm,
+ * that relative path is no longer correct, so it's overwritten here.
+ */
+function correctApiDefinitionsPath(extensionRootPath) {
+    const apiDefinitionsDestPath = path.join(extensionRootPath, 'src/typings/refs.d.ts');
+
+    if (fs.existsSync(apiDefinitionsDestPath)) {
+        fs.writeFileSync(
+            apiDefinitionsDestPath,
+            `/// <reference path='${apiDefinitionsSrcPath}' />`,
+            'utf-8'
+        );
+    }
+}
 
 module.exports = function installExtensions(clientDir) {
     const directories = getExtensionDirectoriesSync(clientDir);
@@ -14,21 +72,8 @@ module.exports = function installExtensions(clientDir) {
     directories.forEach(({extensionRootPath, extensionSrcPath}) => {
         // if src dir doesn't exist, assume that the extension is already built (e.g. when installed from npm)
         if (fs.existsSync(extensionSrcPath)) {
-            const apiDefinitionsDestPath = path.join(extensionRootPath, 'src/typings/refs.d.ts');
-
-            /**
-             * Extensions that are located outside of superdesk-client-core repository,
-             * can't reference API definitions relatively. They can in development,
-             * but if the extension is installed using build-tools rather than from npm,
-             * that relative path is no longer correct, so it's overwritten here.
-             */
-            if (fs.existsSync(apiDefinitionsDestPath)) {
-                fs.writeFileSync(
-                    apiDefinitionsDestPath,
-                    `/// <reference path='${apiDefinitionsSrcPath}' />`,
-                    'utf-8'
-                );
-            }
+            correctApiDefinitionsPath(extensionRootPath);
+            correctMainPathInPackageJson(extensionRootPath);
 
             execSync(
                 `cd ${extensionRootPath} && npm install --no-audit && npm run compile --if-present`,

--- a/build-tools/src/extensions/install-extensions.js
+++ b/build-tools/src/extensions/install-extensions.js
@@ -69,19 +69,17 @@ function correctApiDefinitionsPath(extensionRootPath, clientDir) {
 module.exports = function installExtensions(clientDir) {
     const directories = getExtensionDirectoriesSync(clientDir);
 
-    console.log('d');
+    directories.forEach(({extensionRootPath, extensionSrcPath}) => {
+        // if src dir doesn't exist, assume that the extension is already built (e.g. when installed from npm)
+        if (fs.existsSync(extensionSrcPath)) {
+            correctApiDefinitionsPath(extensionRootPath, clientDir);
 
-    // directories.forEach(({extensionRootPath, extensionSrcPath}) => {
-    //     // if src dir doesn't exist, assume that the extension is already built (e.g. when installed from npm)
-    //     if (fs.existsSync(extensionSrcPath)) {
-    //         correctApiDefinitionsPath(extensionRootPath, clientDir);
+            execSync(
+                `cd ${extensionRootPath} && npm install --no-audit && npm run compile --if-present`,
+                {stdio: 'inherit'}
+            );
 
-    //         execSync(
-    //             `cd ${extensionRootPath} && npm install --no-audit && npm run compile --if-present`,
-    //             {stdio: 'inherit'}
-    //         );
-
-    //         correctMainPathInPackageJson(extensionRootPath);
-    //     }
-    // });
+            correctMainPathInPackageJson(extensionRootPath);
+        }
+    });
 };

--- a/build-tools/src/extensions/install-extensions.js
+++ b/build-tools/src/extensions/install-extensions.js
@@ -53,6 +53,10 @@ function correctMainPathInPackageJson(extensionRootPath) {
 function correctApiDefinitionsPath(extensionRootPath) {
     const apiDefinitionsDestPath = path.join(extensionRootPath, 'src/typings/refs.d.ts');
 
+    const apiDefinitionsSrcPath = require.resolve(
+        path.join(clientDir, 'node_modules/superdesk-core/scripts/core/superdesk-api.d.ts')
+    );
+
     if (fs.existsSync(apiDefinitionsDestPath)) {
         fs.writeFileSync(
             apiDefinitionsDestPath,
@@ -64,10 +68,6 @@ function correctApiDefinitionsPath(extensionRootPath) {
 
 module.exports = function installExtensions(clientDir) {
     const directories = getExtensionDirectoriesSync(clientDir);
-
-    const apiDefinitionsSrcPath = require.resolve(
-        path.join(clientDir, 'node_modules/superdesk-core/scripts/core/superdesk-api.d.ts')
-    );
 
     directories.forEach(({extensionRootPath, extensionSrcPath}) => {
         // if src dir doesn't exist, assume that the extension is already built (e.g. when installed from npm)

--- a/build-tools/src/extensions/install-extensions.js
+++ b/build-tools/src/extensions/install-extensions.js
@@ -73,12 +73,13 @@ module.exports = function installExtensions(clientDir) {
         // if src dir doesn't exist, assume that the extension is already built (e.g. when installed from npm)
         if (fs.existsSync(extensionSrcPath)) {
             correctApiDefinitionsPath(extensionRootPath, clientDir);
-            correctMainPathInPackageJson(extensionRootPath);
 
             execSync(
                 `cd ${extensionRootPath} && npm install --no-audit && npm run compile --if-present`,
                 {stdio: 'inherit'}
             );
+
+            correctMainPathInPackageJson(extensionRootPath);
         }
     });
 };

--- a/build-tools/src/extensions/install-extensions.js
+++ b/build-tools/src/extensions/install-extensions.js
@@ -69,17 +69,19 @@ function correctApiDefinitionsPath(extensionRootPath, clientDir) {
 module.exports = function installExtensions(clientDir) {
     const directories = getExtensionDirectoriesSync(clientDir);
 
-    directories.forEach(({extensionRootPath, extensionSrcPath}) => {
-        // if src dir doesn't exist, assume that the extension is already built (e.g. when installed from npm)
-        if (fs.existsSync(extensionSrcPath)) {
-            correctApiDefinitionsPath(extensionRootPath, clientDir);
+    console.log('d');
 
-            execSync(
-                `cd ${extensionRootPath} && npm install --no-audit && npm run compile --if-present`,
-                {stdio: 'inherit'}
-            );
+    // directories.forEach(({extensionRootPath, extensionSrcPath}) => {
+    //     // if src dir doesn't exist, assume that the extension is already built (e.g. when installed from npm)
+    //     if (fs.existsSync(extensionSrcPath)) {
+    //         correctApiDefinitionsPath(extensionRootPath, clientDir);
 
-            correctMainPathInPackageJson(extensionRootPath);
-        }
-    });
+    //         execSync(
+    //             `cd ${extensionRootPath} && npm install --no-audit && npm run compile --if-present`,
+    //             {stdio: 'inherit'}
+    //         );
+
+    //         correctMainPathInPackageJson(extensionRootPath);
+    //     }
+    // });
 };

--- a/build-tools/src/extensions/install-extensions.js
+++ b/build-tools/src/extensions/install-extensions.js
@@ -50,7 +50,7 @@ function correctMainPathInPackageJson(extensionRootPath) {
  * but if the extension is installed using build-tools rather than from npm,
  * that relative path is no longer correct, so it's overwritten here.
  */
-function correctApiDefinitionsPath(extensionRootPath) {
+function correctApiDefinitionsPath(extensionRootPath, clientDir) {
     const apiDefinitionsDestPath = path.join(extensionRootPath, 'src/typings/refs.d.ts');
 
     const apiDefinitionsSrcPath = require.resolve(
@@ -72,7 +72,7 @@ module.exports = function installExtensions(clientDir) {
     directories.forEach(({extensionRootPath, extensionSrcPath}) => {
         // if src dir doesn't exist, assume that the extension is already built (e.g. when installed from npm)
         if (fs.existsSync(extensionSrcPath)) {
-            correctApiDefinitionsPath(extensionRootPath);
+            correctApiDefinitionsPath(extensionRootPath, clientDir);
             correctMainPathInPackageJson(extensionRootPath);
 
             execSync(

--- a/build-tools/src/extensions/translations.js
+++ b/build-tools/src/extensions/translations.js
@@ -71,7 +71,9 @@ function mergeTranslationsFromExtensions(clientDir) {
         }
     }
 
-    fs.rmdirSync(translationsJsonTemp, {recursive: true});
+    if (fs.existsSync(translationsJsonTemp)) {
+        fs.rmdirSync(translationsJsonTemp, {recursive: true});
+    }
 }
 
 module.exports = {


### PR DESCRIPTION
Initially I have published the planning extension to npm, because of the issue of not being able to find API typescript definitions when building (superdesk-core is a devDependency of planning extension so it can be referenced during development). It wouldn't work to use the npm package with `planning-mvp` that is used for building test instances on fireq, so I'm copying the API typescript definitions to all extensions.