### PR TITLE
fix getEntityMap fn

### DIFF
--- a/scripts/core/editor3/helpers/get-entity-map.tsx
+++ b/scripts/core/editor3/helpers/get-entity-map.tsx
@@ -1,6 +1,8 @@
 import {ContentState} from 'draft-js';
 import {Map} from 'immutable';
+import {noop} from 'lodash';
 
+// .getAllEntities isn't available in current draft-js version.
 // .getEntityMap doesn't work
 // .entityMap appears to be private and only works sometimes. Other times it returns what appears to be a entity class.
 
@@ -9,20 +11,20 @@ type DraftEntityInstance = ReturnType<ContentState['getEntity']>;
 export function getEntityMap(contentState: ContentState): Map<string, DraftEntityInstance> {
     let entityMap = Map<string, DraftEntityInstance>();
 
-    let endReached = false;
-    let i = 1;
+    contentState.getBlockMap().forEach((block) => {
+        block.findEntityRanges(
+            (char) => {
+                const entityKey = char.getEntity();
 
-    while (!endReached) {
-        try {
-            const entity = contentState.getEntity(i.toString());
+                if (entityKey != null) {
+                    entityMap = entityMap.set(entityKey, contentState.getEntity(entityKey));
+                }
 
-            entityMap = entityMap.set(i.toString(), entity);
-
-            i++;
-        } catch (e) {
-            endReached = true;
-        }
-    }
+                return false;
+            },
+            noop,
+        );
+    });
 
     return entityMap;
 }


### PR DESCRIPTION
TGA-80

It was causing an issue with embedding articles. It should add embedded articles as associations, but because getEntityMap was reading entities from ALL content states that existed during page lifecycle - associations were being added to articles that didn't have any article embeds