### PR TITLE
hide authoring header toggle when dropdowns are open

### DIFF
--- a/scripts/apps/authoring/styles/authoring.scss
+++ b/scripts/apps/authoring/styles/authoring.scss
@@ -659,6 +659,9 @@ $authoring-toolbar-spacing: 10px;
     position: relative;
 }
 
+.legacyAngularDropdownOpen .authoring-header__toggle-container {
+    display: none;
+}
 
 .authoring-header__toggle {
     --toggleBG: var(--authoringHeaderBG);


### PR DESCRIPTION
STT-1383

Quick workaround to hide header toggle while there are open dropdowns. I wasn't able to adjust the dropdown to render to body. There is `appendToBody` option, but I couldn't get it to work. It would append to body but entire dropdown would no longer work.

Requires https://github.com/superdesk/superdesk-ui-framework/pull/973


https://github.com/user-attachments/assets/c31fd7f2-a4e7-43b6-9afa-66cc7183767f

