### PR TITLE
[STT-1484] - Configure publish tab to show the "sent to" as default 

### DIFF
--- a/scripts/core/interactive-article-actions-panel/index-ui.tsx
+++ b/scripts/core/interactive-article-actions-panel/index-ui.tsx
@@ -7,7 +7,7 @@ import {Button} from 'superdesk-ui-framework/react';
 import {gettext} from 'core/utils';
 import {Panel} from './panel/panel-main';
 import {PanelHeader} from './panel/panel-header';
-import {authoringReactViewEnabled} from 'appConfig';
+import {authoringReactViewEnabled, appConfig} from 'appConfig';
 import {DuplicateToTab} from './actions/duplicate-to-tab';
 import {WithPublishTab} from './actions/publish-tab';
 import {logger} from 'core/services/logger';
@@ -63,8 +63,14 @@ export class InteractiveArticleActionsPanel
     constructor(props: IPropsInteractiveArticleActionsPanelStateless) {
         super(props);
 
+        const configuredDefaultTab = appConfig.authoring_actions_default_tab;
+        const initialActiveTab =
+            configuredDefaultTab != null && props.tabs.includes(configuredDefaultTab)
+                ? configuredDefaultTab
+                : props.activeTab;
+
         this.state = {
-            activeTab: props.activeTab,
+            activeTab: initialActiveTab,
         };
     }
 

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -3536,6 +3536,9 @@ declare module 'superdesk-api' {
 
         default_timezone: string;
 
+        /** allow setting default tab to open in authoring sidebar */
+        authoring_actions_default_tab?: 'publish' | 'send_to';
+
         // TANSA SERVER CONFIG
         tansa?: {
             base_url: string;


### PR DESCRIPTION
### Purpose
This PR allows for the authoring panel active tab to be configured and default to the one set in the backend 

### What has changed
- Added `authoring_actions_default_tab` to the global config typings.
- Updated the authoring actions panel to set its `activeTab` from the configured default when that tab is available and then falling back to the previously supplied tab.

### How to test
1. Set the server env to `AUTHORING_ACTIONS_DEFAULT_TAB=send_to`, open any authoring pane, and ensure the widget opens on “Send to” when both tabs are available.
2. Switch the env back to `publish` (or remove it) and verify the widget opens on “Publish” as the default.

**NOTE:** This PR is coupled with the server changes in this [PR](https://github.com/superdesk/superdesk-core/pull/3077).

Resolves: #[STT-1484](https://sofab.atlassian.net/browse/STT-1484)

[STT-1484]: https://sofab.atlassian.net/browse/STT-1484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ