### PR TITLE
[STT-1622] Embargo and Schedule info lost when doing the "Copy and send to Desk" action

### DIFF
--- a/scripts/api/article-duplicate.tsx
+++ b/scripts/api/article-duplicate.tsx
@@ -10,6 +10,7 @@ import ng from 'core/services/ng';
 export function duplicateItems(
     itemIds: Array<IArticle['_id']>,
     destination: ISendToDestination,
+    preserveEmbargoAndSchedule?: boolean,
 ): Promise<Array<IArticle>> {
     return Promise.all(
         itemIds.map((id) => {
@@ -24,6 +25,7 @@ export function duplicateItems(
                         type: 'archive',
                         desk: destination.desk,
                         stage: destination.stage,
+                        preserve_embargo_and_schedule: preserveEmbargoAndSchedule,
                     };
                 } else {
                     assertNever(destination);

--- a/scripts/api/article.ts
+++ b/scripts/api/article.ts
@@ -610,7 +610,11 @@ interface IArticleApi {
 
     sendItemToNextStage(item: IArticle): Promise<void>;
 
-    duplicateItems(items: Array<IArticle['_id']>, destination: ISendToDestination): Promise<Array<IArticle>>;
+    duplicateItems(
+        items: Array<IArticle['_id']>,
+        destination: ISendToDestination,
+        preserveEmbargoAndSchedule?: boolean,
+    ): Promise<Array<IArticle>>;
 
     canPublish(item: IArticle): boolean;
 

--- a/scripts/apps/authoring-react/toolbar-components/angular-integration/send-and-duplicate.tsx
+++ b/scripts/apps/authoring-react/toolbar-components/angular-integration/send-and-duplicate.tsx
@@ -5,6 +5,7 @@ import {gettext} from 'core/utils';
 import {sdApi} from 'api';
 import {getSendAndDuplicateTarget} from 'apps/authoring/authoring/get-send-and-duplicate-target';
 import {useInlineToolbarContext} from './inline-toolbar-context';
+import {appConfig} from 'appConfig';
 
 export const SendAndDuplicateComponent: React.ComponentType<{entity: IArticle}> = ({entity}) => {
     const {exposed} = useInlineToolbarContext<IArticle>();
@@ -19,6 +20,8 @@ export const SendAndDuplicateComponent: React.ComponentType<{entity: IArticle}> 
                 exposed?.handleUnsavedChanges()
                     .then(() => {
                         const {deskId, stageId} = getSendAndDuplicateTarget();
+                        const preserveEmbargoAndSchedule = appConfig.features
+                            ?.customAuthoringTopbar?.sendAndDuplicate?.preserveEmbargoAndSchedule;
 
                         sdApi.article.duplicateItems(
                             [entity._id],
@@ -27,6 +30,7 @@ export const SendAndDuplicateComponent: React.ComponentType<{entity: IArticle}> 
                                 desk: deskId,
                                 stage: stageId,
                             },
+                            preserveEmbargoAndSchedule,
                         );
                     })
                     .catch(() => {

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -707,6 +707,8 @@ export function AuthoringDirective(
                     }
 
                     const {deskId, stageId} = getSendAndDuplicateTarget();
+                    const preserveEmbargoAndSchedule = appConfig.features
+                        ?.customAuthoringTopbar?.sendAndDuplicate?.preserveEmbargoAndSchedule;
 
                     sdApi.article.duplicateItems(
                         [$scope.item._id],
@@ -715,6 +717,7 @@ export function AuthoringDirective(
                             desk: deskId,
                             stage: stageId,
                         },
+                        preserveEmbargoAndSchedule,
                     ).then(() => {
                         openArticle($scope.item._id, 'edit');
                     });

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -3700,6 +3700,7 @@ declare module 'superdesk-api' {
                 sendAndDuplicate?: {
                     deskName: string;
                     stageName: string;
+                    preserveEmbargoAndSchedule?: boolean;
                 };
             },
             showPublishSchedule?: boolean


### PR DESCRIPTION
### Purpose
This PR ensures that embargo, publish_schedule, and schedule_settings fields are preserved when duplicating content to a desk in the "Send and Duplicate" flow. This is implemented via a client-side configuration flag that only affects the Send and Duplicate action, leaving regular duplication flows unchanged.

### What has changed
- Updated client-side type definitions and API layer to support the new parameter
- Modified Angular and React Send and Duplicate components to read config flag and pass to API

### Steps to test
1. Configure `sendAndDuplicate.preserveEmbargoAndSchedule: true` in superdesk.config.js like for STT
2. Create a story on any desk and add embargo and publishing schedule dates
3. Save the story
4. Click the "Send and Duplicate" button (sends to the configured target desk, e.g., Deski)
5. Verify the duplicated story in the target desk has the same:
   - Embargo date
   - Publishing schedule date
   - Schedule settings (timezone)
6. Verify the original story retains its embargo and schedule information
7. Test regular "Duplicate To" flow - fields should NOT be preserved

Note: This PR is related to this [PR in superdesk-stt](https://github.com/superdesk/superdesk-stt/pull/710), and [PR in superdesk-core](https://github.com/superdesk/superdesk-core/pull/3150)

Resolves: [STT-1622](https://sofab.atlassian.net/browse/STT-1622

[STT-1622]: https://sofab.atlassian.net/browse/STT-1622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ