### PR TITLE
[STT-1525] - Unlock item after sending it to another desk

### DIFF
--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -728,7 +728,7 @@ export function AuthoringDirective(
             };
 
             /**
-             * Called by the sendItem directive before send.
+             * Called by the sendItem directive before send and makes sure to unlock the item.
              * If the $scope is dirty then upon confirmation save the item and then unlock the item.
              * If the $scope is not dirty then unlock the item.
              * @param {String} action - action to display in confirmation dialog
@@ -739,6 +739,7 @@ export function AuthoringDirective(
                 if ($scope.dirty) {
                     return confirm.confirmSendTo(action)
                         .then(() => $scope.save())
+                        .then(() => lock.unlock($scope.origItem))
                         .catch(() => $q.reject());
                 }
 


### PR DESCRIPTION
### Purpose
Ensures that an item is unlocked after sending to another desk even when the item was not previously saved

[STT-1525]

[STT-1525]: https://sofab.atlassian.net/browse/STT-1525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ