### PR TITLE
fix spellchecker initialization

### DIFF
--- a/scripts/core/editor3/components/Editor3InitializeSpellchecker.tsx
+++ b/scripts/core/editor3/components/Editor3InitializeSpellchecker.tsx
@@ -63,6 +63,11 @@ export class Editor3InitializeSpellchecker extends React.PureComponent<IProps, I
                     });
                 });
             } else {
+                // update redux store to mark spellchecker as disabled
+                this.props.dispatch(setExternalOptions({
+                    spellchecking: getInitialSpellcheckerData(null, language),
+                }));
+
                 this.setState({loading: false});
             }
         });


### PR DESCRIPTION
STT-193

Set spellchecker info to redux store even if spellchecker is disabled. In the spellcheck config it will have `enabled:false`. Otherwise redux store will not be in sync with actual config and still perform spellchecking.