### PR TITLE
handle mjs module issues

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -132,7 +132,7 @@ module.exports = function makeConfig(grunt) {
         module: {
             rules: [
                 {
-                    test: /\.(ts|tsx|js|jsx|mjs)$/,
+                    test: /\.(ts|tsx|js|jsx)$/,
                     exclude: function(absolutePath) {
                         // don't exclude anything outside node_modules
                         if (absolutePath.indexOf('node_modules') === -1) {


### PR DESCRIPTION
It was crashing at runtime (with planning#develop enabled) with this error:

```
_object_spread.mjs:6 Uncaught ReferenceError: exports is not defined
    at ./node_modules/@swc/helpers/src/_object_spread.mjs (app.bundle.js:28514:1)
    at __webpack_require__ (app.bundle.js:790:30)
    at fn (app.bundle.js:101:20)
    at ./node_modules/@superdesk/react-resizable-panels/dist/react-resizable-panels.module.js (app.bundle.js:28502:1)
    at __webpack_require__ (app.bundle.js:790:30)
    at fn (app.bundle.js:101:20)
    at ./node_modules/superdesk-ui-framework/react/components/ResizablePanels.js (app.bundle.js:64904:1)
```

When building availability manager I needed to load `.mjs` modules for reason I don't remember now.