### PR TITLE
Update handling of react-resizable-panels in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -200,7 +200,6 @@ module.exports = function makeConfig(grunt) {
                  */
                 react: getModuleDir('react'),
                 'react-dom': getModuleDir('react-dom'),
-                'react-resizable-panels': path.join(getModuleDir('react-resizable-panels'), 'dist/react-resizable-panels.js'),
 
                 /**
                  * Required for development mode only.
@@ -235,6 +234,14 @@ module.exports = function makeConfig(grunt) {
                         // don't exclude anything outside node_modules
                         if (absolutePath.indexOf('node_modules') === -1) {
                             return false;
+                        }
+
+                        // Exclude these packages from ts-loader - they are pre-built ESM modules
+                        if (
+                            absolutePath.includes('/@babel/runtime/')
+                            || absolutePath.includes('/react-resizable-panels/')
+                        ) {
+                            return true;
                         }
 
                         if (


### PR DESCRIPTION
This pull request makes targeted updates to the Webpack configuration to improve how certain dependencies are handled during the build process. The main focus is on optimizing module resolution and TypeScript loader behavior for pre-built ESM modules.

Dependency resolution and build optimization:

* Removed the custom path resolution for `react-resizable-panels` in the `resolve.alias` section, allowing Webpack to use its default resolution for this package.
* Updated the `ts-loader` exclusion logic to skip TypeScript processing for pre-built ESM modules, specifically `@babel/runtime` and `react-resizable-panels`, which helps prevent unnecessary transpilation and potential build issues.
