### PR TITLE
Add vocabulary deletion UI

### DIFF
--- a/scripts/api/vocabularies.ts
+++ b/scripts/api/vocabularies.ts
@@ -2,6 +2,7 @@ import {OrderedMap} from 'immutable';
 import ng from 'core/services/ng';
 import {IArticle, IVocabulary, IVocabularyItem} from 'superdesk-api';
 import {getVocabularyItemNameTranslated} from 'core/utils';
+import {httpRequestVoidLocal} from 'core/helpers/network';
 
 function getAll(): OrderedMap<IVocabulary['_id'], IVocabulary> {
     return OrderedMap<string, IVocabulary>(
@@ -92,6 +93,13 @@ function getCustomFieldVocabularies(): Array<IVocabulary> {
     return getAll().filter((vocabulary) => isCustomFieldVocabulary(vocabulary)).toArray();
 }
 
+function deleteVocabulary(vocabulary: IVocabulary): Promise<void> {
+    return httpRequestVoidLocal({
+        method: 'DELETE',
+        path: `/vocabularies/${vocabulary._id}`,
+        headers: {'If-Match': vocabulary._etag},
+    });
+}
 
 interface IVocabulariesApi {
     getAll: () => OrderedMap<IVocabulary['_id'], IVocabulary>;
@@ -100,6 +108,7 @@ interface IVocabulariesApi {
     isSelectionVocabulary: (vocabulary: IVocabulary) => boolean;
     isCustomVocabulary: (vocabulary: IVocabulary) => boolean;
     getVocabularyItemLabel: (term: IVocabularyItem, item: IArticle) => string;
+    deleteVocabulary(vocabulary: IVocabulary): Promise<void>;
     getVocabularyItemsPreview: (
         array: Array<IVocabularyItem>,
         propertyName?: keyof IVocabularyItem,
@@ -122,4 +131,5 @@ export const vocabularies: IVocabulariesApi = {
     vocabularyItemsToString,
     isCustomVocabulary,
     getCustomFieldVocabularies,
+    deleteVocabulary,
 };

--- a/scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx
+++ b/scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import {Modal, Button, ButtonGroup, Text, Spacer} from 'superdesk-ui-framework/react';
+import {gettext, gettextPlural} from 'core/utils';
+import {IVocabulary} from 'superdesk-api';
+import {sdApi} from 'api';
+
+interface IProps {
+    vocabulary: IVocabulary;
+    onDelete: () => void;
+    onCancel: () => void;
+    closeModal: () => void;
+    navigateToContentProfiles: () => void;
+}
+
+export class VocabularyDeletionModal extends React.PureComponent<IProps> {
+    render() {
+        const {vocabulary, onDelete, onCancel, navigateToContentProfiles, closeModal} = this.props;
+        const profiles = sdApi.contentProfiles.getAll();
+        const profilesWithVocabulary = profiles.filter((profile) => profile.editor[vocabulary._id] != null);
+
+        if (profilesWithVocabulary.length > 0) {
+            return (
+                <Modal
+                    visible
+                    size="small"
+                    position="center"
+                    closeOnEscape
+                    contentPadding="small"
+                    headerTemplate={gettext('Cannot delete vocabulary')}
+                    onHide={closeModal}
+                    footerTemplate={(
+                        <ButtonGroup align="end">
+                            <Button
+                                type="tertiary"
+                                text={gettext('Go to content profiles')}
+                                onClick={navigateToContentProfiles}
+                            />
+                            <Button
+                                type="primary"
+                                text={gettext('Go back')}
+                                onClick={onCancel}
+                            />
+                        </ButtonGroup>
+                    )}
+                    data-test-id="vocabulary-deletion-modal--cannot-delete"
+                >
+                    <Spacer gap="8" v justifyContent="space-between" noWrap>
+                        <Text>
+                            {gettextPlural(
+                                profilesWithVocabulary.length,
+                                'The vocabulary {{name}} can\'t be deleted because it is currently used ' +
+                                'in the following Content Profile:',
+                                'The vocabulary {{name}} can\'t be deleted because it is currently used ' +
+                                'in the following Content Profiles:',
+                                {name: () => <strong>{vocabulary.display_name}</strong>},
+                            )}
+                        </Text>
+                        <ul style={{listStyle: 'inside'}}>
+                            {profilesWithVocabulary.map((profile) => (
+                                <li key={profile._id}><strong>{profile.label}</strong></li>
+                            ))}
+                        </ul>
+                        <Text>
+                            {gettext(
+                                'To delete this vocabulary, you must first remove it from all ' +
+                                'Content Profiles listed above.',
+                            )}
+                        </Text>
+                    </Spacer>
+                </Modal>
+            );
+        } else {
+            return (
+                <Modal
+                    visible
+                    size="small"
+                    position="center"
+                    closeOnEscape
+                    onHide={closeModal}
+                    contentPadding="small"
+                    headerTemplate={gettext('Delete vocabulary?')}
+                    footerTemplate={(
+                        <ButtonGroup align="end">
+                            <Button
+                                type="tertiary"
+                                text={gettext('Cancel')}
+                                onClick={onCancel}
+                            />
+                            <Button
+                                type="primary"
+                                text={gettext('Delete')}
+                                onClick={onDelete}
+                            />
+                        </ButtonGroup>
+                    )}
+                    data-test-id="vocabulary-deletion-modal--can-delete"
+                >
+                    <>
+                        <Text>
+                            {gettext(
+                                'You are about to delete the vocabulary {{name}}. This action can\'t be undone.',
+                                {name: () => <strong>{vocabulary.display_name}</strong>},
+                            )}
+                        </Text>
+                        <Text>
+                            {gettext(
+                                'This vocabulary is not currently used in any Content Profile ' +
+                                'and can be safely removed.',
+                            )}
+                        </Text>
+                    </>
+                </Modal>
+            );
+        }
+    }
+}

--- a/scripts/apps/vocabularies/controllers/VocabularyConfigController.ts
+++ b/scripts/apps/vocabularies/controllers/VocabularyConfigController.ts
@@ -6,6 +6,7 @@ import {gettext, downloadFile} from 'core/utils';
 import {showModal} from '@sourcefabric/common';
 import {UploadConfig} from '../components/UploadConfigModal';
 import {EDITOR_BLOCK_FIELD_TYPE} from 'apps/workspace/content/constants';
+import {showVocabularyDeletionModal} from './utils';
 
 function getOther() {
     return gettext('Other');
@@ -51,10 +52,26 @@ function getTags(_vocabularies: Array<IVocabulary>): IVocabulary['tags'] {
     return wordList.map((word) => ({text: word}));
 }
 
-VocabularyConfigController.$inject = ['$scope', '$route', '$routeParams', 'vocabularies', '$rootScope',
-    'api', 'notify', 'modal', 'session'];
-export function VocabularyConfigController($scope: IScope, $route, $routeParams, vocabularies, $rootScope,
-    api, notify, modal, session) {
+VocabularyConfigController.$inject = [
+    '$scope',
+    '$route',
+    '$routeParams',
+    'vocabularies',
+    '$rootScope',
+    'notify',
+    'session',
+    '$location',
+];
+export function VocabularyConfigController(
+    $scope: IScope,
+    $route,
+    $routeParams,
+    vocabularies,
+    $rootScope,
+    notify,
+    session,
+    $location,
+) {
     $scope.loading = true;
     $scope.mediaTypes = getMediaTypes();
 
@@ -203,34 +220,27 @@ export function VocabularyConfigController($scope: IScope, $route, $routeParams,
         $rootScope.$broadcast('vocabularies:updated', dataVocabulary);
     };
 
-    // remove is the UI callback for deleting a vocabulary entry
     $scope.remove = (vocabulary: IVocabulary) => {
-        modal.confirm(gettext('Please confirm you want to delete the vocabulary.'))
-            .then(() => api.remove(vocabulary, {}, 'vocabularies'))
-            .then(vocabularyRemoved(vocabulary), errorRemovingVocabulary);
+        showVocabularyDeletionModal(
+            vocabulary,
+            () => {
+                vocabularyRemoved(vocabulary);
+            },
+            (error) => {
+                notify.error(error._message);
+            },
+            () => {
+                $location.path('/settings/content-profiles');
+                $scope.$applyAsync();
+            },
+        );
     };
 
-    // vocabularyRemoved updates the UI after the given vocabulary has been removed via the API.
-    const vocabularyRemoved = (vocabulary) => () => {
+    // Update UI
+    const vocabularyRemoved = (vocabulary) => {
         remove($scope.vocabularies, (v) => v._id === vocabulary._id);
         $scope.reloadList();
         notify.success(gettext('Vocabulary was deleted.'));
-    };
-
-    // errorRemoving alerts the user of an error that occurred while attempting to remove a vocabulary.
-    const errorRemovingVocabulary = (response) => {
-        const issues = response.data._issues;
-
-        if (!issues) {
-            notify.error(gettext('Error removing the vocabulary.'));
-        } else if (issues._message) {
-            notify.error(issues._message);
-        } else if (issues.content_types) {
-            const contentTypes = reduce(issues.content_types,
-                (result, value) => result ? `${result}, ${value.label}` : value.label, null);
-
-            notify.error(gettext('The vocabulary is used in the following content types:') + ' ' + contentTypes);
-        }
     };
 
     $scope.$on('$routeUpdate', setupActiveVocabulary);

--- a/scripts/apps/vocabularies/controllers/utils.tsx
+++ b/scripts/apps/vocabularies/controllers/utils.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {showModal} from '@sourcefabric/common';
+import {IVocabulary} from 'superdesk-api';
+import {VocabularyDeletionModal} from '../components/VocabularyDeletionModal';
+import {sdApi} from 'api';
+
+export const showVocabularyDeletionModal = (
+    vocabulary: IVocabulary,
+    handleVocabularyRemoved: () => void,
+    handleError: (error: any) => void,
+    navigateToContentProfiles: () => void,
+) => {
+    showModal(({closeModal}) => {
+        const handleDelete = () => {
+            sdApi.vocabularies.deleteVocabulary(vocabulary)
+                .then(handleVocabularyRemoved)
+                .catch(handleError)
+                .finally(closeModal);
+        };
+
+        const handleGoToContentProfiles = () => {
+            closeModal();
+            navigateToContentProfiles();
+        };
+
+        return (
+            <VocabularyDeletionModal
+                vocabulary={vocabulary}
+                onDelete={handleDelete}
+                onCancel={closeModal}
+                closeModal={closeModal}
+                navigateToContentProfiles={handleGoToContentProfiles}
+            />
+        );
+    });
+};

--- a/scripts/apps/vocabularies/views/vocabulary-config.html
+++ b/scripts/apps/vocabularies/views/vocabulary-config.html
@@ -89,12 +89,17 @@
                       </div>
                         <button
                           ng-click="openVocabulary(vocabulary)"
-                          sd-tooltip="{{:: 'Edit vocabulary' | translate }}"
+                          sd-tooltip="{{:: 'Edit' | translate }}"
                           data-test-id="vocabulary-item--start-editing"
                         >
                           <i class="icon-pencil"></i>
                         </button>
-                        <button ng-click="remove(vocabulary)" ng-if="tab !== 'vocabularies'" sd-tooltip="{{:: 'Remove vocabulary' | translate }}">
+                        <button
+                          ng-click="remove(vocabulary)"
+                          ng-disabled="vocabulary.field_type === undefined"
+                          sd-tooltip="{{:: vocabulary.field_type === undefined ? ('Can\'t delete system vocabularies' | translate) : ('Delete' | translate) }}"
+                          data-test-id="vocabulary-item--start-removing"
+                        >
                             <i class="icon-trash"></i>
                         </button>
                     </div>

--- a/scripts/apps/vocabularies/views/vocabulary-config.html
+++ b/scripts/apps/vocabularies/views/vocabulary-config.html
@@ -100,7 +100,7 @@
                           sd-tooltip="{{:: vocabulary.field_type === undefined ? ('Can\'t delete system vocabularies' | translate) : ('Delete' | translate) }}"
                           data-test-id="vocabulary-item--start-removing"
                         >
-                            <i class="icon-trash"></i>
+                            <i class="icon-trash" ng-class="{'icon--disabled': vocabulary.field_type === undefined}"></i>
                         </button>
                     </div>
                 </div>

--- a/scripts/core/get-superdesk-api-implementation.tsx
+++ b/scripts/core/get-superdesk-api-implementation.tsx
@@ -503,8 +503,8 @@ export function getSuperdeskApiImplementation(
             },
         },
         localization: {
-            gettext: (message, params) => gettext(message, params),
-            gettextPlural: (count, singular, plural, params) => gettextPlural(count, singular, plural, params),
+            gettext,
+            gettextPlural,
             formatDate: formatDate,
             formatDateTime: formatDateTime,
             longFormatDateTime: (date: Date | string, timezoneId?: string) => {

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -3342,8 +3342,14 @@ declare module 'superdesk-api' {
             ): JSX.Element;
         };
         localization: {
-            gettext(message: string, params?: {[placeholder: string]: string | number | React.ComponentType}): string;
-            gettextPlural(count: number, singular: string, plural: string, params?: {[placeholder: string]: string | number | React.ComponentType}): string;
+            gettext(message: string): string;
+            gettext(message: string, params: {[placeholder: string]: string | number}): string;
+            gettext(message: string, params: {[placeholder: string]: string | number | React.ComponentType | (() => JSX.Element)}): Array<JSX.Element>;
+
+            gettextPlural(count: number, singular: string, plural: string): string;
+            gettextPlural(count: number, singular: string, plural: string, params: {[key: string]: string | number}): string;
+            gettextPlural(count: number, singular: string, plural: string, params: {[key: string]: string | number | React.ComponentType | (() => JSX.Element)}): Array<JSX.Element>;
+
             formatDate(date: Date | string | moment.Moment, options?: {timezoneId?: string; longFormat?: boolean}): string;
             formatDateTime(date: Date, timezoneId?: string): string;
             longFormatDateTime(date: Date | string, timezoneId?: string): string;

--- a/scripts/core/utils.tsx
+++ b/scripts/core/utils.tsx
@@ -162,6 +162,32 @@ const gettextReact = (
     return result;
 };
 
+/**
+ * Core translation logic that handles parameter replacement.
+ * Used by both `gettext` and `gettextPlural`.
+ */
+function gettextCore(
+    translated: string,
+    params?: {[key: string]: string | number | React.ComponentType | (() => JSX.Element)},
+): string | Array<JSX.Element> {
+    const hasReactPlaceholders = Object.values(params ?? {}).some((val) => typeof val === 'function');
+
+    if (hasReactPlaceholders) {
+        return gettextReact(translated, params ?? {});
+    } else {
+        let result = translated;
+
+        Object.keys(params ?? {}).forEach((param) => {
+            /**
+             * Casting param to string because we can't do full type narrowing here based on params type
+             */
+            result = result.replace(new RegExp(`{{\s*${param}\s*}}`, 'g'), String(params[param]));
+        });
+
+        return result;
+    }
+}
+
 // example: gettext('Item was locked by {{user}}.', {user: 'John Doe'});
 export function gettext(text: string): string;
 export function gettext(
@@ -180,19 +206,9 @@ export function gettext(
         return '';
     }
 
-    let translated: string = i18n.gettext(text);
+    const translated: string = i18n.gettext(text);
 
-    const hasReactPlaceholders = Object.values(params ?? {}).some((val) => typeof val === 'function');
-
-    if (hasReactPlaceholders) {
-        return gettextReact(translated, params ?? {});
-    } else {
-        Object.keys(params ?? {}).forEach((param) => {
-            translated = translated.replace(new RegExp(`{{\s*${param}\s*}}`, 'g'), params[param] as string);
-        });
-
-        return translated;
-    }
+    return gettextCore(translated, params);
 }
 
 /*
@@ -232,18 +248,9 @@ export function gettextPlural(
         return '';
     }
 
-    let translated: string = i18n.ngettext(text, pluralText, count);
-    const hasReactPlaceholders = Object.values(params ?? {}).some((val) => typeof val === 'function');
+    const translated: string = i18n.ngettext(text, pluralText, count);
 
-    if (hasReactPlaceholders) {
-        return gettextReact(translated, params ?? {});
-    } else {
-        Object.keys(params ?? {}).forEach((param) => {
-            translated = translated.replace(new RegExp(`{{\s*${param}\s*}}`), params[param]);
-        });
-
-        return translated;
-    }
+    return gettextCore(translated, params);
 }
 
 /**

--- a/scripts/core/utils.tsx
+++ b/scripts/core/utils.tsx
@@ -111,7 +111,7 @@ export function getProjectedFieldsArticle(): Array<string> {
  */
 const gettextReact = (
     text: string,
-    params: {[placeholder: string]: string | number | React.ComponentType},
+    params: {[placeholder: string]: string | number | React.ComponentType | (() => JSX.Element)},
 ): Array<JSX.Element> => {
     let matches: Array<{index: number, str: string, placeholder: string}> = [];
 
@@ -163,15 +163,24 @@ const gettextReact = (
 };
 
 // example: gettext('Item was locked by {{user}}.', {user: 'John Doe'});
-export const gettext = (
+export function gettext(text: string): string;
+export function gettext(
     text: string,
-    params: {[placeholder: string]: string | number | React.ComponentType} = {},
-) => {
+    params: {[placeholder: string]: string | number},
+): string;
+export function gettext(
+    text: string,
+    params: {[placeholder: string]: string | number | React.ComponentType | (() => JSX.Element)},
+): Array<JSX.Element>;
+export function gettext(
+    text: string,
+    params?: {[placeholder: string]: string | number | React.ComponentType | (() => JSX.Element)},
+): string | Array<JSX.Element> {
     if (!text) {
         return '';
     }
 
-    let translated = i18n.gettext(text);
+    let translated: string = i18n.gettext(text);
 
     const hasReactPlaceholders = Object.values(params ?? {}).some((val) => typeof val === 'function');
 
@@ -179,12 +188,12 @@ export const gettext = (
         return gettextReact(translated, params ?? {});
     } else {
         Object.keys(params ?? {}).forEach((param) => {
-            translated = translated.replace(new RegExp(`{{\\s*${param}\\s*}}`, 'g'), params[param]);
+            translated = translated.replace(new RegExp(`{{\s*${param}\s*}}`, 'g'), params[param] as string);
         });
 
         return translated;
     }
-};
+}
 
 /*
     Example:
@@ -196,24 +205,46 @@ export const gettext = (
         {count: 6, user: 'John Doe'},
     );
 */
-export const gettextPlural = (
+export function gettextPlural(
     count: number,
     text: string,
     pluralText: string,
-    params: {[key: string]: string | number | React.ComponentType} = {},
-): string => {
+): string;
+export function gettextPlural(
+    count: number,
+    text: string,
+    pluralText: string,
+    params: {[key: string]: string | number},
+): string;
+export function gettextPlural(
+    count: number,
+    text: string,
+    pluralText: string,
+    params: {[key: string]: string | number | React.ComponentType | (() => JSX.Element)},
+): Array<JSX.Element>;
+export function gettextPlural(
+    count: number,
+    text: string,
+    pluralText: string,
+    params?: {[key: string]: string | number | React.ComponentType | (() => JSX.Element)},
+): string | Array<JSX.Element> {
     if (!text) {
         return '';
     }
 
-    let translated = i18n.ngettext(text, pluralText, count);
+    let translated: string = i18n.ngettext(text, pluralText, count);
+    const hasReactPlaceholders = Object.values(params ?? {}).some((val) => typeof val === 'function');
 
-    Object.keys(params ?? {}).forEach((param) => {
-        translated = translated.replace(new RegExp(`{{\\s*${param}\\s*}}`), params[param]);
-    });
+    if (hasReactPlaceholders) {
+        return gettextReact(translated, params ?? {});
+    } else {
+        Object.keys(params ?? {}).forEach((param) => {
+            translated = translated.replace(new RegExp(`{{\s*${param}\s*}}`), params[param]);
+        });
 
-    return translated;
-};
+        return translated;
+    }
+}
 
 /**
  * Escape given string for reg exp


### PR DESCRIPTION
### Purpose
- Allow users to delete vocabularies
- Improve `gettext` types

### Screenshots
When vocabulary is used in content profile/s:
<img width="1478" height="923" alt="image" src="https://github.com/user-attachments/assets/b88a2423-2456-4034-9972-8178f93f7820" />

When it's not:
<img width="1478" height="923" alt="image" src="https://github.com/user-attachments/assets/1ff39750-0886-4082-a56b-582e49be487e" />

Small improvement for system needed vocabularies:
<img width="1108" height="112" alt="image" src="https://github.com/user-attachments/assets/6f3b5d21-3eaf-40c0-a4e7-7b862e68affc" />


### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7824]

[SDESK-7824]: https://sofab.atlassian.net/browse/SDESK-7824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ