### PR TITLE
fix export loading indicator not closing

### DIFF
--- a/scripts/apps/search/components/actions-menu/Item.tsx
+++ b/scripts/apps/search/components/actions-menu/Item.tsx
@@ -47,7 +47,7 @@ export default class MenuItem extends React.Component<IProps, IState> {
     }
 
     updateActioningStatus(isActioning) {
-        if (this._mounted && !this.props.item.gone) {
+        if (this.props.item.gone !== true) {
             this.props.onActioning(isActioning);
         }
     }


### PR DESCRIPTION
the menu was already unmounted when the action
finished and thus it was not reporting the status back.

SDESK-7659