### PR TITLE
[STT-1382] - Pinning of the Planning details and AI widget breaks the UI

### DIFF
--- a/scripts/apps/authoring/widgets/widgets-article.scss
+++ b/scripts/apps/authoring/widgets/widgets-article.scss
@@ -164,14 +164,6 @@
     }
 }
 
-/*
-    Disable CSS transitions during pin/unpin operations
-    to prevent sliding animations for the react widgets
-*/
-.widget-pin-unpin-operation .tabpane {
-    transition: none !important;
-}
-
 .tabpane .sd-widget .widget-content .content {
     grid-row: 2 / 3;
     overflow-y: auto;

--- a/scripts/apps/authoring/widgets/widgets-article.scss
+++ b/scripts/apps/authoring/widgets/widgets-article.scss
@@ -163,6 +163,15 @@
         display: contents;
     }
 }
+
+/*
+    Disable CSS transitions during pin/unpin operations
+    to prevent sliding animations for the react widgets
+*/
+.widget-pin-unpin-operation .tabpane {
+    transition: none !important;
+}
+
 .tabpane .sd-widget .widget-content .content {
     grid-row: 2 / 3;
     overflow-y: auto;

--- a/scripts/apps/authoring/widgets/widgets.ts
+++ b/scripts/apps/authoring/widgets/widgets.ts
@@ -335,7 +335,7 @@ function WidgetsManagerCtrl(
 
         // Temporarily disable CSS transitions during pin/unpin to prevent sliding animations
         // during remount for the react based widgets
-        angular.element('body').addClass('widget-pin-unpin-operation');
+        angular.element('.widget-wrapper .tabpane').css('transition', 'none');
 
         if ($scope.pinnedWidget) {
             $scope.pinnedWidget.pinned = false;
@@ -373,9 +373,9 @@ function WidgetsManagerCtrl(
 
         IS_WIDGET_PINNED = $scope.pinnedWidget?.pinned ?? false;
 
-        // Then remove the transition suppression class after the DOM updates
+        // Then remove the transition suppression after the DOM updates
         setTimeout(() => {
-            angular.element('body').removeClass('widget-pin-unpin-operation');
+            angular.element('.widget-wrapper .tabpane').css('transition', '');
         }, 50);
     };
 

--- a/scripts/apps/authoring/widgets/widgets.ts
+++ b/scripts/apps/authoring/widgets/widgets.ts
@@ -330,6 +330,9 @@ function WidgetsManagerCtrl(
     };
 
     $scope.pinWidget = (widget: IWidget) => {
+        // Add fallback for both angular/react widgets
+        const widgetToPin = widget || $scope.active;
+
         // Temporarily disable CSS transitions during pin/unpin to prevent sliding animations
         // during remount for the react based widgets
         angular.element('body').addClass('widget-pin-unpin-operation');
@@ -338,13 +341,13 @@ function WidgetsManagerCtrl(
             $scope.pinnedWidget.pinned = false;
         }
 
-        if (!PINNED_WIDGET_RESIZED && widget && !$scope.pinnedWidget) {
+        if (!PINNED_WIDGET_RESIZED && widgetToPin && !$scope.pinnedWidget) {
             $rootScope.$broadcast('resize:monitoring', -SIDE_WIDGET_WIDTH);
 
             PINNED_WIDGET_RESIZED = true;
         }
 
-        if (!widget || $scope.pinnedWidget === widget) {
+        if (!widgetToPin || $scope.pinnedWidget === widgetToPin) {
             $rootScope.$broadcast('resize:monitoring', SIDE_WIDGET_WIDTH);
 
             angular.element('body').removeClass('main-section--pinned-tabs');
@@ -354,18 +357,18 @@ function WidgetsManagerCtrl(
 
             this.widgetFromPreferences = null;
 
-            if (widget) {
-                widget.pinned = false;
+            if (widgetToPin) {
+                widgetToPin.pinned = false;
             }
 
             this.updateUserPreferences();
         } else {
             angular.element('body').addClass('main-section--pinned-tabs');
-            $scope.pinnedWidget = widget;
-            $scope.active = widget;
-            widget.pinned = true;
+            $scope.pinnedWidget = widgetToPin;
+            $scope.active = widgetToPin;
+            widgetToPin.pinned = true;
 
-            this.updateUserPreferences(widget);
+            this.updateUserPreferences(widgetToPin);
         }
 
         IS_WIDGET_PINNED = $scope.pinnedWidget?.pinned ?? false;
@@ -376,9 +379,7 @@ function WidgetsManagerCtrl(
         }, 50);
     };
 
-    widgetReactIntegration.pinWidget = (sideWidget?: IWidget) => {
-        $scope.pinWidget(sideWidget || $scope.active);
-    };
+    widgetReactIntegration.pinWidget = $scope.pinWidget;
     widgetReactIntegration.getActiveWidget = () => $scope.active ?? $scope.pinnedWidget;
     widgetReactIntegration.getPinnedWidget =
         () => $scope.widgets?.find(({pinned}) => pinned === true)?.name ?? null;

--- a/scripts/apps/authoring/widgets/widgets.ts
+++ b/scripts/apps/authoring/widgets/widgets.ts
@@ -367,7 +367,9 @@ function WidgetsManagerCtrl(
         IS_WIDGET_PINNED = $scope.pinnedWidget?.pinned ?? false;
     };
 
-    widgetReactIntegration.pinWidget = $scope.pinWidget;
+    widgetReactIntegration.pinWidget = (sideWidget?: IWidget) => {
+        $scope.pinWidget(sideWidget || $scope.active);
+    };
     widgetReactIntegration.getActiveWidget = () => $scope.active ?? $scope.pinnedWidget;
     widgetReactIntegration.getPinnedWidget =
         () => $scope.widgets?.find(({pinned}) => pinned === true)?.name ?? null;

--- a/scripts/apps/authoring/widgets/widgets.ts
+++ b/scripts/apps/authoring/widgets/widgets.ts
@@ -330,6 +330,10 @@ function WidgetsManagerCtrl(
     };
 
     $scope.pinWidget = (widget: IWidget) => {
+        // Temporarily disable CSS transitions during pin/unpin to prevent sliding animations
+        // during remount for the react based widgets
+        angular.element('body').addClass('widget-pin-unpin-operation');
+
         if ($scope.pinnedWidget) {
             $scope.pinnedWidget.pinned = false;
         }
@@ -365,6 +369,11 @@ function WidgetsManagerCtrl(
         }
 
         IS_WIDGET_PINNED = $scope.pinnedWidget?.pinned ?? false;
+
+        // Then remove the transition suppression class after the DOM updates
+        setTimeout(() => {
+            angular.element('body').removeClass('widget-pin-unpin-operation');
+        }, 50);
     };
 
     widgetReactIntegration.pinWidget = (sideWidget?: IWidget) => {


### PR DESCRIPTION
[STT-1382](https://sofab.atlassian.net/browse/STT-1382)

Fix pinning of planning details and ai widget breaking the UI. Now they pin without shifting the layout but as expected. Also added a suppression logic to avoid transition on unpin during remount.

### Before
[dWs3_planning-widget-breaks-ui.webm](https://github.com/user-attachments/assets/669ad512-aca8-4dea-9a85-22be5dea83d6)

### After

https://github.com/user-attachments/assets/3f47b2ef-ab4e-4856-8057-46b21a0fce93


[STT-1382]: https://sofab.atlassian.net/browse/STT-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ