### PR TITLE
manual refresh fixes

### DIFF
--- a/scripts/appConfig.ts
+++ b/scripts/appConfig.ts
@@ -19,6 +19,14 @@ if (appConfig.ui == null) {
     }
 }
 
+if (appConfig.features == null) {
+    appConfig.features = {};
+}
+
+if (appConfig.features.autorefreshContent == null) {
+    appConfig.features.autorefreshContent = true; // default to true
+}
+
 export const dashboardRoute = '/workspace';
 export const IDENTITY_KEY = 'sess:user';
 

--- a/scripts/apps/monitoring/directives/MonitoringGroup.ts
+++ b/scripts/apps/monitoring/directives/MonitoringGroup.ts
@@ -360,7 +360,14 @@ export function MonitoringGroup(
             });
 
             // refreshes the list for matching group or view type only or if swimlane view is ON.
-            scope.$on('refresh:list', (event, group) => {
+            scope.$on('refresh:list', (event, group, options) => {
+                /**
+                 * When manual refreshing is enabled, scrolling should not automatically refresh the list.
+                 */
+                if (scope.showRefresh === true && options.event_origin === 'scroll') {
+                    return;
+                }
+
                 const currentScope: IScope = event.currentScope as IScope;
                 const _viewType = currentScope.viewType || '';
                 const viewTypeMatches = [

--- a/scripts/apps/search/directives/ItemList.tsx
+++ b/scripts/apps/search/directives/ItemList.tsx
@@ -320,7 +320,7 @@ export function ItemList(
                         .some((item) => item.selected === true);
 
                     if (elem[0].scrollTop === 0 && !multiSelectInProgress) {
-                        $rootScope.$broadcast('refresh:list', scope.group);
+                        $rootScope.$broadcast('refresh:list', scope.group, {event_origin: 'scroll'});
                     }
 
                     if (scope.rendering) { // ignore


### PR DESCRIPTION
SDESK-6314

* `autorefreshContent` now defaults to `true`
* if automatic refresh is disabled and refresh button is visible in the UI, scrolling should not trigger an automatic refresh

needs to be merged to `release/2.4`