### PR TITLE
[SDESK-6847] fix: Update moment and use newer timezone file for webpack alias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -371,24 +371,6 @@
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
-    "@types/moment": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.13.0.tgz",
-      "integrity": "sha512-DyuyYGpV6r+4Z1bUznLi/Y7HpGn4iQ4IVcGn8zrr1P4KotKLdH0sbK1TFR6RGyX6B+G8u83wCzL+bpawKU/hdQ==",
-      "dev": true,
-      "requires": {
-        "moment": "*"
-      }
-    },
-    "@types/moment-timezone": {
-      "version": "0.5.30",
-      "resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.5.30.tgz",
-      "integrity": "sha512-aDVfCsjYnAQaV/E9Qc24C5Njx1CoDjXsEgkxtp9NyXDpYu4CCbmclb6QhWloS9UTU/8YROUEEdEkWI0D7DxnKg==",
-      "dev": true,
-      "requires": {
-        "moment-timezone": "*"
-      }
-    },
     "@types/node": {
       "version": "15.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
@@ -10916,16 +10898,16 @@
       }
     },
     "moment": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moment-timezone": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
-      "integrity": "sha512-4RkNPVuQ/ClAXqd3T+tkBy85tEUxnNNIaG4hbviFp7vZ2hRY0mjHGRIWG/NdkUzSaH36nchdBXyvPwrODjPzUA==",
+      "version": "0.5.41",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.41.tgz",
+      "integrity": "sha512-e0jGNZDOHfBXJGz8vR/sIMXvBIGJJcqFjmlg9lmE+5KX1U7/RZNMswfD8nKnNCnQdKTIj50IaRKwl1fvMLyyRg==",
       "requires": {
-        "moment": ">= 2.9.0"
+        "moment": "^2.29.4"
       }
     },
     "moo": {

--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
     "medium-editor": "5.23.3",
     "medium-editor-tables": "0.6.1",
     "ment.io": "0.9.23",
-    "moment": "2.20.1",
-    "moment-timezone": "0.5.14",
+    "moment": "2.29.4",
+    "moment-timezone": "0.5.41",
     "ng-file-upload": "12.2.13",
     "node-sass": "4.14.0",
     "owl.carousel": "2.2.0",
@@ -131,8 +131,6 @@
   "devDependencies": {
     "@superdesk/build-tools": "file:build-tools",
     "@types/classnames": "^2.2.10",
-    "@types/moment": "^2.13.0",
-    "@types/moment-timezone": "^0.5.13",
     "@types/webpack-env": "^1.17.0",
     "enzyme": "3.9.0",
     "enzyme-adapter-react-16": "^1.15.5",
@@ -151,7 +149,7 @@
     "typescript-eslint-parser": "^18.0.0"
   },
   "resolutions": {
-    "moment": "2.20.1"
+    "moment": "2.29.4"
   },
   "scripts": {
     "gettext-extract": "grunt gettext:extract",

--- a/scripts/core/datetime/datetime.ts
+++ b/scripts/core/datetime/datetime.ts
@@ -20,7 +20,7 @@ const SERVER_FORMAT = 'YYYY-MM-DDTHH:mm:ssZZ';
 *
 * @param {String} d iso format datetime
 */
-export function longFormat(d: string): string {
+export function longFormat(d: string | moment.Moment): string {
     return moment(d).format(LONG_FORMAT);
 }
 

--- a/scripts/core/get-superdesk-api-implementation.tsx
+++ b/scripts/core/get-superdesk-api-implementation.tsx
@@ -163,7 +163,7 @@ export function getRelativeOrAbsoluteDateTime(
     datetimeString: string,
     format: string,
     relativeDuration: number = 1,
-    relativeUnit: string = 'days',
+    relativeUnit: moment.unitOfTime.Diff = 'days',
 ): string {
     const datetime = moment(datetimeString);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,7 @@ module.exports = function makeConfig(grunt) {
                 'node_modules',
             ],
             alias: {
-                'moment-timezone': 'moment-timezone/builds/moment-timezone-with-data-2012-2022',
+                'moment-timezone': 'moment-timezone/builds/moment-timezone-with-data-10-year-range',
                 'rangy-saverestore': 'rangy/lib/rangy-selectionsaverestore',
                 'angular-embedly': 'angular-embedly/em-minified/angular-embedly.min',
                 'jquery-gridster': 'gridster/dist/jquery.gridster.min',


### PR DESCRIPTION
Looks like the timezone information was missing daylight savings changes for newer years. Types are also included in the moment packages directly now

Without these changes:
```ts
moment.tz('2022-06-02', 'Australia/Sydney').utcOffset() / 60 === 10
moment.tz('2023-06-02', 'Australia/Sydney').utcOffset() / 60 === 11
```

After these changes:
```ts
moment.tz('2022-06-02', 'Australia/Sydney').utcOffset() / 60 === 10
moment.tz('2023-06-02', 'Australia/Sydney').utcOffset() / 60 === 10
```