### PR TITLE
Apply soft limit only if it's defined

### DIFF
--- a/scripts/core/editor3/components/text-length-overflow-decorator.tsx
+++ b/scripts/core/editor3/components/text-length-overflow-decorator.tsx
@@ -97,16 +97,21 @@ export function getTextLimitHighlightDecorator(hardLimit: number, softLimit?: nu
         }
     }
 
-    const decorator = new CompositeDecorator([
+    const decorators = [
         {
             strategy: strategyForHardLimit,
             component: (props) => <Component {...props} color="#ff0000" />,
         },
-        {
+    ];
+
+    if (typeof softLimit === 'number') {
+        decorators.push({
             strategy: strategyForSoftLimit,
             component: (props) => <Component {...props} color="#E6731A" />,
-        },
-    ]);
+        });
+    }
+
+    const decorator = new CompositeDecorator(decorators);
 
     return decorator;
 }


### PR DESCRIPTION
SDESK-7727

Undefined: In the UI it's currently possible to apply a soft limit longer than the hard limit, but then soft limit doesn't render in the editor field. Should that be possible in the first place?