### PR TITLE
[SDBELGA-1003] - Add support for external-only related content fields

### DIFF
--- a/scripts/apps/relations/directives/RelatedItemsDirective.ts
+++ b/scripts/apps/relations/directives/RelatedItemsDirective.ts
@@ -145,11 +145,8 @@ export function RelatedItemsDirective(
                         return;
                     }
 
-                    const isExternalProviderAllowed = relationsService
-                        .isItemFromExternalProviderAllowed(item, scope.field);
-
-                    if (!isExternalProviderAllowed)
-                        return notify.error(gettext('Content from external providers is not allowed in this field.'));
+                    if (!relationsService.isItemAllowedInField(item, scope.field))
+                        return notify.error(gettext('Only content from external providers is allowed in this field.'));
 
                     if (scope.item._id === item._id) {
                         notify.error(gettext('Cannot add self as related item.'));

--- a/scripts/apps/relations/directives/RelatedItemsDirective.ts
+++ b/scripts/apps/relations/directives/RelatedItemsDirective.ts
@@ -145,6 +145,12 @@ export function RelatedItemsDirective(
                         return;
                     }
 
+                    const isExternalProviderAllowed = relationsService
+                        .isItemFromExternalProviderAllowed(item, scope.field);
+
+                    if (!isExternalProviderAllowed)
+                        return notify.error(gettext('Content from external providers is not allowed in this field.'));
+
                     if (scope.item._id === item._id) {
                         notify.error(gettext('Cannot add self as related item.'));
                         return;

--- a/scripts/apps/relations/services/RelationsService.ts
+++ b/scripts/apps/relations/services/RelationsService.ts
@@ -85,12 +85,21 @@ export function RelationsService(api, $q) {
         return validateWorkflow(item, field?.field_options?.allowed_workflows ?? {}).result;
     };
 
-    this.isItemFromExternalProviderAllowed = function(item: IArticle, field: VocabularyField): boolean {
-        if (field.field_type !== 'related_content' || item?._type !== 'externalsource')
+    /**
+     * Checks if an item can be added to a related content field.
+     * Returns false if the field requires external providers but the item is not from an external source.
+     */
+    this.isItemAllowedInField = (item: IArticle, field: VocabularyField): boolean => {
+        if (field.field_type !== 'related_content')
             return true;
 
-        return (field as IVocabularyRelatedContent)
+        const onlyExternalProvidersAllowed = (field as IVocabularyRelatedContent)
             ?.field_options
-            ?.allowed_external_providers === true;
+            ?.only_allow_external_providers === true;
+
+        if (item._type !== 'externalsource' && onlyExternalProvidersAllowed)
+            return false;
+
+        return true;
     };
 }

--- a/scripts/apps/relations/services/RelationsService.ts
+++ b/scripts/apps/relations/services/RelationsService.ts
@@ -5,6 +5,8 @@ import {gettext} from 'core/utils';
 
 const RELATED_LINK_KEYS = 3; // links only have _id, type keys and order (and some old ones only _id)
 
+type VocabularyField = IVocabularyRelatedContent | IVocabularyMedia;
+
 export const isLink = (association) =>
     association != null && Object.keys(association).length <= RELATED_LINK_KEYS;
 
@@ -79,7 +81,16 @@ export function RelationsService(api, $q) {
         })).then((values) => zipObject(relatedItemsKeys, values));
     };
 
-    this.itemHasAllowedStatus = function(item: IArticle, field: IVocabularyRelatedContent | IVocabularyMedia) {
+    this.itemHasAllowedStatus = function(item: IArticle, field: VocabularyField) {
         return validateWorkflow(item, field?.field_options?.allowed_workflows ?? {}).result;
+    };
+
+    this.isItemFromExternalProviderAllowed = function(item: IArticle, field: VocabularyField): boolean {
+        if (field.field_type !== 'related_content' || item?._type !== 'externalsource')
+            return true;
+
+        return (field as IVocabularyRelatedContent)
+            ?.field_options
+            ?.allowed_external_providers === true;
     };
 }

--- a/scripts/apps/vocabularies/views/vocabulary-config-modal.html
+++ b/scripts/apps/vocabularies/views/vocabulary-config-modal.html
@@ -220,7 +220,10 @@
                             <div class="sd-line-input sd-line-input--boxed sd-line-input--no-margin">
                                 <label for="field-media-type" class="sd-line-input__label" translate>Content Type</label>
 
-                                <div class="form__row form__row--flex">
+                                <div
+                                    class="form__row form__row--flex"
+                                    ng-class="{'sd-padding--0': vocabulary.field_type !== mediaTypes.RELATED_CONTENT.id}"
+                                >
                                     <div class="form__row-item form__row-item--no-grow">
                                         <div class="sd-line-input sd-line-input--is-select sd-line-input--no-label sd-line-input--no-margin">
                                             <select id="field-media-type" class="input-medium sd-line-input__select" ng-model="vocabulary.field_type">
@@ -241,7 +244,8 @@
                                                 ng-model="vocabulary.field_options.allowed_types.audio" data-icon="audio">
                                                 {{'Audio' | translate}}</sd-check>
                                         </div>
-                                        <div class="form__row sd-padding--0"
+                                        <div
+                                            class="form__row sd-padding--0"
                                             ng-if="vocabulary.field_type === mediaTypes.RELATED_CONTENT.id">
                                             <sd-check name="field_type"
                                                 ng-model="vocabulary.field_options.allowed_types.text" data-icon="text">

--- a/scripts/apps/vocabularies/views/vocabulary-config-modal.html
+++ b/scripts/apps/vocabularies/views/vocabulary-config-modal.html
@@ -269,19 +269,6 @@
                             </div>
                         </div>
 
-                        <div
-                            class="form__row"
-                            ng-show="
-                                matchFieldTypeToTab('related-content-fields', vocabulary.field_type) &&
-                                vocabulary.field_type === mediaTypes.RELATED_CONTENT.id"
-                        >
-                            <div class="sd-line-input sd-line-input--boxed sd-line-input--no-margin">
-                                <label for="allowed_external_providers" class="sd-line-input__label" translate>Allow External Providers</label>
-                                <span id="allowed_external_providers" sd-switch
-                                    ng-model="vocabulary.field_options.allowed_external_providers"></span>
-                            </div>
-                        </div>
-
                         <div class="form__row"
                             ng-show="matchFieldTypeToTab('related-content-fields', vocabulary.field_type)"
                         >
@@ -312,10 +299,29 @@
                             </div>
                         </div>
 
+                        <div
+                            class="form__row"
+                            ng-show="
+                                matchFieldTypeToTab('related-content-fields', vocabulary.field_type) &&
+                                vocabulary.field_type === mediaTypes.RELATED_CONTENT.id"
+                        >
+                            <div class="sd-line-input">
+                                <label for="only_allow_external_providers" class="sd-line-input__label" translate>External Providers Only</label>
+                                <div>
+                                <span id="only_allow_external_providers" sd-switch
+                                    ng-model="vocabulary.field_options.only_allow_external_providers">
+                                </span>
+                                </div>
+                                <div class="sd-line-input__hint" translate>
+                                    Only allow content from external providers.
+                                </div>
+                            </div>
+                        </div>
+
                         <div class="form__row"
                             ng-if="matchFieldTypeToTab('related-content-fields', vocabulary.field_type)"
                         >
-                            <div class="sd-line-input sd-line-input--boxed sd-line-input--no-margin">
+                            <div class="sd-line-input sd-line-input--no-margin">
                                 <label class="sd-line-input__label" translate>Filters</label>
                                 <sd-check class="sd-margin-r--1" ng-model="vocabulary.field_options.allowed_workflows.in_progress">
                                     <span translate>In Progress</span>

--- a/scripts/apps/vocabularies/views/vocabulary-config-modal.html
+++ b/scripts/apps/vocabularies/views/vocabulary-config-modal.html
@@ -269,6 +269,19 @@
                             </div>
                         </div>
 
+                        <div
+                            class="form__row"
+                            ng-show="
+                                matchFieldTypeToTab('related-content-fields', vocabulary.field_type) &&
+                                vocabulary.field_type === mediaTypes.RELATED_CONTENT.id"
+                        >
+                            <div class="sd-line-input sd-line-input--boxed sd-line-input--no-margin">
+                                <label for="allowed_external_providers" class="sd-line-input__label" translate>Allow External Providers</label>
+                                <span id="allowed_external_providers" sd-switch
+                                    ng-model="vocabulary.field_options.allowed_external_providers"></span>
+                            </div>
+                        </div>
+
                         <div class="form__row"
                             ng-show="matchFieldTypeToTab('related-content-fields', vocabulary.field_type)"
                         >

--- a/scripts/apps/vocabularies/views/vocabulary-config-modal.html
+++ b/scripts/apps/vocabularies/views/vocabulary-config-modal.html
@@ -215,68 +215,76 @@
                         </div>
 
                         <div class="form__row"
-                            ng-show="matchFieldTypeToTab('related-content-fields', vocabulary.field_type)">
-                            <label for="field-media-type" class="form-label form__row-label" translate>Content
-                                Type</label>
+                            ng-show="matchFieldTypeToTab('related-content-fields', vocabulary.field_type)"
+                        >
+                            <div class="sd-line-input sd-line-input--boxed sd-line-input--no-margin">
+                                <label for="field-media-type" class="sd-line-input__label" translate>Content Type</label>
 
-                            <div class="form__row form__row--inner form__row--flex">
-                                <div class="form__row-item form__row-item--no-grow">
-                                    <div class="sd-line-input sd-line-input--is-select sd-line-input--no-label sd-line-input--no-margin">
-                                        <select id="field-media-type" class="input-medium sd-line-input__select" ng-model="vocabulary.field_type">
-                                            <option value="{{type.id}}" ng-repeat="type in mediaTypes">{{type.label}}
-                                            </option>
-                                        </select>
+                                <div class="form__row form__row--flex">
+                                    <div class="form__row-item form__row-item--no-grow">
+                                        <div class="sd-line-input sd-line-input--is-select sd-line-input--no-label sd-line-input--no-margin">
+                                            <select id="field-media-type" class="input-medium sd-line-input__select" ng-model="vocabulary.field_type">
+                                                <option value="{{type.id}}" ng-repeat="type in mediaTypes">{{type.label}}
+                                                </option>
+                                            </select>
+                                        </div>
                                     </div>
-                                </div>
-                                <div class="form__row-item form__row-item--no-grow">
-                                    <div class="form__row">
-                                        <sd-check name="field_type" aria-label="{{'Image' | translate}}"
-                                            ng-model="vocabulary.field_options.allowed_types.picture" data-icon="photo">
-                                            {{'Image' | translate}}</sd-check>
-                                        <sd-check name="field_type"
-                                            ng-model="vocabulary.field_options.allowed_types.video" data-icon="video">
-                                            {{'Video' | translate}}</sd-check>
-                                        <sd-check name="field_type"  aria-label="{{'Audio' | translate}}"
-                                            ng-model="vocabulary.field_options.allowed_types.audio" data-icon="audio">
-                                            {{'Audio' | translate}}</sd-check>
-                                    </div>
-                                    <div class="form__row"
-                                        ng-if="vocabulary.field_type === mediaTypes.RELATED_CONTENT.id">
-                                        <sd-check name="field_type"
-                                            ng-model="vocabulary.field_options.allowed_types.text" data-icon="text">
-                                            {{'Text' | translate}}</sd-check>
-                                        <sd-check name="field_type"
-                                            ng-model="vocabulary.field_options.allowed_types.preformatted"
-                                            data-icon="text">{{'Preformatted' | translate}}</sd-check>
-                                        <sd-check name="field_type"
-                                            ng-model="vocabulary.field_options.allowed_types.graphic"
-                                            data-icon="graphic">{{'Graphic' | translate}}</sd-check>
-                                        <sd-check name="field_type"
-                                            ng-model="vocabulary.field_options.allowed_types.composite"
-                                            data-icon="composite">{{'Package' | translate}}</sd-check>
+                                    <div class="form__row-item form__row-item--no-grow form__row-item-content-type">
+                                        <div class="form__row sd-padding-b--1">
+                                            <sd-check name="field_type" aria-label="{{'Image' | translate}}"
+                                                ng-model="vocabulary.field_options.allowed_types.picture" data-icon="photo">
+                                                {{'Image' | translate}}</sd-check>
+                                            <sd-check name="field_type"
+                                                ng-model="vocabulary.field_options.allowed_types.video" data-icon="video">
+                                                {{'Video' | translate}}</sd-check>
+                                            <sd-check name="field_type"  aria-label="{{'Audio' | translate}}"
+                                                ng-model="vocabulary.field_options.allowed_types.audio" data-icon="audio">
+                                                {{'Audio' | translate}}</sd-check>
+                                        </div>
+                                        <div class="form__row sd-padding--0"
+                                            ng-if="vocabulary.field_type === mediaTypes.RELATED_CONTENT.id">
+                                            <sd-check name="field_type"
+                                                ng-model="vocabulary.field_options.allowed_types.text" data-icon="text">
+                                                {{'Text' | translate}}
+                                            </sd-check>
+                                            <sd-check name="field_type"
+                                                ng-model="vocabulary.field_options.allowed_types.graphic"
+                                                data-icon="graphic">{{'Graphic' | translate}}
+                                            </sd-check>
+                                            <sd-check name="field_type"
+                                                ng-model="vocabulary.field_options.allowed_types.composite"
+                                                data-icon="composite">{{'Package' | translate}}
+                                            </sd-check>
+                                            <sd-check name="field_type"
+                                                ng-model="vocabulary.field_options.allowed_types.preformatted"
+                                                data-icon="text">{{'Preformatted' | translate}}
+                                            </sd-check>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
 
                         <div class="form__row"
-                            ng-show="matchFieldTypeToTab('related-content-fields', vocabulary.field_type)">
-                            <div class="form__row-item">
+                            ng-show="matchFieldTypeToTab('related-content-fields', vocabulary.field_type)"
+                        >
+                            <div class="sd-line-input sd-line-input--boxed sd-line-input--no-margin">
+                                <label for="multiple_items" class="sd-line-input__label" translate>Allow Multiple Items</label>
                                 <span id="multiple_items" sd-switch
                                     ng-model="vocabulary.field_options.multiple_items.enabled"></span>
-                                <label for="multiple_items" translate>Allow Multiple Items</label>
                             </div>
-                            <div class="form__row form__row--inner form__row--flex"
-                                ng-if="vocabulary.field_options.multiple_items.enabled">
-                                <div class="form__row-item form__row-item--no-grow">
-                                    <span translate>Max. number of items</span>
-                                </div>
-                                <div class="form__row-item form__row-item--no-grow">
-                                    <input id="max_items" name="max_items" type="number" min="2" max="99"
-                                        class="input-small line-input"
-                                        ng-model="vocabulary.field_options.multiple_items.max_items"
-                                        style="width: 60px; text-align: center;">
-                                </div>
+                        </div>
+
+                        <div class="form__row" ng-if="vocabulary.field_options.multiple_items.enabled">
+                            <div
+                                class="sd-line-input sd-line-input--boxed sd-line-input--no-margin"
+                            >
+                                <label for="max_items" class="sd-line-input__label" translate>Max. number of items</label>
+                                <input id="max_items" name="max_items" type="number" min="2" max="99"
+                                    class="input-small line-input"
+                                    ng-model="vocabulary.field_options.multiple_items.max_items"
+                                >
+
                                 <div ng-if="vocabularyForm.max_items.$invalid"
                                     class="sd-line-input sd-line-input--invalid">
                                     <p ng-if="vocabularyForm.max_items.$error.min" class="sd-line-input__message"
@@ -287,20 +295,18 @@
                             </div>
                         </div>
 
-                        <div class="sd-line-input"
-                            ng-if="matchFieldTypeToTab('related-content-fields', vocabulary.field_type)">
-                            <label class="form-label form__row-label" translate>Filters</label>
-                            <div class="sd-line-input__message sd-margin-b--1" translate>Only allow content with the
-                                following status:</div>
-                            <div class="form__row-item form__row-item--no-grow">
-                                <div class="form__row">
-                                    <sd-check ng-model="vocabulary.field_options.allowed_workflows.in_progress">
-                                        <span translate>In Progress</span>
-                                    </sd-check>
-                                    <sd-check ng-model="vocabulary.field_options.allowed_workflows.published">
-                                        <span translate>Published</span>
-                                    </sd-check>
-                                </div>
+                        <div class="form__row"
+                            ng-if="matchFieldTypeToTab('related-content-fields', vocabulary.field_type)"
+                        >
+                            <div class="sd-line-input sd-line-input--boxed sd-line-input--no-margin">
+                                <label class="sd-line-input__label" translate>Filters</label>
+                                <sd-check class="sd-margin-r--1" ng-model="vocabulary.field_options.allowed_workflows.in_progress">
+                                    <span translate>In Progress</span>
+                                </sd-check>
+                                <sd-check ng-model="vocabulary.field_options.allowed_workflows.published">
+                                    <span translate>Published</span>
+                                </sd-check>
+                                <div class="sd-line-input__hint" translate>Only allow content with the selected statuses above.</div>
                             </div>
                         </div>
 

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -1660,6 +1660,7 @@ declare module 'superdesk-api' {
                 audio?: boolean;
                 video?: boolean;
             };
+            allowed_external_providers?: boolean;
             allowed_workflows?: {
                 in_progress?: boolean;
                 published?: boolean;

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -1660,7 +1660,7 @@ declare module 'superdesk-api' {
                 audio?: boolean;
                 video?: boolean;
             };
-            allowed_external_providers?: boolean;
+            only_allow_external_providers?: boolean;
             allowed_workflows?: {
                 in_progress?: boolean;
                 published?: boolean;

--- a/styles/sass/forms.scss
+++ b/styles/sass/forms.scss
@@ -1439,3 +1439,8 @@ input {
         background-color: var(--sd-colour-bg__searchbar);
     }
 }
+
+.form__row-item-content-type .sd-checkbox--button-style {
+    min-width: 100px;
+    margin-right: calc(0.5 * var(--base-increment));
+}


### PR DESCRIPTION
### Purpose
Add support to related content field to only allow content from external providers. Also clean up the related-content vocabulary UI.

### What has changed
- Added `isItemAllowedInField()` in RelationsService. 
- If a field is configured as external-providers-only, internal (Superdesk) items are blocked.
- New field option `only_allow_external_providers` in related-content vocabulary 
- UI improvements in the edit vocabulary modal (alignments, spacing and paddings)

### User warning if the content is not allowed
<img width="950" alt="image" src="https://github.com/user-attachments/assets/bdff0476-5637-4957-b752-7f35c7973b67" />

### UI Improvements

<table>
  <tr>
    <td>BEFORE</td>
     <td>AFTER</td>
  </tr>
  <tr>
    <td><img width="500" alt="image" src="https://github.com/user-attachments/assets/11732999-8608-4915-9c93-c050e71c3757" /></td>
    <td><img width="500" alt="image" src="https://github.com/user-attachments/assets/ffad1974-0a66-45d8-91d0-be8339997990" /></td>
  </tr>
 </table>
 
 Thanks for checking!

Resolves: [SDBELGA-1003]

[SDBELGA-1003]: https://sofab.atlassian.net/browse/SDBELGA-1003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ