### PR TITLE
[STT-1400] - Adding Department and Tapahtumatyyppi fields to a content profile breaks the content profile dialog

### DIFF
--- a/scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx
+++ b/scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx
@@ -170,7 +170,7 @@ export function getContentProfileFormConfig(
     if (
         field?.id != null
         && (
-            schema[field.id].type === 'string'
+            schema?.[field.id]?.type === 'string'
             || customField?.field_type === 'text'
         )
     ) {
@@ -237,7 +237,7 @@ export function getContentProfileFormConfig(
         fields.push(showInPreviewField);
     }
 
-    if (field?.id != null && schema[field.id]?.type === 'string') {
+    if (field?.id != null && schema?.[field.id]?.type === 'string') {
         const cleanPastedHtmlField: IContentProfileFormField = {
             label: gettext('Clean Pasted HTML'),
             type: GenericFormFieldType.checkbox,
@@ -295,7 +295,7 @@ export function getContentProfileFormConfig(
         fields.push(formattingOptionsEditor3Field);
     }
 
-    if (field?.id != null && field.id === 'feature_media' && schema[field.id].type === 'media') {
+    if (field?.id != null && field.id === 'feature_media' && schema?.[field.id]?.type === 'media') {
         const showCropsField: IContentProfileFormField = {
             label: gettext('Show Crops'),
             type: GenericFormFieldType.checkbox,
@@ -309,7 +309,7 @@ export function getContentProfileFormConfig(
     if (
         field?.id != null
         && (
-            schema[field.id].type === 'media'
+            schema?.[field.id]?.type === 'media'
             || (
                 hasFormattingOptions(field.id, editor, customFields)
                 && field.formatOptions?.includes('media') === true


### PR DESCRIPTION
# Purpose
This PR introduces a null-safety guard around retrieving the type value to prevent runtime errors on some custom vocabularies

## Before
[3muE.webm](https://github.com/user-attachments/assets/8baff198-8811-4e1d-b856-a24f7e8e136e)

## After
https://github.com/user-attachments/assets/6eee3b90-c119-4fdd-832d-dcf8d827d062

