### PR TITLE
SDCP-1054: Hide action buttons during async publish to prevent flicker

### DIFF
--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -624,8 +624,10 @@ export function AuthoringDirective(
                                 }
                             }, (response) => {
                                 notify.error(gettext('Error. Item not published.'));
-                                $scope.publishingInProgress = false;
                                 return $q.reject(false);
+                            })
+                            .finally(() => {
+                                $scope.publishingInProgress = false;
                             });
                     }
 

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -127,6 +127,7 @@ export function AuthoringDirective(
             $scope.refreshTrigger = 0;
             $scope.isPreview = false;
             $scope.isCorrectionInProgress = false;
+            $scope.publishingInProgress = false;
 
             $scope.$watch('origItem', (newValue, oldValue) => {
                 $scope.itemActions = null;
@@ -603,6 +604,8 @@ export function AuthoringDirective(
             };
 
             function performPublish(): Promise<any> {
+                $scope.publishingInProgress = true;
+
                 if (validatePublishScheduleAndEmbargo($scope.item) && validateForPublish($scope.item)) {
                     var message = 'publish';
 
@@ -621,13 +624,18 @@ export function AuthoringDirective(
                                 }
                             }, (response) => {
                                 notify.error(gettext('Error. Item not published.'));
+                                $scope.publishingInProgress = false;
                                 return $q.reject(false);
                             });
                     }
 
-                    return publishItem($scope.origItem, $scope.item);
+                    return publishItem($scope.origItem, $scope.item)
+                        .finally(() => {
+                            $scope.publishingInProgress = false;
+                        });
                 }
 
+                $scope.publishingInProgress = false;
                 return $q.reject(false);
             }
 

--- a/scripts/apps/authoring/views/authoring-topbar.html
+++ b/scripts/apps/authoring/views/authoring-topbar.html
@@ -214,27 +214,28 @@
         <button class="btn btn--primary" type="submit"
                 id="send-correction-btn"
                 ng-if="action === 'correct' && !isCorrection(item)"
-                ng-show="_editable"
+                ng-show="_editable && !publishingInProgress"
                 ng-click="publish()"
                 translate>Send Correction</button>
 
         <button class="btn btn--primary" type="submit"
                 id="send-kill-btn"
                 ng-if="action === 'kill'"
-                ng-show="_editable"
+                ng-show="_editable && !publishingInProgress"
                 ng-click="publish()"
                 translate>Send Kill</button>
 
         <button class="btn btn--primary" type="submit"
                 id="send-takedown-btn"
                 ng-if="action === 'takedown'"
-                ng-show="_editable"
+                ng-show="_editable && !publishingInProgress"
                 ng-click="publish()"
                 translate>Send Takedown</button>
 
         <button class="btn"
                 id="cancelAuthoringBtn"
                 ng-if="action === 'correct' && !isCorrection(item) || action === 'kill'"
+                ng-show="!publishingInProgress"
                 ng-click="close()"
                 translate>Cancel</button>
 


### PR DESCRIPTION
### Purpose
This PR prevent a brief UI flicker that shows legacy correction buttons while a correction publish is in flight.

### What has changed
- Added a publish-in-progress flag in authoring directive which disables correction action buttons during async publish

### Steps to test
1. Click the drop menu on an article and select "Publishing actions" and then "Correct Item"
2. Make a change, save the changes and then hit the publish button.
3. Verify legacy correction buttons do not appear/flicker while the request is processing

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDCP-1054](https://sofab.atlassian.net/browse/SDCP-1054)


[SDCP-1054]: https://sofab.atlassian.net/browse/SDCP-1054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ