### PR TITLE
improve notifications toggle for parent-child relationship [SDBELGA-818]

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "test": "npm run lint && npm run unit && node tasks/verify-client-api-changes.js",
     "debug-unit-tests": "karma start --reporters=progress --browsers=Chrome",
     "unit": "karma start --single-run",
-    "lint": "tsc -p scripts --noEmit && eslint --parser=@typescript-eslint/parser --ext .js --ext .jsx --ext .ts --ext .tsx scripts e2e/client tasks",
+    "lint": "tsc -p scripts --noEmit && eslint --quiet --parser=@typescript-eslint/parser --ext .js --ext .jsx --ext .ts --ext .tsx scripts e2e/client tasks",
     "lint-fix": "eslint --fix --parser=@typescript-eslint/parser --ext .js --ext .jsx --ext .ts --ext .tsx scripts e2e/client tasks",
     "server": "grunt server",
     "dev": "npm run server"

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "test": "npm run lint && npm run unit && node tasks/verify-client-api-changes.js",
     "debug-unit-tests": "karma start --reporters=progress --browsers=Chrome",
     "unit": "karma start --single-run",
-    "lint": "tsc -p scripts --noEmit && eslint --quiet --parser=@typescript-eslint/parser --ext .js --ext .jsx --ext .ts --ext .tsx scripts e2e/client tasks",
+    "lint": "tsc -p scripts --noEmit && eslint --parser=@typescript-eslint/parser --ext .js --ext .jsx --ext .ts --ext .tsx scripts e2e/client tasks",
     "lint-fix": "eslint --fix --parser=@typescript-eslint/parser --ext .js --ext .jsx --ext .ts --ext .tsx scripts e2e/client tasks",
     "server": "grunt server",
     "dev": "npm run server"

--- a/scripts/apps/search/index.ts
+++ b/scripts/apps/search/index.ts
@@ -10,6 +10,7 @@ import {MultiActionBarReact} from 'apps/monitoring/MultiActionBarReact';
 import {reactToAngular1} from 'superdesk-ui-framework';
 import {SearchPanelWidgets} from './components/search-panel-widgets';
 import {PreviewSubject} from './components/preview-subject';
+import EmailNotificationPreferences from 'apps/users/components/EmailNotificationPreferences';
 
 angular.module('superdesk.apps.search.react', [
     'superdesk.apps.highlights',
@@ -71,6 +72,14 @@ angular.module('superdesk.apps.search', [
             MultiActionBarReact,
             ['articles', 'hideMultiActionBar', 'getCoreActions', 'compact'],
         ),
+    )
+
+    .component(
+        'sdNotificationsList',
+        reactToAngular1(
+            EmailNotificationPreferences,
+            ['toggleEmailNotification'],
+        )
     )
 
     .component(

--- a/scripts/apps/search/index.ts
+++ b/scripts/apps/search/index.ts
@@ -78,7 +78,7 @@ angular.module('superdesk.apps.search', [
         'sdNotificationsList',
         reactToAngular1(
             EmailNotificationPreferences,
-            ['toggleEmailNotification'],
+            ['toggleEmailNotification', 'preferences'],
         ),
     )
 

--- a/scripts/apps/search/index.ts
+++ b/scripts/apps/search/index.ts
@@ -79,7 +79,7 @@ angular.module('superdesk.apps.search', [
         reactToAngular1(
             EmailNotificationPreferences,
             ['toggleEmailNotification'],
-        )
+        ),
     )
 
     .component(

--- a/scripts/apps/search/index.ts
+++ b/scripts/apps/search/index.ts
@@ -10,7 +10,7 @@ import {MultiActionBarReact} from 'apps/monitoring/MultiActionBarReact';
 import {reactToAngular1} from 'superdesk-ui-framework';
 import {SearchPanelWidgets} from './components/search-panel-widgets';
 import {PreviewSubject} from './components/preview-subject';
-import EmailNotificationPreferences from 'apps/users/components/EmailNotificationPreferences';
+import {EmailNotificationPreferences} from 'apps/users/components/EmailNotificationPreferences';
 
 angular.module('superdesk.apps.search.react', [
     'superdesk.apps.highlights',
@@ -75,7 +75,7 @@ angular.module('superdesk.apps.search', [
     )
 
     .component(
-        'sdNotificationsList',
+        'sdEmailNotificationsList',
         reactToAngular1(
             EmailNotificationPreferences,
             ['toggleEmailNotification', 'preferences'],

--- a/scripts/apps/users/components/EmailNotificationPreferences.tsx
+++ b/scripts/apps/users/components/EmailNotificationPreferences.tsx
@@ -6,7 +6,7 @@ interface IProps {
     preferences?: {[key: string]: any};
 }
 
-export default class EmailNotificationPreferences extends React.PureComponent<IProps> {
+export class EmailNotificationPreferences extends React.PureComponent<IProps> {
     render(): React.ReactNode {
         return (
             <CheckGroup orientation="vertical">

--- a/scripts/apps/users/components/EmailNotificationPreferences.tsx
+++ b/scripts/apps/users/components/EmailNotificationPreferences.tsx
@@ -9,7 +9,7 @@ interface IProps {
 export default class EmailNotificationPreferences extends React.PureComponent<IProps> {
     render(): React.ReactNode {
         return (
-            <CheckGroup orientation='vertical'>
+            <CheckGroup orientation="vertical">
                 {Object.entries(this.props.preferences ?? []).map(([key, value]) => {
                     return (
                         <Checkbox

--- a/scripts/apps/users/components/EmailNotificationPreferences.tsx
+++ b/scripts/apps/users/components/EmailNotificationPreferences.tsx
@@ -1,0 +1,41 @@
+import {extensions} from 'appConfig';
+import React from 'react';
+import {CheckGroup, Checkbox} from 'superdesk-ui-framework/react';
+import ng from 'core/services/ng';
+
+interface IProps {
+    toggleEmailNotification: (notificationId: string) => void;
+}
+
+export default class EmailNotificationPreferences extends React.PureComponent<IProps, any> {
+
+    render(): React.ReactNode {
+        const notificationsFromExtensions: {[key: string]: {type: string}} = {};
+        const preferences = ng.get('preferencesService');
+
+        for (const extension of Object.values(extensions)) {
+            for (const [key, value] of Object.entries(extension.activationResult.contributions?.notifications ?? [])) {
+                if (value.type === 'email') {
+                    notificationsFromExtensions[key] = value;
+                }
+            }
+        }
+
+        return (
+            <CheckGroup>
+                {Object.entries(notificationsFromExtensions).map(([key]) => {
+                    return (
+                        <Checkbox
+                            key={key}
+                            label={{text: preferences[key].label}}
+                            onChange={() => {
+                                this.props.toggleEmailNotification(key);
+                            }}
+                            checked={preferences?.[key]?.enabled}
+                        />
+                    )
+                })}
+            </CheckGroup>
+        );
+    }
+}

--- a/scripts/apps/users/components/EmailNotificationPreferences.tsx
+++ b/scripts/apps/users/components/EmailNotificationPreferences.tsx
@@ -1,36 +1,24 @@
-import {extensions} from 'appConfig';
 import React from 'react';
 import {CheckGroup, Checkbox} from 'superdesk-ui-framework/react';
-import ng from 'core/services/ng';
 
 interface IProps {
     toggleEmailNotification: (notificationId: string) => void;
+    preferences: {[key: string]: any};
 }
 
-export default class EmailNotificationPreferences extends React.PureComponent<IProps, any> {
+export default class EmailNotificationPreferences extends React.PureComponent<IProps> {
     render(): React.ReactNode {
-        const notificationsFromExtensions: {[key: string]: {type: string}} = {};
-        const preferences = ng.get('preferencesService');
-
-        for (const extension of Object.values(extensions)) {
-            for (const [key, value] of Object.entries(extension.activationResult.contributions?.notifications ?? [])) {
-                if (value.type === 'email') {
-                    notificationsFromExtensions[key] = value;
-                }
-            }
-        }
-
         return (
-            <CheckGroup>
-                {Object.entries(notificationsFromExtensions).map(([key]) => {
+            <CheckGroup orientation='vertical'>
+                {Object.entries(this.props.preferences ?? []).map(([key, value]) => {
                     return (
                         <Checkbox
                             key={key}
-                            label={{text: preferences[key].label}}
+                            label={{text: value.label}}
                             onChange={() => {
                                 this.props.toggleEmailNotification(key);
                             }}
-                            checked={preferences?.[key]?.enabled}
+                            checked={value?.enabled ?? value?.default ?? false}
                         />
                     );
                 })}

--- a/scripts/apps/users/components/EmailNotificationPreferences.tsx
+++ b/scripts/apps/users/components/EmailNotificationPreferences.tsx
@@ -3,25 +3,23 @@ import {CheckGroup, Checkbox} from 'superdesk-ui-framework/react';
 
 interface IProps {
     toggleEmailNotification: (notificationId: string) => void;
-    preferences: {[key: string]: any};
+    preferences?: {[key: string]: any};
 }
 
 export default class EmailNotificationPreferences extends React.PureComponent<IProps> {
     render(): React.ReactNode {
         return (
             <CheckGroup orientation="vertical">
-                {Object.entries(this.props.preferences ?? []).map(([key, value]) => {
-                    return (
-                        <Checkbox
-                            key={key}
-                            label={{text: value.label}}
-                            onChange={() => {
-                                this.props.toggleEmailNotification(key);
-                            }}
-                            checked={value?.enabled ?? value?.default ?? false}
-                        />
-                    );
-                })}
+                {Object.entries(this.props.preferences ?? []).map(([key, value]) => (
+                    <Checkbox
+                        key={key}
+                        label={{text: value.label}}
+                        onChange={() => {
+                            this.props.toggleEmailNotification(key);
+                        }}
+                        checked={value?.enabled ?? value?.default ?? false}
+                    />
+                ))}
             </CheckGroup>
         );
     }

--- a/scripts/apps/users/components/EmailNotificationPreferences.tsx
+++ b/scripts/apps/users/components/EmailNotificationPreferences.tsx
@@ -8,7 +8,6 @@ interface IProps {
 }
 
 export default class EmailNotificationPreferences extends React.PureComponent<IProps, any> {
-
     render(): React.ReactNode {
         const notificationsFromExtensions: {[key: string]: {type: string}} = {};
         const preferences = ng.get('preferencesService');
@@ -33,7 +32,7 @@ export default class EmailNotificationPreferences extends React.PureComponent<IP
                             }}
                             checked={preferences?.[key]?.enabled}
                         />
-                    )
+                    );
                 })}
             </CheckGroup>
         );

--- a/scripts/apps/users/directives/UserPreferencesDirective.ts
+++ b/scripts/apps/users/directives/UserPreferencesDirective.ts
@@ -96,7 +96,7 @@ export function UserPreferencesDirective(
                 const notificationsForGroupAreOff = Object.keys(scope.extensionsNotifications)
                     .some((notificationId) => scope.preferences?.[notificationId]?.enabled == true);
 
-                scope.preferences['email:notification'].enabled = notificationsForGroupAreOff
+                scope.preferences['email:notification'].enabled = notificationsForGroupAreOff;
 
                 scope.userPrefs.$setDirty();
                 scope.$applyAsync();

--- a/scripts/apps/users/directives/UserPreferencesDirective.ts
+++ b/scripts/apps/users/directives/UserPreferencesDirective.ts
@@ -94,10 +94,10 @@ export function UserPreferencesDirective(
                     enabled: enabledUpdate,
                 };
 
-                const allFalse = Object.values(scope.emailNotificationsFromExtensions)
+                const notificationsForGroupAreOff = Object.values(scope.emailNotificationsFromExtensions)
                     .every((value: any) => value?.enabled == false);
 
-                scope.preferences['email:notification'].enabled = !allFalse;
+                scope.preferences['email:notification'].enabled = !notificationsForGroupAreOff;
 
                 scope.userPrefs.$setDirty();
                 scope.$applyAsync();

--- a/scripts/apps/users/directives/UserPreferencesDirective.ts
+++ b/scripts/apps/users/directives/UserPreferencesDirective.ts
@@ -56,13 +56,13 @@ export function UserPreferencesDirective(
             scope.preferencesLoaded = false;
             var orig: {[key: string]: any}; // original preferences, before any changes
 
-            scope.extensionsNotifications = {};
+            scope.emailNotificationsFromExtensions = {};
 
             for (const extension of Object.values(extensions)) {
                 for (const [key, value] of Object.entries(extension.activationResult.contributions?.notifications ?? [])) {
                     if (value.type === 'email') {
                         preferencesService.registerUserPreference(key, 1);
-                        scope.extensionsNotifications[key] = preferencesService.getSync(key);
+                        scope.emailNotificationsFromExtensions[key] = preferencesService.getSync(key);
                     }
                 }
             }
@@ -70,10 +70,10 @@ export function UserPreferencesDirective(
             scope.toggleEmailGroupNotifications = function() {
                 const isGroupEnabled = scope.preferences['email:notification'].enabled;
 
-                Object.keys(scope.extensionsNotifications).forEach((notificationId) => {
+                Object.keys(scope.emailNotificationsFromExtensions).forEach((notificationId) => {
                     scope.preferences[notificationId].enabled = isGroupEnabled;
-                    scope.extensionsNotifications[notificationId] = {
-                        ...scope.extensionsNotifications[notificationId],
+                    scope.emailNotificationsFromExtensions[notificationId] = {
+                        ...scope.emailNotificationsFromExtensions[notificationId],
                         enabled: isGroupEnabled,
                     };
                 });
@@ -89,15 +89,15 @@ export function UserPreferencesDirective(
                     ...(scope.preferences[notificationId] ?? {}),
                     enabled: enabledUpdate,
                 };
-                scope.extensionsNotifications[notificationId] = {
-                    ...scope.extensionsNotifications[notificationId],
+                scope.emailNotificationsFromExtensions[notificationId] = {
+                    ...scope.emailNotificationsFromExtensions[notificationId],
                     enabled: enabledUpdate,
                 };
 
-                const notificationsForGroupAreOff = Object.keys(scope.extensionsNotifications)
-                    .some((notificationId) => scope.preferences?.[notificationId]?.enabled == true);
+                const allFalse = Object.values(scope.emailNotificationsFromExtensions)
+                    .every((value: any) => value?.enabled == false);
 
-                scope.preferences['email:notification'].enabled = notificationsForGroupAreOff;
+                scope.preferences['email:notification'].enabled = !allFalse;
 
                 scope.userPrefs.$setDirty();
                 scope.$applyAsync();

--- a/scripts/apps/users/directives/UserPreferencesDirective.ts
+++ b/scripts/apps/users/directives/UserPreferencesDirective.ts
@@ -58,6 +58,27 @@ export function UserPreferencesDirective(
             scope.preferencesLoaded = false;
             var orig; // original preferences, before any changes
 
+            scope.toggleParentNotification = function() {
+                const parentEnabled = scope.preferences['email:notification'].enabled;
+                scope.preferences['assignment:notification'].enabled = parentEnabled;
+                scope.preferences['mark_for_user:notification'].enabled = parentEnabled;
+            };
+        
+            scope.toggleChildNotification = function(child) {
+                if (scope.preferences[child].enabled) {
+                    // Turn on parent if any child is turned on
+                    scope.preferences['email:notification'].enabled = true;
+                } else {
+                    // Check if all children are off
+                    const allChildrenOff = !scope.preferences['assignment:notification'].enabled &&
+                                           !scope.preferences['mark_for_user:notification'].enabled;
+                    if (allChildrenOff) {
+                        // Turn off parent if all children are off
+                        scope.preferences['email:notification'].enabled = false;
+                    }
+                }
+            };
+
             preferencesService.get(null, true).then((result) => {
                 orig = result;
                 buildPreferences(orig);

--- a/scripts/apps/users/directives/UserPreferencesDirective.ts
+++ b/scripts/apps/users/directives/UserPreferencesDirective.ts
@@ -60,10 +60,11 @@ export function UserPreferencesDirective(
 
             scope.toggleParentNotification = function() {
                 const parentEnabled = scope.preferences['email:notification'].enabled;
+
                 scope.preferences['assignment:notification'].enabled = parentEnabled;
                 scope.preferences['mark_for_user:notification'].enabled = parentEnabled;
             };
-        
+
             scope.toggleChildNotification = function(child) {
                 if (scope.preferences[child].enabled) {
                     // Turn on parent if any child is turned on
@@ -72,6 +73,7 @@ export function UserPreferencesDirective(
                     // Check if all children are off
                     const allChildrenOff = !scope.preferences['assignment:notification'].enabled &&
                                            !scope.preferences['mark_for_user:notification'].enabled;
+
                     if (allChildrenOff) {
                         // Turn off parent if all children are off
                         scope.preferences['email:notification'].enabled = false;

--- a/scripts/apps/users/directives/UserPreferencesDirective.ts
+++ b/scripts/apps/users/directives/UserPreferencesDirective.ts
@@ -83,14 +83,15 @@ export function UserPreferencesDirective(
             };
 
             scope.toggleEmailNotification = function(notificationId: string) {
+                const enabledUpdate = !(scope.preferences[notificationId]?.enabled ?? false);
+
                 scope.preferences[notificationId] = {
                     ...(scope.preferences[notificationId] ?? {}),
-                    enabled: !(scope.preferences[notificationId]?.enabled ?? false),
+                    enabled: enabledUpdate,
                 };
-
                 scope.extensionsNotifications[notificationId] = {
                     ...scope.extensionsNotifications[notificationId],
-                    enabled: scope.preferences[notificationId].enabled,
+                    enabled: enabledUpdate,
                 };
 
                 const notificationsForGroupAreOff = Object.keys(scope.extensionsNotifications)

--- a/scripts/apps/users/directives/UserPreferencesDirective.ts
+++ b/scripts/apps/users/directives/UserPreferencesDirective.ts
@@ -458,7 +458,7 @@ export function UserPreferencesDirective(
                     }
 
                     patchObject[key] = Object.assign(val, scope.preferences[key]);
-                })
+                });
 
                 if (orig['editor:theme'] != null) {
                     patchObject['editor:theme'] = {

--- a/scripts/apps/users/views/user-preferences.html
+++ b/scripts/apps/users/views/user-preferences.html
@@ -81,11 +81,11 @@
                             </div>
 
                             <div class="item ms-1 ps-5">
-                                <sd-notifications-list
-                                    data-preferences="extensionsNotifications"
+                                <sd-email-notifications-list
+                                    data-preferences="emailNotificationsFromExtensions"
                                     data-toggle-email-notification="toggleEmailNotification"
                                 >
-                                </sd-notifications-list>
+                                </sd-email-notifications-list>
                             </div>
                             <div sd-info-item>
                                 <span ng-hide="preferences['desktop:notification'].allowed" sd-switch ng-model="preferences['desktop:notification'].enabled"></span>

--- a/scripts/apps/users/views/user-preferences.html
+++ b/scripts/apps/users/views/user-preferences.html
@@ -71,20 +71,35 @@
                     <div class="sd-container sd-container--flex sd-container--gap-none sd-container--direction-column sd-radius--medium sd-panel-bg--000 sd-shadow--z2 sd-padding--3 sd-state--focus sd-margin-b--1">
                         <div class="sd-switch__group sd-switch__group--vertical">
                             <div sd-info-item>
-                                <span ng-hide="preferences['email:notification'].allowed" sd-switch ng-model="preferences['email:notification'].enabled"></span>
+                                <span
+                                    ng-hide="preferences['email:notification'].allowed"
+                                    sd-switch
+                                    ng-model="preferences['email:notification'].enabled"
+                                    ng-change="toggleParentNotification()">
+                                </span>
                                 <label>{{ :: preferences['email:notification'].label | translate }}</label>
+                            </div>
+                            <div sd-info-item ng-show="preferences['assignment:notification']" class="item ms-1 ps-5">
+                                <span 
+                                    ng-hide="preferences['assignment:notification'].allowed"
+                                    sd-switch
+                                    ng-model="preferences['assignment:notification'].enabled"
+                                    ng-change="toggleChildNotification('assignment:notification')">
+                                </span>
+                                <label>{{ preferences['assignment:notification'].label }}</label>
+                            </div>
+                            <div sd-info-item ng-show="preferences['mark_for_user:notification']" class="item ms-1 ps-5">
+                            <span 
+                                ng-hide="preferences['mark_for_user:notification'].allowed"
+                                sd-switch
+                                ng-model="preferences['mark_for_user:notification'].enabled"
+                                ng-change="toggleChildNotification('mark_for_user:notification')">
+                            </span>
+                                <label>{{ preferences['mark_for_user:notification'].label }}</label>
                             </div>
                             <div sd-info-item>
                                 <span ng-hide="preferences['desktop:notification'].allowed" sd-switch ng-model="preferences['desktop:notification'].enabled"></span>
                                 <label>{{ :: preferences['desktop:notification'].label | translate }}</label>
-                            </div>
-                            <div sd-info-item ng-show="preferences['assignment:notification']">
-                                <span ng-hide="preferences['assignment:notification'].allowed" sd-switch ng-model="preferences['assignment:notification'].enabled"></span>
-                                <label>{{ preferences['assignment:notification'].label }}</label>
-                            </div>
-                            <div sd-info-item ng-show="preferences['mark_for_user:notification']">
-                                <span ng-hide="preferences['mark_for_user:notification'].allowed" sd-switch ng-model="preferences['mark_for_user:notification'].enabled"></span>
-                                <label>{{ preferences['mark_for_user:notification'].label }}</label>
                             </div>
                             <div sd-info-item ng-hide="!$root.config.features.slackNotifications">
                                 <span ng-hide="preferences['slack:notification'].allowed" sd-switch ng-model="preferences['slack:notification'].enabled"></span>

--- a/scripts/apps/users/views/user-preferences.html
+++ b/scripts/apps/users/views/user-preferences.html
@@ -82,6 +82,7 @@
 
                             <div class="item ms-1 ps-5">
                                 <sd-notifications-list
+                                    data-preferences="extensionsNotifications"
                                     data-toggle-email-notification="toggleEmailNotification"
                                 >
                                 </sd-notifications-list>

--- a/scripts/apps/users/views/user-preferences.html
+++ b/scripts/apps/users/views/user-preferences.html
@@ -42,7 +42,7 @@
                 <li class="simple-list__item simple-list__item--stacked simple-list__item--justify-flex-start">
                     <h3 id="view-formats" class="sd-heading sd-text-align--left sd-text--sans sd-heading--h3" translate>View formats</h3>
                     <div class="sd-container sd-container--flex sd-container--gap-none sd-container--direction-column sd-radius--medium sd-panel-bg--000 sd-shadow--z2 sd-padding--3 sd-state--focus sd-margin-b--1">
-                        <p class="sd-text sd-text--normal sd-text-align--left sd-text--sans sd-text-color--light">Select the prefered default view format for specific areas of Superdesks interface. The sections 
+                        <p class="sd-text sd-text--normal sd-text-align--left sd-text--sans sd-text-color--light">Select the prefered default view format for specific areas of Superdesks interface. The sections
                             will always open in the selected view format, but can be always changed using the view option dropdown in each section.</p>
                         <ul class="simple-list simple-list--compact simple-list--dotted  sd-margin-t--3 sd-margin-b--0 sd-padding-b--0">
                             <li class="simple-list__item simple-list__item--stacked simple-list__item--justify-flex-start"
@@ -75,27 +75,16 @@
                                     ng-hide="preferences['email:notification'].allowed"
                                     sd-switch
                                     ng-model="preferences['email:notification'].enabled"
-                                    ng-change="toggleParentNotification()">
+                                    ng-change="toggleEmailGroupNotifications()">
                                 </span>
                                 <label>{{ :: preferences['email:notification'].label | translate }}</label>
                             </div>
-                            <div sd-info-item ng-show="preferences['assignment:notification']" class="item ms-1 ps-5">
-                                <span 
-                                    ng-hide="preferences['assignment:notification'].allowed"
-                                    sd-switch
-                                    ng-model="preferences['assignment:notification'].enabled"
-                                    ng-change="toggleChildNotification('assignment:notification')">
-                                </span>
-                                <label>{{ preferences['assignment:notification'].label }}</label>
-                            </div>
-                            <div sd-info-item ng-show="preferences['mark_for_user:notification']" class="item ms-1 ps-5">
-                            <span 
-                                ng-hide="preferences['mark_for_user:notification'].allowed"
-                                sd-switch
-                                ng-model="preferences['mark_for_user:notification'].enabled"
-                                ng-change="toggleChildNotification('mark_for_user:notification')">
-                            </span>
-                                <label>{{ preferences['mark_for_user:notification'].label }}</label>
+
+                            <div class="item ms-1 ps-5">
+                                <sd-notifications-list
+                                    data-toggle-email-notification="toggleEmailNotification"
+                                >
+                                </sd-notifications-list>
                             </div>
                             <div sd-info-item>
                                 <span ng-hide="preferences['desktop:notification'].allowed" sd-switch ng-model="preferences['desktop:notification'].enabled"></span>
@@ -127,7 +116,7 @@
                                 </div>
                             </div>
                         </div>
-        
+
                         <div class="sd-display--contents" sd-info-item ng-if="preferencesLoaded === true" ng-hide="profileConfig.place === false">
                             <label class="form-label">{{ :: preferences['article:default:place'].label | translate}}</label>
                             <div class="form__group form__group--default form__group--mb-3">
@@ -159,13 +148,13 @@
                                    title="{{:: 'Select all categories' | translate}}"
                                    translate>all</a>
                                 <div class="button-group__divider button-group__divider--small button-group__divider--border"></div>
-        
+
                                 <a ng-click="checkNone()"
                                    class="btn btn--primary btn--text-only"
                                    title="{{:: 'Clear all selected' | translate}}"
                                    translate>none</a>
                                 <div class="button-group__divider button-group__divider--small button-group__divider--border"></div>
-        
+
                                 <a ng-click="checkDefault()"
                                    class="btn btn--primary btn--text-only"
                                    title="{{:: 'Select default categories only' | translate}}"
@@ -441,7 +430,7 @@
                                 </div>
                             </div>
                         </div>
-        
+
                     </div>
                 </li>
 

--- a/scripts/core/menu/notifications/notifications.ts
+++ b/scripts/core/menu/notifications/notifications.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import {gettext} from 'core/utils';
 import {AuthoringWorkspaceService} from 'apps/authoring/authoring/services/AuthoringWorkspaceService';
 import {extensions} from 'appConfig';
-import {IExtensionActivationResult} from 'superdesk-api';
+import {IDesktopNotification} from 'superdesk-api';
 import {logger} from 'core/services/logger';
 import emptyState from 'superdesk-ui-framework/dist/empty-state--small-2.svg';
 
@@ -296,17 +296,19 @@ angular.module('superdesk.core.menu.notifications', ['superdesk.core.services.as
                     scope.emptyState = emptyState;
 
                     // merged from all extensions
-                    const notificationsKeyed: IExtensionActivationResult['contributions']['notifications'] = {};
+                    const notificationsKeyed: {[key: string]: IDesktopNotification['handler']} = {};
 
                     for (const extension of Object.values(extensions)) {
-                        if (
-                            extension.activationResult.contributions != null
-                            && extension.activationResult.contributions.notifications != null
-                        ) {
-                            for (const key in extension.activationResult.contributions.notifications) {
+                        const notificationsFromExtensions = extension.activationResult.contributions?.notifications;
+
+                        if (notificationsFromExtensions != null) {
+                            for (const key in notificationsFromExtensions) {
                                 if (notificationsKeyed[key] == null) {
-                                    notificationsKeyed[key] =
-                                        extension.activationResult.contributions.notifications[key];
+                                    const notificationValue = notificationsFromExtensions[key];
+
+                                    if (notificationValue.type == 'desktop') {
+                                        notificationsKeyed[key] = notificationValue.handler;
+                                    }
                                 } else {
                                     logger.error(new Error(`Notification key ${key} already registered.`));
                                 }

--- a/scripts/core/services/preferencesService.ts
+++ b/scripts/core/services/preferencesService.ts
@@ -145,6 +145,8 @@ export default angular.module('superdesk.core.preferences', ['superdesk.core.not
                     initPreferences(preferences);
                     return preferences;
                 }
+
+                return preferencesPromise;
             }
 
             /**

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -708,7 +708,7 @@ declare module 'superdesk-api' {
         type: 'email';
     }
 
-    interface IDesktopNotification {
+    export interface IDesktopNotification {
         type: 'desktop';
         label: string;
         handler: (notification: any) => {

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -704,6 +704,19 @@ declare module 'superdesk-api' {
         preview?: React.ComponentType<IIngestRuleHandlerPreviewProps>;
     }
 
+    interface IEmailNotification {
+        type: 'email';
+    }
+
+    interface IDesktopNotification {
+        type: 'desktop';
+        label: string;
+        handler: (notification: any) => {
+            body: string;
+            actions: Array<{label: string; onClick: () => void;}>;
+        };
+    }
+
     export interface IExtensionActivationResult {
         contributions?: {
             globalMenuHorizontal?: Array<React.ComponentType>;
@@ -742,10 +755,7 @@ declare module 'superdesk-api' {
             workspaceMenuItems?: Array<IWorkspaceMenuItem>;
             customFieldTypes?: Array<ICustomFieldType>;
             notifications?: {
-                [id: string]: (notification) => {
-                    body: string;
-                    actions: Array<{label: string; onClick(): void;}>;
-                };
+                [id: string]: IEmailNotification | IDesktopNotification;
             };
             entities?: {
                 article?: {

--- a/scripts/extensions/broadcasting/src/notifications.ts
+++ b/scripts/extensions/broadcasting/src/notifications.ts
@@ -18,10 +18,12 @@ interface IRundownItemCommentNotification {
 type IExtensionNotifications = Required<Required<IExtensionActivationResult>['contributions']>['notifications'];
 
 export const notifications: IExtensionNotifications = {
-    'rundown-item-comment': (notification: IRundownItemCommentNotification) => ({
-        body: notification.message,
-        actions: [
-            {
+    'rundown-item-comment': {
+        label: gettext('Open item'),
+        type: 'desktop',
+        handler: (notification) => ({
+            body: notification.message,
+            actions: [{
                 label: gettext('Open item'),
                 onClick: () => {
                     const {rundownId, rundownItemId} = notification.data;
@@ -42,7 +44,7 @@ export const notifications: IExtensionNotifications = {
                         superdesk.browser.location.setPage(BROADCASTING_MODULE_PATH);
                     }
                 },
-            },
-        ],
-    }),
+            }],
+        }),
+    },
 };

--- a/scripts/extensions/broadcasting/src/notifications.ts
+++ b/scripts/extensions/broadcasting/src/notifications.ts
@@ -21,7 +21,7 @@ export const notifications: IExtensionNotifications = {
     'rundown-item-comment': {
         label: gettext('Open item'),
         type: 'desktop',
-        handler: (notification) => ({
+        handler: (notification: IRundownItemCommentNotification) => ({
             body: notification.message,
             actions: [{
                 label: gettext('Open item'),

--- a/scripts/extensions/markForUser/src/extension.tsx
+++ b/scripts/extensions/markForUser/src/extension.tsx
@@ -2,7 +2,6 @@ import {
     ISuperdesk,
     IExtension,
     IExtensionActivationResult,
-    IArticle,
     IMonitoringFilter,
     IPersonalSpaceSection,
 } from 'superdesk-api';
@@ -11,11 +10,6 @@ import {getActionsInitialize} from './get-article-actions';
 import {getActionsBulkInitialize} from './get-article-actions-bulk';
 import {getMarkedForMeComponent} from './get-marked-for-me-component';
 import {getQueryMarkedForUser, getQueryNotMarkedForAnyoneOrMarkedForMe} from './get-article-queries';
-
-interface IMarkForUserNotification {
-    message: string;
-    item: IArticle['_id'];
-}
 
 const extension: IExtension = {
     exposes: {
@@ -53,28 +47,31 @@ const extension: IExtension = {
                         getSections: () => personalSpaceSections,
                     },
                     notifications: {
-                        'item:marked': (notification: IMarkForUserNotification) => {
-                            return {
+                        'item:marked': {
+                            type: 'desktop',
+                            label: gettext('open item'),
+                            handler: (notification: any) => ({
                                 body: notification.message,
-                                actions: [
-                                    {
-                                        label: gettext('open item'),
-                                        onClick: () => superdesk.ui.article.view(notification.item),
-                                    },
-                                ],
-                            };
+                                actions: [{
+                                    label: gettext('open item'),
+                                    onClick: () => superdesk.ui.article.view(notification.item),
+                                }],
+                            }),
                         },
-                        'item:unmarked': (notification: IMarkForUserNotification) => {
-                            return {
+                        'item:unmarked': {
+                            label: gettext('open item'),
+                            type: 'desktop',
+                            handler: (notification: any) => ({
                                 body: notification.message,
-                                actions: [
-                                    {
-                                        label: gettext('open item'),
-                                        onClick: () => superdesk.ui.article.view(notification.item),
-                                    },
-                                ],
-                            };
+                                actions: [{
+                                    label: gettext('open item'),
+                                    onClick: () => superdesk.ui.article.view(notification.item),
+                                }],
+                            }),
                         },
+                        'mark_for_user:notification': {
+                            type: 'email',
+                        }
                     },
                     entities: {
                         article: {

--- a/scripts/extensions/markForUser/src/extension.tsx
+++ b/scripts/extensions/markForUser/src/extension.tsx
@@ -71,7 +71,7 @@ const extension: IExtension = {
                         },
                         'mark_for_user:notification': {
                             type: 'email',
-                        }
+                        },
                     },
                     entities: {
                         article: {


### PR DESCRIPTION
SDBELGA-818

- [x] Check default settings before merging, should all be set to true by default. Check if planning-ext assignments registration works as well.
- [x] Before merging, refactor existing notification handling in the panel/modal such that it matches the new type signatures

Note: having `scope.preferences` and `scope.extensionsNotifications` both is necessary since we have to update both separately and together while having them in completely separate components (first variable is responsible for the whole email notifications group updating, second only for notifications from extensions, being passed to a react component).

Also `preferencesService.registerUserPreference(key, 1);` is the core for how notifications from extensions should be done. This prevents any strings hardcoding and allows for modularity.

**Demo (a notification registered as an extension coming from client-core and one coming from the planning extension)**

https://github.com/user-attachments/assets/e3ad8a28-1e3d-4ae6-8b89-53fe71a480ec