### PR TITLE
prevent authoring angular from initializing with old data

### DIFF
--- a/scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts
@@ -156,7 +156,7 @@ export function ArticleEditDirective(
                     }
                 }
 
-                // Needed only for #ANGULAR_AUTHORING. In authoring react we have a generic
+                // Needed only for TAG: AUTHORING-ANGULAR. In authoring react we have a generic
                 // event ('resource:updated') which listens to all item changes.
                 scope.$on('author_approval:updated', (_event, extra) => {
                     if (extra.item_id === scope.item?._id) {

--- a/scripts/apps/authoring/preview/fullPreviewMultiple.tsx
+++ b/scripts/apps/authoring/preview/fullPreviewMultiple.tsx
@@ -92,7 +92,7 @@ class FullPreviewMultiple extends React.PureComponent<IProps, IState> {
 }
 
 /**
- * #ANGULAR_AUTHORING This is used from angular based authoring - leave it as it is for compatibility
+ * TAG: AUTHORING-ANGULAR This is used from angular based authoring - leave it as it is for compatibility
  * and build a new one for authoring-react
  */
 export function previewItems(articles: Array<IArticle>) {


### PR DESCRIPTION
SDESK-7025

This is only relevant when switching(and saving the item in each step) between authoring-angular and authoring-react at least 4 times e.g. angular>react>angular>react.