### PR TITLE
Add default field value and grouping in crud form

### DIFF
--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -2117,7 +2117,7 @@ declare module 'superdesk-api' {
         getFormConfig(item?: Partial<T>): IFormGroup;
         defaultSortOption: ISortOption;
         additionalSortOptions?: Array<{label: string; field: string;}>;
-        additionalProps?: P; // allows passing props which will be available in container and item components
+        additionalProps?: P & {groupBy?: {field: Paths<T>; label: string}}; // allows passing props which will be available in container and item components
         defaultFilters?: Partial<T>;
         ItemComponent: React.ComponentType<IPropsGenericFormItemComponent<T> & {additionalProps?: P}>;
         ItemsContainerComponent?: React.ComponentType<IPropsGenericFormContainer<T> & {additionalProps?: P}>;
@@ -2163,6 +2163,9 @@ declare module 'superdesk-api' {
         // can be used to pass read-only fields or display specific flags
         // component theme, variant or initial state could be set using this
         component_parameters?: {[key: string]: any};
+
+        // default value for the field when creating new items
+        defaultValue?: any;
     }
 
     export interface IFormGroupCollapsible { // don't forget to update runtime type checks

--- a/scripts/core/ui/components/ListPage/generic-list-page.tsx
+++ b/scripts/core/ui/components/ListPage/generic-list-page.tsx
@@ -33,11 +33,15 @@ import {
     IFormGroup,
     IBaseRestApiResponse,
     ISortOption,
+    Dictionary,
 } from 'superdesk-api';
 import {gettext} from 'core/utils';
 import ng from 'core/services/ng';
 import {OnlyWithChildren} from '../only-with-children';
 import {connectCrudManagerHttp} from 'core/helpers/crud-manager-http';
+import {groupBy as _groupBy} from 'lodash';
+import {SpacerBlock} from 'core/ui/components/Spacer';
+import {Header} from 'core/ui/components/List/Header';
 
 interface IState<T extends object> {
     previewItem: T | null;
@@ -434,6 +438,45 @@ export class GenericListPageComponent<T extends object, P>
                     );
                 }
             } else {
+                const groupBy = additionalProps?.groupBy;
+
+                if (groupBy != null) {
+                    const groupedItems: Dictionary<string, Array<T>> = _groupBy(
+                        this.props.crudManager._items,
+                        groupBy.field,
+                    );
+
+                    return (
+                        <div>
+                            {Object.keys(groupedItems).map((groupKey, index) => (
+                                <React.Fragment key={groupKey}>
+                                    {index > 0 && <SpacerBlock v gap="32" />}
+                                    <Header title={groupBy.label} />
+                                    <SpacerBlock v gap="8" />
+                                    <ItemsContainerComponent page={page} additionalProps={additionalProps}>
+                                        {groupedItems[groupKey].map((item, i) => (
+                                            <ItemComponent
+                                                key={this.props.getId(item)}
+                                                item={item}
+                                                page={page}
+                                                inEditMode={
+                                                    this.state.editItem == null
+                                                        ? false
+                                                        : this.props.getId(this.state.editItem)
+                                                            === this.props.getId(item)
+                                                }
+                                                index={i}
+                                                getId={this.props.getId}
+                                                additionalProps={additionalProps}
+                                            />
+                                        ))}
+                                    </ItemsContainerComponent>
+                                </React.Fragment>
+                            ))}
+                        </div>
+                    );
+                }
+
                 return (
                     <ItemsContainerComponent page={page} additionalProps={additionalProps}>
                         {

--- a/scripts/core/ui/components/generic-form/get-initial-values.tsx
+++ b/scripts/core/ui/components/generic-form/get-initial-values.tsx
@@ -5,6 +5,11 @@ import {IFormField, IFormGroup} from 'superdesk-api';
 function getInitialValueForFieldType<T extends object>(fieldConfig: IFormField<T>): {readonly [field: string]: any} {
     const {field} = fieldConfig;
 
+    // Fallback to default
+    if (fieldConfig.defaultValue !== undefined) {
+        return {[field]: fieldConfig.defaultValue};
+    }
+
     const type: GenericFormFieldType = fieldConfig.type;
 
     switch (type) {


### PR DESCRIPTION
## Purpose
Add support for additional props like default field value and groupBy, so we can support some functionality in the planning Manage Agendas action modal.


## What has changed
Added an option to group items by a given field. Also added default value for fields, so if field value is `undefined` we can render something else.

Resolves: [SDESK-7267]

[SDESK-7267]: https://sofab.atlassian.net/browse/SDESK-7267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ