### PR TITLE
Temporary performance workaround

### DIFF
--- a/scripts/apps/highlights/index.ts
+++ b/scripts/apps/highlights/index.ts
@@ -74,7 +74,7 @@ export default angular.module('superdesk.apps.highlights', [
                 topTemplateUrl: 'scripts/apps/dashboard/views/workspace-topnav.html',
                 sideTemplateUrl: 'scripts/apps/workspace/views/workspace-sidenav.html',
                 privileges: {highlights_read: 1},
-                reloadOnSearch: true,
+                reloadOnSearch: false,
             });
 
         workspaceMenuProvider.item({

--- a/scripts/core/ArticlesListV2.tsx
+++ b/scripts/core/ArticlesListV2.tsx
@@ -80,6 +80,7 @@ export class ArticlesListV2 extends SuperdeskReactComponent<IProps, IState> {
         this.fetchRelatedEntities = this.fetchRelatedEntities.bind(this);
         this.loadMore = this.loadMore.bind(this);
         this.getItemsByIds = this.getItemsByIds.bind(this);
+        this.reloadList = this.reloadList.bind(this);
 
         this.handleContentChanges = throttleAndCombineArray(
             (changes) => {
@@ -135,6 +136,10 @@ export class ArticlesListV2 extends SuperdeskReactComponent<IProps, IState> {
         };
 
         this.eventListenersToRemoveBeforeUnmounting = [];
+    }
+
+    public reloadList() {
+        this.lazyLoaderRef?.reset();
     }
 
     fetchRelatedEntities(items: OrderedMap<ITrackById, IArticle>): Promise<OrderedMap<ITrackById, IArticle>> {

--- a/scripts/core/itemList/LazyLoader.tsx
+++ b/scripts/core/itemList/LazyLoader.tsx
@@ -54,7 +54,7 @@ export class LazyLoader<T> extends React.Component<IProps<T>, IState<T>> {
      * because items use ITrackById as their ID, and ITrackById changes on every update
      */
     public updateItems(ids: Set<string>): void {
-        const onlyLoadedIds = Array.from(ids);
+        const onlyLoadedIds = Array.from(ids).filter((id) => this.state.items.has(id));
 
         let promise: Promise<IState<T>['items']> = Promise.resolve(this.state.items);
 

--- a/scripts/core/itemList/LazyLoader.tsx
+++ b/scripts/core/itemList/LazyLoader.tsx
@@ -49,13 +49,41 @@ export class LazyLoader<T> extends React.Component<IProps<T>, IState<T>> {
         this.updateItems = this.updateItems.bind(this);
     }
 
+    /**
+     * Items that are about to be updated need to be removed and updated items added at the same index
+     * because items use ITrackById as their ID, and ITrackById changes on every update
+     */
     public updateItems(ids: Set<string>): void {
-        const {items} = this.state;
-        const onlyLoadedIds = Array.from(ids).filter((id) => items.has(id));
+        const onlyLoadedIds = Array.from(ids);
 
-        this.props.getItemsByIds(onlyLoadedIds).then((updates) => {
+        let promise: Promise<IState<T>['items']> = Promise.resolve(this.state.items);
+
+        /**
+         * Chaining required in order to be able to apply updates one by one.
+         * Doing it one by one is required in order to be able to insert updated item at the same index.
+         * Since ITrackById changes on every update, it would otherwise be hard to determine
+         * which old item the new item is supposed to replace.
+         */
+        for (const id of Array.from(onlyLoadedIds)) {
+            promise = promise.then((items) => {
+                return this.props.getItemsByIds([id]).then((updates) => {
+                    const item = items.get(id);
+                    const index = items.toIndexedSeq().indexOf(item);
+
+                    const start = items.slice(0, index);
+                    const end = items.slice(index + 1, items.size);
+                    //                            ^ removing item at index
+
+                    const next = start.concat(updates).concat(end).toOrderedMap();
+
+                    return next;
+                });
+            });
+        }
+
+        promise.then((next) => {
             this.setState({
-                items: items.merge(updates),
+                items: next,
             });
         });
     }


### PR DESCRIPTION
SDESK-6157

There might be cases when the list would end up out of sync.

Known issues:
* ~When highlighted item is published, highlights is not updated. There are no WS messages to listen for updating this, unless we update all highlights lists when any item is published, no matter highlighted or not.~ Highlighted items do not lose the highlight after publishing - they stay in the list, so it's not a problem that the list is not getting updated. (individual item does get updated via a different WS notification)
* ~When item is opened from highlights the, the view [blinks briefly](https://user-images.githubusercontent.com/2076953/131481449-306bffea-01b1-4f53-a496-330ce0a84b3f.gif)~ **(fixed with d1259f7)**
