### PR TITLE
fix embed loading in editor

### DIFF
--- a/scripts/core/editor3/components/embeds/EmbedBlock.tsx
+++ b/scripts/core/editor3/components/embeds/EmbedBlock.tsx
@@ -41,12 +41,16 @@ export class EmbedBlockComponent extends React.Component<IProps> {
     static propTypes: any;
     static defaultProps: any;
 
+    globalKeys: Array<string>;
+
     constructor(props) {
         super(props);
 
         this.onClickDelete = this.onClickDelete.bind(this);
         this.editEmbedHtml = this.editEmbedHtml.bind(this);
         this.onChangeDescription = this.onChangeDescription.bind(this);
+
+        this.globalKeys = [];
     }
 
     /**
@@ -59,14 +63,22 @@ export class EmbedBlockComponent extends React.Component<IProps> {
 
         tree.find('script').each((i, s) => {
             if (s.hasAttribute('src')) {
-                let url = s.getAttribute('src');
-                const async = s.hasAttribute('async');
+                const newScript = document.createElement('script');
+                const oldKeys = Object.keys(window);
 
-                if (url.startsWith('http')) {
-                    url = url.substring(url.indexOf(':') + 1);
-                }
+                newScript.setAttribute('src', s.getAttribute('src'));
+                newScript.setAttribute('async', s.hasAttribute('async') ? 'async' : '');
+                document.body.appendChild(newScript);
+                newScript.onload = () => {
+                    const newKeys = Object.keys(window);
 
-                return $.ajax({url: url, async: async, dataType: 'script'});
+                    // keep track of new global objects created after the script was loaded
+                    this.globalKeys = newKeys.filter((k) => !oldKeys.includes(k) && isNaN(parseInt(k, 10)));
+
+                    document.body.removeChild(newScript);
+                };
+
+                return;
             }
 
             try {
@@ -147,10 +159,19 @@ export class EmbedBlockComponent extends React.Component<IProps> {
 
     componentDidMount() {
         const embed = this.data();
+        const html = embed.data.html;
+        const isQumu = isQumuWidget(html);
 
         if (embed.data.html.includes('iframe.ly')) {
             loadIframely();
+        } else if (isQumu !== true) {
+            this.runScripts(html);
         }
+    }
+
+    componentWillUnmount(): void {
+        this.globalKeys.forEach((k) => delete window[k]);
+        this.globalKeys = [];
     }
 
     render() {
@@ -158,10 +179,6 @@ export class EmbedBlockComponent extends React.Component<IProps> {
         const html = embed.data.html;
         const isQumu = isQumuWidget(html);
         const {readOnly} = this.props;
-
-        if (isQumu !== true) {
-            this.runScripts(html);
-        }
 
         const setLocked = () => {
             this.props.dispatch(actions.setLocked(true));

--- a/scripts/core/editor3/components/embeds/EmbedBlock.tsx
+++ b/scripts/core/editor3/components/embeds/EmbedBlock.tsx
@@ -41,53 +41,12 @@ export class EmbedBlockComponent extends React.Component<IProps> {
     static propTypes: any;
     static defaultProps: any;
 
-    globalKeys: Array<string>;
-
     constructor(props) {
         super(props);
 
         this.onClickDelete = this.onClickDelete.bind(this);
         this.editEmbedHtml = this.editEmbedHtml.bind(this);
         this.onChangeDescription = this.onChangeDescription.bind(this);
-
-        this.globalKeys = [];
-    }
-
-    /**
-     * @name EmbedBlockComponent#runScripts
-     * @param {string} html
-     * @description Runs and imports all the scripts in the given HTML.
-     */
-    runScripts(html) {
-        const tree = $('<div />').html(html);
-
-        tree.find('script').each((i, s) => {
-            if (s.hasAttribute('src')) {
-                const newScript = document.createElement('script');
-                const oldKeys = Object.keys(window);
-
-                newScript.setAttribute('src', s.getAttribute('src'));
-                newScript.setAttribute('async', s.hasAttribute('async') ? 'async' : '');
-                document.body.appendChild(newScript);
-                newScript.onload = () => {
-                    const newKeys = Object.keys(window);
-
-                    // keep track of new global objects created after the script was loaded
-                    this.globalKeys = newKeys.filter((k) => !oldKeys.includes(k) && isNaN(parseInt(k, 10)));
-
-                    document.body.removeChild(newScript);
-                };
-
-                return;
-            }
-
-            try {
-                // eslint-disable-next-line no-eval
-                eval(s.innerHTML);
-            } catch (e) {
-                /* carry on */
-            }
-        });
     }
 
     getEntityKey() {
@@ -159,19 +118,10 @@ export class EmbedBlockComponent extends React.Component<IProps> {
 
     componentDidMount() {
         const embed = this.data();
-        const html = embed.data.html;
-        const isQumu = isQumuWidget(html);
 
         if (embed.data.html.includes('iframe.ly')) {
             loadIframely();
-        } else if (isQumu !== true) {
-            this.runScripts(html);
         }
-    }
-
-    componentWillUnmount(): void {
-        this.globalKeys.forEach((k) => delete window[k]);
-        this.globalKeys = [];
     }
 
     render() {
@@ -204,7 +154,20 @@ export class EmbedBlockComponent extends React.Component<IProps> {
                 {
                     isQumu
                         ? <QumuWidget html={html} />
-                        : <div className="embed-block__wrapper" dangerouslySetInnerHTML={{__html: html}} />
+                        : (
+                            <div className="embed-block__wrapper">
+                                <iframe
+                                    srcDoc={html}
+                                    style={{border: 0}}
+                                    onLoad={(event) => {
+                                        const iframe = event.currentTarget;
+
+                                        // set the height of the iframe to the content height
+                                        iframe.height = iframe.contentWindow.document.body.scrollHeight + 'px';
+                                    }}
+                                />
+                            </div>
+                        )
                 }
 
                 <Textarea

--- a/scripts/core/editor3/components/tests/embeds.spec.tsx
+++ b/scripts/core/editor3/components/tests/embeds.spec.tsx
@@ -21,7 +21,7 @@ describe('editor3.components.embed-block', () => {
         );
 
         expect(wrapper.find('.embed-block__wrapper').html())
-            .toBe('<div class="embed-block__wrapper"><h1>Embed Title</h1></div>');
+            .toContain('<h1>Embed Title</h1>');
     });
 });
 

--- a/scripts/core/editor3/directive.tsx
+++ b/scripts/core/editor3/directive.tsx
@@ -148,7 +148,10 @@ class Editor3Directive {
     headerStyles?: boolean;
     helperText: string;
 
+    reactRoot: any;
+
     $onInit: () => void;
+    $onDestroy: () => void;
 
     constructor() {
         this.scope = {};
@@ -348,6 +351,8 @@ class Editor3Directive {
 
                     const renderEditor3 = () => {
                         const element = $element.get(0);
+
+                        this.reactRoot = element;
 
                         ReactDOM.unmountComponentAtNode(element);
 
@@ -638,6 +643,13 @@ class Editor3Directive {
                         () => generateHtml(store, this.item, this.pathToValue),
                     );
                 });
+        };
+
+        this.$onDestroy = () => {
+            if (this.reactRoot) {
+                ReactDOM.unmountComponentAtNode(this.reactRoot);
+                this.reactRoot = null;
+            }
         };
     }
 }


### PR DESCRIPTION
we need to execute the external script each time we render the embed,
but the libraries usually create some global object and when it's present
they won't init again, so it's removing all new window keys created on load.

SDAAP-128