### PR TITLE
manual refresh fix v4 - reset page size to default

### DIFF
--- a/scripts/apps/monitoring/directives/MonitoringGroup.ts
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.ts
@@ -631,6 +631,9 @@ export function MonitoringGroup(
                             // update scope items only with the matching fetched items
                             scope.items = search.updateItems(items, scopeItemsSaved);
                         }
+                    }).finally(() => {
+                        // reset page size to default
+                        criteria.source.size = PAGE_SIZE;
                     });
             }
 

--- a/scripts/apps/monitoring/directives/MonitoringGroup.ts
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.ts
@@ -678,7 +678,7 @@ export function MonitoringGroup(
                 })()
                     .then((items) => {
                         scope.$applyAsync(() => {
-                            if (scope.total !== items._meta.total) {
+                            if (!scope.showRefresh && scope.total !== items._meta.total) {
                                 scope.total = items._meta.total;
                             }
                             let onlyHighlighted = scope.group.type === 'highlights'


### PR DESCRIPTION
SDESK-6314

Addresses a bug with page size. To reproduce the bug:
* open any monitoring stage with >100 items
* load more items by pressing "end" button on a keyboard when stage is focused
* log in with a second user and spike one item from that stage
* using the main user, scroll one page more
If you look at HTTP requests being made, page size will now be equal to number of items already loaded, not the default 25