### PR TITLE
fix custom datetime field showing previous date

### DIFF
--- a/scripts/extensions/datetimeField/src/getDateTimeField.tsx
+++ b/scripts/extensions/datetimeField/src/getDateTimeField.tsx
@@ -42,10 +42,7 @@ export function getDateTimeField(superdesk: ISuperdesk) {
                 );
             } else {
                 const date = new Date(this.props.value);
-
-                const day = format(date, 'yyyy-MM-dd'); // ISO8601
                 const hour = format(date, 'HH:mm'); // ISO8601
-
                 const steps = this.props.config?.increment_steps ?? [];
 
                 // Get the DatePicker locale using the language of this item
@@ -60,7 +57,7 @@ export function getDateTimeField(superdesk: ISuperdesk) {
                             <DatePickerISO
                                 dateFormat={superdesk.instance.config.view.dateformat}
                                 locale={datePickerLocale}
-                                value={day}
+                                value={this.props.value} // we have to pass the full datetime here so the component knows the timezone
                                 onChange={(dateString) => {
                                     if (dateString === '') {
                                         this.props.setValue(null);

--- a/scripts/extensions/datetimeField/src/getDateTimeField.tsx
+++ b/scripts/extensions/datetimeField/src/getDateTimeField.tsx
@@ -57,7 +57,7 @@ export function getDateTimeField(superdesk: ISuperdesk) {
                             <DatePickerISO
                                 dateFormat={superdesk.instance.config.view.dateformat}
                                 locale={datePickerLocale}
-                                value={this.props.value} // we have to pass the full datetime here so the component knows the timezone
+                                value={this.props.value} // must be full datetime here to avoid timezone conversion
                                 onChange={(dateString) => {
                                     if (dateString === '') {
                                         this.props.setValue(null);


### PR DESCRIPTION
it was happening for timezones with negative utc offset, there `new Date("2022-12-07")` would become previous day in the local timezone, now it's parsing the full datetime so there is no conversion happening.

SDESK-6712