### PR TITLE
fix clearing spellchecker stores

### DIFF
--- a/scripts/core/editor3/directive.tsx
+++ b/scripts/core/editor3/directive.tsx
@@ -378,12 +378,12 @@ class Editor3Directive {
                 };
 
                 // Expose the store in the editor3 spellchecker service
-                const storeIndex = editor3.addSpellcheckerStore(store, this.pathToValue);
+                editor3.addSpellcheckerStore(store, this.pathToValue);
 
                 initListeners();
 
                 $scope.$on('$destroy', () => {
-                    editor3.removeSpellcheckerStore(storeIndex);
+                    editor3.removeAllSpellcheckerStores();
                     removeListeners();
                 });
 

--- a/scripts/core/editor3/service.ts
+++ b/scripts/core/editor3/service.ts
@@ -19,7 +19,7 @@ let store = null;
  * if they are spellchecker targets
  * @private
  */
-const spellcheckerStores = [];
+let spellcheckerStores = [];
 
 /**
  * @ngdoc service
@@ -76,14 +76,8 @@ export class EditorService {
         store = null;
     }
 
-    /**
-     * @ngdoc method
-     * @name editor3#removeSpellcheckerStore
-     * @param {Integer}
-     * @description Clears a spellchecker store
-     */
-    removeSpellcheckerStore(i) {
-        spellcheckerStores.slice(i, 1);
+    removeAllSpellcheckerStores() {
+        spellcheckerStores = [];
     }
 
     /**


### PR DESCRIPTION
SDBELGA-658

Spellchecker stores from multiple articles were present at once which in turn caused overwriting of unrelated articles after running certain macros(where macro.replace_type === 'editor_state')