### PR TITLE
Non greedy regexp if multiple embeds on same line

### DIFF
--- a/scripts/core/editor3/html/from-html/index.ts
+++ b/scripts/core/editor3/html/from-html/index.ts
@@ -66,11 +66,11 @@ class HTMLParser {
 
     manageEmbeds(__html: string): string {
         let html = __html;
-        const embedCount = html.match(/<!-- EMBED START.*-->/g)?.length ?? 0;
+        const embedCount = html.match(/<!-- EMBED START.*?-->/g)?.length ?? 0;
 
         for (let i = 0; i < embedCount; i++) {
-            const startTag = html.match(/<!-- EMBED START.*-->/);
-            const endTag = html.match(/<!-- EMBED END.*-->/);
+            const startTag = html.match(/<!-- EMBED START.*?-->/);
+            const endTag = html.match(/<!-- EMBED END.*?-->/);
 
             if (startTag == null || endTag == null) {
                 continue;


### PR DESCRIPTION
# What does this MR do?
- Fixes the regex-pattern in `manageEmbeds()` so it will only match one embed-group at a time.
 
When parsing embeds from ingest feed, if html is printed on same row `.*` will match everything from the first `<!-- EMBED START` to the last `-->` in the string, capturing everything in between.

By using `.*?`, it will stop at the first occurrence of `-->` rather than the last and it will only match one pair at a time if the html is compressed into single line.