### PR TITLE
decouple datetime component from angular service

### DIFF
--- a/scripts/core/datetime/datetime.ts
+++ b/scripts/core/datetime/datetime.ts
@@ -137,32 +137,36 @@ export function scheduledFormat(__item: IArticle): {short: string, long: string}
     };
 }
 
+/**
+ * Get short representation of given datetime
+ *
+ * It returns time for current day, day + time for current week, date otherwise.
+ *
+ * @param {String} d iso format datetime
+ * @return {String}
+ */
+export function shortFormat(d) {
+    var m = moment(d);
+    var now = moment();
+
+    if (isSameDay(m, now)) {
+        return m.format(TIME_FORMAT);
+    } else if (isSameWeek(m, now)) {
+        return m.format(WEEK_FORMAT);
+    } else if (isArchiveYear(m, now)) {
+        return m.format(ARCHIVE_FORMAT);
+    }
+
+    return m.format(DATE_FORMAT);
+}
+
+export const longFormat = (date) => formatDate(date, {longFormat: true});
+
 DateTimeService.$inject = [];
 function DateTimeService() {
-    /**
-     * Get short representation of given datetime
-     *
-     * It returns time for current day, day + time for current week, date otherwise.
-     *
-     * @param {String} d iso format datetime
-     * @return {String}
-     */
-    this.shortFormat = function(d) {
-        var m = moment(d);
-        var now = moment();
+    this.shortFormat = shortFormat;
 
-        if (isSameDay(m, now)) {
-            return m.format(TIME_FORMAT);
-        } else if (isSameWeek(m, now)) {
-            return m.format(WEEK_FORMAT);
-        } else if (isArchiveYear(m, now)) {
-            return m.format(ARCHIVE_FORMAT);
-        }
-
-        return m.format(DATE_FORMAT);
-    };
-
-    this.longFormat = (date) => formatDate(date, {longFormat: true});
+    this.longFormat = longFormat;
 }
 
 DateTimeHelperService.$inject = [];

--- a/scripts/core/ui/components/DateTime.tsx
+++ b/scripts/core/ui/components/DateTime.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
-import ng from 'core/services/ng';
 import {IPropsDateTime} from 'superdesk-api';
+import {longFormat, shortFormat} from 'core/datetime/datetime';
 
 export class DateTime extends React.PureComponent<IPropsDateTime> {
     render() {
-        const datetimeService = ng.get('datetime');
         const {dateTime} = this.props;
 
-        const dateShort = datetimeService.shortFormat(dateTime);
-        const dateLong = datetimeService.longFormat(dateTime);
+        const dateShort = shortFormat(dateTime);
+        const dateLong = longFormat(dateTime);
         const tooltip = this.props.tooltip == null ? dateLong : this.props.tooltip(dateLong, dateShort);
 
         return (


### PR DESCRIPTION
STT-63

Unit tests in planning crash if `ng.get` is used in any of the components since planning doesn't have angular specific setup. The plan is to reduce angular usage anyway so I don't think it's worth adding that angular support in planning tests. We'll simply update components not to use angular if we get into similar issues in the future.