### PR TITLE
[SDESK-6201] Fix sticky toolbar requiring a second render of Editor3Component`

### DIFF
--- a/scripts/core/editor3/components/Editor3Component.tsx
+++ b/scripts/core/editor3/components/Editor3Component.tsx
@@ -160,7 +160,11 @@ export class Editor3Component extends React.Component<IProps, IState> {
     static defaultProps: any;
 
     editorKey: any;
-    editorNode: any;
+
+    // Use an object otherwise a second render will be required after mounting
+    // to use this reference in a render property to a component.
+    editorNode: React.MutableRefObject<HTMLDivElement>;
+
     div: any;
     editor: any;
     spellcheckCancelFn: () => void;
@@ -171,7 +175,7 @@ export class Editor3Component extends React.Component<IProps, IState> {
         super(props);
 
         this.editorKey = null;
-        this.editorNode = undefined;
+        this.editorNode = React.createRef();
 
         this.focus = this.focus.bind(this);
         this.onDragOver = this.onDragOver.bind(this);
@@ -490,7 +494,9 @@ export class Editor3Component extends React.Component<IProps, IState> {
         this.editorKey = this.editor === null ? null : this.editor._editorKey;
 
         // eslint-disable-next-line react/no-find-dom-node
-        this.editorNode = this.editor === null ? undefined : ReactDOM.findDOMNode(this.editor);
+        this.editorNode.current = this.editor === null ?
+            undefined :
+            ReactDOM.findDOMNode(this.editor) as HTMLDivElement;
     }
 
     componentWillUnmount() {
@@ -607,8 +613,8 @@ export class Editor3Component extends React.Component<IProps, IState> {
 
                             const selectionRect = getVisibleSelectionRect(window);
 
-                            if (this.editorNode != null && selectionRect != null) {
-                                this.editorNode.dataset.editorSelectionRect = JSON.stringify(selectionRect);
+                            if (this.editorNode?.current != null && selectionRect != null) {
+                                this.editorNode.current.dataset.editorSelectionRect = JSON.stringify(selectionRect);
                             }
 
                             onChange(editorStateNext);

--- a/scripts/core/editor3/components/HighlightsPopup.tsx
+++ b/scripts/core/editor3/components/HighlightsPopup.tsx
@@ -101,7 +101,7 @@ export class HighlightsPopup extends React.Component<any, any> {
                     annotation={h}
                     highlightId={highlightId}
                     highlightsManager={this.props.highlightsManager}
-                    editorNode={this.props.editorNode}
+                    editorNode={this.props.editorNode.current}
                     close={() => this.unmountCustom()}
                 />
             );
@@ -113,14 +113,14 @@ export class HighlightsPopup extends React.Component<any, any> {
                     highlightsManager={this.props.highlightsManager}
                     onChange={this.props.onChange}
                     editorState={this.props.editorState}
-                    editorNode={this.props.editorNode}
+                    editorNode={this.props.editorNode.current}
                 />
             );
         } else if (getSuggestionsTypes().indexOf(type) !== -1) {
             return (
                 <SuggestionPopup
                     suggestion={h}
-                    editorNode={this.props.editorNode}
+                    editorNode={this.props.editorNode.current}
                 />
             );
         } else {
@@ -185,7 +185,7 @@ export class HighlightsPopup extends React.Component<any, any> {
         const t = $(e.target);
         const {editorNode} = this.props;
         const onPopup = t.closest('.editor-popup').length || t.closest('.mentions-input__suggestions').length;
-        const onEditor = t.closest(editorNode).length;
+        const onEditor = t.closest(editorNode.current).length;
         const onModal = t.closest('.modal__dialog');
 
         if (!onPopup && !onEditor && !onModal) {

--- a/scripts/core/editor3/components/toolbar/index.tsx
+++ b/scripts/core/editor3/components/toolbar/index.tsx
@@ -41,7 +41,6 @@ class ToolbarComponent extends React.Component<any, IState> {
     constructor(props) {
         super(props);
 
-        this.scrollContainer = $(props.scrollContainer || window);
         this.onScroll = this.onScroll.bind(this);
 
         this.computeState = this.computeState.bind(this);
@@ -57,11 +56,11 @@ class ToolbarComponent extends React.Component<any, IState> {
             width: 'auto',
         };
 
-        if (!this.props.editorNode || !this.toolbarNode) {
+        if (!this.props.editorNode?.current || !this.toolbarNode.current) {
             return defaultState;
         }
 
-        const editorRect = this.props.editorNode.getBoundingClientRect();
+        const editorRect = this.props.editorNode.current.getBoundingClientRect();
         const pageRect = this.scrollContainer[0].getBoundingClientRect();
 
         if (!editorRect || !pageRect) {
@@ -71,7 +70,7 @@ class ToolbarComponent extends React.Component<any, IState> {
         const isToolbarOut = editorRect.top < pageRect.top + 80;
         const isBottomOut = editorRect.bottom < pageRect.top + 70;
 
-        const isContentLarger = this.props.editorNode.clientHeight < this.toolbarNode.current.clientHeight;
+        const isContentLarger = this.props.editorNode.current.clientHeight < this.toolbarNode.current.clientHeight;
 
         const floating = !isContentLarger && isToolbarOut && !isBottomOut;
         const width = floating ? editorRect.width : 'auto';
@@ -126,6 +125,7 @@ class ToolbarComponent extends React.Component<any, IState> {
     }
 
     componentDidMount() {
+        this.scrollContainer = $(this.props.scrollContainer || window);
         this.scrollContainer.on('scroll', this.onScroll);
     }
 


### PR DESCRIPTION
Otherwise the `editorNode` prop in `ToolbarComponent.computeState` will be undefined on first render