### PR TITLE
fix manual refresh v2

### DIFF
--- a/scripts/apps/monitoring/directives/MonitoringGroup.ts
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.ts
@@ -5,9 +5,10 @@ import {GET_LABEL_MAP, getLabelForStage} from '../../workspace/content/constants
 import {isPublished} from 'apps/archive/utils';
 import {AuthoringWorkspaceService} from 'apps/authoring/authoring/services/AuthoringWorkspaceService';
 import {DESK_OUTPUT} from 'apps/desks/constants';
-import {appConfig, extensions} from 'appConfig';
+import {appConfig} from 'appConfig';
 import {IMonitoringFilter, IRestApiResponse, IArticle} from 'superdesk-api';
 import {getExtensionSections} from '../services/CardsService';
+import {showRefresh} from 'apps/search/services/SearchService';
 
 function translateCustomSorts(customSorts: GroupSortOptions) {
     const translated = {};
@@ -518,21 +519,6 @@ export function MonitoringGroup(
                 return items;
             }
 
-            // Determine if item is previewing for its respective view type.
-            function isItemPreviewing() {
-                if (scope.group.type === 'spike') {
-                    return monitoring.previewItem &&
-                        monitoring.previewItem.task.desk === scope.group._id;
-                } else if (scope.group.type === 'highlights') {
-                    return monitoring.previewItem &&
-                        _.includes(monitoring.previewItem.highlights, monitoring.queryParam.highlight);
-                } else if (scope.group.type === 'search') {
-                    return !!monitoring.previewItem;
-                }
-
-                return monitoring.previewItem && monitoring.previewItem.task.stage === scope.group._id;
-            }
-
             function queryItems(event?, data?, params?) {
                 var originalQuery;
 
@@ -627,16 +613,10 @@ export function MonitoringGroup(
                         }
 
                         if (!scope.showRefresh && data && !data.force && data.user !== session.identity._id) {
-                            var itemPreviewing = isItemPreviewing();
-
-                            var _data = {
-                                newItems: items,
-                                scopeItems: scopeItemsSaved,
-                                scrollTop: containerElem.scrollTop(),
-                                isItemPreviewing: itemPreviewing,
-                            };
-
-                            monitoring.showRefresh = scope.showRefresh = search.canShowRefresh(_data);
+                            monitoring.showRefresh = scope.showRefresh = showRefresh(
+                                (scopeItemsSaved?._items ?? []),
+                                items._items,
+                            );
                         }
 
                         if (!scope.showRefresh || data && data.force) {

--- a/scripts/apps/search/directives/SearchResults.ts
+++ b/scripts/apps/search/directives/SearchResults.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import {gettext} from 'core/utils';
 import {appConfig} from 'appConfig';
-import {ISearchOptions} from '../services/SearchService';
+import {ISearchOptions, showRefresh} from '../services/SearchService';
 import {IPackagesService} from 'types/Services/Packages';
 
 SearchResults.$inject = [
@@ -246,7 +246,7 @@ export function SearchResults(
                             isItemPreviewing: !!scope.selected.preview,
                         };
 
-                        scope.showRefresh = search.canShowRefresh(_data);
+                        scope.showRefresh = showRefresh((scope.items?._items ?? []), items._items);
                     }
 
                     if (!scope.showRefresh || data && data.force) {

--- a/scripts/apps/search/services/SearchService.ts
+++ b/scripts/apps/search/services/SearchService.ts
@@ -91,6 +91,10 @@ export function generateTrackByIdentifier(
  * It is shown if items are added/removed or order has changed.
  */
 export function showRefresh(currentItems: Array<IArticle>, newItems: Array<IArticle>) {
+    if (newItems.length !== currentItems?.length) {
+        return true;
+    }
+
     for (let i = 0; i < newItems.length; i++) {
         const _new = newItems[i];
         const _current = currentItems[i];

--- a/scripts/apps/search/services/SearchService.ts
+++ b/scripts/apps/search/services/SearchService.ts
@@ -90,7 +90,7 @@ export function generateTrackByIdentifier(
  * Determine if refresh button needs to be shown.
  * It is shown if items are added/removed or order has changed.
  */
-export function showRefresh(currentItems: Array<IArticle>, newItems: Array<IArticle>) {
+export function showRefresh(currentItems: Array<IArticle> | null, newItems: Array<IArticle>) {
     if (newItems.length !== currentItems?.length) {
         return true;
     }

--- a/scripts/apps/search/services/SearchService.ts
+++ b/scripts/apps/search/services/SearchService.ts
@@ -87,6 +87,23 @@ export function generateTrackByIdentifier(
 }
 
 /**
+ * Determine if refresh button needs to be shown.
+ * It is shown if items are added/removed or order has changed.
+ */
+export function showRefresh(currentItems: Array<IArticle>, newItems: Array<IArticle>) {
+    for (let i = 0; i < newItems.length; i++) {
+        const _new = newItems[i];
+        const _current = currentItems[i];
+
+        if (_new._id !== _current?._id) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
  * @ngdoc service
  * @module superdesk.apps.search
  * @name search
@@ -693,32 +710,6 @@ export function SearchService($location, session, multi,
             return !_.find(b._items, {_id: item._id});
         });
     }
-
-    /*
-     * To determine if refresh button needs to be shown, i-e:
-     * when any difference found in scopeItems and recently fetched newItems
-     *
-     * @param {Object} data - {newItems, scopeItems, scrollTop, isItemPreviewing}
-     */
-    this.canShowRefresh = function(data) {
-        var _showRefresh, diff = [];
-
-        if (data.scopeItems) {
-            // determine if items are different (in terms of added or removed) in scope items from
-            // fetched new items or vice versa.
-            diff = compareWith(data.scopeItems, data.newItems);
-            if (_.isEmpty(diff)) {
-                diff = compareWith(data.newItems, data.scopeItems);
-            }
-        }
-
-        if (!_.isEmpty(diff)) {
-            // if different, then determine _showReferesh, such that, if item is previewing or scroll in not on top.
-            _showRefresh = data.isItemPreviewing || !!data.scrollTop;
-        }
-
-        return _showRefresh;
-    };
 
     /**
      * @ngdoc method

--- a/scripts/apps/search/tests/search.spec.ts
+++ b/scripts/apps/search/tests/search.spec.ts
@@ -168,35 +168,6 @@ describe('search service', () => {
         expect(nextItems._items[0].slugline).toBe('slugline updated');
     }));
 
-    it('can evalute canShowRefresh for refresh button display', inject((search) => {
-        var newItems, scopeItems, scrollTop, isItemPreviewing, _data;
-
-        newItems = {_items: [{_id: 'foo', _current_version: 1}]};
-        scopeItems = {_items: [{_id: 'bar', _current_version: 1}]};
-        // consider item is not currently previewing but scroll is not on top.
-        scrollTop = 50;
-
-        _data = prepareData(newItems, scopeItems, scrollTop, isItemPreviewing);
-        expect(search.canShowRefresh(_data)).toBe(true);
-
-        // consider published item ids are same, but version is different as in case of take/update.
-        newItems = {_items: [{_id: 'foo', _current_version: 1, _type: 'published'}]};
-        scopeItems = {_items: [{_id: 'foo', _current_version: 2, _type: 'published'}]};
-        // consider scroll on Top but item is currently previewing.
-        scrollTop = 0;
-        isItemPreviewing = true;
-
-        _data = prepareData(newItems, scopeItems, scrollTop, isItemPreviewing);
-        expect(search.canShowRefresh(_data)).toBe(true);
-
-        // consider newItems and scopeItems are same and scroll is on top and no item is currently previewing.
-        newItems = {_items: [{_id: 'foo', _current_version: 1}]};
-        scopeItems = {_items: [{_id: 'foo', _current_version: 1}]};
-
-        _data = prepareData(newItems, scopeItems, scrollTop, isItemPreviewing);
-        expect(search.canShowRefresh(_data)).toBe(undefined);
-    }));
-
     it('can create query for notdesk facet', inject(($rootScope, search, session) => {
         // only to desk is specified
         session.identity = {_id: 'foo'};
@@ -228,15 +199,6 @@ describe('search service', () => {
 
         expect(criteria.query.filtered.query.query_string.query).toBe('(item5) AND (item3 OR item4)');
     }));
-
-    function prepareData(newItems, scopeItems, scrollTop, isItemPreviewing) {
-        return {
-            newItems: newItems,
-            scopeItems: scopeItems,
-            scrollTop: scrollTop,
-            isItemPreviewing: isItemPreviewing,
-        };
-    }
 
     describe('multi action bar directive', () => {
         var scope;


### PR DESCRIPTION
SDESK-6314

Simplified logic. If the config is enabled, it will now always show refresh button if items were added, removed or updated in a way that caused order of items to change. Scroll position or user session will no longer affect the feature.