### PR TITLE
fix patch-package main directory resolution

### DIFF
--- a/tasks/patch-package.js
+++ b/tasks/patch-package.js
@@ -20,7 +20,7 @@ function copyFolderSync(from, to) {
 let copied = false;
 
 const clientCoreRoot = path.join(__dirname, '../');
-const maybeParentModulePath = path.join(clientCoreRoot, '../../');
+const maybeParentModulePath = process.cwd();
 
 // If node_modules exists in `maybeParentModulePath` set it as mainDirectory where patches will be put
 const mainDirectory = fs.existsSync(path.join(maybeParentModulePath, 'node_modules'))


### PR DESCRIPTION
it was going into my home due to some assumptions about
node_modules and parent directory, imo it will be more reliable
to start with working directory from which the script is called.