### PR TITLE
[SDESK-7709] Allow clearing embargo and publish schedule dates

### DIFF
--- a/scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx
+++ b/scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx
@@ -95,13 +95,14 @@ export class PublishingDateOptions extends React.PureComponent<IProps> {
                 {canSetEmbargo && (
                     <ToggleBox variant="simple" title={gettext('Embargo')} initiallyOpen>
                         <DateTimePicker
-                            value={new TZDate(embargo, timezoneApplied)}
+                            value={embargo === null ? null : new TZDate(embargo, timezoneApplied)}
                             valueType="date"
                             dateFormat={appConfig.view.dateformat}
                             onChange={(val) => {
                                 const isValidDate = isValid(val);
+                                const isDateBeingReset = val === null;
 
-                                if (isValidDate) {
+                                if (isValidDate || isDateBeingReset) {
                                     this.props.onChange({
                                         embargo: val,
                                         timeZone: timeZone ?? appConfig.default_timezone,
@@ -117,13 +118,14 @@ export class PublishingDateOptions extends React.PureComponent<IProps> {
                 {canSetPublishSchedule && (
                     <ToggleBox variant="simple" title={gettext('Publish schedule')} initiallyOpen>
                         <DateTimePicker
-                            value={new TZDate(publishSchedule, timezoneApplied)}
+                            value={publishSchedule === null ? null : new TZDate(publishSchedule, timezoneApplied)}
                             valueType="date"
                             dateFormat={appConfig.view.dateformat}
                             onChange={(val) => {
                                 const isValidDate = isValid(val);
+                                const isDateBeingReset = val === null;
 
-                                if (isValidDate) {
+                                if (isValidDate || isDateBeingReset) {
                                     this.props.onChange({
                                         publishSchedule: val,
                                         timeZone: timeZone ?? appConfig.default_timezone,


### PR DESCRIPTION
### Purpose
Fix a bug preventing users from clearing the embargo and publish schedule date fields. This issue stemmed from how the JavaScript `Date` constructor (used internally by `TZDate`) treats null, coercing it to the Unix epoch (`1970-01-01T00:00`) instead of treating it as an intentional reset.

### What has changed
- The `PublishingDateOptions` component now explicitly checks for `null` values before creating `TZDate` instances, avoiding unintended conversions
- The `DateTimePicker` `onChange` handler now properly handles both valid dates and `null`

Resolves: [SDESK-7709]

[SDESK-7709]: https://sofab.atlassian.net/browse/SDESK-7709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ