### PR TITLE
[SDESK-7783] Add getUniqueClientId to SuperdeskApi

### DIFF
--- a/scripts/api/user.ts
+++ b/scripts/api/user.ts
@@ -1,6 +1,7 @@
 import ng from 'core/services/ng';
 import {IUser} from 'superdesk-api';
 import {OrderedMap} from 'immutable';
+import {uuid} from 'core/helpers/uuid';
 
 function hasPrivilege(privilege: string): boolean {
     const privileges = ng.get('privileges');
@@ -24,9 +25,21 @@ function getAll(): OrderedMap<IUser['_id'], IUser> {
     return OrderedMap(ng.get('desks').users._items.map((user) => [user._id, user]));
 }
 
+function getUniqueClientId(): string {
+    let clientId: string | null = sessionStorage.getItem('clientId');
+
+    if (clientId == null) {
+        clientId = uuid();
+        sessionStorage.setItem('clientId', clientId);
+    }
+
+    return clientId;
+}
+
 export const user = {
     hasPrivilege,
     isLoggedIn,
     getCurrentUserId,
     getAll,
+    getUniqueClientId,
 };

--- a/scripts/core/get-superdesk-api-implementation.tsx
+++ b/scripts/core/get-superdesk-api-implementation.tsx
@@ -556,6 +556,7 @@ export function getSuperdeskApiImplementation(
             getCurrentUser: () => session.getIdentity(),
             getSessionId: () => session.sessionId,
             getCurrentUserId: () => sdApi.user.getCurrentUserId(),
+            getUniqueClientId: () => sdApi.user.getUniqueClientId(),
         },
         browser: {
             location: {

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -3358,6 +3358,7 @@ declare module 'superdesk-api' {
             getCurrentUser(): Promise<IUser>;
             getSessionId(): String;
             getCurrentUserId(): String;
+            getUniqueClientId(): string;
         };
         browser: {
             location: {


### PR DESCRIPTION
### Purpose
In Planning, we need a way to uniquely identify clients based on the browser tab. This is used in the changes for item locking.

### What has changed
Add a new SuperdeskApi function to generate and store a unique ID in the browser tabs session.

Related To: [SDESK-7783](https://sofab.atlassian.net/browse/SDESK-7783)

[SDESK-7783]: https://sofab.atlassian.net/browse/SDESK-7783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ