### PR TITLE
Fix ui issues in the toolbar in compact mode

### DIFF
--- a/scripts/apps/search/views/multi-action-bar.html
+++ b/scripts/apps/search/views/multi-action-bar.html
@@ -8,10 +8,10 @@
 
     <div class="pull-right">
         <sd-multi-action-bar-react
-            articles="multi.getItems()"
-            get-core-actions="getActions"
-            compact="elementState === 'compact'"
-            hide-multi-action-bar="hideMultiActionBar"
+            data-articles="multi.getItems()"
+            data-get-core-actions="getActions"
+            data-compact="elementState === 'compact'"
+            data-hide-multi-action-bar="hideMultiActionBar"
         ></sd-multi-action-bar-react>
     </div>
 </div>


### PR DESCRIPTION
SDESK-6124

The issue was that `compact` property was not being received by `sd-multi-action-bar-react` component, but only when code was built in production mode(via `npm run build`). When running in development mode(`grunt server`) it worked fine. Other properties were being forwarded even in production mode. I suspect it only doesn't work with primitives. Adding `data-` prefix fixed it.