### PR TITLE
update version of build tools

### DIFF
--- a/build-tools/package-lock.json
+++ b/build-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.17",
+  "version": "1.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.17",
+  "version": "1.0.19",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
SDESK-7204

Follow up for https://github.com/superdesk/superdesk-client-core/pull/4455. I couldn't push the new version to npm because it was already released. `0.0.17` was adding some branch specific stuff that `0.0.18` reverted - so the code at develop is up to date, but we need to jump over those two npm versions that were released from a local a branch.