### PR TITLE
fix custom editor3 tags not showing up

### DIFF
--- a/scripts/core/editor3/store/index.ts
+++ b/scripts/core/editor3/store/index.ts
@@ -32,6 +32,7 @@ import {
 } from '../components/spellchecker/SpellcheckerDecorator';
 import {appConfig} from 'appConfig';
 import {
+    customEditorTags,
     formattingOptionsUnsafeToParseFromHTML,
 } from 'apps/workspace/content/components/get-content-profiles-form-config';
 import {RICH_FORMATTING_OPTION, IArticle} from 'superdesk-api';
@@ -342,8 +343,12 @@ export function getInitialContent(props): ContentState {
         ).getCurrentContent();
     }
 
+    const customTagStyles = new Set(customEditorTags.map(({editor3Style}) => editor3Style));
+
     const hasUnsafeFormattingOptions = props.editorFormat != null && props.editorFormat.some(
-        (option: RICH_FORMATTING_OPTION) => formattingOptionsUnsafeToParseFromHTML.includes(option),
+        (option: RICH_FORMATTING_OPTION) => {
+            return formattingOptionsUnsafeToParseFromHTML.includes(option) || customTagStyles.has(option);
+        },
     );
 
     /**


### PR DESCRIPTION
 STT-1369

Editor3 initializes from `body_html` by default. Unless there are unsafe formatting options that can only work when initialized from `fields_meta`.

I've added custom editor tags to unsafe formatting options.
