### PR TITLE
Fix authoring react vocabulary field moving on a different row if selected item is long

### DIFF
--- a/scripts/apps/authoring-react/fields/README.md
+++ b/scripts/apps/authoring-react/fields/README.md
@@ -1,0 +1,190 @@
+# Fields and Field Adapters
+
+This document explains the architecture of **fields** and **field-adapters** in the authoring-react module.
+
+## Overview
+
+The authoring system uses two complementary concepts:
+
+- **Fields**: Generic, reusable UI components for editing specific data types (e.g., dropdown, date, editor3 rich text)
+- **Field Adapters**: Mappings that connect article fields (e.g., `headline`, `slugline`) to field types and handle data transformation
+
+## Fields (`/fields`)
+
+Fields are **generic, reusable field type implementations** that define how to edit and display a particular kind of data. They are registered as `customFieldTypes` via the extension system.
+
+### Structure
+
+Each field type typically contains:
+
+| File | Purpose |
+|------|---------|
+| `index.ts` | Exports the field definition implementing `ICustomFieldType` |
+| `editor.tsx` | The editing component shown in the authoring view |
+| `preview.tsx` | The read-only preview component |
+| `config.tsx` | Configuration UI for content profile setup (optional) |
+| `difference.tsx` | Component for showing changes between versions (optional) |
+
+### Field Definition (`ICustomFieldType`)
+
+```typescript
+const field: ICustomFieldType<TValueOperational, TValueStorage, TConfig, TUserPreferences> = {
+    id: 'dropdown',                    // Unique identifier
+    label: gettext('Dropdown'),        // Display name in UI
+    editorComponent: Editor,           // React component for editing
+    previewComponent: Preview,         // React component for preview
+    configComponent: Config,           // React component for field configuration
+    differenceComponent: Difference,   // React component for diff view
+    hasValue: (value) => value != null,// Function to check if field has a value
+    getEmptyValue: (config) => null,   // Function to get initial empty value
+};
+```
+
+### Available Field Types
+
+- `editor3` - Rich text editor (Draft.js based)
+- `dropdown` - Single/multi-select dropdown (supports manual entries, vocabularies, remote sources)
+- `date` / `datetime` / `time` - Date and time pickers
+- `duration` - Duration input
+- `media` - Media attachments (images, video, audio)
+- `linked-items` - Related article links
+- `attachments` - File attachments
+- `embed` - Embedded content (iframes, social media)
+- `urls` - URL list input
+- `tag-input` - Tag/keyword input
+- `dateline` - Dateline with location and date
+- `boolean` - Checkbox/toggle
+- `package-items` - Package article items
+
+## Field Adapters (`/field-adapters`)
+
+Field adapters are the **bridge between article fields and field types**. They handle:
+
+1. **Mapping** an article field to a field type
+2. **Retrieving** stored values from the article
+3. **Storing** edited values back to the article
+
+### Why Adapters?
+
+Articles have many predefined properties (`headline`, `slugline`, `body_html`, etc.) that are stored in specific formats. Field adapters:
+
+- Map these properties to appropriate field types (e.g., `headline` → `editor3`)
+- Configure the field type appropriately (e.g., single-line, character limits)
+- Transform data between the field's operational format and the article's storage format
+
+### Adapter Interface (`IFieldAdapter`)
+
+```typescript
+const slugline: IFieldAdapter<IArticle> = {
+    // Converts field editor/schema config to IAuthoringFieldV2
+    getFieldV2: (fieldEditor, fieldSchema) => {
+        const fieldConfig: IEditor3Config = {
+            editorFormat: [],
+            minLength: fieldSchema?.minlength,
+            maxLength: fieldSchema?.maxlength,
+            singleLine: true,
+            // ...
+        };
+
+        return {
+            id: 'slugline',
+            name: gettext('Slugline'),
+            fieldType: 'editor3',      // References a registered field type
+            fieldConfig,
+        };
+    },
+
+    // Extracts the value from an article for editing
+    retrieveStoredValue: (item: IArticle, authoringStorage) => {
+        return retrieveStoredValueEditor3Generic('slugline', item, authoringStorage);
+    },
+
+    // Saves the edited value back to the article
+    storeValue: (value, item, config) => {
+        const result = storeEditor3ValueBase('slugline', item, value, config);
+        return {
+            ...result.article,
+            slugline: result.stringValue,  // Store in article.slugline
+        };
+    },
+};
+```
+
+### Base Adapters
+
+The `getBaseFieldsAdapter()` function returns adapters for all standard article fields:
+
+- `headline`, `slugline`, `abstract`, `byline` → `editor3` (single-line)
+- `body_html`, `body_footer` → `editor3` (multi-line)
+- `urgency`, `priority` → `dropdown`
+- `genre`, `place`, `subject`, `anpa_category` → `dropdown` (vocabulary-based)
+- `feature_media` → `media`
+- `attachments` → `attachments`
+- `dateline` → `dateline`
+- And more...
+
+### Dynamic Adapters
+
+For custom fields defined in vocabularies (`vocabulary.field_type`), adapters are generated dynamically in `getFieldsAdapter()`:
+
+```typescript
+for (const vocabulary of customFieldVocabularies) {
+    if (vocabulary.field_type === 'text') {
+        adapter[vocabulary._id] = {
+            getFieldV2: (...) => ({ fieldType: 'editor3', ... }),
+            retrieveStoredValue: ...,
+            storeValue: ...,
+        };
+    } else if (vocabulary.field_type === 'date') {
+        adapter[vocabulary._id] = {
+            getFieldV2: (...) => ({ fieldType: 'date', ... }),
+        };
+    }
+    // ... more field types
+}
+```
+
+## How They Work Together
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Content Profile                           │
+│  Defines which fields appear and their validation rules          │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                       Field Adapter                              │
+│  - Maps article field → field type                            │
+│  - Configures the field (limits, formats, etc.)                  │
+│  - Handles retrieve/store value transformations                  │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                          Field                                   │
+│  - Generic UI component (editor, preview, config)                │
+│  - Knows nothing about specific article fields               │
+│  - Works with operational values and config                      │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Example Flow: Editing `headline`
+
+1. **Load article**: System looks up adapter for `headline`
+2. **Retrieve value**: Adapter's `retrieveStoredValue` extracts Draft.js content from `article.fields_meta.headline` or creates it from `article.headline` string
+3. **Render editor**: Adapter's `getFieldV2` returns config saying to use `editor3` field type with single-line mode
+4. **User edits**: The `editor3` field component handles all editing UI
+5. **Save**: Adapter's `storeValue` converts Draft.js state back to string and updates both `article.headline` and `article.fields_meta.headline`
+
+## Adding a New Field Type
+
+1. Create a new folder under `/fields` with the field type name
+2. Implement `ICustomFieldType` with editor, preview, and optionally config/difference components
+3. Register in `register-fields.ts` via `customFieldTypes` array
+
+## Adding an Adapter for an Article Field
+
+1. Create a new file in `/field-adapters`
+2. Implement `IFieldAdapter<IArticle>` with `getFieldV2`, `retrieveStoredValue`, and `storeValue`
+3. Add to the adapter object in `getBaseFieldsAdapter()`

--- a/scripts/apps/authoring-react/fields/dropdown/dropdown-item-template.tsx
+++ b/scripts/apps/authoring-react/fields/dropdown/dropdown-item-template.tsx
@@ -13,9 +13,80 @@ interface IProps {
     noPadding: boolean;
 }
 
-export class DropdownItemTemplate extends React.PureComponent<IProps> {
+interface IState {
+    availableWidth: number | null;
+}
+
+/**
+ * This component should only be used within a `MultiSelectTreeWithTemplate` component
+ */
+export class DropdownItemTemplate extends React.PureComponent<IProps, IState> {
+    private containerRef: React.RefObject<HTMLSpanElement>;
+
+    constructor(props: IProps) {
+        super(props);
+        this.containerRef = React.createRef();
+        this.state = {
+            availableWidth: null,
+        };
+    }
+
+    componentDidMount() {
+        this.calculateAvailableWidth();
+    }
+
+    componentDidUpdate() {
+        this.calculateAvailableWidth();
+    }
+
+    private calculateAvailableWidth = () => {
+        const container = this.containerRef.current;
+
+        if (container == null) {
+            return;
+        }
+
+        // Find the tags-input__helper-box or tags-input__single-item container
+        let widthContainer: HTMLElement | null = container.parentElement;
+
+        while (widthContainer != null) {
+            if (
+                widthContainer.classList.contains('tags-input__helper-box') ||
+                widthContainer.classList.contains('tags-input__single-item')
+            ) {
+                break;
+            }
+
+            widthContainer = widthContainer.parentElement;
+        }
+
+        if (widthContainer == null) {
+            return;
+        }
+
+        const containerWidth = widthContainer.clientWidth;
+        const containerStyle = window.getComputedStyle(widthContainer);
+        const containerPadding = parseFloat(containerStyle.paddingLeft) + parseFloat(containerStyle.paddingRight);
+
+        // Account for sibling elements (like the remove button)
+        let siblingsWidth = 0;
+
+        for (const child of Array.from(widthContainer.children)) {
+            if (!child.contains(container)) {
+                siblingsWidth += (child as HTMLElement).offsetWidth;
+            }
+        }
+
+        const availableWidth = containerWidth - containerPadding - siblingsWidth;
+
+        if (availableWidth !== this.state.availableWidth && availableWidth > 0) {
+            this.setState({availableWidth});
+        }
+    };
+
     render() {
         const {option, noPadding, config} = this.props;
+        const {availableWidth} = this.state;
 
         if (option == null) {
             return null;
@@ -24,6 +95,7 @@ export class DropdownItemTemplate extends React.PureComponent<IProps> {
         const itemStyle: React.CSSProperties = {
             height: '1.5em',
             minWidth: '1.5em',
+            maxWidth: availableWidth != null ? `${availableWidth}px` : undefined,
             backgroundColor: option.color ?? 'transparent',
             color: option.color == null ? 'black' : getTextColor(option.color),
             display: 'inline-flex',
@@ -31,11 +103,18 @@ export class DropdownItemTemplate extends React.PureComponent<IProps> {
             alignItems: 'center',
             borderRadius: config.source === 'manual-entry' && config.roundCorners ? '999px' : '2px',
             padding: noPadding ? '0' : '4px',
+        };
+
+        const labelStyle: React.CSSProperties = {
             whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
         };
 
         return (
-            <span style={itemStyle}>{option.label}</span>
+            <span ref={this.containerRef} style={itemStyle}>
+                <span style={labelStyle}>{option.label}</span>
+            </span>
         );
     }
 }

--- a/scripts/apps/authoring-react/fields/dropdown/editor-using-manual-source-or-vocabulary.tsx
+++ b/scripts/apps/authoring-react/fields/dropdown/editor-using-manual-source-or-vocabulary.tsx
@@ -30,37 +30,35 @@ export class EditorUsingManualSourceOrVocabulary extends React.PureComponent<IPr
     render() {
         const {config} = this.props;
         const Container = this.props.container;
-        const values: Array<string> | Array<number> = (() => {
-            if (this.props.value == null) {
-                return [];
-            } else if (Array.isArray(this.props.value)) {
-                return this.props.value;
-            } else {
-                return [this.props.value];
-            }
-        })();
+        let values: Array<string> | Array<number>;
 
-        const options: ITreeWithLookup<IDropdownOption> = (() => {
-            if (config.source === 'manual-entry') {
-                const _options: ITreeWithLookup<IDropdownOption> = {
-                    nodes: arrayToTree(
-                        config.options,
-                        ({id}) => id.toString(),
-                        ({parent}) => parent?.toString(),
-                    ).result,
-                    lookup: keyBy(
-                        config.options.map((opt) => ({value: opt})),
-                        (opt) => opt.value.id.toString(),
-                    ),
-                };
+        if (this.props.value == null) {
+            values = [];
+        } else if (Array.isArray(this.props.value)) {
+            values = this.props.value;
+        } else {
+            values = [this.props.value] as Array<string> | Array<number>;
+        }
 
-                return _options;
-            } else if (config.source === 'vocabulary') {
-                return getOptions(config, this.props.getVocabularyItems);
-            } else {
-                assertNever(config);
-            }
-        })();
+        let options: ITreeWithLookup<IDropdownOption>;
+
+        if (config.source === 'manual-entry') {
+            options = {
+                nodes: arrayToTree(
+                    config.options,
+                    ({id}) => id.toString(),
+                    ({parent}) => parent?.toString(),
+                ).result,
+                lookup: keyBy(
+                    config.options.map((opt) => ({value: opt})),
+                    (opt) => opt.value.id.toString(),
+                ),
+            };
+        } else if (config.source === 'vocabulary') {
+            options = getOptions(config, this.props.getVocabularyItems);
+        } else {
+            assertNever(config);
+        }
 
         const selected =
             values

--- a/scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx
+++ b/scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx
@@ -16,7 +16,13 @@ export class VocabularyDeletionModal extends React.PureComponent<IProps> {
     render() {
         const {vocabulary, onDelete, onCancel, navigateToContentProfiles, closeModal} = this.props;
         const profiles = sdApi.contentProfiles.getAll();
-        const profilesWithVocabulary = profiles.filter((profile) => profile.editor[vocabulary._id] != null);
+        const profilesWithVocabulary = profiles.filter((profile) => {
+            if (profile?.editor == null) {
+                return false;
+            }
+
+            return profile.editor[vocabulary._id] != null;
+        });
 
         if (profilesWithVocabulary.length > 0) {
             return (


### PR DESCRIPTION
### Purpose
The bug occurred in the place field but it might also happen in other fields of the same type. This PR fixes the bug where the field would change its width based on the selected item label width. We now calculate the available width for the field, based on the available space in the row its placed in, and if the item label element is longer we add ellipsis to it. 

This PR also adds some documentation that describes the reasoning behind base field types and field adapters. 

### Steps to test
1. Add three fields on the same row in a content profile - e.g headline - half width, place - 1/4 width, priority 1/4 width. 
2. To the priority vocabulary add an active item with a very long label - i.e. more than 20 chars. 
3. Create an article with the pre-configured content profile
4. Select the priority item with the long label. 
5. Watch if the whole field goes on the next line, or ellipsis is added to the selected item. 

### Screenshots
Before: 
<img width="699" height="810" alt="image" src="https://github.com/user-attachments/assets/8504f250-5ea8-474d-8919-7740cd204cdf" />

After: 
<img width="699" height="810" alt="image" src="https://github.com/user-attachments/assets/3706dddf-59c1-4827-94a2-bac3af5fce3a" />

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7172] [SDESK-7405]


[SDESK-7172]: https://sofab.atlassian.net/browse/SDESK-7172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ