### PR TITLE
fix internal destinations e2e test

### DIFF
--- a/e2e/client/specs/helpers/setup.ts
+++ b/e2e/client/specs/helpers/setup.ts
@@ -24,7 +24,7 @@ function resize(width, height) {
 export function setup(params) {
     // runs before every spec
     beforeEach((done) => {
-        resize(1280, 800)
+        resize(1280, 900)
             .then(() => {
                 resetApp(params.fixture_profile, () => {
                     openBaseUrl()

--- a/e2e/client/specs/internal_destinations_spec.ts
+++ b/e2e/client/specs/internal_destinations_spec.ts
@@ -2,7 +2,7 @@
 
 import {browser, element, by, ExpectedConditions as EC} from 'protractor';
 import {el, els, s, ECE, hover} from '@superdesk/end-to-end-testing-helpers';
-import {nav, scrollToView} from './helpers/utils';
+import {nav} from './helpers/utils';
 
 describe('internal destinations & generic-page-list', () => {
     // The following tests also cover all other pages using generic-page-list
@@ -162,8 +162,6 @@ describe('internal destinations & generic-page-list', () => {
         expect(els(['list-page--filters-active', 'tag-label']).count()).toBe(0);
 
         el(['toggle-filters']).click();
-
-        scrollToView(el(['list-page--filters-form', 'gform-input--desk']));
 
         el(['list-page--filters-form', 'gform-input--desk']).click();
         el(['list-page--filters-form', 'gform-input--desk'], by.buttonText('Sports Desk')).click();

--- a/e2e/client/specs/internal_destinations_spec.ts
+++ b/e2e/client/specs/internal_destinations_spec.ts
@@ -2,7 +2,7 @@
 
 import {browser, element, by, ExpectedConditions as EC} from 'protractor';
 import {el, els, s, ECE, hover} from '@superdesk/end-to-end-testing-helpers';
-import {nav} from './helpers/utils';
+import {nav, scrollToView} from './helpers/utils';
 
 describe('internal destinations & generic-page-list', () => {
     // The following tests also cover all other pages using generic-page-list
@@ -162,6 +162,8 @@ describe('internal destinations & generic-page-list', () => {
         expect(els(['list-page--filters-active', 'tag-label']).count()).toBe(0);
 
         el(['toggle-filters']).click();
+
+        scrollToView(el(['list-page--filters-form', 'gform-input--desk']));
 
         el(['list-page--filters-form', 'gform-input--desk']).click();
         el(['list-page--filters-form', 'gform-input--desk'], by.buttonText('Sports Desk')).click();


### PR DESCRIPTION
The problem was absolute positioning on filter sidebar footer combined with a dropdown that still drops down rather than up when there's little space below. It only happens on very small screens and can be worked around by scrolling so I don't think it's worth doing a proper fix at the moment.

The reason why it started failing is probably a browser update that reduces window height - likely due to those toolbars warning it's a test browser.

![image](https://github.com/user-attachments/assets/d6b7817e-5343-4482-9064-a0c3bcb9b3d0)
