### PR TITLE
Fix multiline field

### DIFF
--- a/scripts/core/ui/components/generic-form/input-types/plain-text.tsx
+++ b/scripts/core/ui/components/generic-form/input-types/plain-text.tsx
@@ -37,8 +37,8 @@ export class PlainText extends React.Component<IInputType<string>> {
                         style={{resize: 'vertical', height: 'auto'}}
                         data-test-id={`gform-input--${this.props.formField.field}`}
                     />
-                    {this.props.issues.map((str, i) => (
-                        <div key={i} className="sd-input__message">{str}</div>
+                    {this.props.issues.map((str) => (
+                        <div key={str} className="sd-input__message">{str}</div>
                     ))}
                 </div>
             );

--- a/scripts/core/ui/components/generic-form/input-types/plain-text.tsx
+++ b/scripts/core/ui/components/generic-form/input-types/plain-text.tsx
@@ -17,9 +17,9 @@ export class PlainText extends React.Component<IInputType<string>> {
                 <div
                     className={
                         classNames(
-                            "sd-input",
-                            "d-flex",
-                            "flex-col",
+                            'sd-input',
+                            'd-flex',
+                            'flex-col',
                             {
                                 'sd-input--invalid': this.props.issues.length > 0,
                                 'sd-input--required': this.props.formField.required === true,

--- a/scripts/core/ui/components/generic-form/input-types/plain-text.tsx
+++ b/scripts/core/ui/components/generic-form/input-types/plain-text.tsx
@@ -14,32 +14,32 @@ export class PlainText extends React.Component<IInputType<string>> {
 
         if (this.props.formField?.component_parameters?.multiline === true) {
             return (
-                <div className="sd-input">
-                    <div
-                        className={classNames(
-                            'sd-input__input',
+                <div
+                    className={
+                        classNames(
+                            "sd-input",
+                            "d-flex",
+                            "flex-col",
                             {
                                 'sd-input--invalid': this.props.issues.length > 0,
                                 'sd-input--required': this.props.formField.required === true,
                             },
-                        )}
-                    >
-                        <label className="sd-input__label">{this.props.formField.label}</label>
-                        <textarea
-                            disabled={this.props.disabled}
-                            value={valueWithDefaultValue}
-                            onChange={(event) => this.props.onChange(event.target.value)}
-                            rows={3}
-                            style={{resize: 'vertical', height: 'auto'}}
-                            className="sd-input"
-                            data-test-id={`gform-input--${this.props.formField.field}`}
-                        />
-                        {
-                            this.props.issues.map((str, i) => (
-                                <div key={i} className="sd-input__message">{str}</div>
-                            ))
-                        }
-                    </div>
+                        )
+                    }
+                >
+                    <label className="sd-input__label">{this.props.formField.label}</label>
+                    <textarea
+                        className="sd-input__input pt-1"
+                        disabled={this.props.disabled}
+                        value={valueWithDefaultValue}
+                        onChange={(event) => this.props.onChange(event.target.value)}
+                        rows={3}
+                        style={{resize: 'vertical', height: 'auto'}}
+                        data-test-id={`gform-input--${this.props.formField.field}`}
+                    />
+                    {this.props.issues.map((str, i) => (
+                        <div key={i} className="sd-input__message">{str}</div>
+                    ))}
                 </div>
             );
         }


### PR DESCRIPTION
### Purpose
Fix styles of generic crud form multiline field

### Screenshots

#### Before:
<img width="378" height="173" alt="image" src="https://github.com/user-attachments/assets/f38cc98e-7227-48b3-860f-ebdc02736422" />

#### After: 
<img width="378" height="173" alt="image" src="https://github.com/user-attachments/assets/f3b54230-30d7-45d9-b731-52f9e30d3446" />
<img width="378" height="173" alt="image" src="https://github.com/user-attachments/assets/aa7d4b31-b29f-4f8d-9f47-37aff10392f2" />
<img width="378" height="173" alt="image" src="https://github.com/user-attachments/assets/2c203b85-f912-4f47-9980-9528d1a8a029" />



### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7267]


[SDESK-7267]: https://sofab.atlassian.net/browse/SDESK-7267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ