### PR TITLE
[STT-1299] Add getStageById to SuperdeskApi

### DIFF
--- a/scripts/api/desks.ts
+++ b/scripts/api/desks.ts
@@ -53,6 +53,10 @@ function getDeskMembers(deskId: IDesk['_id']): Array<IUser> {
     return ng.get('desks').deskMembers[deskId] ?? [];
 }
 
+function getStageById(id: IStage['_id']): IStage {
+    return ng.get('desks').stageLookup[id];
+}
+
 interface IDesksApi {
     /** Desk is considered active if it is being viewed in monitoring at the moment */
     getActiveDeskId(): IDesk['_id'] | null;
@@ -63,6 +67,7 @@ interface IDesksApi {
     getDeskStages(deskId: IDesk['_id']): OrderedMap<IStage['_id'], IStage>;
     getCurrentUserDesks(): Array<IDesk>; // desks that current user has access to
     getDeskMembers(deskId: IDesk['_id']): Array<IUser>; // members of the desk
+    getStageById(id: IStage['_id']): IStage;
 }
 
 export const desks: IDesksApi = {
@@ -74,4 +79,5 @@ export const desks: IDesksApi = {
     getDeskStages,
     getCurrentUserDesks,
     getDeskMembers,
+    getStageById,
 };

--- a/scripts/core/get-superdesk-api-implementation.tsx
+++ b/scripts/core/get-superdesk-api-implementation.tsx
@@ -358,6 +358,7 @@ export function getSuperdeskApiImplementation(
                 getActiveDeskId: sdApi.desks.getActiveDeskId,
                 waitTilReady: sdApi.desks.waitTilReady,
                 getDeskById: sdApi.desks.getDeskById,
+                getStageById: sdApi.desks.getStageById,
             },
             contentProfile: {
                 get: (id) => sdApi.contentProfiles.get(id),

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -3140,6 +3140,7 @@ declare module 'superdesk-api' {
                 getActiveDeskId(): IDesk['_id'] | null;
                 waitTilReady(): Promise<void>;
                 getDeskById(id: IDesk['_id']): IDesk;
+                getStageById(id: IStage['_id']): IStage;
             };
             attachment: IAttachmentsApi;
             users: {


### PR DESCRIPTION
### Purpose
Add `superdeskApi.entities.desk.getStageById` to the SuperdeskAPI (which doesn't require a network request)