### PR TITLE
Filter out items in personal space except for current user

### DIFF
--- a/scripts/apps/search/services/SearchService.ts
+++ b/scripts/apps/search/services/SearchService.ts
@@ -668,13 +668,16 @@ export function SearchService($location, session, multi,
         }
 
         /**
-         * Filter out items in personal space except for current user
+         * Filter out personal items that don't belong to current user.
          */
         this.filter({
-            or: [
-                {exists: {field: 'task.desk'}},
-                {term: {'task.user': session.identity._id}},
-            ],
+            not: {
+                and: [ // matches personal items that belong to other users
+                    {not: {exists: {field: 'task.desk'}}},
+                    {exists: {field: 'task.user'}},
+                    {not: {term: {'task.user': session.identity._id}}},
+                ],
+            },
         });
 
         // this is needed for archived collection

--- a/scripts/apps/search/services/SearchService.ts
+++ b/scripts/apps/search/services/SearchService.ts
@@ -667,10 +667,20 @@ export function SearchService($location, session, multi,
             this.filter({not: {term: {state: 'scheduled'}}});
         }
 
-        // remove other users drafts.
-        this.filter({or: [{and: [{term: {state: 'draft'}},
-            {term: {original_creator: session.identity._id}}]},
-        {not: {terms: {state: ['draft']}}}]});
+        /**
+         * Filter out items in personal space except for current user
+         */
+        this.filter({
+            or: [
+                {
+                    and: [
+                        {exists: {field: 'task.desk'}},
+                        {term: {original_creator: session.identity._id}},
+                    ],
+                },
+                {not: {exists: {field: 'task.desk'}}},
+            ],
+        });
 
         // this is needed for archived collection
         this.filter({not: {term: {package_type: 'takes'}}});

--- a/scripts/apps/search/services/SearchService.ts
+++ b/scripts/apps/search/services/SearchService.ts
@@ -672,13 +672,8 @@ export function SearchService($location, session, multi,
          */
         this.filter({
             or: [
-                {
-                    and: [
-                        {exists: {field: 'task.desk'}},
-                        {term: {original_creator: session.identity._id}},
-                    ],
-                },
-                {not: {exists: {field: 'task.desk'}}},
+                {exists: {field: 'task.desk'}},
+                {term: {'task.user': session.identity._id}},
             ],
         });
 


### PR DESCRIPTION
SDBELGA-610

It only used to filter out items with status draft which didn't work when "in progress" items were duplicated to personal space.