### PR TITLE
[STT-1416] - Refactor AnnotationPopup to functional component

### DIFF
--- a/scripts/core/editor3/components/annotations/AnnotationPopup.tsx
+++ b/scripts/core/editor3/components/annotations/AnnotationPopup.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect} from 'react';
 import moment from 'moment';
 import {connect} from 'react-redux';
 import {showPopup, PopupTypes} from '../../actions';
@@ -13,6 +13,7 @@ import {FluidRow} from '../../fluid-flex-rows/fluid-row';
 import {gettext} from 'core/utils';
 import {editor3StateToHtml} from 'core/editor3/html/to-html/editor3StateToHtml';
 import {notify} from 'core/notify/notify';
+import {noop} from 'lodash';
 
 interface IAnnotationType {
     qcode: string;
@@ -58,49 +59,18 @@ const Annotation: React.FC<IAnnotationProps> = ({
     close,
     showPopup,
 }) => {
-    const hasNotified = useRef(false);
+    const {author, authorId, date, msg, annotationType} = annotation.data;
 
     useEffect(() => {
-        if (hasNotified.current) return;
-
-        const {annotationType} = annotation.data;
-
         if (!annotationTypes || annotationTypes.length === 0) {
             notify.warning(gettext('Annotation Types information is not available. ' +
                 'Please check your metadata configuration.'));
             console.warn('Annotation types not available or empty', {annotationType});
-            hasNotified.current = true;
-            return;
         }
+    }, []);
 
-        const foundType = annotationTypes.find((t) => t.qcode === annotationType);
-
-        if (!foundType) {
-            notify.warning(gettext('Annotation type "{{type}}" is not configured in the system metadata.',
-                {type: annotationType}));
-            console.warn('Annotation type not found in metadata', {
-                annotationType,
-                availableTypes: annotationTypes.map((t) => t.qcode),
-            });
-            hasNotified.current = true;
-        }
-    }, [annotationTypes, annotation.data]);
-
-    const {author, authorId, date, msg, annotationType} = annotation.data;
-    let type: string;
-
-    if (!annotationTypes || annotationTypes.length === 0) {
-        type = gettext('Unknown Type');
-    } else {
-        const foundType = annotationTypes.find((t) => t.qcode === annotationType);
-
-        if (foundType) {
-            type = foundType.name;
-        } else {
-            type = gettext('Unknown Type ({{qcode}})', {qcode: annotationType});
-        }
-    }
-
+    const foundType = annotationTypes.find((t) => t.qcode === annotationType);
+    const type = foundType?.name ?? gettext('Unknown Type ({{qcode}})', {qcode: annotationType});
     const relativeDateString = moment(date).calendar();
     const absoluteDateString = moment(date).format('MMMM Do YYYY, h:mm:ss a');
     const html = editor3StateToHtml(convertFromRaw(JSON.parse(msg)));
@@ -115,7 +85,7 @@ const Annotation: React.FC<IAnnotationProps> = ({
         .confirm(gettext('The annotation will be deleted. Are you sure?'))
         .then(() => {
             highlightsManager.removeHighlight(highlightId);
-        });
+        }).catch(noop);
 
     const availableActions = [
         {
@@ -170,7 +140,13 @@ const AnnotationWithDependenciesLoaded = connectPromiseResults<IPromiseResults>(
         .then(() => ng.get('metadata').values.annotation_types ?? []),
 }))(Annotation);
 
-export const AnnotationPopup = connect(
+interface IDispatchProps {
+    showPopup: (type: typeof PopupTypes.Annotation, data: {annotation: IAnnotation; highlightId: string}) => void;
+}
+
+type IConnectedProps = Omit<IAnnotationProps, keyof IDispatchProps | keyof IPromiseResults>;
+
+export const AnnotationPopup: React.ComponentType<IConnectedProps> = connect<{}, IDispatchProps, IConnectedProps>(
     () => ({}),
     {showPopup},
 )(AnnotationWithDependenciesLoaded);

--- a/scripts/core/editor3/components/annotations/AnnotationPopup.tsx
+++ b/scripts/core/editor3/components/annotations/AnnotationPopup.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, {useEffect, useRef} from 'react';
 import moment from 'moment';
 import {connect} from 'react-redux';
 import {showPopup, PopupTypes} from '../../actions';
@@ -13,95 +12,165 @@ import {FluidRows} from '../../fluid-flex-rows/fluid-rows';
 import {FluidRow} from '../../fluid-flex-rows/fluid-row';
 import {gettext} from 'core/utils';
 import {editor3StateToHtml} from 'core/editor3/html/to-html/editor3StateToHtml';
+import {notify} from 'core/notify/notify';
 
-class Annotation extends React.Component<any, any> {
-    static propTypes: any;
-    static defaultProps: any;
-
-    render() {
-        const {annotation, editorNode, highlightId, highlightsManager, annotationTypes, close} = this.props;
-        const _showPopup = this.props.showPopup;
-        const {author, authorId, date, msg, annotationType} = annotation.data;
-        const {name: type} = annotationTypes.find((t) => t.qcode === annotationType);
-        const relativeDateString = moment(date).calendar();
-        const absoluteDateString = moment(date).format('MMMM Do YYYY, h:mm:ss a');
-        const html = editor3StateToHtml(convertFromRaw(JSON.parse(msg)));
-        const modal = ng.get('modal');
-
-        const onEdit = () => {
-            _showPopup(PopupTypes.Annotation, {annotation, highlightId});
-            close();
-        };
-        const onDelete = () => modal
-            .confirm(gettext('The annotation will be deleted. Are you sure?'))
-            .then(() => {
-                highlightsManager.removeHighlight(highlightId);
-            });
-
-        const availableActions = [
-            {
-                text: gettext('Edit'),
-                icon: 'icon-pencil',
-                onClick: onEdit,
-            },
-            {
-                text: gettext('Delete'),
-                icon: 'icon-trash',
-                onClick: onDelete,
-            },
-        ];
-
-        return (
-            <HighlightsPopupPositioner editorNode={editorNode}>
-                <FluidRows>
-                    <FluidRow scrollable={false}>
-                        <EditorHighlightsHeader availableActions={availableActions}>
-                            <div className="sd-display--flex sd-gap--small">
-                                <UserAvatarFromUserId userId={authorId} />
-                                <div>
-                                    <p className="editor-popup__author-name">{author}</p>
-                                    <time className="editor-popup__time" title={relativeDateString}>
-                                        {absoluteDateString}
-                                    </time>
-                                </div>
-                            </div>
-                        </EditorHighlightsHeader>
-
-                        <div className="editor-popup__content-block">
-                            <div className="editor-popup__info-bar">
-                                <span className="label">{gettext('Annotation')}</span>
-                            </div>
-
-                            <div><b>{gettext('Annotation type')}: </b>{type}</div>
-                        </div>
-                    </FluidRow>
-
-                    <FluidRow scrollable={true} className="editor-popup__secondary-content">
-                        <div className="editor-popup__content-block">
-                            <div dangerouslySetInnerHTML={{__html: html}} />
-                        </div>
-                    </FluidRow>
-                </FluidRows>
-            </HighlightsPopupPositioner>
-        );
-    }
+interface IAnnotationType {
+    qcode: string;
+    name: string;
 }
 
-Annotation.propTypes = {
-    showPopup: PropTypes.func,
-    annotation: PropTypes.object,
-    highlightsManager: PropTypes.object.isRequired,
-    highlightId: PropTypes.string,
-    editorNode: PropTypes.object,
-    annotationTypes: PropTypes.array.isRequired,
+interface IAnnotationData {
+    author: string;
+    authorId: string;
+    date: string;
+    msg: string;
+    annotationType: string;
+}
+
+interface IAnnotation {
+    data: IAnnotationData;
+}
+
+interface IHighlightsManager {
+    removeHighlight: (highlightId: string) => void;
+}
+
+interface IAnnotationProps {
+    annotation: IAnnotation;
+    editorNode: HTMLElement;
+    highlightId: string;
+    highlightsManager: IHighlightsManager;
+    annotationTypes: Array<IAnnotationType>;
+    close: () => void;
+    showPopup: (type: typeof PopupTypes.Annotation, data: {annotation: IAnnotation; highlightId: string}) => void;
+}
+
+interface IPromiseResults {
+    annotationTypes: Array<IAnnotationType>;
+}
+
+const Annotation: React.FC<IAnnotationProps> = ({
+    annotation,
+    editorNode,
+    highlightId,
+    highlightsManager,
+    annotationTypes,
+    close,
+    showPopup,
+}) => {
+    const hasNotified = useRef(false);
+
+    useEffect(() => {
+        if (hasNotified.current) return;
+
+        const {annotationType} = annotation.data;
+
+        if (!annotationTypes || annotationTypes.length === 0) {
+            notify.warning(gettext('Annotation Types information is not available. ' +
+                'Please check your metadata configuration.'));
+            console.warn('Annotation types not available or empty', {annotationType});
+            hasNotified.current = true;
+            return;
+        }
+
+        const foundType = annotationTypes.find((t) => t.qcode === annotationType);
+
+        if (!foundType) {
+            notify.warning(gettext('Annotation type "{{type}}" is not configured in the system metadata.',
+                {type: annotationType}));
+            console.warn('Annotation type not found in metadata', {
+                annotationType,
+                availableTypes: annotationTypes.map((t) => t.qcode),
+            });
+            hasNotified.current = true;
+        }
+    }, [annotationTypes, annotation.data]);
+
+    const {author, authorId, date, msg, annotationType} = annotation.data;
+    let type: string;
+
+    if (!annotationTypes || annotationTypes.length === 0) {
+        type = gettext('Unknown Type');
+    } else {
+        const foundType = annotationTypes.find((t) => t.qcode === annotationType);
+
+        if (foundType) {
+            type = foundType.name;
+        } else {
+            type = gettext('Unknown Type ({{qcode}})', {qcode: annotationType});
+        }
+    }
+
+    const relativeDateString = moment(date).calendar();
+    const absoluteDateString = moment(date).format('MMMM Do YYYY, h:mm:ss a');
+    const html = editor3StateToHtml(convertFromRaw(JSON.parse(msg)));
+    const modal = ng.get('modal');
+
+    const onEdit = () => {
+        showPopup(PopupTypes.Annotation, {annotation, highlightId});
+        close();
+    };
+
+    const onDelete = () => modal
+        .confirm(gettext('The annotation will be deleted. Are you sure?'))
+        .then(() => {
+            highlightsManager.removeHighlight(highlightId);
+        });
+
+    const availableActions = [
+        {
+            text: gettext('Edit'),
+            icon: 'icon-pencil',
+            onClick: onEdit,
+        },
+        {
+            text: gettext('Delete'),
+            icon: 'icon-trash',
+            onClick: onDelete,
+        },
+    ];
+
+    return (
+        <HighlightsPopupPositioner editorNode={editorNode}>
+            <FluidRows>
+                <FluidRow scrollable={false}>
+                    <EditorHighlightsHeader availableActions={availableActions}>
+                        <div className="sd-display--flex sd-gap--small">
+                            <UserAvatarFromUserId userId={authorId} />
+                            <div>
+                                <p className="editor-popup__author-name">{author}</p>
+                                <time className="editor-popup__time" title={relativeDateString}>
+                                    {absoluteDateString}
+                                </time>
+                            </div>
+                        </div>
+                    </EditorHighlightsHeader>
+
+                    <div className="editor-popup__content-block">
+                        <div className="editor-popup__info-bar">
+                            <span className="label">{gettext('Annotation')}</span>
+                        </div>
+
+                        <div><b>{gettext('Annotation type')}: </b>{type}</div>
+                    </div>
+                </FluidRow>
+
+                <FluidRow scrollable={true} className="editor-popup__secondary-content">
+                    <div className="editor-popup__content-block">
+                        <div dangerouslySetInnerHTML={{__html: html}} />
+                    </div>
+                </FluidRow>
+            </FluidRows>
+        </HighlightsPopupPositioner>
+    );
 };
 
-const AnnotationWithDependenciesLoaded = connectPromiseResults(() => ({
+const AnnotationWithDependenciesLoaded = connectPromiseResults<IPromiseResults>(() => ({
     annotationTypes: ng.get('metadata').initialize()
-        .then(() => ng.get('metadata').values.annotation_types),
+        .then(() => ng.get('metadata').values.annotation_types ?? []),
 }))(Annotation);
 
-export const AnnotationPopup: any = connect(
+export const AnnotationPopup = connect(
     () => ({}),
     {showPopup},
 )(AnnotationWithDependenciesLoaded);

--- a/scripts/core/editor3/components/annotations/AnnotationPopup.tsx
+++ b/scripts/core/editor3/components/annotations/AnnotationPopup.tsx
@@ -46,7 +46,7 @@ interface IAnnotationProps {
     showPopup: (type: typeof PopupTypes.Annotation, data: {annotation: IAnnotation; highlightId: string}) => void;
 }
 
-interface IPromiseResults {
+interface IPromiseAnnotationTypes {
     annotationTypes: Array<IAnnotationType>;
 }
 
@@ -135,7 +135,7 @@ const Annotation: React.FC<IAnnotationProps> = ({
     );
 };
 
-const AnnotationWithDependenciesLoaded = connectPromiseResults<IPromiseResults>(() => ({
+const AnnotationWithDependenciesLoaded = connectPromiseResults<IPromiseAnnotationTypes>(() => ({
     annotationTypes: ng.get('metadata').initialize()
         .then(() => ng.get('metadata').values.annotation_types ?? []),
 }))(Annotation);
@@ -144,7 +144,7 @@ interface IDispatchProps {
     showPopup: (type: typeof PopupTypes.Annotation, data: {annotation: IAnnotation; highlightId: string}) => void;
 }
 
-type IConnectedProps = Omit<IAnnotationProps, keyof IDispatchProps | keyof IPromiseResults>;
+type IConnectedProps = Omit<IAnnotationProps, keyof IDispatchProps | keyof IPromiseAnnotationTypes>;
 
 export const AnnotationPopup: React.ComponentType<IConnectedProps> = connect<{}, IDispatchProps, IConnectedProps>(
     () => ({}),


### PR DESCRIPTION
### Purpose
To fix the bug of annotations not loading. The problem was not in the code but it was due to the missing "Annotation Types" in the system metadata. I took advantage of the ticket to improve this component and the handling of missing metadata and annotation type.

### What has changed
- Converted `AnnotationPopup` from a class-based to a functional React component using hooks
- Added TypeScript interfaces for props and improved handling of missing annotation types with notifications. 
- Removed PropTypes and updated dependency loading logic for annotation types.

### To test
- Create a new item and add an annotation in the body html
- Delete the `annotation_types` record from the database collections `vocabularies`
- Reload your browser
- Try to open the annotation in the editor
- Observe the warnings instead of the app breaking because of the missing types

Thanks for checking! 

Resolves: [STT-1416]

[STT-1416]: https://sofab.atlassian.net/browse/STT-1416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ