### PR TITLE
warn about incompatible extensions

### DIFF
--- a/e2e/client/playwright/multiedit.spec.ts
+++ b/e2e/client/playwright/multiedit.spec.ts
@@ -36,6 +36,11 @@ test.describe('Multiedit', async () => {
 
         await multiedit.save('story 2');
 
+        /**
+         * TAG: AUTHORING-ANGULAR implementation is unreliable and "Exit" button doesn't always work
+         */
+        page.waitForTimeout(1000);
+
         await page.locator(s('multiedit-subnav')).getByRole('button', {name: 'Exit'}).click();
 
         await monitoring.executeActionOnMonitoringItem(

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -761,6 +761,11 @@ declare module 'superdesk-api' {
             authoringTopbar2Widgets?: Array<React.ComponentType<{article: IArticle}>>;
 
             authoringSideWidgets?: Array<IArticleSideWidget>;
+
+            /**
+             * @deprecated
+             * use customFieldTypes
+             */
             authoringHeaderComponents?: Array<AuthoringHeaderItem>;
 
             getAuthoringActions?(

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -159,7 +159,10 @@ export function startApp(
 
                         registerLegacyExtensionCompatibilityLayer();
 
-                        if (ng.get('session').sessionId != null) { // user logged in
+                        if (
+                            ng.get('session').sessionId != null // user logged in
+                            && ng.get('session').identity.user_type === 'administrator'
+                        ) {
                             maybeDisplayInvalidInstanceConfigurationMessage();
                         }
                     });

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -158,6 +158,10 @@ export function startApp(
                         }
 
                         registerLegacyExtensionCompatibilityLayer();
+
+                        if (ng.get('session').sessionId != null) { // user logged in
+                            maybeDisplayInvalidInstanceConfigurationMessage();
+                        }
                     });
                 });
             },
@@ -182,12 +186,6 @@ export function startApp(
                 'superdesk.apps',
                 'superdesk.register_extensions',
             ].concat(appConfig.apps || []), {strictDi: true});
-
-            setTimeout(() => { // required to avoid protractor timing out and failing tests
-                if (ng.get('session').sessionId != null) { // user logged in
-                    maybeDisplayInvalidInstanceConfigurationMessage();
-                }
-            });
 
             window['superdeskIsReady'] = true;
 

--- a/scripts/validate-instance-configuration.tsx
+++ b/scripts/validate-instance-configuration.tsx
@@ -3,41 +3,77 @@ import {Modal} from 'superdesk-ui-framework/react';
 import ng from 'core/services/ng';
 import {gettext} from 'core/utils';
 import {showModal} from '@superdesk/common';
+import {authoringReactEnabledUserSelection, extensions} from 'appConfig';
+import {flatMap} from 'lodash';
 
-const modalHeader = (
-    <span
-        style={{background: 'red', color: 'white', padding: 4}}
-    >
-        {gettext('Instance configuration is missing!')}
-    </span>
-);
+interface IError {
+    title: string;
+    content: React.ReactNode;
+}
 
-export function maybeDisplayInvalidInstanceConfigurationMessage() {
-    const issues: Array<React.ReactNode> = [];
+function getError(): Promise<IError | null> {
+    const authoringHeaderComponentsFromExtensions = flatMap(
+        Object.values(extensions),
+        (extension) => extension.activationResult?.contributions?.authoringHeaderComponents ?? [],
+    );
 
-    ng.get('vocabularies').getAllActiveVocabularies().then((vocabularies) => {
+    if (authoringHeaderComponentsFromExtensions.length > 0 && authoringReactEnabledUserSelection === true) {
+        return Promise.resolve({
+            title: 'Incompatible extension detected',
+            content: (
+                <>
+                    <p>
+                        Unsupported extension point is being used: `contributions.authoringHeaderComponents`
+                    </p>
+
+                    <p>
+                        You are likely running an outdated version of auto tagging extension.
+                    </p>
+
+                    <p>
+                        Update or disable incompatible extensions.
+                    </p>
+                </>
+            ),
+        });
+    }
+
+    return ng.get('vocabularies').getAllActiveVocabularies().then((vocabularies) => {
         const categoriesMissing = vocabularies.find(({_id}) => _id === 'categories') == null;
 
         if (categoriesMissing) {
-            issues.push(
-                (
+            return {
+                title: 'Instance configuration is missing!',
+                content: (
                     <>
                         <p>{gettext('Vocabulary with ID "categories" is required.')}</p>
                         <p>{gettext('Add it via Settings > Metadata')}</p>
                     </>
                 ),
-            );
+            };
+        } else {
+            return null;
         }
+    });
+}
 
-        if (issues.length > 0) {
+export function maybeDisplayInvalidInstanceConfigurationMessage() {
+    getError().then((error) => {
+        if (error != null) {
             showModal(({closeModal}) => (
                 <Modal
                     visible={true}
-                    headerTemplate={modalHeader}
+                    headerTemplate={(
+                        <span
+                            style={{background: 'red', color: 'white', padding: 4}}
+                        >
+                            {error.title}
+                        </span>
+                    )}
                     onHide={closeModal}
                     zIndex={9999}
                 >
-                    {issues[0]}
+                    {error.content}
                 </Modal>
             ));
         }


### PR DESCRIPTION
SDESK-7399

Display invalid instance configuration modal if unsupported extension point `contributions.authoringHeaderComponents` is being used. It is now deprecated, but still supported - until authoring-react is released. The message will only show up if authoring-react is running.