### PR TITLE
STT-1509 - As an STT journalist I´d like to know the status of the article I am working on

### DIFF
--- a/e2e/client/playwright/correct-item-corrections-workflow.spec.ts
+++ b/e2e/client/playwright/correct-item-corrections-workflow.spec.ts
@@ -37,7 +37,7 @@ test('can correct published item using corrections workflow', async ({page}) => 
     await expect(
         page
             .locator(s('monitoring-group=Sports / Working Stage', 'article-item=Story 5'))
-            .getByTitle('Correction', {exact: true}),
+            .getByText('Correction', {exact: true}),
     ).toBeVisible();
 
     // edit item
@@ -58,12 +58,12 @@ test('can correct published item using corrections workflow', async ({page}) => 
         page.locator(s('monitoring-group=Sports desk output', 'article-item=Story 5.1')),
     ).toBeVisible();
     await expect(
-        page.locator(s('monitoring-group=Sports desk output', 'article-item=Story 5.1')).getByTitle('Corrected'),
+        page.locator(s('monitoring-group=Sports desk output', 'article-item=Story 5.1')).getByText('Corrected'),
     ).toBeVisible();
     await expect(
         page
             .locator(s('monitoring-group=Sports desk output', 'article-item=Story 5.1'))
-            .getByTitle('Correction', {exact: true}),
+            .getByText('Correction', {exact: true}),
     ).not.toBeVisible();
 
     await page.goto('/#/publish_queue');

--- a/e2e/client/specs/helpers/authoring.ts
+++ b/e2e/client/specs/helpers/authoring.ts
@@ -956,7 +956,7 @@ class Authoring {
         };
 
         this.getItemState = function() {
-            return element(by.id('metadata')).all(by.css('.label, .state-label')).first();
+            return element(by.css('[data-test-id="authoring-toolbar-1"]')).all(by.css('.label')).first();
         };
 
         this.isPublishedState = function() {

--- a/e2e/client/specs/helpers/authoring.ts
+++ b/e2e/client/specs/helpers/authoring.ts
@@ -952,11 +952,11 @@ class Authoring {
 
             browser.wait(ECE.presenceOf(duplicatedItem), 500);
 
-            return duplicatedItem.element(by.className('state-label')).getText();
+            return duplicatedItem.element(by.css('.label')).getText();
         };
 
         this.getItemState = function() {
-            return element(by.className('metadata')).element(by.className('state-label'));
+            return element(by.className('metadata')).element(by.css('.label'));
         };
 
         this.isPublishedState = function() {

--- a/e2e/client/specs/helpers/authoring.ts
+++ b/e2e/client/specs/helpers/authoring.ts
@@ -956,7 +956,7 @@ class Authoring {
         };
 
         this.getItemState = function() {
-            return element(by.css('[data-test-id="authoring-toolbar-1"]')).all(by.css('.label')).first();
+            return element(by.css('.widget-content__main sd-state-label'));
         };
 
         this.isPublishedState = function() {

--- a/e2e/client/specs/helpers/authoring.ts
+++ b/e2e/client/specs/helpers/authoring.ts
@@ -956,7 +956,7 @@ class Authoring {
         };
 
         this.getItemState = function() {
-            return element(by.className('metadata')).element(by.css('.label'));
+            return element(by.id('metadata')).all(by.css('.label, .state-label')).first();
         };
 
         this.isPublishedState = function() {

--- a/e2e/client/specs/search_spec.ts
+++ b/e2e/client/specs/search_spec.ts
@@ -287,8 +287,8 @@ describe('search', () => {
         dateScheduled.click();
 
         globalSearch.waitForItemCount(1);
-        expect(globalSearch.getItem(0).element(by.className('state-scheduled')).isDisplayed()).toBe(true);
-        expect(globalSearch.getItem(0).element(by.className('state-scheduled')).getText()).toEqual('SCHEDULED');
+        expect(globalSearch.getItem(0).element(by.css('.label')).isDisplayed()).toBe(true);
+        expect(globalSearch.getItem(0).element(by.css('.label')).getText()).toEqual('SCHEDULED');
         expect(element.all(by.repeater('key in keys')).count()).toBe(1);
         element(by.css('.tag-label__remove')).click();
         globalSearch.waitForItemCount(16);

--- a/e2e/client/specs/search_spec.ts
+++ b/e2e/client/specs/search_spec.ts
@@ -287,8 +287,8 @@ describe('search', () => {
         dateScheduled.click();
 
         globalSearch.waitForItemCount(1);
-        expect(globalSearch.getItem(0).element(by.css('.label')).isDisplayed()).toBe(true);
-        expect(globalSearch.getItem(0).element(by.css('.label')).getText()).toEqual('SCHEDULED');
+        expect(globalSearch.getItem(0).element(by.css('.label, .state-label')).isDisplayed()).toBe(true);
+        expect(globalSearch.getItem(0).element(by.css('.label, .state-label')).getText()).toEqual('SCHEDULED');
         expect(element.all(by.repeater('key in keys')).count()).toBe(1);
         element(by.css('.tag-label__remove')).click();
         globalSearch.waitForItemCount(16);

--- a/e2e/client/specs/send_spec.ts
+++ b/e2e/client/specs/send_spec.ts
@@ -11,7 +11,7 @@ import {TreeSelectDriver} from './helpers/tree-select-driver';
 
 describe('send', () => {
     function getItemState(index) {
-        var label = content.getItem(index).element(by.css('.label'));
+        var label = content.getItem(index).element(by.css('.label, .state-label'));
 
         return label.getText();
     }

--- a/e2e/client/specs/send_spec.ts
+++ b/e2e/client/specs/send_spec.ts
@@ -11,7 +11,7 @@ import {TreeSelectDriver} from './helpers/tree-select-driver';
 
 describe('send', () => {
     function getItemState(index) {
-        var label = content.getItem(index).element(by.css('.state-label'));
+        var label = content.getItem(index).element(by.css('.label'));
 
         return label.getText();
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12804,9 +12804,9 @@
       }
     },
     "superdesk-ui-framework": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-6.0.2.tgz",
-      "integrity": "sha512-2RpYPmNR2WnfkwvtMCUYwJFkhAR75ANurGuYS3Y9hPAAs3XaG4OqIOie7IHZYJiv6OWfj4wJYakfdVbsUQjuJg==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-6.0.3.tgz",
+      "integrity": "sha512-VZHzSh7cN5SPBdA0ddzhB+HYg+ft/4iNyaWJ+ghdpWVZ87dbWw1T8uFl6FdYCSTV6yygxmALdZLYgrvi0k9dfA==",
       "requires": {
         "@popperjs/core": "^2.4.0",
         "@sourcefabric/common": "0.0.66",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "sass-loader": "^10.5.2",
     "shallow-equal": "^3.1.0",
     "shortid": "2.2.8",
-    "superdesk-ui-framework": "6.0.2",
+    "superdesk-ui-framework": "6.0.3",
     "ts-loader": "^8.4.0",
     "typescript": "~4.9.5",
     "uuid": "8.3.1",

--- a/scripts/apps/archive/index.tsx
+++ b/scripts/apps/archive/index.tsx
@@ -42,7 +42,10 @@ angular.module('superdesk.apps.archive.directives', [
     .directive('sdMediaPreviewWidget', directive.MediaPreviewWidget)
     .directive('sdMediaMetadata', directive.MediaMetadata)
     .component('sdRelatedView', reactToAngular1(RelatedView, ['relatedItems'], []))
-    .component('sdStateLabel', reactToAngular1(StateLabel, ['state', 'text', 'onClick', 'color', 'noTransform', 'size'], []))
+    .component(
+        'sdStateLabel',
+        reactToAngular1(StateLabel, ['state', 'text', 'onClick', 'color', 'noTransform', 'size'], []),
+    )
     .directive('sdFetchedDesks', directive.FetchedDesks)
     .directive('sdMetaIngest', directive.MetaIngest)
     .directive('sdDraggableItem', directive.DraggableItem)

--- a/scripts/apps/archive/index.tsx
+++ b/scripts/apps/archive/index.tsx
@@ -5,7 +5,7 @@ import './styles/related-item.scss';
 import './styles/assignment.scss';
 import './styles/html-preview.scss';
 import {includes, flatMap} from 'lodash';
-import {reactToAngular1} from 'superdesk-ui-framework';
+import {reactToAngular1, StateLabel} from 'superdesk-ui-framework';
 
 // scripts
 import './related-item-widget/relatedItem';
@@ -42,6 +42,7 @@ angular.module('superdesk.apps.archive.directives', [
     .directive('sdMediaPreviewWidget', directive.MediaPreviewWidget)
     .directive('sdMediaMetadata', directive.MediaMetadata)
     .component('sdRelatedView', reactToAngular1(RelatedView, ['relatedItems'], []))
+    .component('sdStateLabel', reactToAngular1(StateLabel, ['state', 'text', 'onClick', 'color', 'noTransform', 'size'], []))
     .directive('sdFetchedDesks', directive.FetchedDesks)
     .directive('sdMetaIngest', directive.MetaIngest)
     .directive('sdDraggableItem', directive.DraggableItem)

--- a/scripts/apps/archive/views/item-state.html
+++ b/scripts/apps/archive/views/item-state.html
@@ -1,5 +1,5 @@
-<span
-ng-class="state === 'correction' || state === 'being_corrected' && isCorrectionWorkflowEnabled
-? state === 'being_corrected' ? 'label label--hollow hollow-pink--500' : 'label pink--500'
-: 'state-label state-{{state}}'">{{state|translate|removeLodash}}</span>
+<sd-state-label
+    state="state"
+    text="state | translate | removeLodash"
+></sd-state-label>
 <span class="state-label" ng-if="embargo" ng-class="{state_embargo: embargo}" translate>embargo</span>

--- a/scripts/apps/archive/views/item-state.html
+++ b/scripts/apps/archive/views/item-state.html
@@ -1,5 +1,12 @@
 <sd-state-label
+    class="pull-right"
     state="state"
     text="state | translate | removeLodash"
 ></sd-state-label>
-<span class="state-label" ng-if="embargo" ng-class="{state_embargo: embargo}" translate>embargo</span>
+<sd-state-label
+    ng-if="embargo"
+    class="pull-right"
+    state="'embargo'"
+    text="'embargo' | translate"
+    color="'hsl(337, 100%, 60%)'"
+></sd-state-label>

--- a/scripts/apps/authoring/authoring/authoring-topbar2-react.tsx
+++ b/scripts/apps/authoring/authoring/authoring-topbar2-react.tsx
@@ -7,9 +7,19 @@ import {extensions} from 'appConfig';
 import {dataApi} from 'core/helpers/CrudManager';
 import {CreatedInfo} from './created-info';
 import {ModifiedInfo} from './modified-info';
+import {StatusInfo} from './status-info';
 import {AuthoringToolbar} from 'apps/authoring-react/subcomponents/authoring-toolbar';
 
 const getDefaultToolbarItems = (item: IArticle): Array<ITopBarWidget<IArticle>> => [{
+    availableOffline: true,
+    component: () => (
+        <StatusInfo
+            entity={item}
+        />
+    ),
+    group: 'start',
+    priority: 0,
+}, {
     availableOffline: true,
     component: () => (
         <CreatedInfo
@@ -42,7 +52,7 @@ interface IState {
 /**
  * Only used from angular based authoring view
  */
-export class AuthoringTopbar2React extends React.PureComponent<IProps, IState> {
+export class AuthoringTopbar2React extends React.Component<IProps, IState> {
     constructor(props: IProps) {
         super(props);
 
@@ -72,6 +82,7 @@ export class AuthoringTopbar2React extends React.PureComponent<IProps, IState> {
             this.fetchArticleFromServer();
         }
     }
+
     shouldComponentUpdate(nextProps: IProps, nextState: IState) {
         for (const key of Object.keys(this.props)) {
             if (key === 'children') continue;
@@ -81,7 +92,9 @@ export class AuthoringTopbar2React extends React.PureComponent<IProps, IState> {
             }
         }
 
-        for (const key of Object.keys(this.state)) {
+        const stateKeys = new Set([...Object.keys(this.state), ...Object.keys(nextState)]);
+
+        for (const key of Array.from(stateKeys)) {
             if (this.state[key] !== nextState[key]) {
                 return true;
             }
@@ -89,6 +102,7 @@ export class AuthoringTopbar2React extends React.PureComponent<IProps, IState> {
 
         return false;
     }
+
     render() {
         if (this.props.action === 'view' && typeof this.state.articleOriginal === 'undefined') {
             return null; // fetching article from the server

--- a/scripts/apps/authoring/authoring/status-info.tsx
+++ b/scripts/apps/authoring/authoring/status-info.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {IArticle} from 'superdesk-api';
+import {getStateLabel} from 'apps/search/components/fields/state';
+
+interface IProps {
+    entity: IArticle;
+}
+
+export class StatusInfo extends React.PureComponent<IProps> {
+    render() {
+        const {entity} = this.props;
+
+        if (entity.state == null) {
+            return null;
+        }
+
+        const label = getStateLabel(entity.state);
+        const cssClass = entity.state === 'correction'
+            ? 'label pink--500'
+            : (entity.state === 'being_corrected'
+                ? 'label label--hollow hollow-pink--500'
+                : 'state-label state-' + entity.state);
+
+        return (
+            <span
+                className={cssClass}
+                title={label}
+            >
+                {label}
+            </span>
+        );
+    }
+}

--- a/scripts/apps/authoring/authoring/status-info.tsx
+++ b/scripts/apps/authoring/authoring/status-info.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {IArticle} from 'superdesk-api';
 import {getStateLabel} from 'apps/search/components/fields/state';
+import {StateLabel} from 'superdesk-ui-framework';
 
 interface IProps {
     entity: IArticle;
@@ -15,19 +16,12 @@ export class StatusInfo extends React.PureComponent<IProps> {
         }
 
         const label = getStateLabel(entity.state);
-        const cssClass = entity.state === 'correction'
-            ? 'label pink--500'
-            : (entity.state === 'being_corrected'
-                ? 'label label--hollow hollow-pink--500'
-                : 'state-label state-' + entity.state);
 
         return (
-            <span
-                className={cssClass}
-                title={label}
-            >
-                {label}
-            </span>
+            <StateLabel
+                state={entity.state}
+                text={label}
+            />
         );
     }
 }

--- a/scripts/apps/search/components/fields/state.tsx
+++ b/scripts/apps/search/components/fields/state.tsx
@@ -4,6 +4,7 @@ import {IPropsItemListInfo} from '../ListItemInfo';
 import {assertNever} from 'core/helpers/typescript-helpers';
 import {ITEM_STATE} from 'apps/search/interfaces';
 import {formatDate, openArticle} from 'core/get-superdesk-api-implementation';
+import {StateLabel} from 'superdesk-ui-framework';
 
 export function getStateLabel(itemState: ITEM_STATE) {
     switch (itemState) {
@@ -46,19 +47,16 @@ export class StateComponent extends React.Component<Pick<IPropsItemListInfo, 'it
                 }
             }
 
+            const handleClick = props.item.state === 'being_corrected'
+                ? () => openItem(new Event('click'))
+                : undefined;
+
             return (
-                <span
-                    title={title}
-                    className={props.item.state === 'correction'
-                        ? 'label pink--500'
-                        : (props.item.state === 'being_corrected'
-                            ? 'label label--hollow hollow-pink--500'
-                            : 'state-label state-' + props.item.state)}
-                    key="state"
-                    onClick={props.item.state === 'being_corrected' ? openItem : null}
-                >
-                    {text}
-                </span>
+                <StateLabel
+                    state={props.item.state}
+                    text={text}
+                    onClick={handleClick}
+                />
             );
         } else {
             return null;


### PR DESCRIPTION
### Purpose
This PR adds the same status pill found in the monitoring list view to the editor header so journalists can see the article status as they work.

### What has changed
- Created `StatusInfo` component to display status label in authoring topbar with the same styling as the list view
- Added status widget with priority 0 to the authoring topbar to display before Created/Modified info as per the design in the ticket
- **Bug fix**: Corrected `shouldComponentUpdate()` to properly detect new state keys. This fixed an issue where metadata wasn't displaying for published/archived articles in view mode
- Changed component from `PureComponent` to `Component` to support custom `shouldComponentUpdate()` logic which resolved React console warnings on the same.

### Screenshots

Before : 
<img width="638" height="290" alt="2026-01-14_15-00-53" src="https://github.com/user-attachments/assets/abd32de7-4aff-427c-be3c-0352435b5d11" />

After: 
<img width="641" height="388" alt="2026-01-14_15-01-35" src="https://github.com/user-attachments/assets/1a5c1a46-dc70-4e42-9bc7-3d936cc74509" />

And also after the bug fix, published items also show the metadata too: 
<img width="638" height="285" alt="2026-01-14_15-02-44" src="https://github.com/user-attachments/assets/069e213d-9567-47c7-aba9-ca89448a3d8b" />

Ticket: [STT-1509](https://sofab.atlassian.net/browse/STT-1509)



[STT-1509]: https://sofab.atlassian.net/browse/STT-1509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ