### PR TITLE
[SDESK-7830] - CI Improvements to E2E tests

### DIFF
--- a/.github/actions/setup-e2e/action.yml
+++ b/.github/actions/setup-e2e/action.yml
@@ -16,7 +16,7 @@ runs:
       working-directory: ./end-to-end-testing-helpers
       shell: bash
 
-    - run: npm install
+    - run: npm ci
       working-directory: ./e2e/client
       shell: bash
 
@@ -32,10 +32,38 @@ runs:
       working-directory: ./e2e/client
       shell: bash
 
-    - name: Start e2e server
+    - name: Cache base Docker images
+      uses: actions/cache@v4
+      with:
+        path: /tmp/base-docker-images.tar
+        key: base-docker-images-${{ hashFiles('e2e/server/docker-compose.yml') }}
+        restore-keys: |
+          base-docker-images-
+
+    - name: Load or pull base Docker images
       run: |
-        docker compose pull
-        docker compose build
-        docker compose up -d
+        if [ -f /tmp/base-docker-images.tar ]; then
+          echo "Loading base images from cache"
+          docker load -i /tmp/base-docker-images.tar
+        else
+          echo "Pulling base images and saving to cache"
+          docker compose pull
+          docker save \
+            redis:alpine \
+            mongo:6 \
+            docker.elastic.co/elasticsearch/elasticsearch:7.17.22 \
+            marlonb/mailcrab:latest \
+            -o /tmp/base-docker-images.tar
+        fi
+      working-directory: e2e/server
+      shell: bash
+
+    - name: Build superdesk server
+      run: docker compose build
+      working-directory: e2e/server
+      shell: bash
+
+    - name: Start superdesk server
+      run: docker compose up -d
       working-directory: e2e/server
       shell: bash

--- a/.github/actions/setup-e2e/action.yml
+++ b/.github/actions/setup-e2e/action.yml
@@ -1,0 +1,41 @@
+name: 'Setup E2E Environment'
+description: 'Install dependencies and start e2e server'
+
+runs:
+  using: "composite"
+  steps:
+    - run: npm ci
+      working-directory: ./
+      shell: bash
+
+    - run: npm ci
+      working-directory: ./build-tools
+      shell: bash
+
+    - run: npm ci
+      working-directory: ./end-to-end-testing-helpers
+      shell: bash
+
+    - run: npm install
+      working-directory: ./e2e/client
+      shell: bash
+
+    - run: npm run build
+      working-directory: ./e2e/client
+      shell: bash
+
+    - run: npm run specs--compile
+      working-directory: ./e2e/client
+      shell: bash
+
+    - run: npm run start-client-server
+      working-directory: ./e2e/client
+      shell: bash
+
+    - name: Start e2e server
+      run: |
+        docker compose pull
+        docker compose build
+        docker compose up -d
+      working-directory: e2e/server
+      shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,95 @@ jobs:
       env:
         TZ: "Europe/Prague"
 
-  e2e:
+  playwright-e2e:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22']
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
+    defaults:
+      run:
+        working-directory: e2e/client
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+
+    - run: npm ci
+      working-directory: ./
+
+    - run: npm ci
+      working-directory: ./build-tools
+
+    - run: npm ci
+      working-directory: ./end-to-end-testing-helpers
+
+    - run: npm install
+    - run: npm run build
+    - run: npm run specs--compile
+    - run: npm run start-client-server
+
+    - name: Start e2e server
+      run: |
+        docker compose pull
+        docker compose build
+        docker compose up -d
+      working-directory: e2e/server
+
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+
+    - name: Run Playwright tests
+      run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+
+    - name: Upload blob report to GitHub Actions Artifacts
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: blob-report-${{ matrix.shardIndex }}
+        path: e2e/client/blob-report
+        retention-days: 1
+
+    - name: Server Logs
+      if: ${{ failure() }}
+      run: docker compose logs server
+      working-directory: e2e/server
+
+  merge-playwright-reports:
+    if: ${{ !cancelled() }}
+    needs: [playwright-e2e]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: e2e/client
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+
+    - name: Download blob reports from GitHub Actions Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: e2e/client/all-blob-reports
+        pattern: blob-report-*
+        merge-multiple: true
+
+    - name: Merge into HTML Report
+      run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+    - name: Upload HTML report
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-html-report
+        path: e2e/client/playwright-report
+        retention-days: 14
+
+  protractor-e2e:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -64,19 +152,6 @@ jobs:
         docker compose up -d
       working-directory: e2e/server
 
-    # playwright start
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
-    - name: Run Playwright tests
-      run: npx playwright test
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: playwright-report-${{ matrix.node-version }}-${{ matrix.suite }}
-        path: e2e/client/test-results
-    # playwright end
-
-    # protractor start
     - name: Setup Chrome
       uses: browser-actions/setup-chrome@v1
       id: setup-chrome
@@ -97,10 +172,8 @@ jobs:
       if: ${{ failure() }}
       uses: actions/upload-artifact@v4
       with:
-        name: screenshots-e2e-node-${{ matrix.node-version }}-${{ matrix.suite }}
+        name: screenshots-protractor-node-${{ matrix.node-version }}-${{ matrix.suite }}
         path: /tmp/*.png
-
-    # protractor end
 
     - name: Server Logs
       if: ${{ failure() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
 
-    - uses: ./.github/actions/setup-e2e
+    - name: Setup E2E Environment
+      uses: ./.github/actions/setup-e2e
 
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
@@ -51,21 +52,13 @@ jobs:
     - name: Run Playwright tests
       run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
-    - name: Upload blob report to GitHub Actions Artifacts
+    - name: Upload blob report to Artifacts
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
         name: blob-report-${{ matrix.shardIndex }}
         path: e2e/client/blob-report
         retention-days: 1
-
-    - name: Upload Playwright test results (screenshots, videos, traces)
-      if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: playwright-results-${{ matrix.shardIndex }}
-        path: e2e/client/test-results
-        retention-days: 7
 
     - name: Server Logs
       if: ${{ failure() }}
@@ -85,8 +78,8 @@ jobs:
       with:
         node-version: '22'
 
-    - name: Download blob reports from GitHub Actions Artifacts
-      uses: actions/download-artifact@v4
+    - name: Download blob reports from Artifacts
+      uses: actions/download-artifact@v5
       with:
         path: e2e/client/all-blob-reports
         pattern: blob-report-*
@@ -119,7 +112,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
 
-    - uses: ./.github/actions/setup-e2e
+    - name: Setup E2E Environment
+      uses: ./.github/actions/setup-e2e
 
     - name: Setup Chrome
       uses: browser-actions/setup-chrome@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,6 @@ jobs:
         cache: 'npm'
 
     - run: npm ci
-
     - run: npm run test
 
       env:
@@ -32,8 +31,8 @@ jobs:
       fail-fast: false
       matrix:
         node-version: ['22']
-        shardIndex: [1, 2, 3, 4]
-        shardTotal: [4]
+        shardIndex: [1, 2]
+        shardTotal: [2]
     defaults:
       run:
         working-directory: e2e/client
@@ -44,26 +43,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
 
-    - run: npm ci
-      working-directory: ./
-
-    - run: npm ci
-      working-directory: ./build-tools
-
-    - run: npm ci
-      working-directory: ./end-to-end-testing-helpers
-
-    - run: npm install
-    - run: npm run build
-    - run: npm run specs--compile
-    - run: npm run start-client-server
-
-    - name: Start e2e server
-      run: |
-        docker compose pull
-        docker compose build
-        docker compose up -d
-      working-directory: e2e/server
+    - uses: ./.github/actions/setup-e2e
 
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
@@ -78,6 +58,14 @@ jobs:
         name: blob-report-${{ matrix.shardIndex }}
         path: e2e/client/blob-report
         retention-days: 1
+
+    - name: Upload Playwright test results (screenshots, videos, traces)
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-results-${{ matrix.shardIndex }}
+        path: e2e/client/test-results
+        retention-days: 7
 
     - name: Server Logs
       if: ${{ failure() }}
@@ -131,26 +119,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
 
-    - run: npm ci
-      working-directory: ./
-
-    - run: npm ci
-      working-directory: ./build-tools
-
-    - run: npm ci
-      working-directory: ./end-to-end-testing-helpers
-
-    - run: npm install
-    - run: npm run build
-    - run: npm run specs--compile
-    - run: npm run start-client-server
-
-    - name: Start e2e server
-      run: |
-        docker compose pull
-        docker compose build
-        docker compose up -d
-      working-directory: e2e/server
+    - uses: ./.github/actions/setup-e2e
 
     - name: Setup Chrome
       uses: browser-actions/setup-chrome@v1

--- a/e2e/client/playwright.config.ts
+++ b/e2e/client/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     /* Opt out of parallel tests on CI. */
     workers: process.env.CI ? 1 : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-    reporter: 'html',
+    reporter: process.env.CI ? 'blob' : 'html',
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
### Purpose
Speed up and streamline our E2E pipelines by introducing Playwright test `sharding`, centralising setup steps and improving how reports are generated and merged in CI.

### What has changed
- Refactored Playwright workflow: introduced test sharding (2 shards), switched CI reporter to blob, and added blob-report artifact uploads.
- Added a new setup-e2e composite action to centralize dependency installation, client build, spec compilation, and server startup for all E2E jobs.
- Added a new merge-playwright-reports job to collect shard outputs, merge them, and generate a single HTML report.
- Updated Protractor workflow to use the new shared setup action and cleaned up artifact naming and logging.

> [!IMPORTANT]
> It's worth mentioning that I've also tried having a unified build step and then reusing the same build for both protractor and playwright but that actually took longer as both runners need to wait for the build before starting, while with this approach they start running in parallel which makes it faster. 
This makes the E2E tests to run up to 15 mins faster. See screenshots below. 

### Before
<img width="850" alt="image" src="https://github.com/user-attachments/assets/7123d3a6-37a1-42bf-b0a2-4d948d123c9f" />

<img width="850" alt="image" src="https://github.com/user-attachments/assets/4faee158-fd9b-457b-b334-e6a3ea362207" />

### After
<img width="850" alt="image" src="https://github.com/user-attachments/assets/f024444c-1968-488c-851e-1395e85c938b" />

 [SDESK-7830]


[SDESK-7830]: https://sofab.atlassian.net/browse/SDESK-7830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ