### PR TITLE
improve memory usage when caching api requests

### DIFF
--- a/scripts/core/helpers/CrudManager.tsx
+++ b/scripts/core/helpers/CrudManager.tsx
@@ -148,7 +148,7 @@ function findOne<T>(endpoint: string, id: string): Promise<T> {
             method: 'GET',
             path: '/' + endpoint + '/' + id,
         }).finally(() => {
-            cache[key] = null;
+            delete cache[key];
         });
     }
 

--- a/spec/authoring_spec.ts
+++ b/spec/authoring_spec.ts
@@ -7,7 +7,7 @@ import {
     ctrlShiftKey,
     assertToastMsg,
     assertToastMsgNotDisplayed,
-    waitForToastMsgDissapear,
+    waitForToastMsgDisappear,
     nav,
     shiftKey,
 } from './helpers/utils';
@@ -717,7 +717,7 @@ describe('authoring', () => {
         uploadMedia('image-big.jpg');
 
         assertToastMsg('success', 'Item updated.');
-        waitForToastMsgDissapear('success', 'Item updated.');
+        waitForToastMsgDisappear('success', 'Item updated.');
 
         browser.wait(ECE.hasElementCount(els(['authoring-field--media-gallery', 'media-gallery-image']), 1));
 

--- a/spec/helpers/utils.ts
+++ b/spec/helpers/utils.ts
@@ -179,7 +179,18 @@ export function assertToastMsg(type: 'info' | 'success' | 'error', msg: string) 
     const elem = element(s([`notification--${type}`], msg));
 
     browser.wait(ECE.elementToBeClickable(elem), 2000);
-    elem.click();
+
+    /**
+     * It seems there's an issue with protractor:
+     * Clicking an element throws `StaleElementReferenceError` when clicked immediately
+     * after waiting until it's clickable.
+     */
+    elem.isPresent().then((present) => {
+        // Only click if the toast is still present.
+        if (present) {
+            elem.click();
+        }
+    });
 }
 
 // Don't expect message to appear
@@ -187,7 +198,7 @@ export function assertToastMsgNotDisplayed(type, msg) {
     expect(element.all(by.cssContainingText(`[data-test-id="notification--${type}"]`, msg)).isPresent()).toBe(false);
 }
 
-export function waitForToastMsgDissapear(type, msg) {
+export function waitForToastMsgDisappear(type, msg) {
     browser.wait(protractor.ExpectedConditions.invisibilityOf(
         element(by.cssContainingText(`[data-test-id="notification--${type}"]`, msg)),
     ), 3000);


### PR DESCRIPTION
SDESK-6086

Forgot to fix in https://github.com/superdesk/superdesk-client-core/pull/3892. Setting to `null` instead of deleting entry, may increase the size of the object and cause memory leaks.