### PR TITLE
increase max_results API limit for availability manager

### DIFF
--- a/scripts/extensions/availability-manager/src/correspondent-availability/get-query-with-filters.ts
+++ b/scripts/extensions/availability-manager/src/correspondent-availability/get-query-with-filters.ts
@@ -71,7 +71,7 @@ export function getQueryWithFilters(
             $and: where,
         },
         page: 1,
-        max_results: 200,
+        max_results: 500,
         sort: [{'versioncreated': 'asc'}], // sorting isn't relevant
     };
 

--- a/scripts/extensions/availability-manager/src/correspondent-availability/participants.ts
+++ b/scripts/extensions/availability-manager/src/correspondent-availability/participants.ts
@@ -16,7 +16,7 @@ export function fetchParticipants(): Promise<Set<IUser['_id']>> {
             ],
         },
         page: 1,
-        max_results: 200,
+        max_results: 500,
         sort: [{[nameof<IDefaultAvailability>('_created')]: 'asc'}],
     };
 


### PR DESCRIPTION
SDBELGA-982

For week view we fetch 7 records per user which with 50 users was 350 and was getting cut off by our limit of 200.