### PR TITLE
fix publish schedule time when using different timezone

### DIFF
--- a/scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx
+++ b/scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {TZDate} from '@sourcefabric/date-fns-tz';
 import {IArticle} from 'superdesk-api';
 import {correctTimezone, gettext, toIsoStringWithoutTimezoneOffset} from 'core/utils';
 import {appConfig} from 'appConfig';
@@ -72,10 +71,10 @@ export function getPublishingDatePatch(item: IArticle, options: IPublishingDateO
     const nextOptions: Partial<IArticle> = {
         embargo: embargo == null
             ? null
-            : toIsoStringWithoutTimezoneOffset(new TZDate(embargo, timeZone)),
+            : toIsoStringWithoutTimezoneOffset(embargo),
         publish_schedule: publishSchedule == null
             ? null
-            : toIsoStringWithoutTimezoneOffset(new TZDate(publishSchedule, timeZone)),
+            : toIsoStringWithoutTimezoneOffset(publishSchedule),
         schedule_settings: {
             ...item.schedule_settings,
             time_zone: timeZone,

--- a/scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx
+++ b/scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {IArticle} from 'superdesk-api';
-import {correctTimezone, gettext, toIsoStringWithoutTimezoneOffset} from 'core/utils';
+import {gettext, toIsoStringWithoutTimezoneOffset} from 'core/utils';
 import {appConfig} from 'appConfig';
 import {DateTimePicker, ToggleBox} from 'superdesk-ui-framework/react';
 import {TimeZonePicker} from 'core/ui/components/time-zone-picker';
@@ -13,6 +13,16 @@ export interface IPublishingDateOptions {
     embargo: Date | null;
     publishSchedule: Date | null;
     timeZone: string | null;
+}
+
+function ignoreTimezone(
+    /**
+     * Server adds +0000 to embargo/publish_schedule no matter what timezone it is,
+     * so ignore that and treat it as local time for editing to avoid further conversion.
+     */
+    date: string,
+): TZDate {
+    return new TZDate(date.replace('+0000', ''));
 }
 
 export function getInitialPublishingDateOptions(items: Array<IArticle>): IPublishingDateOptions {
@@ -30,7 +40,7 @@ export function getInitialPublishingDateOptions(items: Array<IArticle>): IPublis
                 return null;
             }
 
-            return correctTimezone(embargo, timeZone);
+            return ignoreTimezone(embargo);
         })(),
         publishSchedule: (() => {
             if (items.length != 1) {
@@ -43,7 +53,7 @@ export function getInitialPublishingDateOptions(items: Array<IArticle>): IPublis
                 return null;
             }
 
-            return correctTimezone(publishSchedule, timeZone);
+            return ignoreTimezone(publishSchedule);
         })(),
         timeZone: timeZone,
     };

--- a/scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx
+++ b/scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx
@@ -7,6 +7,7 @@ import {TimeZonePicker} from 'core/ui/components/time-zone-picker';
 import {generatePatch} from 'core/patch';
 import {sdApi} from 'api';
 import {isValid} from 'date-fns';
+import {TZDate} from '@sourcefabric/date-fns-tz';
 
 export interface IPublishingDateOptions {
     embargo: Date | null;
@@ -71,10 +72,10 @@ export function getPublishingDatePatch(item: IArticle, options: IPublishingDateO
     const nextOptions: Partial<IArticle> = {
         embargo: embargo == null
             ? null
-            : toIsoStringWithoutTimezoneOffset(embargo),
+            : toIsoStringWithoutTimezoneOffset(new TZDate(embargo)),
         publish_schedule: publishSchedule == null
             ? null
-            : toIsoStringWithoutTimezoneOffset(publishSchedule),
+            : toIsoStringWithoutTimezoneOffset(new TZDate(publishSchedule)),
         schedule_settings: {
             ...item.schedule_settings,
             time_zone: timeZone,

--- a/scripts/core/utils.tsx
+++ b/scripts/core/utils.tsx
@@ -398,8 +398,8 @@ export function getUTCOffset(timezoneId: string) {
     return trimStartExact(offsetStr, 'GMT');
 }
 
-export function toIsoStringWithoutTimezoneOffset(date: TZDate) {
-    return date.toISOString().slice(0, 16);
+export function toIsoStringWithoutTimezoneOffset(date: Date) {
+    return date.toISOString().slice(0, 19);
 }
 
 export function correctTimezone(

--- a/scripts/core/utils.tsx
+++ b/scripts/core/utils.tsx
@@ -398,7 +398,10 @@ export function getUTCOffset(timezoneId: string) {
     return trimStartExact(offsetStr, 'GMT');
 }
 
-export function toIsoStringWithoutTimezoneOffset(date: Date) {
+/**
+ * Enforce TZDate because Date is inconsistent, sometimes it returns the time in UTC and sometimes in local timezone.
+ */
+export function toIsoStringWithoutTimezoneOffset(date: TZDate) {
     return date.toISOString().slice(0, 19);
 }
 


### PR DESCRIPTION
SDESK-7688

avoid converting time from local to selected timezone, that's handled on the server, the time should be sent as it is.