### PR TITLE
[SDESK-6206] Support storing cookies from server requests

### DIFF
--- a/scripts/core/helpers/network.tsx
+++ b/scripts/core/helpers/network.tsx
@@ -48,6 +48,7 @@ function httpRequestBase(options: IHttpRequestOptions): Promise<Response> {
         method,
         headers: headers || {},
         mode: 'cors',
+        credentials: 'include',
         body: JSON.stringify(payload || undefined), // works when `payload` is `undefined`
         signal: abortSignal,
     });


### PR DESCRIPTION
Using `credentials: 'include'` is required for cookies to be stored
Otherwise the browser denies to store the cookie from the request's response