### PR TITLE
Add primary action text optional param

### DIFF
--- a/scripts/core/get-superdesk-api-implementation.tsx
+++ b/scripts/core/get-superdesk-api-implementation.tsx
@@ -418,9 +418,10 @@ export function getSuperdeskApiImplementation(
                 return showModal(Component, containerClass);
             },
             alert: (message: string) => modal.alert({bodyText: message}),
-            confirm: (message: string, title?: string) => showConfirmationPrompt({
+            confirm: (message: string, title?: string, primaryActionText?: string) => showConfirmationPrompt({
                 title: title ?? gettext('Confirm'),
                 message,
+                primaryActionText,
             }),
             prompt: ui.prompt,
             showIgnoreCancelSaveDialog,


### PR DESCRIPTION
### Purpose
I just extended the API which we use in other projects, e.g. `planning` to have the option for changing the primary action button text, so I can use the `confirm` functionality and pass `"Delete"` as the primary action text. 

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7267]

[SDESK-7267]: https://sofab.atlassian.net/browse/SDESK-7267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ