### PR TITLE
FIX: original metadata cv should be visible in header fields instead of the content field while adding fields in the content profile

### DIFF
--- a/scripts/apps/authoring/metadata/metadata.ts
+++ b/scripts/apps/authoring/metadata/metadata.ts
@@ -1330,8 +1330,7 @@ export function MetadataService(api, subscribersService, vocabularies, $rootScop
         getAllCustomVocabulariesForArticleHeader: function(editor, schema) {
             return this.fetchMetadataValues().then(() => {
                 const customVocabulariesForArticleHeader = this.cvs.filter(
-                    (cv) => (cv.items.length || cv.field_type == null) &&
-                        cv.service && (editor[cv._id] || schema[cv._id]),
+                    (cv) => cv.field_type == null && cv.service && (editor[cv._id] || schema[cv._id]),
                 );
 
                 const customTextAndDateVocabularies = this.cvs.filter(


### PR DESCRIPTION
Related to SDBELGA-555