### PR TITLE
make build tools compatible with node 10

### DIFF
--- a/build-tools/package-lock.json
+++ b/build-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -234,6 +234,14 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2",

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "publishConfig": {
     "access": "public"
   },
@@ -13,6 +13,7 @@
     "css-selector-tokenizer": "0.7.1",
     "gettext.js": "^0.9.0",
     "glob": "^7.1.7",
-    "lodash": "^4.17.19"
+    "lodash": "^4.17.19",
+    "rimraf": "^3.0.2"
   }
 }

--- a/build-tools/src/extensions/translations.js
+++ b/build-tools/src/extensions/translations.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-depth */
 
 const _ = require('lodash');
+const rimraf = require('rimraf');
 const fs = require('fs');
 const path = require('path');
 const getExtensionDirectoriesSync = require('./get-extension-directories-sync');
@@ -72,7 +73,7 @@ function mergeTranslationsFromExtensions(clientDir) {
     }
 
     if (fs.existsSync(translationsJsonTemp)) {
-        fs.rmdirSync(translationsJsonTemp, {recursive: true});
+        rimraf.sync(translationsJsonTemp);
     }
 }
 


### PR DESCRIPTION
`recursive` option doesn't work on node 10(`fs.rmdirSync`).