### PR TITLE
Fix isssues with `_editable` state after reverting an older version

### DIFF
--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -878,6 +878,14 @@ export function AuthoringDirective(
             $scope.revert = function(version) {
                 $scope.isPreview = false;
                 helpers.forcedExtend($scope.item, version);
+
+                /**
+                 * Before restoring, a version can be previewed in read only mode.
+                 * For this to work, `_editable` is set to false.
+                 * It has to be set back to true so the story is editable after reverting.
+                 */
+                $scope._editable = true;
+
                 $scope.refreshTrigger++;
                 if ($scope.item.annotations == null) {
                     $scope.item.annotations = [];

--- a/scripts/apps/authoring/versioning/versions/versions.ts
+++ b/scripts/apps/authoring/versioning/versions/versions.ts
@@ -62,7 +62,12 @@ function VersioningController($scope, authoring, desks, archiveService) {
      *
      * If the version is the last one and there is an autosave - drop autosave
      */
-    $scope.revert = function(version) {
+    $scope.revert = function(version, event) {
+        /**
+         * The button is nested in element that calls `openVersion` on click.
+         */
+        event.stopPropagation();
+
         $scope.$parent.revert(version).then(fetchVersions);
     };
 

--- a/scripts/apps/authoring/versioning/versions/views/versions.html
+++ b/scripts/apps/authoring/versioning/versions/views/versions.html
@@ -19,7 +19,7 @@
                 <span class="state-label state-{{ :: version.state}}" translate>{{ :: version.state | removeLodash }}</span>
                 <button class="btn btn--small btn--hollow ml-auto"
                         ng-show="canRevert && !$first && !dirty"
-                        ng-click="revert(version)"
+                        ng-click="revert(version, $event)"
                         translate>revert</button>
             </div>
         </li>


### PR DESCRIPTION
SDESK-6139

When items are previewed from history view, `_editable` is set to false(to prevent editing of old versions). It was not set back to true when performing revert operation and the item was remaining in uneditable state after the revert. There was also another issue that version previewing was called when clicked on "revert" button, because event propagation was not stopped.
The issue was only reproducible on slower network - when simulating fast 4G connection.