### PR TITLE
[SDESK-7305] - Week start day setting not respected globally

### DIFF
--- a/scripts/core/get-superdesk-api-implementation.tsx
+++ b/scripts/core/get-superdesk-api-implementation.tsx
@@ -524,7 +524,7 @@ export function getSuperdeskApiImplementation(
             getRelativeOrAbsoluteDateTime: getRelativeOrAbsoluteDateTime,
             locale: {
                 code: userInterfaceLanguage.replace('_', '-'),
-                firstDayOfWeek: appConfig.startingDay,
+                firstDayOfWeek: Number(appConfig.startingDay),
             },
         },
         privileges: {

--- a/scripts/core/helpers/ui-framework.ts
+++ b/scripts/core/helpers/ui-framework.ts
@@ -5,7 +5,7 @@ import {appConfig} from 'appConfig';
 export function getLocaleForDatePicker(targetLocale?: string): DatePickerLocaleSettings {
     function getLocale() {
         return {
-            firstDayOfWeek: appConfig.startingDay,
+            firstDayOfWeek: Number(appConfig.startingDay),
             dayNames: moment.weekdays(),
             dayNamesShort: moment.weekdaysShort(),
             dayNamesMin: moment.weekdaysMin(),

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -3649,8 +3649,8 @@ declare module 'superdesk-api' {
         };
         apps: any;
         defaultRoute: string;
-        startingDay: any;
-        start_of_week?: any;
+        startingDay?: number | string | null;
+        start_of_week?: number | string | null;
         features: {
             swimlane?: {
                 defaultNumberOfColumns: number;

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -3650,6 +3650,7 @@ declare module 'superdesk-api' {
         apps: any;
         defaultRoute: string;
         startingDay: any;
+        start_of_week?: any;
         features: {
             swimlane?: {
                 defaultNumberOfColumns: number;

--- a/scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx
+++ b/scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx
@@ -351,7 +351,9 @@ export class RundownTemplateViewEdit extends React.PureComponent<IProps, IState>
                                                                 });
                                                             }}
 
-                                                            firstDayOfWeek={superdesk.instance.config.startingDay}
+                                                            firstDayOfWeek={
+                                                                Number(superdesk.instance.config.startingDay) || 0
+                                                            }
                                                             readOnly={this.props.readOnly}
                                                         />
 

--- a/scripts/init.ts
+++ b/scripts/init.ts
@@ -47,6 +47,31 @@ fetchSync(
         // apply config from server
         merge(_appConfig, res.config);
 
+        // Normalize and sync week start with startingDay taking precedence.
+        const normalizeWeekStart = (value: any): number | null => {
+            if (value == null) {
+                return null;
+            }
+
+            const normalized = typeof value === 'string' ? parseInt(value, 10) : value;
+
+            return Number.isNaN(normalized) ? null : normalized;
+        };
+
+        const normalizedStartingDay = normalizeWeekStart(_appConfig.startingDay);
+        const normalizedStartOfWeek = normalizeWeekStart(_appConfig.start_of_week);
+
+        if (normalizedStartingDay != null) {
+            _appConfig.startingDay = normalizedStartingDay;
+            _appConfig.start_of_week = normalizedStartingDay;
+        } else if (normalizedStartOfWeek != null) {
+            _appConfig.start_of_week = normalizedStartOfWeek;
+            _appConfig.startingDay = normalizedStartOfWeek;
+        } else {
+            _appConfig.startingDay = 0;
+            _appConfig.start_of_week = 0;
+        }
+
         // allow e2e tests to overwrite appConfig via local storage
         merge(_appConfig, merge(_appConfig, JSON.parse(localStorage.getItem('TEST_APP_CONFIG') ?? '{}')));
 
@@ -96,4 +121,3 @@ if (language === 'en') {
         applyTranslations(translations);
     });
 }
-

--- a/scripts/init.ts
+++ b/scripts/init.ts
@@ -48,29 +48,26 @@ fetchSync(
         merge(_appConfig, res.config);
 
         // Normalize and sync week start with startingDay taking precedence.
-        const normalizeWeekStart = (value: any): number | null => {
+        const normalizeWeekStart = (value: string | number | null | undefined): number | null => {
             if (value == null) {
                 return null;
             }
 
             const normalized = typeof value === 'string' ? parseInt(value, 10) : value;
 
-            return Number.isNaN(normalized) ? null : normalized;
+            if (Number.isNaN(normalized) || normalized < 0 || normalized > 6) {
+                return null;
+            }
+
+            return normalized;
         };
 
         const normalizedStartingDay = normalizeWeekStart(_appConfig.startingDay);
         const normalizedStartOfWeek = normalizeWeekStart(_appConfig.start_of_week);
+        const weekStart = normalizedStartingDay ?? normalizedStartOfWeek ?? 0;
 
-        if (normalizedStartingDay != null) {
-            _appConfig.startingDay = normalizedStartingDay;
-            _appConfig.start_of_week = normalizedStartingDay;
-        } else if (normalizedStartOfWeek != null) {
-            _appConfig.start_of_week = normalizedStartOfWeek;
-            _appConfig.startingDay = normalizedStartOfWeek;
-        } else {
-            _appConfig.startingDay = 0;
-            _appConfig.start_of_week = 0;
-        }
+        _appConfig.startingDay = weekStart;
+        _appConfig.start_of_week = weekStart;
 
         // allow e2e tests to overwrite appConfig via local storage
         merge(_appConfig, merge(_appConfig, JSON.parse(localStorage.getItem('TEST_APP_CONFIG') ?? '{}')));


### PR DESCRIPTION
### Purpose
Unify week-start configuration so client-core is the single source of truth while remaining backward compatible with backend `start_of_week`.

### What has changed
<!--- Explain what has changed and how -->
Normalized `startingDay` and `start_of_week` during app config initialization so both values stay in sync, with `startingDay` taking precedence.

### Steps to test
1. Set `startingDay: 1` in `superdesk.config.js` and set backend to `START_OF_WEEK=0`.
2. Rebuild and start the client.
3. Verify non-Planning date pickers start on Monday (and match `startingDay`).

### Checklist
- [X] I reviewed my code
- [X] I tested all affected functionality and made sure it works

Note: This PR goes hand in hand with this change in [superdesk-planning](https://github.com/superdesk/superdesk-planning/pull/2736)


Resolves: [SDESK-7305](https://sofab.atlassian.net/browse/SDESK-7305)

[SDESK-7305]: https://sofab.atlassian.net/browse/SDESK-7305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ