### PR TITLE
[STT-1530] - Superdesk writing mode: In text link seems empty but is not

### DIFF
--- a/scripts/core/editor3/components/links/LinkInput.tsx
+++ b/scripts/core/editor3/components/links/LinkInput.tsx
@@ -35,6 +35,7 @@ const linkTypes = {
 
 export interface ILink {
     href: string;
+    url?: string;
 }
 
 interface IProps extends Partial<IEditorStore> {

--- a/scripts/core/editor3/components/links/LinkInput.tsx
+++ b/scripts/core/editor3/components/links/LinkInput.tsx
@@ -90,7 +90,7 @@ export class LinkInputComponent extends React.Component<IProps, any> {
         const initialValue = '';
 
         this.state = {
-            url: this.props.data ? this.props.data.href || initialValue : initialValue,
+            url: this.props.data ? (this.props.data.href || this.props.data.url || initialValue) : initialValue,
             selected: selectedAttachment,
         };
 

--- a/scripts/core/editor3/components/links/LinkToolbar.tsx
+++ b/scripts/core/editor3/components/links/LinkToolbar.tsx
@@ -36,7 +36,8 @@ export class LinkToolbarComponent extends React.Component<IProps, any> {
 
     render() {
         const {editorState, onEdit} = this.props;
-        const {link} = getSelectedEntityData(editorState);
+        const entityData = getSelectedEntityData(editorState);
+        const link = entityData.link || (entityData.url ? {href: entityData.url} : undefined);
         const isLink = getSelectedEntityType(editorState) === 'LINK';
         const cx = classNames({
             'dropdown': true,

--- a/scripts/core/editor3/components/tables/TableCell.tsx
+++ b/scripts/core/editor3/components/tables/TableCell.tsx
@@ -138,8 +138,8 @@ export class TableCell extends React.Component<IProps, IState> {
         }
 
         // eslint-disable-next-line no-alert
-        const url = prompt('Enter a URL');
-        const contentState = editorState.getCurrentContent().createEntity('LINK', 'MUTABLE', {url});
+        const link = {href: prompt('Enter a URL')};
+        const contentState = editorState.getCurrentContent().createEntity('LINK', 'MUTABLE', {link});
 
         return RichUtils.toggleLink(
             editorState,


### PR DESCRIPTION
### Purpose
Links created in table cells had different data structure `{url: "...", href: "..."}` instead of correct `{link: {href: "..."}}`. This caused edit link input to be empty, even though links worked when hovering.

### What has changed
Added fallback logic to handle legacy `{url}` format if it exists in other articles and fixed table cell link creation.

### How to test
1. Create an article with a link and then malform the data in the entity map like the prod example [here](https://sofab.atlassian.net/browse/IN-7438?focusedCommentId=147351). As you can see, the structure for entity 0 is 
```
data: {
  href: "",
  title: "",
  url: ""
}
``` 
and not like entity 1
```
data: {
  link: {
    href: ""
  }
}
```
2. Without the new fallbacks, when you edit the link, it doesn't populate the edit field. But with the new fallback and changes to the TableCell link creation, it shouldn't reoccur.
3. The fallbacks have been added incase there exists more articles that have the old format