### PR TITLE
avoid updating single user multiple times in parallel

### DIFF
--- a/scripts/core/data/index.ts
+++ b/scripts/core/data/index.ts
@@ -54,7 +54,7 @@ addWebsocketEventListener(
                 console.error(`got error when fetching ${resource}/${_id}: ${reason}`);
             })
             .finally(() => {
-                updating[_id] = null;
+                delete updating[_id];
             });
     },
 );

--- a/scripts/core/data/index.ts
+++ b/scripts/core/data/index.ts
@@ -1,9 +1,10 @@
 import {combineReducers, createStore} from 'redux';
 import {IBaseRestApiResponse, IResourceUpdateEvent, IWebsocketMessage} from 'superdesk-api';
 import {addWebsocketEventListener} from 'core/notification/notification';
-import {dataApi} from 'core/helpers/CrudManager';
 import {users, IUserState, IUserAction} from './users';
 import {getMiddlewares} from 'core/redux-utils';
+import {httpRequestJsonLocal} from 'core/helpers/network';
+import {debounceAsync, IDebounced} from 'core/helpers/debounce-async';
 
 export type IEntityAction = {
     type: 'UPDATE_ENTITY',
@@ -24,7 +25,8 @@ export const store = createStore<IStoreState, IAction, {}, {}>(combineReducers({
     users,
 }), getMiddlewares());
 
-const updating = {};
+const updating: {[key: string]: IDebounced} = {};
+
 const resourcesInStore = [
     'users',
 ];
@@ -34,27 +36,41 @@ addWebsocketEventListener(
     (event: IWebsocketMessage<IResourceUpdateEvent>) => {
         const {resource, _id} = event.extra;
 
-        if (!resourcesInStore.includes(resource) || updating[_id] === true) {
+        if (!resourcesInStore.includes(resource)) {
             return;
         }
 
-        updating[_id] = true;
+        const updateKey = resource + _id;
 
-        dataApi.findOne(resource, _id)
-            .then((data: IBaseRestApiResponse) => {
-                store.dispatch({
-                    type: 'UPDATE_ENTITY',
-                    payload: {
-                        resource,
-                        _id,
-                        data,
-                    },
-                });
-            }, (reason) => {
-                console.error(`got error when fetching ${resource}/${_id}: ${reason}`);
-            })
-            .finally(() => {
-                delete updating[_id];
-            });
+        if (updating[updateKey] != null) {
+            updating[updateKey]();
+        } else {
+            const requestDebounced = debounceAsync(
+                (abortController) => {
+                    return httpRequestJsonLocal({
+                        method: 'GET',
+                        path: `/${resource}/${_id}`,
+                        abortSignal: abortController.signal,
+                    })
+                        .then((data: IBaseRestApiResponse) => {
+                            store.dispatch({
+                                type: 'UPDATE_ENTITY',
+                                payload: {
+                                    resource,
+                                    _id,
+                                    data,
+                                },
+                            });
+                        }).finally(() => {
+                            delete updating[updateKey];
+                        });
+                },
+                1000,
+                3000,
+            );
+
+            updating[updateKey] = requestDebounced;
+            updating[updateKey]();
+        }
     },
 );

--- a/scripts/core/helpers/debounce-async.ts
+++ b/scripts/core/helpers/debounce-async.ts
@@ -1,0 +1,75 @@
+export interface IDebounced {
+    (): void;
+    cancel(): void;
+}
+
+/**
+ * Promise returned by calling `fn` must use provided `abortController` to stop processing
+ * on receiving abort signal and and reject with `{name: 'AbortError'}`.
+ *
+ * If .catch() is used on the promise returned by `fn`, it must rethrow if rejection is `{name: 'AbortError'}`.
+ */
+export function debounceAsync<T>(
+    fn: (abortController: AbortController) => Promise<T>,
+    timeout: number, // in miliseconds
+    maxWait?, // in miliseconds, must be >= timeout
+): IDebounced {
+    let timer;
+    let firstCallTimestamp = null;
+
+    let promiseInProgress = false;
+    let abortController: AbortController | null = null;
+
+    let cancelled = false;
+
+    const debouncedFn = () => {
+        cancelled = false;
+
+        if (firstCallTimestamp == null) {
+            firstCallTimestamp = Date.now();
+        }
+
+        const accumulatedWait = Date.now() - firstCallTimestamp;
+
+        if (promiseInProgress) {
+            abortController.abort();
+        } else if (accumulatedWait < Math.max((maxWait ?? 0) - timeout, timeout)) {
+            clearTimeout(timer);
+
+            timer = window.setTimeout(() => {
+                promiseInProgress = true;
+
+                abortController = new AbortController();
+
+                fn(abortController)
+                    .then((result) => {
+                        firstCallTimestamp = null;
+                        promiseInProgress = false;
+
+                        return result;
+                    })
+                    .catch((err) => {
+                        if (err?.name === 'AbortError') {
+                            firstCallTimestamp = null;
+                            promiseInProgress = false;
+
+                            if (!cancelled) {
+                                debouncedFn();
+                            }
+                        }
+                    });
+            }, timeout);
+        }
+    };
+
+    debouncedFn.cancel = () => {
+        if (promiseInProgress) {
+            cancelled = true;
+            abortController.abort();
+        } else {
+            clearTimeout(timer);
+        }
+    };
+
+    return debouncedFn;
+}

--- a/scripts/core/helpers/debounce-async.ts
+++ b/scripts/core/helpers/debounce-async.ts
@@ -5,7 +5,7 @@ export interface IDebounced {
 
 /**
  * Promise returned by calling `fn` must use provided `abortController` to stop processing
- * on receiving abort signal and and reject with `{name: 'AbortError'}`.
+ * on receiving abort signal and reject with `{name: 'AbortError'}`.
  *
  * If .catch() is used on the promise returned by `fn`, it must rethrow if rejection is `{name: 'AbortError'}`.
  */


### PR DESCRIPTION
we keep user data in sync for master desk view but
when load testing there is same user logging in all
the time which fires update requests.