### PR TITLE
Languagetool spellchecker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,4 @@ You can override default search repos (all set `true` by default).
 - `validatorMediaMetadata`: `object` - describes a fields that are required for media items (images/video). If the field is present in the object then it is displayed.
 - `infoRemovedFields`: `object` - contains fields that should be removed from metadata editing
 - `profileLanguages` - list of languages available in user profile
+

--- a/scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx
+++ b/scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx
@@ -45,6 +45,8 @@ export function getSpellchecker(language: string): ISpellchecker {
     const spellcheckerName = ({
         fr: 'grammalecte',
         nl: 'leuven_dutch',
+        en: 'languagetool',
+        sv: 'languagetool',
     })[language];
     const ignore = spellcheck.getIgnoredWords();
 

--- a/scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx
+++ b/scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx
@@ -46,7 +46,7 @@ export function getSpellchecker(language: string): ISpellchecker {
         fr: 'grammalecte',
         nl: 'leuven_dutch',
         en: 'languagetool',
-        sv: 'languagetool',
+        sv_SE: 'languagetool',
     })[language];
     const ignore = spellcheck.getIgnoredWords();
 

--- a/scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx
+++ b/scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx
@@ -2,6 +2,7 @@ import ng from 'core/services/ng';
 import {ISpellchecker, ISpellcheckerAction, ISpellcheckWarning, ISpellcheckerSuggestion} from './interfaces';
 import {httpRequestJsonLocal} from 'core/helpers/network';
 import {gettext} from 'core/utils';
+import {appConfig} from 'appConfig';
 
 function getSuggestions(text: string): Promise<Array<ISpellcheckerSuggestion>> {
     return ng.getService('spellcheck')
@@ -45,8 +46,7 @@ export function getSpellchecker(language: string): ISpellchecker {
     const spellcheckerName = ({
         fr: 'grammalecte',
         nl: 'leuven_dutch',
-        en: 'languagetool',
-        sv_SE: 'languagetool',
+        ...(appConfig.spellcheckers ?? {}),
     })[language];
     const ignore = spellcheck.getIgnoredWords();
 

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -3430,6 +3430,11 @@ declare module 'superdesk-api' {
 
         userOnlineMinutes: number;
 
+        // e.g. {nl: 'leuven_dutch'}
+        spellcheckers?: {
+            [languageCode: string]: string;
+        };
+
         iMatricsFields: {
             entities: {
                 [key: string]: {


### PR DESCRIPTION
## What does this PR do?
- Adds support for LanguageTool spellchecker (https://languagetool.org) in English (en) and Swedish (sv_SE) 
- Dependent on superdesk-core [PR 2617](https://github.com/superdesk/superdesk-core/pull/2617)