### PR TITLE
[STT-1466] - Added keyboard combos for ndash and thinspace in editor

### DIFF
--- a/scripts/core/editor3/components/Editor3Component.tsx
+++ b/scripts/core/editor3/components/Editor3Component.tsx
@@ -297,7 +297,7 @@ export class Editor3Component extends React.Component<IPropsEditor3Component, IS
     }
 
     keyBindingFn(e) {
-        const {key, ctrlKey, shiftKey, metaKey} = e;
+        const {key, ctrlKey, shiftKey, metaKey, altKey} = e;
         const selectionState = this.props.editorState.getSelection();
         const modifierKey = isMacOS() ? metaKey : ctrlKey;
 
@@ -349,6 +349,18 @@ export class Editor3Component extends React.Component<IPropsEditor3Component, IS
                 e.preventDefault();
                 return '';
             }
+        }
+
+        // Alt + - for ndash
+        if (key === '-' && altKey && !ctrlKey && !shiftKey) {
+            e.preventDefault();
+            return 'custom-ndash';
+        }
+
+        // Alt + Space for thin space
+        if (key === ' ' && altKey && !ctrlKey && !shiftKey) {
+            e.preventDefault();
+            return 'custom-thin-space';
         }
 
         return getDefaultKeyBinding(e);
@@ -428,6 +440,34 @@ export class Editor3Component extends React.Component<IPropsEditor3Component, IS
             case 'secondary-paste': // this is blocking redo on non-windows systems, should be osx specific
                 newState = EditorState.redo(editorState);
                 break;
+            case 'custom-ndash': {
+                const ndashContentState = Modifier.replaceText(
+                    editorState.getCurrentContent(),
+                    editorState.getSelection(),
+                    '\u2013',
+                );
+
+                newState = EditorState.push(
+                    editorState,
+                    ndashContentState,
+                    'insert-characters',
+                );
+                break;
+            }
+            case 'custom-thin-space': {
+                const thinSpaceContentState = Modifier.replaceText(
+                    editorState.getCurrentContent(),
+                    editorState.getSelection(),
+                    '\u2009',
+                );
+
+                newState = EditorState.push(
+                    editorState,
+                    thinSpaceContentState,
+                    'insert-characters',
+                );
+                break;
+            }
             case 'backspace': {
                 this.setState({contentChangesAfterLastFocus: this.state.contentChangesAfterLastFocus + 1});
 

--- a/scripts/core/editor3/components/Editor3Component.tsx
+++ b/scripts/core/editor3/components/Editor3Component.tsx
@@ -351,16 +351,28 @@ export class Editor3Component extends React.Component<IPropsEditor3Component, IS
             }
         }
 
-        // Alt + - for ndash
-        if (key === '-' && altKey && !ctrlKey && !shiftKey) {
-            e.preventDefault();
-            return 'custom-ndash';
+        // Cmd/Ctrl + Alt + - for ndash
+        if (key === '-' && altKey && !shiftKey) {
+            const isMac = isMacOS();
+            const macCombo = isMac && metaKey && !ctrlKey;
+            const winCombo = !isMac && !metaKey && ctrlKey;
+
+            if (macCombo || winCombo) {
+                e.preventDefault();
+                return 'custom-ndash';
+            }
         }
 
-        // Alt + Space for thin space
-        if (key === ' ' && altKey && !ctrlKey && !shiftKey) {
-            e.preventDefault();
-            return 'custom-thin-space';
+        // Cmd/Ctrl + Alt + Shift + Space for thin space
+        if (key === ' ' && altKey && shiftKey) {
+            const isMac = isMacOS();
+            const macCombo = isMac && metaKey && !ctrlKey;
+            const winCombo = !isMac && !metaKey && ctrlKey;
+
+            if (macCombo || winCombo) {
+                e.preventDefault();
+                return 'custom-thin-space';
+            }
         }
 
         return getDefaultKeyBinding(e);

--- a/scripts/core/editor3/components/Editor3Component.tsx
+++ b/scripts/core/editor3/components/Editor3Component.tsx
@@ -32,7 +32,13 @@ import {getSpellcheckWarningsByBlock} from './spellchecker/SpellcheckerDecorator
 import {getSpellchecker} from './spellchecker/default-spellcheckers';
 import {IEditorStore} from '../store';
 import {appConfig} from 'appConfig';
-import {EDITOR_BLOCK_TYPE, formattingOptionsThatRequireDragAndDrop, MIME_TYPE_SUPERDESK_TEXT_ITEM} from '../constants';
+import {
+    EDITOR_BLOCK_TYPE,
+    formattingOptionsThatRequireDragAndDrop,
+    MIME_TYPE_SUPERDESK_TEXT_ITEM,
+    NDASH_CHAR,
+    THIN_SPACE_CHAR,
+} from '../constants';
 import {IEditorComponentProps, RICH_FORMATTING_OPTION} from 'superdesk-api';
 import {preventInputWhenLimitIsPassed} from '../helpers/characters-limit';
 import {handleBeforeInputHighlights} from '../helpers/handleBeforeInputHighlights';
@@ -456,7 +462,7 @@ export class Editor3Component extends React.Component<IPropsEditor3Component, IS
                 const ndashContentState = Modifier.replaceText(
                     editorState.getCurrentContent(),
                     editorState.getSelection(),
-                    '\u2013',
+                    NDASH_CHAR,
                 );
 
                 newState = EditorState.push(
@@ -470,7 +476,7 @@ export class Editor3Component extends React.Component<IPropsEditor3Component, IS
                 const thinSpaceContentState = Modifier.replaceText(
                     editorState.getCurrentContent(),
                     editorState.getSelection(),
-                    '\u2009',
+                    THIN_SPACE_CHAR,
                 );
 
                 newState = EditorState.push(

--- a/scripts/core/editor3/components/tables/TableCell.tsx
+++ b/scripts/core/editor3/components/tables/TableCell.tsx
@@ -232,6 +232,7 @@ export class TableCell extends React.Component<IProps, IState> {
                                 language: spellchecking.language,
                                 warnings: spellcheckWarningsByBlock,
                             },
+                            invisibles: false,
                         },
                     ).decorator,
                 },

--- a/scripts/core/editor3/components/tests/editor3.spec.tsx
+++ b/scripts/core/editor3/components/tests/editor3.spec.tsx
@@ -5,7 +5,7 @@ import {shallow, mount} from 'enzyme';
 import {Editor3Component, getValidMediaType} from '../Editor3Component';
 import {EditorState, ContentBlock} from 'draft-js';
 import mockStore from './utils';
-import {CustomEditor3Entity} from 'core/editor3/constants';
+import {CustomEditor3Entity, NDASH_CHAR, THIN_SPACE_CHAR} from 'core/editor3/constants';
 import {getBlockRenderer} from '../blockRenderer';
 import {IEditorStore} from 'core/editor3/store';
 import ng from 'core/services/ng';
@@ -230,7 +230,7 @@ describe('editor3.component', () => {
             expect(onChange).toHaveBeenCalled();
             const newState = onChange.calls.mostRecent().args[0];
 
-            expect(newState.getCurrentContent().getPlainText()).toBe('\u2013');
+            expect(newState.getCurrentContent().getPlainText()).toBe(NDASH_CHAR);
         });
 
         it('handleKeyCommand inserts thin space and calls onChange', () => {
@@ -244,7 +244,7 @@ describe('editor3.component', () => {
             expect(onChange).toHaveBeenCalled();
             const newState = onChange.calls.mostRecent().args[0];
 
-            expect(newState.getCurrentContent().getPlainText()).toBe('\u2009');
+            expect(newState.getCurrentContent().getPlainText()).toBe(THIN_SPACE_CHAR);
         });
     });
 });

--- a/scripts/core/editor3/components/tests/editor3.spec.tsx
+++ b/scripts/core/editor3/components/tests/editor3.spec.tsx
@@ -8,6 +8,7 @@ import mockStore from './utils';
 import {CustomEditor3Entity} from 'core/editor3/constants';
 import {getBlockRenderer} from '../blockRenderer';
 import {IEditorStore} from 'core/editor3/store';
+import ng from 'core/services/ng';
 
 const spellchecking: IEditorStore['spellchecking'] = {
     enabled: false,
@@ -36,6 +37,17 @@ const stubForHighlights = {
 };
 
 describe('editor3.component', () => {
+    beforeAll(() => {
+        ng.register({
+            get: (serviceName: string) => {
+                if (serviceName === 'session') {
+                    return {identity: {_id: 'test-user'}};
+                }
+
+                throw new Error(`Unexpected service requested: ${serviceName}`);
+            },
+        } as any);
+    });
     it('should hide toolbar when disabled', () => {
         const wrapper = shallow(
             <Editor3Component

--- a/scripts/core/editor3/components/tests/editor3.spec.tsx
+++ b/scripts/core/editor3/components/tests/editor3.spec.tsx
@@ -160,6 +160,81 @@ describe('editor3.component', () => {
 
         expect(getValidMediaType(event)).toBe('application/superdesk.item.picture');
     });
+
+    describe('keyboard shortcuts', () => {
+        const renderComponent = (extraProps = {}) => shallow(
+            <Editor3Component
+                {...editor3mandatoryProps}
+                editorState={EditorState.createEmpty()}
+                {...stubForHighlights}
+                {...extraProps}
+            />,
+        );
+
+        it('maps Alt + - to custom-ndash', () => {
+            const wrapper = renderComponent();
+            const instance = wrapper.instance() as any;
+            const preventDefault = jasmine.createSpy('preventDefault');
+
+            const command = instance.keyBindingFn({
+                key: '-',
+                altKey: true,
+                ctrlKey: false,
+                shiftKey: false,
+                metaKey: false,
+                preventDefault,
+            });
+
+            expect(command).toBe('custom-ndash');
+            expect(preventDefault).toHaveBeenCalled();
+        });
+
+        it('maps Alt + Space to custom-thin-space', () => {
+            const wrapper = renderComponent();
+            const instance = wrapper.instance() as any;
+            const preventDefault = jasmine.createSpy('preventDefault');
+
+            const command = instance.keyBindingFn({
+                key: ' ',
+                altKey: true,
+                ctrlKey: false,
+                shiftKey: false,
+                metaKey: false,
+                preventDefault,
+            });
+
+            expect(command).toBe('custom-thin-space');
+            expect(preventDefault).toHaveBeenCalled();
+        });
+
+        it('handleKeyCommand inserts ndash and calls onChange', () => {
+            const onChange = jasmine.createSpy('onChange');
+            const wrapper = renderComponent({onChange});
+            const instance = wrapper.instance() as any;
+
+            const result = instance.handleKeyCommand('custom-ndash');
+
+            expect(result).toBe('handled');
+            expect(onChange).toHaveBeenCalled();
+            const newState = onChange.calls.mostRecent().args[0];
+
+            expect(newState.getCurrentContent().getPlainText()).toBe('\u2013');
+        });
+
+        it('handleKeyCommand inserts thin space and calls onChange', () => {
+            const onChange = jasmine.createSpy('onChange');
+            const wrapper = renderComponent({onChange});
+            const instance = wrapper.instance() as any;
+
+            const result = instance.handleKeyCommand('custom-thin-space');
+
+            expect(result).toBe('handled');
+            expect(onChange).toHaveBeenCalled();
+            const newState = onChange.calls.mostRecent().args[0];
+
+            expect(newState.getCurrentContent().getPlainText()).toBe('\u2009');
+        });
+    });
 });
 
 describe('editor3.blockRenderer', () => {

--- a/scripts/core/editor3/components/tests/editor3.spec.tsx
+++ b/scripts/core/editor3/components/tests/editor3.spec.tsx
@@ -183,7 +183,7 @@ describe('editor3.component', () => {
             />,
         );
 
-        it('maps Alt + - to custom-ndash', () => {
+        it('maps Cmd/Ctrl + Alt + - to custom-ndash', () => {
             const wrapper = renderComponent();
             const instance = wrapper.instance() as any;
             const preventDefault = jasmine.createSpy('preventDefault');
@@ -191,7 +191,7 @@ describe('editor3.component', () => {
             const command = instance.keyBindingFn({
                 key: '-',
                 altKey: true,
-                ctrlKey: false,
+                ctrlKey: true,
                 shiftKey: false,
                 metaKey: false,
                 preventDefault,
@@ -201,7 +201,7 @@ describe('editor3.component', () => {
             expect(preventDefault).toHaveBeenCalled();
         });
 
-        it('maps Alt + Space to custom-thin-space', () => {
+        it('maps Cmd/Ctrl + Alt + Shift + Space to custom-thin-space', () => {
             const wrapper = renderComponent();
             const instance = wrapper.instance() as any;
             const preventDefault = jasmine.createSpy('preventDefault');
@@ -209,8 +209,8 @@ describe('editor3.component', () => {
             const command = instance.keyBindingFn({
                 key: ' ',
                 altKey: true,
-                ctrlKey: false,
-                shiftKey: false,
+                ctrlKey: true,
+                shiftKey: true,
                 metaKey: false,
                 preventDefault,
             });

--- a/scripts/core/editor3/components/thin-spaces/ThinSpaceDecorator.tsx
+++ b/scripts/core/editor3/components/thin-spaces/ThinSpaceDecorator.tsx
@@ -4,31 +4,35 @@ import {IPropsDraftDecorator} from 'core/editor3/draftjs-types';
 
 class ThinSpaceComponent extends React.Component<IPropsDraftDecorator> {
     render() {
+        const wrapperStyle: React.CSSProperties = {
+            position: 'relative',
+            color: 'var(--sd-colour-interactive)',
+            fontSize: '14px',
+            fontWeight: 'bold',
+            display: 'inline-block',
+            whiteSpace: 'pre',
+            padding: '0 2px',
+        };
+
+        const indicatorStyle: React.CSSProperties = {
+            position: 'absolute',
+            left: '50%',
+            top: '50%',
+            transform: 'translate(-50%, -50%)',
+            opacity: 0.8,
+            pointerEvents: 'none',
+            userSelect: 'none',
+        };
+
         return (
             <span
-                style={{
-                    position: 'relative',
-                    color: 'var(--sd-colour-interactive)',
-                    fontSize: '14px',
-                    fontWeight: 'bold',
-                    display: 'inline-block',
-                    whiteSpace: 'pre',
-                    padding: '0 2px',
-                }}
+                style={wrapperStyle}
                 title="Thin space"
             >
                 {this.props.children}
                 <span
                     aria-hidden={true}
-                    style={{
-                        position: 'absolute',
-                        left: '50%',
-                        top: '50%',
-                        transform: 'translate(-50%, -50%)',
-                        opacity: 0.8,
-                        pointerEvents: 'none',
-                        userSelect: 'none',
-                    }}
+                    style={indicatorStyle}
                 >
                     ¤
                 </span>

--- a/scripts/core/editor3/components/thin-spaces/ThinSpaceDecorator.tsx
+++ b/scripts/core/editor3/components/thin-spaces/ThinSpaceDecorator.tsx
@@ -9,16 +9,19 @@ class ThinSpaceComponent extends React.Component<IPropsDraftDecorator> {
             color: 'var(--sd-colour-interactive)',
             fontSize: '14px',
             fontWeight: 'bold',
-            display: 'inline-block',
+            display: 'inline-grid',
             whiteSpace: 'pre',
             padding: '0 2px',
+            placeItems: 'center',
+        };
+
+        const contentStyle: CSSProperties = {
+            gridArea: '1 / 1 / 2 / 2',
+            opacity: 0,
         };
 
         const indicatorStyle: CSSProperties = {
-            position: 'absolute',
-            left: '50%',
-            top: '50%',
-            transform: 'translate(-50%, -50%)',
+            gridArea: '1 / 1 / 2 / 2',
             opacity: 0.8,
             pointerEvents: 'none',
             userSelect: 'none',
@@ -29,7 +32,7 @@ class ThinSpaceComponent extends React.Component<IPropsDraftDecorator> {
                 style={wrapperStyle}
                 title="Thin space"
             >
-                {this.props.children}
+                <span style={contentStyle}>{this.props.children}</span>
                 <span
                     aria-hidden={true}
                     style={indicatorStyle}

--- a/scripts/core/editor3/components/thin-spaces/ThinSpaceDecorator.tsx
+++ b/scripts/core/editor3/components/thin-spaces/ThinSpaceDecorator.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {ContentBlock, ContentState} from 'draft-js';
 import {IPropsDraftDecorator} from 'core/editor3/draftjs-types';
 
 class ThinSpaceComponent extends React.Component<IPropsDraftDecorator> {
@@ -10,19 +11,37 @@ class ThinSpaceComponent extends React.Component<IPropsDraftDecorator> {
                     color: 'var(--sd-colour-interactive)',
                     fontSize: '14px',
                     fontWeight: 'bold',
-                    userSelect: 'none',
-                    pointerEvents: 'none',
+                    display: 'inline-block',
+                    whiteSpace: 'pre',
+                    padding: '0 2px',
                 }}
                 title="Thin space"
             >
-                <span style={{opacity: 0.8}}>¤</span>
                 {this.props.children}
+                <span
+                    aria-hidden={true}
+                    style={{
+                        position: 'absolute',
+                        left: '50%',
+                        top: '50%',
+                        transform: 'translate(-50%, -50%)',
+                        opacity: 0.8,
+                        pointerEvents: 'none',
+                        userSelect: 'none',
+                    }}
+                >
+                    ¤
+                </span>
             </span>
         );
     }
 }
 
-function ThinSpaceStrategy(contentBlock, callback, contentState) {
+function ThinSpaceStrategy(
+    contentBlock: ContentBlock,
+    callback: (start: number, end: number) => void,
+    contentState: ContentState,
+) {
     const text = contentBlock.getText();
     const thinSpaceChar = '\u2009';
     let index = text.indexOf(thinSpaceChar);

--- a/scripts/core/editor3/components/thin-spaces/ThinSpaceDecorator.tsx
+++ b/scripts/core/editor3/components/thin-spaces/ThinSpaceDecorator.tsx
@@ -1,18 +1,15 @@
 import React, {CSSProperties} from 'react';
 import {ContentBlock, ContentState} from 'draft-js';
 import {IPropsDraftDecorator} from 'core/editor3/draftjs-types';
+import {THIN_SPACE_CHAR} from 'core/editor3/constants';
 
 class ThinSpaceComponent extends React.Component<IPropsDraftDecorator> {
     render() {
         const wrapperStyle: CSSProperties = {
             position: 'relative',
             color: 'var(--sd-colour-interactive)',
-            fontSize: '14px',
-            fontWeight: 'bold',
             display: 'inline-grid',
-            whiteSpace: 'pre',
-            padding: '0 2px',
-            placeItems: 'center',
+            padding: '0 var(--space--0-5)',
         };
 
         const contentStyle: CSSProperties = {
@@ -29,6 +26,7 @@ class ThinSpaceComponent extends React.Component<IPropsDraftDecorator> {
 
         return (
             <span
+                className="whitespace-pre text-sm font-bold place-items-center"
                 style={wrapperStyle}
                 title="Thin space"
             >
@@ -50,12 +48,11 @@ function ThinSpaceStrategy(
     contentState: ContentState,
 ) {
     const text = contentBlock.getText();
-    const thinSpaceChar = '\u2009';
-    let index = text.indexOf(thinSpaceChar);
+    let index = text.indexOf(THIN_SPACE_CHAR);
 
     while (index !== -1) {
         callback(index, index + 1);
-        index = text.indexOf(thinSpaceChar, index + 1);
+        index = text.indexOf(THIN_SPACE_CHAR, index + 1);
     }
 }
 

--- a/scripts/core/editor3/components/thin-spaces/ThinSpaceDecorator.tsx
+++ b/scripts/core/editor3/components/thin-spaces/ThinSpaceDecorator.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, {CSSProperties} from 'react';
 import {ContentBlock, ContentState} from 'draft-js';
 import {IPropsDraftDecorator} from 'core/editor3/draftjs-types';
 
 class ThinSpaceComponent extends React.Component<IPropsDraftDecorator> {
     render() {
-        const wrapperStyle: React.CSSProperties = {
+        const wrapperStyle: CSSProperties = {
             position: 'relative',
             color: 'var(--sd-colour-interactive)',
             fontSize: '14px',
@@ -14,7 +14,7 @@ class ThinSpaceComponent extends React.Component<IPropsDraftDecorator> {
             padding: '0 2px',
         };
 
-        const indicatorStyle: React.CSSProperties = {
+        const indicatorStyle: CSSProperties = {
             position: 'absolute',
             left: '50%',
             top: '50%',

--- a/scripts/core/editor3/components/thin-spaces/ThinSpaceDecorator.tsx
+++ b/scripts/core/editor3/components/thin-spaces/ThinSpaceDecorator.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {IPropsDraftDecorator} from 'core/editor3/draftjs-types';
+
+class ThinSpaceComponent extends React.Component<IPropsDraftDecorator> {
+    render() {
+        return (
+            <span
+                style={{
+                    position: 'relative',
+                    color: 'var(--sd-colour-interactive)',
+                    fontSize: '14px',
+                    fontWeight: 'bold',
+                    userSelect: 'none',
+                    pointerEvents: 'none',
+                }}
+                title="Thin space"
+            >
+                <span style={{opacity: 0.8}}>¤</span>
+                {this.props.children}
+            </span>
+        );
+    }
+}
+
+function ThinSpaceStrategy(contentBlock, callback, contentState) {
+    const text = contentBlock.getText();
+    const thinSpaceChar = '\u2009';
+    let index = text.indexOf(thinSpaceChar);
+
+    while (index !== -1) {
+        callback(index, index + 1);
+        index = text.indexOf(thinSpaceChar, index + 1);
+    }
+}
+
+export const ThinSpaceDecorator = {
+    strategy: ThinSpaceStrategy,
+    component: ThinSpaceComponent,
+};

--- a/scripts/core/editor3/constants.ts
+++ b/scripts/core/editor3/constants.ts
@@ -7,6 +7,9 @@ export const EDITOR_BLOCK_TYPE = 'superdesk/editor3-block';
  */
 export const MIME_TYPE_SUPERDESK_TEXT_ITEM = 'application/superdesk.item.text';
 
+export const THIN_SPACE_CHAR = '\u2009';
+export const NDASH_CHAR = '\u2013';
+
 export enum CustomEditor3Entity {
     MEDIA = 'MEDIA',
     EMBED = 'EMBED',

--- a/scripts/core/editor3/reducers/editor3.tsx
+++ b/scripts/core/editor3/reducers/editor3.tsx
@@ -142,6 +142,7 @@ export function updateDecorators(
         },
         limitConfig: stateCurrent.limitConfig,
         softLimitConfig: stateCurrent.softLimitConfig,
+        invisibles: stateCurrent?.invisibles,
     });
 
     if (result.mustReApplyDecorators !== true) {

--- a/scripts/core/editor3/reducers/editor3.tsx
+++ b/scripts/core/editor3/reducers/editor3.tsx
@@ -145,7 +145,7 @@ export function updateDecorators(
         invisibles: stateCurrent?.invisibles,
     });
 
-    if (result.mustReApplyDecorators !== true && force !== true) {
+    if (result.mustReApplyDecorators !== true) {
         return editorStateNext;
     }
 

--- a/scripts/core/editor3/reducers/editor3.tsx
+++ b/scripts/core/editor3/reducers/editor3.tsx
@@ -145,7 +145,7 @@ export function updateDecorators(
         invisibles: stateCurrent?.invisibles,
     });
 
-    if (result.mustReApplyDecorators !== true) {
+    if (result.mustReApplyDecorators !== true && force !== true) {
         return editorStateNext;
     }
 

--- a/scripts/core/editor3/reducers/toolbar.tsx
+++ b/scripts/core/editor3/reducers/toolbar.tsx
@@ -1,6 +1,6 @@
 import {RichUtils, EditorState, ContentState, SelectionState, EntityInstance} from 'draft-js';
 import * as entityUtils from '../components/links/entityUtils';
-import {onChange} from './editor3';
+import {onChange, updateDecorators} from './editor3';
 import * as Links from '../helpers/links';
 import * as Blocks from '../helpers/blocks';
 import * as Highlights from '../helpers/highlights';
@@ -290,12 +290,15 @@ const removeBlock = (state, {blockKey}) => {
  * @return {Object} returns new state
  * @description Enable/Disable the paragraph marks
  */
-const toggleInvisibles = (state) => {
-    const {invisibles} = state;
+const toggleInvisibles = (state: IEditorStore) => {
+    const resultState: IEditorStore = {
+        ...state,
+        invisibles: !state.invisibles,
+    };
 
     return {
-        ...state,
-        invisibles: !invisibles,
+        ...resultState,
+        editorState: updateDecorators(resultState, resultState.editorState, 'store-based', true),
     };
 };
 

--- a/scripts/core/editor3/store/index.ts
+++ b/scripts/core/editor3/store/index.ts
@@ -102,6 +102,18 @@ export interface IEditorStore {
 
 let editor3Stores = [];
 
+interface IDecoratorStateCache {
+    invisibles: boolean | undefined;
+}
+
+// Cache for tracking decorator state changes across calls.
+// This allows us to detect when configuration changes i.e invisibles toggle on/off
+// and trigger decorator reapplication only when actually needed.
+// Currently tracks invisibles, but can be extended for other decorator dependencies in the future
+let decoratorStateCache: IDecoratorStateCache = {
+    invisibles: undefined,
+};
+
 interface IOptions {
     spellchecker?: {
         acceptSuggestion: IAcceptSuggestion,
@@ -121,10 +133,16 @@ export const getDecorators = (options: IOptions) => {
     let mustReApplyDecorators = false;
 
     const decorators: Array<{strategy: any, component: any}> = [LinkDecorator];
+    const invisiblesChanged = decoratorStateCache.invisibles !== invisibles;
 
     if (invisibles === true) {
+        // When invisbile is toggled on, add ThinSpaceDecorator and force reapplication
         mustReApplyDecorators = true;
         decorators.push(ThinSpaceDecorator);
+    } else if (invisiblesChanged) {
+        // When invisibles is toggled off, we must reapply decorators
+        // to remove the ThinSpaceDecorator that was previously added in the editor
+        mustReApplyDecorators = true;
     }
 
     if (
@@ -153,6 +171,9 @@ export const getDecorators = (options: IOptions) => {
             ),
         );
     }
+
+    // Update cache with current invisibles state for next comparison
+    decoratorStateCache.invisibles = invisibles;
 
     return {
         decorator: new CompositeDecoratorCustom(decorators),

--- a/scripts/core/editor3/store/index.ts
+++ b/scripts/core/editor3/store/index.ts
@@ -122,9 +122,8 @@ export const getDecorators = (options: IOptions) => {
 
     const decorators: Array<{strategy: any, component: any}> = [LinkDecorator];
 
-    // Add thin space decorator when invisibles are enabled
-    mustReApplyDecorators = true;
     if (invisibles === true) {
+        mustReApplyDecorators = true;
         decorators.push(ThinSpaceDecorator);
     }
 

--- a/scripts/core/editor3/store/index.ts
+++ b/scripts/core/editor3/store/index.ts
@@ -42,6 +42,7 @@ import {
 } from 'apps/authoring/authoring/components/CharacterCountConfigButton';
 import {getMiddlewares} from 'core/redux-utils';
 import {getTextLimitHighlightDecorator} from '../components/text-length-overflow-decorator';
+import {ThinSpaceDecorator} from '../components/thin-spaces/ThinSpaceDecorator';
 import {CompositeDecoratorCustom} from './composite-decorator-custom';
 import {IAcceptSuggestion} from '../components/spellchecker/SpellcheckerContextMenu';
 import {IActiveCell} from '../components/tables/TableBlock';
@@ -110,15 +111,22 @@ interface IOptions {
     };
     limitConfig?: EditorLimit,
     softLimitConfig?: number,
+    invisibles?: boolean;
 }
 
 export const getDecorators = (options: IOptions) => {
-    const {limitConfig, softLimitConfig, spellchecker} = options;
+    const {limitConfig, softLimitConfig, spellchecker, invisibles} = options;
 
     // improve performance by not replacing decorators when possible.
     let mustReApplyDecorators = false;
 
     const decorators: Array<{strategy: any, component: any}> = [LinkDecorator];
+
+    // Add thin space decorator when invisibles are enabled
+    mustReApplyDecorators = true;
+    if (invisibles === true) {
+        decorators.push(ThinSpaceDecorator);
+    }
 
     if (
         spellchecker != null
@@ -232,6 +240,7 @@ export default function createEditorStore(
             spellchecker: {acceptSuggestion: 'store-based'},
             limitConfig,
             softLimitConfig,
+            invisibles: false,
         }).decorator,
     );
 


### PR DESCRIPTION
### Purpose
This PR added 2 new keyboard combinations for ndash and thinspace. It also allows for the thinspaces to be seen when the formatting marks are toggled on.

### What has changed
- Added `Cmd/Ctrl + Alt + -` combo for ndash
- Added `Cmd/Ctrl + Alt + Shift + Space` combo for thinspace
- When formatting marks are enabled on the editor and toggled on, the thinspace can be seen as `¤`

### Testing
1. Verify ndash are inserted correctly using `Cmd/Ctrl + Alt + -` combo
2. Verify thinspace are inserted using `Cmd/Ctrl + Alt + Shift + Space` combo
3. When formatting marks are toggled on, verify the thinspace can be seen as `¤` in the editor

### Video

https://github.com/user-attachments/assets/b077e9e6-01d6-46b4-b20f-f1787e5b32a9


