### PR TITLE
remove media_description field

### DIFF
--- a/scripts/apps/authoring-react/data-layer.ts
+++ b/scripts/apps/authoring-react/data-layer.ts
@@ -64,12 +64,20 @@ export function getArticleContentProfile<T>(
         const {editor, fields, schema} = fakeScope;
         const fieldExists = (fieldId) => fakeScope.editor[fieldId] != null;
 
-        // Avoid having unnecessary adapters for fields
-        // to which we do not write data e.g. 'footer'.
-        // Authoring react doesn't support companion
-        // fields like 'footer' that don't have data on
-        // their own but simply modify the data of other fields.
-        const fieldsToOmit = ['footer'];
+        const fieldsToOmit = [
+            /**
+             * Avoid having unnecessary adapters for fields to which we do not write data e.g. 'footer'.
+             * authoring-react doesn't support companion fields like 'footer' that don't have data on
+             * their own but simply modify the data of other fields.
+             */
+            'footer',
+
+            /**
+             * `media_description` isn't used anywhere. It might still be present in content profiles, so
+             * I'm omitting it here to prevent authoring-react from crashing trying to render it.
+             */
+            'media_description',
+        ];
 
         const fieldsOrdered =
             Object.keys(editor)

--- a/scripts/apps/workspace/content/constants.ts
+++ b/scripts/apps/workspace/content/constants.ts
@@ -33,7 +33,6 @@ export const GET_LABEL_MAP = () => ({
     keywords: gettext('Keywords'),
     language: gettext('Language'),
     media: gettext('Media'),
-    media_description: gettext('Media Description'),
     place: gettext('Place'),
     priority: gettext('Priority'),
     publish_schedule: gettext('Scheduled Time'),
@@ -95,12 +94,10 @@ export function getLabelForStage(stage: IStage | ICard): string {
 
 export const EXTRA_SCHEMA_FIELDS = Object.freeze({
     feature_media: {},
-    media_description: {},
 });
 
 export const EXTRA_EDITOR_FIELDS = Object.freeze({
     feature_media: {enabled: true},
-    media_description: {enabled: true},
 });
 
 

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -1111,7 +1111,6 @@ declare module 'superdesk-api' {
         copyrightnotice?: string;
         sign_off: string;
         feature_media?: any;
-        media_description?: string;
         description_text?: string;
 
         associations?: {


### PR DESCRIPTION
SDESK-7362

@petrjasek we already started the conversation about it a while ago 
 - https://sourcefabric.slack.com/archives/D9191P9FD/p1651505039824909
 
 I did try to add it to a picture item in mongo, but couldn't get it to display - which makes sense given it's not used anywhere but these 3 places I'm removing it from. It's be best if you could write an upgrade script to drop it from existing content profiles so I don't have to exclude it manually there.
 
Or do you think I'm missing something and it is used in some way?