### PR TITLE
[SDESK-7795] - Cleanup old mgrid

### DIFF
--- a/scripts/apps/archive/directives/ContentResults.ts
+++ b/scripts/apps/archive/directives/ContentResults.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import {IPackagesService} from 'types/Services/Packages';
 import {GRID_VIEW, COMPACT_LIST_VIEW} from '../utils';
+import {getViewPreference} from '../services/viewPreferences';
 
 ContentResults.$inject = ['$location', 'preferencesService', 'packages', 'tags', 'asset', 'search'];
 
@@ -55,9 +56,9 @@ export function ContentResults($location, preferencesService, packages: IPackage
 
             var savedView;
 
-            preferencesService.get('archive:view').then((result) => {
-                savedView = result.view;
-                scope.view = !!savedView && savedView !== 'undefined' ? savedView : GRID_VIEW;
+            getViewPreference(preferencesService).then((view) => {
+                savedView = view;
+                scope.view = savedView;
             });
 
             scope.$on('key:v', toggleView);

--- a/scripts/apps/archive/services/viewPreferences.ts
+++ b/scripts/apps/archive/services/viewPreferences.ts
@@ -1,0 +1,17 @@
+import {COMPACT_LIST_VIEW} from '../utils';
+
+/**
+ * Handles legacy 'mgrid' view preference
+ */
+export async function getViewPreference(preferencesService): Promise<string> {
+    const result = await preferencesService.get('archive:view');
+
+    // If users still have 'mgrid' set in preferences, override that
+    // so the new view takes place. At some point in the future we can drop this
+    // after all users have set their view preferences to another option.
+    if (result.view === 'mgrid') {
+        return COMPACT_LIST_VIEW;
+    }
+
+    return result.view ?? COMPACT_LIST_VIEW;
+}

--- a/scripts/apps/content-api/controllers/ContentAPIController.ts
+++ b/scripts/apps/content-api/controllers/ContentAPIController.ts
@@ -1,5 +1,6 @@
 import {COMPACT_LIST_VIEW, GRID_VIEW} from 'apps/archive/utils';
 import {gettext} from 'core/utils';
+import {getViewPreference} from 'apps/archive/services/viewPreferences';
 
 /**
  * @ngdoc controller
@@ -45,8 +46,8 @@ export class ContentAPIController {
             },
         };
 
-        preferencesService.get('archive:view').then((result) => {
-            this.$scope.view = result.view ? result.view : GRID_VIEW;
+        getViewPreference(preferencesService).then((view) => {
+            this.$scope.view = view;
         });
     }
 

--- a/scripts/apps/legal-archive/controllers/LegalArchiveController.ts
+++ b/scripts/apps/legal-archive/controllers/LegalArchiveController.ts
@@ -1,4 +1,5 @@
 import {COMPACT_LIST_VIEW, GRID_VIEW} from 'apps/archive/utils';
+import {getViewPreference} from 'apps/archive/services/viewPreferences';
 import _ from 'lodash';
 
 LegalArchiveController.$inject = ['$scope', '$location', 'legal', 'preferencesService'];
@@ -65,9 +66,7 @@ export function LegalArchiveController($scope, $location, legal, preferencesServ
 
     $scope.search();
 
-    preferencesService.get('archive:view').then((result) => {
-        var savedView = result.view;
-
-        $scope.view = !!savedView && savedView !== 'undefined' ? savedView : GRID_VIEW;
+    getViewPreference(preferencesService).then((view) => {
+        $scope.view = view;
     });
 }

--- a/scripts/apps/search/directives/SearchResults.ts
+++ b/scripts/apps/search/directives/SearchResults.ts
@@ -4,6 +4,7 @@ import {appConfig} from 'appConfig';
 import {ISearchOptions, showRefresh} from '../services/SearchService';
 import {IPackagesService} from 'types/Services/Packages';
 import {COMPACT_LIST_VIEW, GRID_VIEW} from 'apps/archive/utils';
+import {getViewPreference} from 'apps/archive/services/viewPreferences';
 
 SearchResults.$inject = [
     '$location',
@@ -57,7 +58,7 @@ export function SearchResults(
     notify,
     $q,
 ) { // uff - should it use injector instead?
-    var preferencesUpdate = {
+    let preferencesUpdate = {
         'archive:view': {
             allowed: [
                 GRID_VIEW,
@@ -65,7 +66,7 @@ export function SearchResults(
             ],
             category: 'archive',
             view: GRID_VIEW,
-            default: GRID_VIEW,
+            default: COMPACT_LIST_VIEW,
             label: 'Users archive view format',
             type: 'string',
         },
@@ -549,11 +550,11 @@ export function SearchResults(
 
             scope.setview = setView;
 
-            var savedView;
+            let savedView;
 
-            preferencesService.get('archive:view').then((result) => {
-                savedView = result.view;
-                scope.view = !!savedView && savedView !== 'undefined' ? savedView : GRID_VIEW;
+            getViewPreference(preferencesService).then((view) => {
+                savedView = view;
+                scope.view = savedView;
             });
 
             scope.$on('key:v', toggleView);


### PR DESCRIPTION
### Purpose:
Prevent old `mgrid` view of showing up for users that already have some set preference.

**Ticket:** [SDESK-7795](https://sofab.atlassian.net/browse/SDESK-7795)

[SDESK-7795]: https://sofab.atlassian.net/browse/SDESK-7795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ