### PR TITLE
fix signoff don't display the value and the read only input

### DIFF
--- a/scripts/apps/authoring/views/article-edit.html
+++ b/scripts/apps/authoring/views/article-edit.html
@@ -585,7 +585,7 @@
            id="sign_off"
            ng-model="item.sign_off"
            ng-change="autosave(item)"
-           ng-disabled="!editSignOff"
+           ng-show="editSignOff"
            placeholder="Sign off"
            sd-focus-element
            data-append-element=".field"


### PR DESCRIPTION
Seems it currently displayes both the value as well as the readonly input item. So this should display the value only when locked and the input item when unlocked. 