### PR TITLE
fix authoring-react not releasing lock when closed without changes

### DIFF
--- a/scripts/apps/authoring-react/authoring-react.tsx
+++ b/scripts/apps/authoring-react/authoring-react.tsx
@@ -1015,17 +1015,13 @@ export class AuthoringReact<T extends IBaseRestApiResponse> extends React.PureCo
      * and unless closing is cancelled by user action in the UI this.props.onClose is called.
      */
     initiateClosing(state: IStateLoaded<T>): void {
-        if (this.hasUnsavedChanges() !== true) {
-            this.props.onClose();
-            return;
-        }
-
         const {authoringStorage} = this.props;
 
         this.setLoadingState(state, true).then(() => {
             authoringStorage.closeAuthoring(
                 this.computeLatestEntity(),
                 state.itemOriginal,
+                this.hasUnsavedChanges(),
                 () => {
                     authoringStorage.autosave.cancel();
 

--- a/scripts/apps/authoring-react/data-layer.ts
+++ b/scripts/apps/authoring-react/data-layer.ts
@@ -342,10 +342,7 @@ export const authoringStorageIArticle: IAuthoringStorage<IArticle> = {
             return getArticleContentProfile(item, fieldsAdapter);
         }
     },
-    closeAuthoring: (current, original, cancelAutosave, doClose) => {
-        const diff = generatePatch(original, current);
-        const hasUnsavedChanges = Object.keys(diff).length > 0;
-
+    closeAuthoring: (current, original, hasUnsavedChanges, cancelAutosave, doClose) => {
         const unlockArticle = (id: string) => httpRequestJsonLocal<void>({
             method: 'POST',
             payload: {},

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -122,6 +122,7 @@ declare module 'superdesk-api' {
         closeAuthoring(
             current: T,
             original: T,
+            hasUnsavedChanges: boolean,
             cancelAutosave: () => Promise<void>,
             doClose: () => void,
         ): Promise<void>;

--- a/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit-rundown-item.ts
+++ b/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit-rundown-item.ts
@@ -1,4 +1,3 @@
-import {isEqual} from 'lodash';
 import {rundownItemContentProfile} from '../rundown-items/content-profile';
 import {
     IAuthoringAutoSave,
@@ -108,10 +107,8 @@ function getRundownItemAuthoringStorage(id: IRundownItem['_id']): IAuthoringStor
         getContentProfile: () => {
             return Promise.resolve(rundownItemContentProfile);
         },
-        closeAuthoring: (current, original, _cancelAutosave, doClose) => {
-            const warnAboutLosingChanges = !isEqual(current, original);
-
-            if (warnAboutLosingChanges) {
+        closeAuthoring: (_current, _original, hasUnsavedChanges, _cancelAutosave, doClose) => {
+            if (hasUnsavedChanges) {
                 return superdesk.ui.confirm('Discard unsaved changes?').then((confirmed) => {
                     if (confirmed) {
                         doClose();
@@ -197,7 +194,7 @@ function getRundownItemCreationAuthoringStorage(
         getContentProfile: () => {
             return Promise.resolve(contentProfile);
         },
-        closeAuthoring: (_current, _original, _cancelAutosave, doClose) => {
+        closeAuthoring: (_current, _original, _hasUnsavedChanges, _cancelAutosave, doClose) => {
             return superdesk.ui.confirm('Discard unsaved changes?').then((confirmed) => {
                 if (confirmed) {
                     doClose();

--- a/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit.ts
+++ b/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit.ts
@@ -56,9 +56,9 @@ function getRundownItemTemplateAuthoringStorage(
         getContentProfile: () => {
             return Promise.resolve(rundownItemContentProfile);
         },
-        closeAuthoring: (current, original, _cancelAutosave, doClose) => {
+        closeAuthoring: (_current, original, hasUnsavedChanges, _cancelAutosave, doClose) => {
             const isCreationMode = Object.keys(original.data).length < 1;
-            const warnAboutLosingChanges = isCreationMode || !isEqual(current.data, original.data);
+            const warnAboutLosingChanges = isCreationMode || hasUnsavedChanges;
 
             if (warnAboutLosingChanges) {
                 return superdesk.ui.confirm('Discard unsaved changes?').then((confirmed) => {

--- a/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit.ts
+++ b/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit.ts
@@ -1,4 +1,3 @@
-import {isEqual} from 'lodash';
 import {rundownItemContentProfile} from '../rundown-items/content-profile';
 import {
     IAuthoringAutoSave,


### PR DESCRIPTION
SDESK-7394

There's a function that handles both - prompts for unsaved changes AND unlocks the item. It wasn't being called without changes. I had to adjust the API a bit to pass an argument whether there are changes or not. Otherwise it's hard to compute a diff due to the fact that latest item is generated by authoring-react component which adds empty values where in the original item those fields are simply not present.