### PR TITLE
[TGA-16] Ability to use template_url from transmitter config

### DIFF
--- a/scripts/apps/publish/services/AdminPublishSettingsService.ts
+++ b/scripts/apps/publish/services/AdminPublishSettingsService.ts
@@ -15,7 +15,9 @@ export function AdminPublishSettingsService(api) {
             return _fetch('io_errors', criteria);
         },
         registerTransmissionService: function(name, props) {
-            const templateUrl = transmissionTypes[name] != null ? transmissionTypes[name].templateUrl : '';
+            const templateUrl = transmissionTypes[name] != null ?
+                transmissionTypes[name].templateUrl :
+                props.templateUrl || '';
 
             this.transmissionServicesMap[name] = {
                 delivery_type: name,
@@ -35,6 +37,7 @@ export function AdminPublishSettingsService(api) {
         service.registerTransmissionService(data.type, {
             label: data.name,
             config: data.config,
+            templateUrl: data.template_url || '',
         });
     });
 

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -2092,6 +2092,7 @@ declare module 'superdesk-api' {
             type: string;
             name: string;
             config: any;
+            template_url?: string;
         }>;
 
         userOnlineMinutes: number;


### PR DESCRIPTION
Making this change minimal, as it's for a 2.4.1 release.
In 2.5.0 we should implement the SuperdeskAPI interface to allow extending the transmitters etc through extensions