### PR TITLE
expose a config option to add a side menu entry

### DIFF
--- a/scripts/extensions/availability-manager/src/configuration.tsx
+++ b/scripts/extensions/availability-manager/src/configuration.tsx
@@ -1,0 +1,11 @@
+import {IPage} from 'superdesk-api';
+
+export interface IConfiguration {
+    addPageToSideMenu?: IPage['addToSideMenu'];
+}
+
+export const configuration: IConfiguration = {};
+
+export function configure(_config: IConfiguration) {
+    Object.assign(configuration, _config);
+}

--- a/scripts/extensions/availability-manager/src/extension.ts
+++ b/scripts/extensions/availability-manager/src/extension.ts
@@ -3,6 +3,7 @@ import {LANGUAGES_VOCABULARY, privileges, TAGS_VOCABULARY_ID} from './constants'
 import {AvailabilitySettingsPage} from './settings/availability-settings-page';
 import {superdesk} from './superdesk';
 import {CorrespondentAvailability} from './correspondent-availability';
+import {configuration} from './configuration';
 
 const {gettext} = superdesk.localization;
 
@@ -69,6 +70,7 @@ const extension: IExtension = {
                     url: '/availability-management',
                     priority: 160,
                     component: CorrespondentAvailability,
+                    addToSideMenu: configuration.addPageToSideMenu,
                 });
             }
         }
@@ -76,5 +78,7 @@ const extension: IExtension = {
         return Promise.resolve({contributions} satisfies IExtensionActivationResult);
     },
 };
+
+export {configure} from './configuration';
 
 export default extension;


### PR DESCRIPTION
SDBELGA-961

Sample usage:

```
startApp(
    [
        {
            id: 'availability-manager',
            load: () => import('superdesk-core/scripts/extensions/availability-manager').then((extension) => {
                extension.configure({
                    addPageToSideMenu: {
                        icon: 'settings',
                        order: 1100,
                        keyBinding: 'ctrl+alt+c',
                    },
                });

                return extension;
            }),
        },

    ],
    {},
    {},
);
 ```