### PR TITLE
Add image suggestion feature to iMatrics widget (#4175)

### DIFF
--- a/scripts/core/get-superdesk-api-implementation.tsx
+++ b/scripts/core/get-superdesk-api-implementation.tsx
@@ -116,7 +116,32 @@ export const removeEventListener = <T extends keyof IEvents>(eventName: T, callb
     }
 };
 
-let applicationState: Writeable<ISuperdesk['state']> = {
+export const dispatchCustomEvent = <T extends keyof IEvents>(eventName: T, payload: IEvents[T]) => {
+    window.dispatchEvent(
+        new CustomEvent(getCustomEventNamePrefixed(eventName), {detail: payload}),
+    );
+};
+
+export function prepareExternalImageForDroppingToEditor(
+    event: DragEvent,
+    renditions: IArticle['renditions'],
+    additionalData?: Partial<IArticle>,
+) {
+    const item: Partial<IArticle> = {
+        _fetchable: false,
+        _type: 'externalsource',
+        ...(additionalData ?? {}),
+        type: 'picture',
+        renditions: renditions,
+    };
+
+    event.dataTransfer.setData(
+        'application/superdesk.item.picture',
+        JSON.stringify(item),
+    );
+}
+
+export let applicationState: Writeable<ISuperdesk['state']> = {
     articleInEditMode: undefined,
 };
 
@@ -281,6 +306,7 @@ export function getSuperdeskApiImplementation(
                 save: () => {
                     dispatchInternalEvent('saveArticleInEditMode', null);
                 },
+                prepareExternalImageForDroppingToEditor,
             },
             alert: (message: string) => modal.alert({bodyText: message}),
             confirm: (message: string, title?: string) => new Promise((resolve) => {

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -1401,10 +1401,16 @@ declare module 'superdesk-api' {
                 addImage(field: string, image: IArticle): void;
 
                 /**
-                 * Programatically triggers saving of an article in edit mode.
+                 * Programmatically triggers saving of an article in edit mode.
                  * Runs the same code as if "save" button was clicked manually.
                 */
                 save(): void;
+
+                prepareExternalImageForDroppingToEditor(
+                    event: DragEvent,
+                    renditions: IArticle['renditions'],
+                    additionalData?: Partial<IArticle>,
+                ): void;
             };
             alert(message: string): Promise<void>;
             confirm(message: string, title?: string): Promise<boolean>;

--- a/scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.tsx
+++ b/scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.tsx
@@ -1,0 +1,385 @@
+import * as React from 'react';
+import {IArticle, ISuperdesk} from 'superdesk-api';
+import {ITagUi} from '../types';
+import {OrderedMap} from 'immutable';
+import {IServerResponse, ITagBase, toServerFormat} from '../adapter';
+import {IconButton, Popover} from 'superdesk-ui-framework/react';
+import {debounce, noop} from 'lodash';
+import {ToggleBox} from './ToggleBoxBackport';
+
+interface ITagInput {
+    title: string;
+    type: string;
+    pubStatus: boolean;
+    weight: number;
+}
+
+interface IImage {
+    imageUrl: string;
+    thumbnailUrl: string;
+    id?: string;
+    headline?: string;
+    caption?: string;
+    credit?: string;
+    byline?: string;
+    source?: string;
+    dateCreated?: string;
+    archivedTime?: string;
+}
+
+interface IImageServerResponse {
+    result: Array<IImage>;
+}
+
+interface IProps {
+    data: OrderedMap<string, ITagUi>;
+    style?: React.CSSProperties;
+    article: IArticle;
+}
+
+interface IState {
+    isLoading: boolean;
+    selectedImage: IImage | null;
+    images: Array<IImage>;
+}
+
+export function getImageTaggingComponent(superdesk: ISuperdesk) {
+    const {httpRequestJsonLocal} = superdesk;
+    const {gettext} = superdesk.localization;
+    const gridContainerStyle: React.CSSProperties = {
+        display: 'grid',
+        gridTemplateColumns: '3fr 1fr',
+        gridColumnGap: '4px',
+        maxHeight: '320px',
+        overflow: 'hidden',
+    };
+
+    const gridItemLeftStyle: React.CSSProperties = {
+        width: '100%',
+        height: '100%',
+        maxHeight: 'inherit',
+    };
+
+    const gridItemRightStyle: React.CSSProperties = {
+        width: '100%',
+        height: '100%',
+        maxHeight: 'inherit',
+    };
+
+    const imageContentStyle: React.CSSProperties = {
+        width: '100%',
+        maxHeight: 'inherit',
+        overflowY: 'auto',
+        display: 'grid',
+        gridRowGap: '4px',
+    };
+
+    const figCaptionStyle: React.CSSProperties = {
+        padding: '4px',
+        overflow: 'auto',
+        color: '#000',
+        backgroundColor: 'rgba(255,255,255,0.75)',
+        height: '100%',
+    };
+
+    const imageStyle: React.CSSProperties = {
+        width: '100%',
+        height: 'auto',
+        cursor: 'grab',
+    };
+
+    const imageWrapperStyle: React.CSSProperties = {
+        cursor: 'pointer',
+        maxHeight: '100%',
+    };
+
+    const selectedCardStyle: React.CSSProperties = {
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        overflow: 'hidden',
+        boxShadow: '1px 3px 6px 0 rgba(0,0,0,0.2)',
+        width: '100%',
+        borderRadius: '4px',
+    };
+
+    const cardStyle: React.CSSProperties = {
+        boxShadow: '1px 3px 6px 0 rgba(0,0,0,0.2)',
+        width: '100%',
+        borderRadius: '2px',
+    };
+
+    const prepareForDropping = (
+        event: React.DragEvent<HTMLImageElement>,
+        image: IImage | null,
+    ) => {
+        if (image == null) {
+            return;
+        }
+
+        const additionalData: Partial<IArticle> = {};
+
+        if ((image.caption?.length ?? 0) > 0) {
+            additionalData.description_text = image.caption;
+        }
+
+        if ((image.headline?.length ?? 0) > 0) {
+            additionalData.headline = image.headline;
+        }
+
+        if ((image.source?.length ?? 0) > 0) {
+            additionalData.source = image.source;
+        }
+
+        if ((image.byline?.length ?? 0) > 0) {
+            additionalData.byline = image.byline;
+        }
+
+        superdesk.ui.article.prepareExternalImageForDroppingToEditor(
+            event.nativeEvent,
+            {
+                thumbnail: {
+                    href: image.thumbnailUrl,
+                    mimetype: 'image/jpeg',
+                },
+                viewImage: {
+                    href: image.imageUrl,
+                    mimetype: 'image/jpeg',
+                },
+                baseImage: {
+                    href: image.imageUrl,
+                    mimetype: 'image/jpeg',
+                },
+            },
+            additionalData,
+        );
+    };
+
+    return class ImageTagging extends React.PureComponent<IProps, IState> {
+        private abortController: AbortController;
+        private debouncedFetch;
+
+        constructor(props: IProps) {
+            super(props);
+
+            this.state = {
+                isLoading: false,
+                selectedImage: null,
+                images: [],
+            };
+            this.abortController = new AbortController();
+            this.debouncedFetch = debounce(() => {
+                this.runFetchImages();
+            }, 1500);
+            this.runFetchImages = this.runFetchImages.bind(this);
+            this.formatTags = this.formatTags.bind(this);
+            this.handleClickImage = this.handleClickImage.bind(this);
+        }
+
+        componentDidMount() {
+            this.runFetchImages();
+        }
+
+        componentWillUnmount() {
+            this.abortController.abort();
+            this.debouncedFetch.cancel();
+        }
+
+        componentDidUpdate(prevProps: IProps) {
+            if (this.props.data !== prevProps.data) {
+                this.debouncedFetch();
+            }
+        }
+
+        runFetchImages() {
+            const formattedTags: Array<ITagInput> = this.formatTags(
+                toServerFormat(this.props.data, superdesk),
+            );
+
+            if ((formattedTags?.length ?? 0) < 1) {
+                this.setState({
+                    selectedImage: null,
+                    images: [],
+                });
+
+                return;
+            }
+
+            this.setState({isLoading: true}, () => {
+                httpRequestJsonLocal<IImageServerResponse>({
+                    abortSignal: this.abortController.signal,
+                    method: 'POST',
+                    path: '/ai_image_suggestions/',
+                    payload: {
+                        service: 'imatrics',
+                        items: formattedTags,
+                    },
+                })
+                    .then((res) => {
+                        this.setState({
+                            selectedImage: res.result[0] ?? null,
+                            images: res.result,
+                        });
+                    })
+                    .catch(() => {
+                        superdesk.ui.alert('Failed to fetch image suggestions. Please, try again!');
+                    })
+                    .finally(() => this.setState({isLoading: false}));
+            });
+        }
+
+        formatTags = (concepts: IServerResponse) => {
+            let res: Array<ITagInput> = [];
+
+            for (const key in concepts) {
+                if (key === 'subject') {
+                    concepts[key]?.forEach((concept: ITagBase) => {
+                        res.push({
+                            title: concept.name,
+                            type: 'category',
+                            pubStatus: true,
+                            weight: 1,
+                        });
+                    });
+                } else if (
+                    key === 'organisation' ||
+                    key === 'person' ||
+                    key === 'event' ||
+                    key === 'place' ||
+                    key === 'object'
+                ) {
+                    concepts[key]?.forEach((concept: ITagBase) => {
+                        res.push({
+                            title: concept.name,
+                            type: key,
+                            pubStatus: true,
+                            weight: 1,
+                        });
+                    });
+                }
+            }
+            return res;
+        }
+
+        handleClickImage = (image: IImage) => {
+            this.setState({selectedImage: image});
+        }
+
+        render() {
+            const {style} = this.props;
+            const {isLoading, selectedImage, images} = this.state;
+
+            return (
+                <ToggleBox
+                    className="toggle-box--circle"
+                    title={
+                        isLoading
+                            ? gettext('loading image suggestions...')
+                            : gettext('image suggestions ({{n}})', {n: images.length})
+                    }
+                    initiallyOpen={true}
+                    badge={(
+                        <IconButton
+                            id="image-suggestions-info-btn"
+                            icon="info-sign"
+                            size="small"
+                            ariaValue="info"
+                            onClick={noop}
+                        />
+                    )}
+                >
+                    <Popover
+                        title={gettext('Information')}
+                        placement="bottom-end"
+                        triggerSelector="#image-suggestions-info-btn"
+                        zIndex={999}
+                    >
+                        {gettext(
+                            'Image suggestions are based on generated tags'
+                            + ' and can be added to article content by dragging.',
+                        )}
+                    </Popover>
+
+                    <div style={style}>
+                        {(() => {
+                            if (isLoading) {
+                                return (
+                                    <div
+                                        style={{
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                        }}
+                                    >
+                                        <div className="spinner-big" />
+                                    </div>
+                                );
+                            } else if (images.length < 1) {
+                                return null;
+                            } else {
+                                return (
+                                    <div style={gridContainerStyle}>
+                                        <div style={gridItemLeftStyle}>
+                                            {selectedImage && (
+                                                <figure style={selectedCardStyle}>
+                                                    <div style={{maxHeight: '72%'}}>
+                                                        <img
+                                                            style={imageStyle}
+                                                            alt=""
+                                                            src={selectedImage.imageUrl}
+                                                            onDragStart={(event) =>
+                                                                prepareForDropping(
+                                                                    // types conflict likely because of react-bootstrap
+                                                                    event as unknown as any,
+                                                                    selectedImage,
+                                                                )
+                                                            }
+                                                        />
+                                                    </div>
+                                                    {selectedImage.caption && (
+                                                        <figcaption style={figCaptionStyle}>
+                                                            {selectedImage.caption}
+                                                        </figcaption>
+                                                    )}
+                                                </figure>
+                                            )}
+                                        </div>
+                                        <div style={gridItemRightStyle}>
+                                            <div style={imageContentStyle}>
+                                                {images.map((image, index) => (
+                                                    <div key={index} style={cardStyle}>
+                                                        <div
+                                                            style={
+                                                                imageWrapperStyle
+                                                            }
+                                                        >
+                                                            <img
+                                                                style={imageStyle}
+                                                                key={index}
+                                                                src={image.imageUrl}
+                                                                onClick={() => {
+                                                                    this.handleClickImage(image);
+                                                                }}
+                                                                onDragStart={(event) =>
+                                                                    prepareForDropping(
+                                                                        // types conflict likely because of
+                                                                        // react-bootstrap
+                                                                        event as unknown as any,
+                                                                        image,
+                                                                    )
+                                                                }
+                                                            />
+                                                        </div>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    </div>
+                                );
+                            }
+                        })()}
+                    </div>
+                </ToggleBox>
+            );
+        }
+    };
+}

--- a/scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ToggleBoxBackport.tsx
+++ b/scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ToggleBoxBackport.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import nextId from 'react-id-generator';
+
+interface IProps {
+    title: string;
+    badge?: JSX.Element;
+    children: any;
+    hideUsingCSS?: boolean;
+    initiallyOpen?: boolean; // defaults to false
+    className?: string;
+    margin?: 'none' | 'small' | 'normal' | 'large';
+    onOpen?(): void;
+    onClose?(): void;
+}
+
+interface IState {
+    isOpen: boolean;
+}
+
+/**
+ * @ngdoc react
+ * @name ToggleBox
+ * @description ToggleBox used to open/close a set of details
+ */
+
+export class ToggleBox extends React.PureComponent<IProps, IState> {
+    htmlId = nextId();
+    constructor(props: IProps) {
+        super(props);
+        this.state = {
+            isOpen: this.props.initiallyOpen ?? false,
+        };
+    }
+
+    handleKeyDown = (event: React.KeyboardEvent<HTMLAnchorElement>): void => {
+        if (event.key === 'ArrowRight' && !this.state.isOpen) {
+            this.setState({isOpen: true});
+        } else if (event.key === 'ArrowLeft' && this.state.isOpen) {
+            this.setState({isOpen: false});
+        } else if (event.key === 'Enter') {
+            this.toggle();
+        }
+    }
+
+    toggle = (): void => {
+        this.setState({isOpen: !this.state.isOpen}, () => {
+            if (!this.state.isOpen && this.props.onClose) {
+                this.props.onClose();
+            } else if (this.props.onOpen) {
+                this.props.onOpen();
+            }
+        });
+    }
+
+    render() {
+        let classes = classNames('toggle-box', {
+            'toggle-box--margin-normal': this.props.margin === undefined,
+            [`toggle-box--margin-${this.props.margin}`]: this.props.margin,
+            'hidden': !this.state.isOpen,
+        }, this.props.className);
+        const {title, hideUsingCSS, children, badge} = this.props;
+        const {isOpen} = this.state;
+
+        return (
+            <div
+                className={classes}
+            >
+                <a
+                    className="toggle-box__header"
+                    onClick={this.toggle}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={this.handleKeyDown}
+                    id={`togglebox-${this.htmlId}`}
+                >
+                    <div className="toggle-box__chevron">
+                        <i className="icon-chevron-right-thin" />
+                    </div>
+                    <div className="toggle-box__label">
+                        {title}
+                    </div>
+                    <div
+                        className="toggle-box__line"
+                    />
+                    {badge ? badge : null}
+                </a>
+                <div className="toggle-box__content-wraper">
+                    {isOpen && !hideUsingCSS && (
+                        <div className="toggle-box__content" aria-describedby={`togglebox-${this.htmlId}`}>
+                            {children}
+                        </div>
+                    )}
+
+                    {hideUsingCSS && (
+                        <div
+                            className={classNames(
+                                'toggle-box__content',
+                                {'toggle-box__content--hidden': !isOpen},
+                            )}
+                            aria-describedby={`togglebox-${this.htmlId}`}
+                        >
+                            {children}
+                        </div>
+                    )}
+                </div>
+            </div>
+        );
+    }
+}

--- a/scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx
+++ b/scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx
@@ -15,6 +15,8 @@ import {getAutoTaggingVocabularyLabels} from './common';
 import {getExistingTags, createTagsPatch} from './data-transformations';
 import {noop} from 'lodash';
 
+import {getImageTaggingComponent} from './ImageTaggingComponent/ImageTaggingComponent';
+
 export const entityGroups = OrderedSet(['place', 'person', 'organisation']);
 
 export type INewItem = Partial<ITagUi>;
@@ -54,9 +56,11 @@ interface IState {
     data: 'not-initialized' | 'loading' | IEditableData;
     newItem: INewItem | null;
     vocabularyLabels: Map<string, string> | null;
+    showImagesPreference: boolean;
 }
 
 const RUN_AUTOMATICALLY_PREFERENCE = 'run_automatically';
+const SHOW_IMAGES_PREFERENCE = 'show_images';
 
 function tagAlreadyExists(data: IEditableData, qcode: string): boolean {
     return data.changes.analysis.has(qcode);
@@ -172,6 +176,7 @@ export function getAutoTaggingComponent(superdesk: ISuperdesk, label: string) {
                 newItem: null,
                 runAutomaticallyPreference: 'loading',
                 vocabularyLabels: null,
+                showImagesPreference: false,
             };
 
             this._mounted = false;
@@ -355,14 +360,15 @@ export function getAutoTaggingComponent(superdesk: ISuperdesk, label: string) {
         }
         componentDidMount() {
             this._mounted = true;
-
             Promise.all([
                 getAutoTaggingVocabularyLabels(superdesk),
                 preferences.get(RUN_AUTOMATICALLY_PREFERENCE),
-            ]).then(([vocabularyLabels, runAutomatically = false]) => {
+                preferences.get(SHOW_IMAGES_PREFERENCE),
+            ]).then(([vocabularyLabels, runAutomatically = false, showImages = false]) => {
                 this.setState({
                     vocabularyLabels,
                     runAutomaticallyPreference: runAutomatically,
+                    showImagesPreference: showImages,
                 });
 
                 this.initializeData(runAutomatically);
@@ -372,7 +378,8 @@ export function getAutoTaggingComponent(superdesk: ISuperdesk, label: string) {
             this._mounted = false;
         }
         render() {
-            const {runAutomaticallyPreference, vocabularyLabels} = this.state;
+            const {runAutomaticallyPreference, vocabularyLabels, showImagesPreference} = this.state;
+            const ImageTagging = getImageTaggingComponent(superdesk);
 
             if (runAutomaticallyPreference === 'loading' || vocabularyLabels == null) {
                 return null;
@@ -474,6 +481,17 @@ export function getAutoTaggingComponent(superdesk: ISuperdesk, label: string) {
                                             }
                                         }}
                                         label={{text: gettext('Run automatically')}}
+                                    />
+                                    <Switch
+                                        value={showImagesPreference}
+                                        disabled={readOnly}
+                                        onChange={() => {
+                                            const newValue = !showImagesPreference;
+
+                                            this.setState({showImagesPreference: newValue});
+                                            superdesk.preferences.set(SHOW_IMAGES_PREFERENCE, newValue);
+                                        }}
+                                        label={{text: gettext('Show image suggestions')}}
                                     />
                                 </ButtonGroup>
                             </div>
@@ -710,6 +728,12 @@ export function getAutoTaggingComponent(superdesk: ISuperdesk, label: string) {
 
                                         <div className="widget-content__main">
                                             {allGroupedAndSorted.map((item) => item).toArray()}
+                                            {this.state.showImagesPreference && (
+                                                <ImageTagging
+                                                    data={data.changes.analysis}
+                                                    article={this.props.article}
+                                                />
+                                            )}
                                         </div>
                                     </React.Fragment>
                                 );


### PR DESCRIPTION
tested against ntb-develop ([video](https://user-images.githubusercontent.com/2076953/232310731-3cf0f700-2ecf-4b66-9158-d4ca02ca916a.mp4)). During testing I found that `/ai` API call doesn't work unless I remove [tags](https://github.com/tomaskikutis/superdesk-client-core/blob/imatrics-image-suggestions-to-hotfix/2.2.2/scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx#L213) which seem not to be defined in server shema. It might not be a problem if it's not expected to work on that instance.

One merge issue was ToggleBox not being present in ui-framework v2, which I copied from ui-framework repo v2 branch into auto tagging extension.

Another was changes accessing `superdesk` API object. I replaced usages to old method which is still supported.

This cherry pick must not be merged back into `develop`. I used `git cherry-pick` continue to resolve the conflicts, but opon trying to merge back to `develop` git still shows conflicts.
