### PR TITLE
Fix vocabulary deletion UI - if `profile.editor` is undefined count as cv not used in profile

### DIFF
--- a/scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx
+++ b/scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx
@@ -16,7 +16,13 @@ export class VocabularyDeletionModal extends React.PureComponent<IProps> {
     render() {
         const {vocabulary, onDelete, onCancel, navigateToContentProfiles, closeModal} = this.props;
         const profiles = sdApi.contentProfiles.getAll();
-        const profilesWithVocabulary = profiles.filter((profile) => profile.editor[vocabulary._id] != null);
+        const profilesWithVocabulary = profiles.filter((profile) => {
+            if (profile?.editor == null) {
+                return false;
+            }
+
+            return profile.editor[vocabulary._id] != null;
+        });
 
         if (profilesWithVocabulary.length > 0) {
             return (


### PR DESCRIPTION
### Purpose
Fix the vocabulary deletion UI crashing, due to some profiles not having the `editor` which holds all fields defined.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7824]


[SDESK-7824]: https://sofab.atlassian.net/browse/SDESK-7824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ