### PR TITLE
use autosave.get in authoring react

### DIFF
--- a/scripts/apps/authoring-react/authoring-angular-template-integration.tsx
+++ b/scripts/apps/authoring-react/authoring-angular-template-integration.tsx
@@ -58,7 +58,7 @@ function getTemplateEditViewAuthoringStorage(article: IArticle): IAuthoringStora
 
     const authoringStorageTemplateEditView: IAuthoringStorage<IArticle> = {
         autosave: new AutoSaveTemplate(),
-        getEntity: () => Promise.resolve({saved: article, autosaved: null}),
+        getEntity: () => Promise.resolve(article),
         isLockedInCurrentSession: () => true,
         forceLock: (entity) => Promise.resolve(entity),
         saveEntity: (current) => Promise.resolve(current),

--- a/scripts/apps/authoring-react/authoring-react.tsx
+++ b/scripts/apps/authoring-react/authoring-react.tsx
@@ -308,6 +308,7 @@ export class AuthoringReact<T extends IBaseRestApiResponse> extends React.PureCo
         this.setLoadingState = this.setLoadingState.bind(this);
         this.reinitialize = this.reinitialize.bind(this);
         this.setRef = this.setRef.bind(this);
+        this.getItemAndAutosave = this.getItemAndAutosave.bind(this);
 
         const setStateOriginal = this.setState.bind(this);
 
@@ -535,6 +536,15 @@ export class AuthoringReact<T extends IBaseRestApiResponse> extends React.PureCo
         }
     }
 
+    private getItemAndAutosave(): Promise<{autosaved: T; saved: T}> {
+        const {authoringStorage, itemId} = this.props;
+
+        return Promise.all([
+            authoringStorage.autosave.get(itemId).catch(() => null),
+            authoringStorage.getEntity(itemId),
+        ]).then(([autosaved, saved]) => ({autosaved, saved}));
+    }
+
     componentDidMount() {
         const authThemes = ng.get('authThemes');
 
@@ -544,7 +554,7 @@ export class AuthoringReact<T extends IBaseRestApiResponse> extends React.PureCo
 
         Promise.all(
             [
-                authoringStorage.getEntity(this.props.itemId).then((item) => {
+                this.getItemAndAutosave().then((item) => {
                     const itemCurrent = item.autosaved ?? item.saved;
 
                     return authoringStorage.getContentProfile(itemCurrent, this.props.fieldsAdapter).then((profile) => {
@@ -803,7 +813,7 @@ export class AuthoringReact<T extends IBaseRestApiResponse> extends React.PureCo
                     return;
                 }
 
-                authoringStorage.getEntity(state.itemOriginal._id).then((item) => {
+                this.getItemAndAutosave().then((item) => {
                     this.setState(getInitialState(
                         item,
                         state.profile,
@@ -829,7 +839,7 @@ export class AuthoringReact<T extends IBaseRestApiResponse> extends React.PureCo
                     return;
                 }
 
-                authoringStorage.getEntity(state.itemOriginal._id).then((item) => {
+                this.getItemAndAutosave().then((item) => {
                     this.setState(getInitialState(
                         item,
                         state.profile,

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -90,8 +90,13 @@ declare module 'superdesk-api' {
     }
 
     export interface IAuthoringAutoSave<T> {
+        /**
+         * Must reject or resolve with null if autosave doesn't have data on item
+         */
         get(id: string): Promise<T>;
+
         delete(id: string, etag: string): Promise<void>;
+
         cancel(): void;
 
         /**
@@ -117,7 +122,7 @@ declare module 'superdesk-api' {
     export interface IAuthoringStorage<T> {
         forceLock(entity: T): Promise<T>;
         isLockedInCurrentSession(item: T): boolean;
-        getEntity(id: string): Promise<{saved: T | null, autosaved: T | null}>;
+        getEntity(id: string): Promise<T>;
         saveEntity(current: T, original: T): Promise<T>;
         closeAuthoring(
             current: T,

--- a/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit-rundown-item.ts
+++ b/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit-rundown-item.ts
@@ -76,7 +76,7 @@ function getRundownItemAuthoringStorage(id: IRundownItem['_id']): IAuthoringStor
             return httpRequestJsonLocal<IRundownItem>({
                 method: 'GET',
                 path: `/rundown_items/${id}`,
-            }).then((saved) => ({saved, autosaved: null}));
+            });
         },
         isLockedInCurrentSession: () => false,
         forceLock: (entity) => {
@@ -161,7 +161,7 @@ function getRundownItemCreationAuthoringStorage(
     const authoringStorageRundownItem: IAuthoringStorage<IRundownItem> = {
         autosave: new AutoSaveRundownItem(),
         getEntity: () => {
-            return Promise.resolve({saved: initialData as IRundownItem, autosaved: null});
+            return Promise.resolve(initialData as IRundownItem);
         },
         isLockedInCurrentSession: () => true,
         forceLock: (entity) => {

--- a/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit.ts
+++ b/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit.ts
@@ -39,7 +39,7 @@ function getRundownItemTemplateAuthoringStorage(
     const authoringStorageRundownItem: IAuthoringStorage<IRundownItemTemplateInitial> = {
         autosave: new AutoSaveRundownItem(),
         getEntity: () => {
-            return Promise.resolve({saved: item, autosaved: null});
+            return Promise.resolve(item);
         },
         isLockedInCurrentSession: () => false,
 


### PR DESCRIPTION
STT-63

It should have been used from the start.

My code using authoring-react was breaking due to an assumption that if  `autosave.schedule` is being called - `autosave.get` must have been already called.