### PR TITLE
[SDCP-1031] - Image uploaded to body_html or feature media does not remove the upload dialogue at the end

### DIFF
--- a/scripts/apps/authoring/authoring/components/CharacterCount.tsx
+++ b/scripts/apps/authoring/authoring/components/CharacterCount.tsx
@@ -10,8 +10,9 @@ interface IProps {
     item: string;
 }
 
-export function getEditorFieldCharactersCount(text: string, html?: boolean) {
-    let input = text?.trim() ?? '';
+export function getEditorFieldCharactersCount(text: string | number, html?: boolean) {
+    const normalized = text == null ? '' : String(text);
+    let input = normalized.trim();
 
     input = html ? cleanHtml(input) : input;
     input = input.replace(/\r?\n|\r/g, '');

--- a/scripts/apps/authoring/authoring/components/CharacterCount.tsx
+++ b/scripts/apps/authoring/authoring/components/CharacterCount.tsx
@@ -11,8 +11,7 @@ interface IProps {
 }
 
 export function getEditorFieldCharactersCount(text: string | number, html?: boolean) {
-    const normalized = text == null ? '' : String(text);
-    let input = normalized.trim();
+    let input = `${text ?? ''}`.trim();
 
     input = html ? cleanHtml(input) : input;
     input = input.replace(/\r?\n|\r/g, '');


### PR DESCRIPTION
### Purpose
This PR adds an extra guard when `getEditorFieldCharactersCount` is called. When a number was passed upstream from a custom iptc extension it would cause an error during the image upload flow. Such a case is this [PR](https://github.com/superdesk/superdesk-cp/pull/527)

### How to test
1. Upload media where slugline is mapped to a number from `object_name` like the image attached below.
2. It should save without issues or errors on the console. It shouldn't stay stuck on the Upload dialogue.

Sample photo to use 
![picture](https://github.com/user-attachments/assets/2c70a3d3-dfad-44b9-95d3-55d46eb8a3b0)

Issue - [SDCP-1031](https://sofab.atlassian.net/browse/SDCP-1031)

[SDCP-1031]: https://sofab.atlassian.net/browse/SDCP-1031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ