### PR TITLE
[SDESK-7694] Include ContentAPI Subscribers in Product modal

### DIFF
--- a/scripts/apps/products/views/products-config-modal.html
+++ b/scripts/apps/products/views/products-config-modal.html
@@ -82,7 +82,7 @@
                 </div>
                 <div ng-if="modalTab === 'subscribers'" class="nav-tabs__pane">
                     <div class="sd-grid-list sd-grid-list--no-margin">
-                        <div ng-repeat="subscriber in subscribers| orderBy:name" class="sd-card sd-card--auto-height" ng-if="subscriber.products.indexOf(product.edit._id) >= 0">
+                        <div ng-repeat="subscriber in subscribers| orderBy:name" class="sd-card sd-card--auto-height" ng-if="subscriber.products.indexOf(product.edit._id) >= 0 || subscriber.api_products.indexOf(product.edit._id) >= 0">
                             <span class="sd-card__content  sd-card__content--padd-10">{{::subscriber.name}}</span>
                         </div>
                     </div>


### PR DESCRIPTION
### Purpose
The `Edit Product Modal` has a `Subscribers` tab. At the moment it does not include `Content API` subscribers.

### What has changed:
Check both `products` and `api_products` to determine if a Subscriber should be shown.

Resolves: [SDESK-7694](https://sofab.atlassian.net/browse/SDESK-7694)

[SDESK-7694]: https://sofab.atlassian.net/browse/SDESK-7694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ