### PR TITLE
[SDESK-7267] - Fix gettext params in strings not being replaced

### DIFF
--- a/scripts/core/utils.tsx
+++ b/scripts/core/utils.tsx
@@ -181,7 +181,7 @@ function gettextCore(
             /**
              * Casting param to string because we can't do full type narrowing here based on params type
              */
-            result = result.replace(new RegExp(`{{\s*${param}\s*}}`, 'g'), String(params[param]));
+            result = result.replace(new RegExp(`{{\\s*${param}\\s*}}`, 'g'), String(params[param]));
         });
 
         return result;


### PR DESCRIPTION
### Purpose
Fix `gettext` parameterised strings not working for e.g. `{{ name }}` but working for `{{name}}`.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7267]


[SDESK-7267]: https://sofab.atlassian.net/browse/SDESK-7267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ