### PR TITLE
Refactor all notifications from extensions and UI toggling such that …

### DIFF
--- a/scripts/apps/search/index.ts
+++ b/scripts/apps/search/index.ts
@@ -78,7 +78,7 @@ angular.module('superdesk.apps.search', [
         'sdEmailNotificationsList',
         reactToAngular1(
             EmailNotificationPreferences,
-            ['toggleEmailNotification', 'preferences'],
+            ['toggleEmailNotification', 'preferences', 'notificationLabels'],
         ),
     )
 

--- a/scripts/apps/users/components/EmailNotificationPreferences.tsx
+++ b/scripts/apps/users/components/EmailNotificationPreferences.tsx
@@ -3,7 +3,7 @@ import {CheckGroup, Checkbox} from 'superdesk-ui-framework/react';
 
 interface IProps {
     toggleEmailNotification: (notificationId: string) => void;
-    preferences?: {[key: string]: any};
+    preferences?: {[key: string]: {label: string; email?: boolean; default?: boolean;}};
 }
 
 export class EmailNotificationPreferences extends React.PureComponent<IProps> {
@@ -17,7 +17,7 @@ export class EmailNotificationPreferences extends React.PureComponent<IProps> {
                         onChange={() => {
                             this.props.toggleEmailNotification(key);
                         }}
-                        checked={value?.enabled ?? value?.default ?? false}
+                        checked={value?.email ?? value?.default ?? false}
                     />
                 ))}
             </CheckGroup>

--- a/scripts/apps/users/components/EmailNotificationPreferences.tsx
+++ b/scripts/apps/users/components/EmailNotificationPreferences.tsx
@@ -3,7 +3,7 @@ import {CheckGroup, Checkbox} from 'superdesk-ui-framework/react';
 
 interface IProps {
     toggleEmailNotification: (notificationId: string) => void;
-    preferences?: {[key: string]: {label: string; email?: boolean; default?: boolean;}};
+    preferences?: {[key: string]: {label: string; email: boolean;}};
 }
 
 export class EmailNotificationPreferences extends React.PureComponent<IProps> {
@@ -17,7 +17,7 @@ export class EmailNotificationPreferences extends React.PureComponent<IProps> {
                         onChange={() => {
                             this.props.toggleEmailNotification(key);
                         }}
-                        checked={value?.email ?? value?.default ?? false}
+                        checked={value.email}
                     />
                 ))}
             </CheckGroup>

--- a/scripts/apps/users/components/EmailNotificationPreferences.tsx
+++ b/scripts/apps/users/components/EmailNotificationPreferences.tsx
@@ -1,25 +1,37 @@
 import React from 'react';
 import {CheckGroup, Checkbox} from 'superdesk-ui-framework/react';
+import {IUser} from 'superdesk-api';
+import {gettext} from 'core/utils';
 
 interface IProps {
     toggleEmailNotification: (notificationId: string) => void;
-    preferences?: {[key: string]: {label: string; email: boolean;}};
+    preferences: {
+        notifications: IUser['user_preferences']['notifications'];
+    };
+    notificationLabels: Dictionary<string, string>;
 }
 
 export class EmailNotificationPreferences extends React.PureComponent<IProps> {
     render(): React.ReactNode {
         return (
             <CheckGroup orientation="vertical">
-                {Object.entries(this.props.preferences ?? []).map(([key, value]) => (
-                    <Checkbox
-                        key={key}
-                        label={{text: value.label}}
-                        onChange={() => {
-                            this.props.toggleEmailNotification(key);
-                        }}
-                        checked={value.email}
-                    />
-                ))}
+                {Object.entries(this.props.preferences.notifications)
+                    .map(([notificationId, notificationSettings]) => {
+                        return (
+                            <Checkbox
+                                key={notificationId}
+                                label={{
+                                    text: gettext(
+                                        'Send {{name}} notifications',
+                                        {name: this.props.notificationLabels[notificationId]},
+                                    )}}
+                                onChange={() => {
+                                    this.props.toggleEmailNotification(notificationId);
+                                }}
+                                checked={notificationSettings.email}
+                            />
+                        );
+                    })}
             </CheckGroup>
         );
     }

--- a/scripts/apps/users/directives/UserPreferencesDirective.ts
+++ b/scripts/apps/users/directives/UserPreferencesDirective.ts
@@ -395,7 +395,7 @@ export function UserPreferencesDirective(
                     if (scope.preferences[NOTIFICATIONS_KEY][notificationId] == null) {
                         scope.preferences[NOTIFICATIONS_KEY][notificationId] = {
                             email: true,
-                            desktop: false,
+                            desktop: true,
                         };
                     }
 

--- a/scripts/apps/users/directives/UserPreferencesDirective.ts
+++ b/scripts/apps/users/directives/UserPreferencesDirective.ts
@@ -66,7 +66,7 @@ export function UserPreferencesDirective(
                             preferencesService.getSync('notifications')[key] ?? {
                                 email: true,
                                 default: true,
-                                label: value.settingsLabel,
+                                label: gettext('Send {{ name }} notifications', {name: value.name}),
                             };
                     }
                 }

--- a/scripts/apps/users/directives/UserPreferencesDirective.ts
+++ b/scripts/apps/users/directives/UserPreferencesDirective.ts
@@ -63,7 +63,7 @@ export function UserPreferencesDirective(
                 for (const extension of Object.values(extensions)) {
                     for (const [key, value] of Object.entries(extension.activationResult.contributions?.notifications ?? [])) {
                         scope.emailNotificationsFromExtensions[key] =
-                            preferencesService.getSync('notifications')[key] ?? {
+                            preferencesService.getSync('notifications')?.[key] ?? {
                                 email: true,
                                 default: true,
                                 label: gettext('Send {{ name }} notifications', {name: value.name}),

--- a/scripts/apps/users/directives/UserPreferencesDirective.ts
+++ b/scripts/apps/users/directives/UserPreferencesDirective.ts
@@ -59,13 +59,12 @@ export function UserPreferencesDirective(
 
             scope.emailNotificationsFromExtensions = {};
 
-            scope.buildNotificationsFromExtensions = function(rebuild: boolean) {
+            scope.buildNotificationsFromExtensions = function() {
                 for (const extension of Object.values(extensions)) {
                     for (const [key, value] of Object.entries(extension.activationResult.contributions?.notifications ?? [])) {
                         scope.emailNotificationsFromExtensions[key] =
                             preferencesService.getSync('notifications')?.[key] ?? {
                                 email: true,
-                                default: true,
                                 label: gettext('Send {{ name }} notifications', {name: value.name}),
                             };
                     }
@@ -73,8 +72,6 @@ export function UserPreferencesDirective(
             };
 
             scope.buildNotificationsFromExtensions();
-
-            scope.buildNotificationsFromExtensions(false);
 
             scope.toggleEmailGroupNotifications = function() {
                 const isGroupEnabled = scope.preferences['email:notification'].enabled;

--- a/scripts/apps/users/views/user-preferences.html
+++ b/scripts/apps/users/views/user-preferences.html
@@ -70,6 +70,7 @@
                     <h3 id="notifications" class="sd-heading sd-text-align--left sd-text--sans sd-heading--h3" translate>Notifications</h3>
                     <div class="sd-container sd-container--flex sd-container--gap-none sd-container--direction-column sd-radius--medium sd-panel-bg--000 sd-shadow--z2 sd-padding--3 sd-state--focus sd-margin-b--1">
                         <div class="sd-switch__group sd-switch__group--vertical">
+                            {{ preferences['notifications'] }}
                             <div sd-info-item>
                                 <span
                                     ng-hide="preferences['email:notification'].allowed"

--- a/scripts/apps/users/views/user-preferences.html
+++ b/scripts/apps/users/views/user-preferences.html
@@ -66,7 +66,7 @@
                     </div>
                 </li>
 
-                <li class="simple-list__item simple-list__item--stacked simple-list__item--justify-flex-start">
+                <li ng-if="preferencesLoaded === true" class="simple-list__item simple-list__item--stacked simple-list__item--justify-flex-start">
                     <h3 id="notifications" class="sd-heading sd-text-align--left sd-text--sans sd-heading--h3" translate>Notifications</h3>
                     <div class="sd-container sd-container--flex sd-container--gap-none sd-container--direction-column sd-radius--medium sd-panel-bg--000 sd-shadow--z2 sd-padding--3 sd-state--focus sd-margin-b--1">
                         <div class="sd-switch__group sd-switch__group--vertical">
@@ -82,10 +82,10 @@
 
                             <div class="item ms-1 ps-5">
                                 <sd-email-notifications-list
-                                    data-preferences="emailNotificationsFromExtensions"
+                                    data-preferences="preferences"
                                     data-toggle-email-notification="toggleEmailNotification"
-                                >
-                                </sd-email-notifications-list>
+                                    data-notification-labels="notificationLabels"
+                                ></sd-email-notifications-list>
                             </div>
                             <div sd-info-item>
                                 <span ng-hide="preferences['desktop:notification'].allowed" sd-switch ng-model="preferences['desktop:notification'].enabled"></span>

--- a/scripts/apps/users/views/user-preferences.html
+++ b/scripts/apps/users/views/user-preferences.html
@@ -70,7 +70,6 @@
                     <h3 id="notifications" class="sd-heading sd-text-align--left sd-text--sans sd-heading--h3" translate>Notifications</h3>
                     <div class="sd-container sd-container--flex sd-container--gap-none sd-container--direction-column sd-radius--medium sd-panel-bg--000 sd-shadow--z2 sd-padding--3 sd-state--focus sd-margin-b--1">
                         <div class="sd-switch__group sd-switch__group--vertical">
-                            {{ preferences['notifications'] }}
                             <div sd-info-item>
                                 <span
                                     ng-hide="preferences['email:notification'].allowed"

--- a/scripts/core/menu/notifications/notifications.ts
+++ b/scripts/core/menu/notifications/notifications.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import {gettext} from 'core/utils';
 import {AuthoringWorkspaceService} from 'apps/authoring/authoring/services/AuthoringWorkspaceService';
 import {extensions} from 'appConfig';
-import {IDesktopNotification} from 'superdesk-api';
+import {IExtensionActivationResult} from 'superdesk-api';
 import {logger} from 'core/services/logger';
 import emptyState from 'superdesk-ui-framework/dist/empty-state--small-2.svg';
 
@@ -296,7 +296,9 @@ angular.module('superdesk.core.menu.notifications', ['superdesk.core.services.as
                     scope.emptyState = emptyState;
 
                     // merged from all extensions
-                    const notificationsKeyed: {[key: string]: IDesktopNotification['handler']} = {};
+                    const notificationsKeyed: {
+                        [key: string]: IExtensionActivationResult['contributions']['notifications'][0]['handler']
+                    } = {};
 
                     for (const extension of Object.values(extensions)) {
                         const notificationsFromExtensions = extension.activationResult.contributions?.notifications;
@@ -306,9 +308,7 @@ angular.module('superdesk.core.menu.notifications', ['superdesk.core.services.as
                                 if (notificationsKeyed[key] == null) {
                                     const notificationValue = notificationsFromExtensions[key];
 
-                                    if (notificationValue.type == 'desktop') {
-                                        notificationsKeyed[key] = notificationValue.handler;
-                                    }
+                                    notificationsKeyed[key] = notificationValue.handler;
                                 } else {
                                     logger.error(new Error(`Notification key ${key} already registered.`));
                                 }

--- a/scripts/core/services/preferencesService.ts
+++ b/scripts/core/services/preferencesService.ts
@@ -23,6 +23,7 @@ export default angular.module('superdesk.core.preferences', ['superdesk.core.not
                 userPreferences = {
                     'feature:preview': 1,
                     'archive:view': 1,
+                    'notifications': 1,
                     'email:notification': 1,
                     'desktop:notification': 1,
                     'slack:notification': 1,
@@ -90,7 +91,7 @@ export default angular.module('superdesk.core.preferences', ['superdesk.core.not
                 },
                 // ask for permission and send a desktop notification
                 send: (msg) => {
-                    if (_.get(preferences, 'user_preferences.desktop:notification.enabled')) {
+                    if (preferences.user_preferences['desktop:notification'].enabled) {
                         if ('Notification' in window && Notification.permission !== 'denied') {
                             Notification.requestPermission((permission) => {
                                 if (permission === 'granted') {

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -706,16 +706,7 @@ declare module 'superdesk-api' {
     }
 
     interface IEmailNotification {
-        type: 'email';
-    }
 
-    export interface IDesktopNotification {
-        type: 'desktop';
-        label: string;
-        handler: (notification: any) => {
-            body: string;
-            actions: Array<{label: string; onClick: () => void;}>;
-        };
     }
 
     export interface IExtensionActivationResult {
@@ -756,7 +747,14 @@ declare module 'superdesk-api' {
             workspaceMenuItems?: Array<IWorkspaceMenuItem>;
             customFieldTypes?: Array<ICustomFieldType>;
             notifications?: {
-                [id: string]: IEmailNotification | IDesktopNotification;
+                [id: string]: {
+                    label: string;
+                    settingsLabel: string;
+                    handler: (notification: any) => {
+                        body: string;
+                        actions: Array<{label: string; onClick: () => void;}>;
+                    };
+                };
             };
             entities?: {
                 article?: {

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -705,10 +705,6 @@ declare module 'superdesk-api' {
         preview?: React.ComponentType<IIngestRuleHandlerPreviewProps>;
     }
 
-    interface IEmailNotification {
-
-    }
-
     export interface IExtensionActivationResult {
         contributions?: {
             globalMenuHorizontal?: Array<React.ComponentType>;

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -1414,6 +1414,14 @@ declare module 'superdesk-api' {
         invisible_stages: Array<any>;
         slack_username: string;
         slack_user_id: string;
+        user_preferences: {
+            notifications: {
+                [key: string]: {
+                    email: boolean;
+                    desktop: boolean;
+                };
+            };
+        };
         last_activity_at?: string;
     }
 

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -748,9 +748,8 @@ declare module 'superdesk-api' {
             customFieldTypes?: Array<ICustomFieldType>;
             notifications?: {
                 [id: string]: {
-                    label: string;
-                    settingsLabel: string;
-                    handler: (notification: any) => {
+                    name: string;
+                    handler?: (notification: any) => {
                         body: string;
                         actions: Array<{label: string; onClick: () => void;}>;
                     };

--- a/scripts/extensions/broadcasting/src/notifications.ts
+++ b/scripts/extensions/broadcasting/src/notifications.ts
@@ -19,8 +19,7 @@ type IExtensionNotifications = Required<Required<IExtensionActivationResult>['co
 
 export const notifications: IExtensionNotifications = {
     'rundown-item-comment': {
-        label: gettext('Open item'),
-        type: 'desktop',
+        name: gettext('Open item'),
         handler: (notification: IRundownItemCommentNotification) => ({
             body: notification.message,
             actions: [{

--- a/scripts/extensions/markForUser/src/extension.tsx
+++ b/scripts/extensions/markForUser/src/extension.tsx
@@ -48,8 +48,8 @@ const extension: IExtension = {
                     },
                     notifications: {
                         'item:marked': {
-                            type: 'desktop',
                             label: gettext('open item'),
+                            settingsLabel: gettext('Send Mark for User notifications'),
                             handler: (notification: any) => ({
                                 body: notification.message,
                                 actions: [{
@@ -57,20 +57,6 @@ const extension: IExtension = {
                                     onClick: () => superdesk.ui.article.view(notification.item),
                                 }],
                             }),
-                        },
-                        'item:unmarked': {
-                            label: gettext('open item'),
-                            type: 'desktop',
-                            handler: (notification: any) => ({
-                                body: notification.message,
-                                actions: [{
-                                    label: gettext('open item'),
-                                    onClick: () => superdesk.ui.article.view(notification.item),
-                                }],
-                            }),
-                        },
-                        'mark_for_user:notification': {
-                            type: 'email',
                         },
                     },
                     entities: {

--- a/scripts/extensions/markForUser/src/extension.tsx
+++ b/scripts/extensions/markForUser/src/extension.tsx
@@ -48,8 +48,7 @@ const extension: IExtension = {
                     },
                     notifications: {
                         'item:marked': {
-                            label: gettext('open item'),
-                            settingsLabel: gettext('Send Mark for User notifications'),
+                            name: gettext('Mark for User'),
                             handler: (notification: any) => ({
                                 body: notification.message,
                                 actions: [{

--- a/scripts/extensions/markForUser/src/get-marked-for-me-component.tsx
+++ b/scripts/extensions/markForUser/src/get-marked-for-me-component.tsx
@@ -72,10 +72,6 @@ export function getMarkedForMeComponent(superdesk: ISuperdesk) {
             });
 
             this.removeMarkedListener = superdesk.addWebsocketMessageListener('item:marked', this.queryAndSetArticles);
-            this.removeUnmarkedListener = superdesk.addWebsocketMessageListener(
-                'item:unmarked',
-                this.queryAndSetArticles,
-            );
         }
         componentWillUnmount() {
             this.removeMarkedListener();


### PR DESCRIPTION
SDBELGA-818

- [x] Registered notifications are displayed with value `true` even if a user doesn't have them saved in preferences
- [x] Email notification group toggling works and does toggle all sub notifications no matter if they haven't been set before by the user, or if they have been
- [x] Saving works in both cases
- [x] Canceling works in both cases
- [x] Desktop notifications aren't shown in the notifications sidebar if a user has toggled them off
- [ ] Email notifications aren't received if a user has toggled them off