### PR TITLE
Make authoring actions work as a widget in authoring react

### DIFF
--- a/e2e/RUN-CLIENT-CORE-FROM-E2E.md
+++ b/e2e/RUN-CLIENT-CORE-FROM-E2E.md
@@ -10,7 +10,6 @@ server: {
     "ws": "ws://sd-develop.test.superdesk.org:5150/ws"
 },
 ```
-
 You can also use any other backend from the instances on https://test.superdesk.org/
 
 5. Open e2e/client/index.js

--- a/e2e/RUN-CLIENT-CORE-FROM-E2E.md
+++ b/e2e/RUN-CLIENT-CORE-FROM-E2E.md
@@ -1,0 +1,19 @@
+1. Pull the latest changes from develop
+2. cd superdesk-client-core
+3. npm ci
+4. Open e2e/client/superdesk.config.js
+
+To work against a remote backend add inside the config:
+```
+server: {
+    "url": "https://sd-develop.test.superdesk.org/api",
+    "ws": "ws://sd-develop.test.superdesk.org:5150/ws"
+},
+```
+
+You can also use any other backend from the instances on https://test.superdesk.org/
+
+5. Open e2e/client/index.js
+6. Remove the custom font styles
+7. cd e2e/client
+8. npm run server

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -16,6 +16,7 @@
     "exclude": [
         "node_modules",
         "bower_components",
-        "po"
+        "po",
+        "dist"
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
         "sass-loader": "^10.5.2",
         "shallow-equal": "^3.1.0",
         "shortid": "2.2.8",
-        "superdesk-ui-framework": "^6.1.1",
+        "superdesk-ui-framework": "^6.1.2",
         "ts-loader": "^8.4.0",
         "typescript": "~4.9.5",
         "uuid": "8.3.1",
@@ -14728,9 +14728,9 @@
       "license": "ISC"
     },
     "node_modules/superdesk-ui-framework": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-6.1.1.tgz",
-      "integrity": "sha512-AelN37+/q5DkujOFVgX9X9iAPe8rJXkqQzXeig0RoM5/TxhrZo2bytvPkF3E+meBuA2UOWRMzyLt+GeIkZEN/A==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-6.1.2.tgz",
+      "integrity": "sha512-4InKQiw/lxUj/NPtHvG3qhBgWrMy/LShoLMTqmknjKhXBH3nvv+ZDtg6oaSA1+tmP/aIH93IHQZejCwS0OxuSQ==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@popperjs/core": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "sass-loader": "^10.5.2",
     "shallow-equal": "^3.1.0",
     "shortid": "2.2.8",
-    "superdesk-ui-framework": "^6.1.2",
+    "superdesk-ui-framework": "6.1.2",
     "ts-loader": "^8.4.0",
     "typescript": "~4.9.5",
     "uuid": "8.3.1",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "moment": "2.30.1",
     "moment-timezone": "0.5.41",
     "ng-file-upload": "12.2.13",
+    "node-polyfill-webpack-plugin": "^4.1.0",
     "owl.carousel": "2.2.0",
     "patch-package": "^7.0.0",
     "popper-max-size-modifier": "0.2.0",
@@ -124,15 +125,14 @@
     "sass-loader": "^10.5.2",
     "shallow-equal": "^3.1.0",
     "shortid": "2.2.8",
-    "superdesk-ui-framework": "6.1.1",
+    "superdesk-ui-framework": "^6.1.2",
     "ts-loader": "^8.4.0",
     "typescript": "~4.9.5",
     "uuid": "8.3.1",
     "web-animations-js": "^2.3.2",
     "webpack": "^5.95.0",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.0.4",
-    "node-polyfill-webpack-plugin": "^4.1.0"
+    "webpack-dev-server": "^5.0.4"
   },
   "devDependencies": {
     "@superdesk/build-tools": "file:build-tools",

--- a/scripts/apps/authoring-react/article-widgets/send-to-publish/interactive-article-actions-widget.tsx
+++ b/scripts/apps/authoring-react/article-widgets/send-to-publish/interactive-article-actions-widget.tsx
@@ -1,0 +1,33 @@
+import {IArticleSideWidget, IArticle} from 'superdesk-api';
+import {gettext} from 'core/utils';
+import {
+    SendToPublishWidget,
+    INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID,
+} from './send-to-publish-widget';
+import {sdApi} from 'api';
+
+export function getInteractiveArticleActionsWidget(): IArticleSideWidget {
+    const widget: IArticleSideWidget = {
+        _id: INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID,
+        label: gettext('Send to / Publish'),
+        order: 1,
+        icon: 'send-to',
+        buttonType: 'highlight',
+        component: SendToPublishWidget,
+        isAllowed: (article: IArticle) => {
+            // Only show for articles that can be sent/published
+            // Not for archived, killed, or recalled items
+            if (['killed', 'recalled'].includes(article.state)) {
+                return false;
+            }
+
+            // Check if the article can be published or at least sent
+            const canPublish = sdApi.article.canPublish(article);
+            const canSend = article._type !== 'archived';
+
+            return canPublish || canSend;
+        },
+    };
+
+    return widget;
+}

--- a/scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx
+++ b/scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx
@@ -1,0 +1,236 @@
+import React from 'react';
+import {IArticleSideWidgetComponentType, IArticle} from 'superdesk-api';
+import {AuthoringWidgetLayout} from 'apps/dashboard/widget-layout';
+import {AuthoringWidgetHeading} from 'apps/dashboard/widget-heading';
+import {gettext} from 'core/utils';
+import {IArticleActionInteractive, IPanelError} from 'core/interactive-article-actions-panel/interfaces';
+import {addInternalEventListener, dispatchInternalEvent} from 'core/internal-events';
+import {assertNever} from 'core/helpers/typescript-helpers';
+import {ActionTabs} from 'core/interactive-article-actions-panel/action-tabs';
+import {SendToAction} from 'core/interactive-article-actions-panel/actions/send-to-action';
+import {DuplicateToAction} from 'core/interactive-article-actions-panel/actions/duplicate-to-action';
+import {UnspikeAction} from 'core/interactive-article-actions-panel/actions/unspike-action';
+import {FetchToAction} from 'core/interactive-article-actions-panel/actions/fetch-to-action';
+import {SendCorrectionAction} from 'core/interactive-article-actions-panel/actions/send-correction-action';
+import {PublishAction} from 'core/interactive-article-actions-panel/actions/publish-action';
+import {Text} from 'superdesk-ui-framework/react';
+
+export const INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID = 'interactive-article-actions-widget';
+
+const getLabel = () => gettext('Send to / Publish');
+
+interface IState {
+    tabs: Array<IArticleActionInteractive>;
+    activeTab: IArticleActionInteractive;
+}
+
+export class SendToPublishWidget extends React.Component<IArticleSideWidgetComponentType, IState> {
+    private eventListenersToRemoveBeforeUnmounting: Array<() => void>;
+
+    constructor(props: IArticleSideWidgetComponentType) {
+        super(props);
+
+        // Parse initial state if provided (from widget state persistence)
+        const initialState = this.props.initialState as IState | undefined;
+
+        this.state = initialState ?? {
+            tabs: ['send_to', 'publish'],
+            activeTab: 'publish',
+        };
+
+        this.eventListenersToRemoveBeforeUnmounting = [];
+        this.handleClose = this.handleClose.bind(this);
+        this.handleError = this.handleError.bind(this);
+        this.handleDataChange = this.handleDataChange.bind(this);
+    }
+
+    componentDidMount() {
+        // Listen for internal events to update tabs/activeTab when triggered from toolbar
+        this.eventListenersToRemoveBeforeUnmounting.push(
+            addInternalEventListener('interactiveArticleActionStart', (event) => {
+                const {items, tabs, activeTab} = event.detail;
+
+                // Only respond if this event is for the current article
+                if (items.length === 1 && items[0]._id === this.props.article._id) {
+                    this.setState({
+                        tabs,
+                        activeTab,
+                    });
+                }
+            }),
+        );
+    }
+
+    componentWillUnmount() {
+        this.eventListenersToRemoveBeforeUnmounting.forEach((removeListener) => {
+            removeListener();
+        });
+    }
+
+    handleClose() {
+        dispatchInternalEvent('interactiveArticleActionEnd', undefined);
+    }
+
+    handleError(error: IPanelError) {
+        if (error.kind === 'publishing-error') {
+            // The parent handles validation errors through the widget props if needed
+        } else {
+            assertNever(error.kind);
+        }
+    }
+
+    handleDataChange(item: IArticle) {
+        this.props.onItemChange?.(item);
+    }
+
+    renderActiveTabContent(): {body: JSX.Element; footer: JSX.Element} {
+        const {activeTab} = this.state;
+
+        if (activeTab === 'send_to') {
+            return {
+                body: null,
+                footer: null,
+            };
+        } else if (activeTab === 'publish') {
+            return {
+                body: null,
+                footer: null,
+            };
+        } else if (activeTab === 'correct') {
+            return {
+                body: null,
+                footer: null,
+            };
+        } else if (activeTab === 'duplicate_to') {
+            return {
+                body: null,
+                footer: null,
+            };
+        } else if (activeTab === 'unspike') {
+            return {
+                body: null,
+                footer: null,
+            };
+        } else if (activeTab === 'fetch_to') {
+            return {
+                body: null,
+                footer: null,
+            };
+        } else {
+            assertNever(activeTab);
+        }
+    }
+
+    render() {
+        const {article} = this.props;
+        const {tabs, activeTab} = this.state;
+
+        const handleUnsavedChanges = () => this.props.handleUnsavedChanges();
+        const handleUnsavedChangesArray = (items: Array<IArticle>) =>
+            handleUnsavedChanges().then((res) => [res]);
+
+        const renderWithLayout = (body: JSX.Element, footer: JSX.Element) => (
+            <AuthoringWidgetLayout
+                header={(
+                    <AuthoringWidgetHeading
+                        widgetId={INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID}
+                        widgetName={getLabel()}
+                        editMode={false}
+                        customContent={(
+                            <ActionTabs
+                                tabs={tabs}
+                                activeTab={activeTab}
+                                onChange={(tab) => {
+                                    this.setState({activeTab: tab});
+                                }}
+                            />
+                        )}
+                    />
+                )}
+                body={body}
+                footer={footer}
+                bodyPadding="small"
+            />
+        );
+
+        if (activeTab === 'send_to') {
+            return (
+                <SendToAction
+                    items={[article]}
+                    closeSendToView={this.handleClose}
+                    handleUnsavedChanges={handleUnsavedChangesArray}
+                >
+                    {({body, footer, noDestinationsAvailable}) => {
+                        if (noDestinationsAvailable) {
+                            return renderWithLayout(
+                                <Text size="medium" align="center" weight="medium">
+                                    {gettext('No destinations are available.')}
+                                </Text>,
+                                null,
+                            );
+                        }
+                        return renderWithLayout(body, footer);
+                    }}
+                </SendToAction>
+            );
+        } else if (activeTab === 'publish') {
+            return (
+                <PublishAction
+                    item={article}
+                    closePublishView={this.handleClose}
+                    handleUnsavedChanges={handleUnsavedChanges}
+                    onError={this.handleError}
+                    onDataChange={this.handleDataChange}
+                >
+                    {({body, footer, loading}) => {
+                        if (loading) {
+                            return renderWithLayout(null, null);
+                        }
+                        return renderWithLayout(body, footer);
+                    }}
+                </PublishAction>
+            );
+        } else if (activeTab === 'correct') {
+            return (
+                <SendCorrectionAction
+                    item={article}
+                    closePublishView={this.handleClose}
+                    handleUnsavedChanges={handleUnsavedChanges}
+                    onDataChange={this.handleDataChange}
+                >
+                    {({body, footer}) => renderWithLayout(body, footer)}
+                </SendCorrectionAction>
+            );
+        } else if (activeTab === 'duplicate_to') {
+            return (
+                <DuplicateToAction
+                    items={[article]}
+                    closeDuplicateToView={this.handleClose}
+                >
+                    {({body, footer}) => renderWithLayout(body, footer)}
+                </DuplicateToAction>
+            );
+        } else if (activeTab === 'unspike') {
+            return (
+                <UnspikeAction
+                    items={[article]}
+                    closeUnspikeView={this.handleClose}
+                >
+                    {({body, footer}) => renderWithLayout(body, footer)}
+                </UnspikeAction>
+            );
+        } else if (activeTab === 'fetch_to') {
+            return (
+                <FetchToAction
+                    items={[article]}
+                    closeFetchToView={this.handleClose}
+                    handleUnsavedChanges={handleUnsavedChangesArray}
+                >
+                    {({body, footer}) => renderWithLayout(body, footer)}
+                </FetchToAction>
+            );
+        } else {
+            assertNever(activeTab);
+        }
+    }
+}

--- a/scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx
+++ b/scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx
@@ -83,6 +83,37 @@ export class SendToPublishWidget extends React.Component<IArticleSideWidgetCompo
         this.props.onItemChange?.(item);
     }
 
+    renderWithLayout(
+        body: JSX.Element,
+        footer: JSX.Element,
+        tabs: Array<IArticleActionInteractive>,
+        activeTab: IArticleActionInteractive,
+    ) {
+        return (
+            <AuthoringWidgetLayout
+                header={(
+                    <AuthoringWidgetHeading
+                        widgetId={INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID}
+                        widgetName={getLabel()}
+                        editMode={false}
+                        customContent={(
+                            <ActionTabs
+                                tabs={tabs}
+                                activeTab={activeTab}
+                                onChange={(tab) => {
+                                    this.setState({activeTab: tab});
+                                }}
+                            />
+                        )}
+                    />
+                )}
+                body={body}
+                footer={footer}
+                bodyPadding="small"
+            />
+        );
+    }
+
     renderActiveTabContent(): {body: JSX.Element; footer: JSX.Element} {
         const {activeTab} = this.state;
 
@@ -129,30 +160,6 @@ export class SendToPublishWidget extends React.Component<IArticleSideWidgetCompo
         const handleUnsavedChangesArray = (items: Array<IArticle>) =>
             handleUnsavedChanges().then((res) => [res]);
 
-        const renderWithLayout = (body: JSX.Element, footer: JSX.Element) => (
-            <AuthoringWidgetLayout
-                header={(
-                    <AuthoringWidgetHeading
-                        widgetId={INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID}
-                        widgetName={getLabel()}
-                        editMode={false}
-                        customContent={(
-                            <ActionTabs
-                                tabs={tabs}
-                                activeTab={activeTab}
-                                onChange={(tab) => {
-                                    this.setState({activeTab: tab});
-                                }}
-                            />
-                        )}
-                    />
-                )}
-                body={body}
-                footer={footer}
-                bodyPadding="small"
-            />
-        );
-
         if (activeTab === 'send_to') {
             return (
                 <SendToAction
@@ -162,14 +169,16 @@ export class SendToPublishWidget extends React.Component<IArticleSideWidgetCompo
                 >
                     {({body, footer, noDestinationsAvailable}) => {
                         if (noDestinationsAvailable) {
-                            return renderWithLayout(
+                            return this.renderWithLayout(
                                 <Text size="medium" align="center" weight="medium">
                                     {gettext('No destinations are available.')}
                                 </Text>,
                                 null,
+                                tabs,
+                                activeTab,
                             );
                         }
-                        return renderWithLayout(body, footer);
+                        return this.renderWithLayout(body, footer, tabs, activeTab);
                     }}
                 </SendToAction>
             );
@@ -184,9 +193,9 @@ export class SendToPublishWidget extends React.Component<IArticleSideWidgetCompo
                 >
                     {({body, footer, loading}) => {
                         if (loading) {
-                            return renderWithLayout(null, null);
+                            return this.renderWithLayout(null, null, tabs, activeTab);
                         }
-                        return renderWithLayout(body, footer);
+                        return this.renderWithLayout(body, footer, tabs, activeTab);
                     }}
                 </PublishAction>
             );
@@ -198,7 +207,7 @@ export class SendToPublishWidget extends React.Component<IArticleSideWidgetCompo
                     handleUnsavedChanges={handleUnsavedChanges}
                     onDataChange={this.handleDataChange}
                 >
-                    {({body, footer}) => renderWithLayout(body, footer)}
+                    {({body, footer}) => this.renderWithLayout(body, footer, tabs, activeTab)}
                 </SendCorrectionAction>
             );
         } else if (activeTab === 'duplicate_to') {
@@ -207,7 +216,7 @@ export class SendToPublishWidget extends React.Component<IArticleSideWidgetCompo
                     items={[article]}
                     closeDuplicateToView={this.handleClose}
                 >
-                    {({body, footer}) => renderWithLayout(body, footer)}
+                    {({body, footer}) => this.renderWithLayout(body, footer, tabs, activeTab)}
                 </DuplicateToAction>
             );
         } else if (activeTab === 'unspike') {
@@ -216,7 +225,7 @@ export class SendToPublishWidget extends React.Component<IArticleSideWidgetCompo
                     items={[article]}
                     closeUnspikeView={this.handleClose}
                 >
-                    {({body, footer}) => renderWithLayout(body, footer)}
+                    {({body, footer}) => this.renderWithLayout(body, footer, tabs, activeTab)}
                 </UnspikeAction>
             );
         } else if (activeTab === 'fetch_to') {
@@ -226,7 +235,7 @@ export class SendToPublishWidget extends React.Component<IArticleSideWidgetCompo
                     closeFetchToView={this.handleClose}
                     handleUnsavedChanges={handleUnsavedChangesArray}
                 >
-                    {({body, footer}) => renderWithLayout(body, footer)}
+                    {({body, footer}) => this.renderWithLayout(body, footer, tabs, activeTab)}
                 </FetchToAction>
             );
         } else {

--- a/scripts/apps/authoring-react/authoring-angular-integration.tsx
+++ b/scripts/apps/authoring-react/authoring-angular-integration.tsx
@@ -498,58 +498,7 @@ function getInlineToolbarActions(
     }
 }
 
-function getPublishToolbarWidget(
-    panelState: IStateInteractiveActionsPanelHOC,
-    panelActions: IActionsInteractiveActionsPanelHOC,
-): ITopBarWidget<IArticle> {
-    const publishWidgetButton: ITopBarWidget<IArticle> = {
-        priority: 99,
-        availableOffline: false,
-        group: 'end',
-        // eslint-disable-next-line react/display-name
-        component: (props: {entity: IArticle}) => (
-            <ButtonGroup align="end">
-                <ButtonGroup subgroup={true} spaces="no-space">
-                    <NavButton
-                        type="highlight"
-                        icon="send-to"
-                        iconSize="big"
-                        text={gettext('Send to / Publish')}
-                        onClick={() => {
-                            if (panelState.active) {
-                                panelActions.closePanel();
-                            } else {
-                                const availableTabs: Array<IArticleActionInteractive> = [
-                                    'send_to',
-                                ];
-
-                                const canPublish =
-                                    sdApi.article.canPublish(props.entity);
-
-                                if (canPublish) {
-                                    availableTabs.push('publish');
-                                }
-
-                                dispatchInternalEvent('interactiveArticleActionStart', {
-                                    items: [props.entity],
-                                    tabs: availableTabs,
-                                    activeTab: canPublish ? 'publish' : availableTabs[0],
-                                });
-                            }
-                        }}
-                    />
-                </ButtonGroup>
-            </ButtonGroup>
-        ),
-    };
-
-    return publishWidgetButton;
-}
-
-export function getAuthoringPrimaryToolbarWidgets(
-    panelState: IStateInteractiveActionsPanelHOC,
-    panelActions: IActionsInteractiveActionsPanelHOC,
-) {
+export function getAuthoringPrimaryToolbarWidgets() {
     return Object.values(extensions)
         .flatMap(({activationResult}) =>
             activationResult?.contributions?.authoringTopbarWidgets ?? [],
@@ -563,8 +512,7 @@ export function getAuthoringPrimaryToolbarWidgets(
                     <Component entity={props.entity} />
                 ),
             };
-        })
-        .concat([getPublishToolbarWidget(panelState, panelActions)]);
+        });
 }
 
 export interface IProps {

--- a/scripts/apps/authoring-react/authoring-integration-wrapper-sidebar.tsx
+++ b/scripts/apps/authoring-react/authoring-integration-wrapper-sidebar.tsx
@@ -43,6 +43,7 @@ export class AuthoringIntegrationWrapperSidebar extends React.PureComponent<IPro
                         tooltip: widget.label,
                         id: widget._id,
                         badgeValue: badge,
+                        type: widget.buttonType,
                     };
 
                     return tab;
@@ -76,6 +77,7 @@ export class AuthoringIntegrationWrapperSidebar extends React.PureComponent<IPro
                         });
                     }
                 }}
+
                 items={this.state.sidebarTabs}
             />
         );

--- a/scripts/apps/authoring-react/manage-widget-registration.ts
+++ b/scripts/apps/authoring-react/manage-widget-registration.ts
@@ -11,11 +11,15 @@ import {getTranslationsWidget} from './article-widgets/translations/translations
 import {getMacrosWidget} from './macros/macros';
 import {getPackagesWidget} from './packages';
 import {getMetadataWidget} from './article-widgets/metadata/metadata';
+import {
+    getInteractiveArticleActionsWidget,
+} from './article-widgets/send-to-publish/interactive-article-actions-widget';
 
 export const authoringReactWidgetsExtension = 'authoring-react-widgets';
 
 export function registerAuthoringReactWidgets() {
     const sidebarWidgets: IExtensionActivationResult['contributions']['authoringSideWidgets'] = [
+        getInteractiveArticleActionsWidget(),
         getFindAndReplaceWidget(),
         getVersionsAndItemHistoryWidget(),
         getTranslationsWidget(),

--- a/scripts/apps/authoring-react/widget-header-component.tsx
+++ b/scripts/apps/authoring-react/widget-header-component.tsx
@@ -37,7 +37,11 @@ export class WidgetHeaderComponent extends React.PureComponent<IWidgetIntegratio
                         <ButtonGroup align="end" spaces="no-space" className="side-panel__btn-group">
                             {iconButtons != null && iconButtons}
                             {!pinned && (
-                                <IconButton icon="close-small" ariaValue="Close" onClick={() => this.props.closeWidget()} />
+                                <IconButton
+                                    icon="close-small"
+                                    ariaValue="Close"
+                                    onClick={() => this.props.closeWidget()}
+                                />
                             )}
                         </ButtonGroup>
                     </div>

--- a/scripts/apps/authoring-react/widget-header-component.tsx
+++ b/scripts/apps/authoring-react/widget-header-component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as Layout from 'superdesk-ui-framework/react/components/Layouts';
 import {IWidgetIntegrationComponentProps, widgetReactIntegration} from 'apps/authoring/widgets/widgets';
-import {IconButton, Rotate} from 'superdesk-ui-framework/react';
+import {IconButton, Rotate, ButtonGroup} from 'superdesk-ui-framework/react';
 import {gettext} from 'core/utils';
 
 export class WidgetHeaderComponent extends React.PureComponent<IWidgetIntegrationComponentProps> {
@@ -13,9 +13,48 @@ export class WidgetHeaderComponent extends React.PureComponent<IWidgetIntegratio
         } = this.props;
         const sidebarPinnedId = widgetReactIntegration.getPinnedWidget();
 
+        if (customContent != null) {
+            const iconButtons = widgetReactIntegration.disableWidgetPinning == null
+                ? undefined
+                : sidebarPinnedId != null && (sidebarPinnedId !== widgetReactIntegration.getActiveWidget()) ? [] : [
+                    <Rotate degrees={pinned ? 90 : 0} key="noop">
+                        <IconButton
+                            icon="pin"
+                            ariaValue={gettext('Pin')}
+                            onClick={() => {
+                                pinWidget();
+                            }}
+                        />
+                    </Rotate>,
+                ];
+
+            return (
+                <div className="side-panel__header side-panel__header--border-b side-panel__header--has-close">
+                    <div className="side-panel__header-wrapper">
+                        <div className="side-panel__header-inner">
+                            {customContent}
+                        </div>
+                        <ButtonGroup align="end" spaces="no-space" className="side-panel__btn-group">
+                            {iconButtons != null && iconButtons}
+                            {!pinned && (
+                                <IconButton icon="close-small" ariaValue="Close" onClick={() => this.props.closeWidget()} />
+                            )}
+                        </ButtonGroup>
+                    </div>
+                    {
+                        this.props.editMode && (
+                            <Layout.PanelHeaderSlidingToolbar right>
+                                {this.props.children}
+                            </Layout.PanelHeaderSlidingToolbar>
+                        )
+                    }
+                </div>
+            );
+        }
+
         return (
             <Layout.PanelHeader
-                title={customContent == null ? this.props.widgetName : ''}
+                title={this.props.widgetName}
                 onClose={pinned ? undefined : () => this.props.closeWidget()}
                 iconButtons={widgetReactIntegration.disableWidgetPinning == null
                     ? undefined
@@ -32,8 +71,6 @@ export class WidgetHeaderComponent extends React.PureComponent<IWidgetIntegratio
                     ]
                 }
             >
-                {customContent ?? null}
-
                 {
                     this.props.editMode && (
                         <Layout.PanelHeaderSlidingToolbar right>

--- a/scripts/apps/authoring-react/widget-header-component.tsx
+++ b/scripts/apps/authoring-react/widget-header-component.tsx
@@ -5,6 +5,31 @@ import {IconButton, Rotate, ButtonGroup} from 'superdesk-ui-framework/react';
 import {gettext} from 'core/utils';
 
 export class WidgetHeaderComponent extends React.PureComponent<IWidgetIntegrationComponentProps> {
+    getIconButtons(): Array<JSX.Element> | undefined {
+        const {pinned, pinWidget} = this.props;
+        const sidebarPinnedId = widgetReactIntegration.getPinnedWidget();
+
+        if (widgetReactIntegration.disableWidgetPinning == null) {
+            return undefined;
+        }
+
+        if (sidebarPinnedId != null && sidebarPinnedId !== widgetReactIntegration.getActiveWidget()) {
+            return [];
+        }
+
+        return [
+            <Rotate degrees={pinned ? 90 : 0} key="noop">
+                <IconButton
+                    icon="pin"
+                    ariaValue={gettext('Pin')}
+                    onClick={() => {
+                        pinWidget();
+                    }}
+                />
+            </Rotate>,
+        ];
+    }
+
     render() {
         const {
             pinned,
@@ -14,19 +39,7 @@ export class WidgetHeaderComponent extends React.PureComponent<IWidgetIntegratio
         const sidebarPinnedId = widgetReactIntegration.getPinnedWidget();
 
         if (customContent != null) {
-            const iconButtons = widgetReactIntegration.disableWidgetPinning == null
-                ? undefined
-                : sidebarPinnedId != null && (sidebarPinnedId !== widgetReactIntegration.getActiveWidget()) ? [] : [
-                    <Rotate degrees={pinned ? 90 : 0} key="noop">
-                        <IconButton
-                            icon="pin"
-                            ariaValue={gettext('Pin')}
-                            onClick={() => {
-                                pinWidget();
-                            }}
-                        />
-                    </Rotate>,
-                ];
+            const iconButtons = this.getIconButtons();
 
             return (
                 <div className="side-panel__header side-panel__header--border-b side-panel__header--has-close">
@@ -60,20 +73,7 @@ export class WidgetHeaderComponent extends React.PureComponent<IWidgetIntegratio
             <Layout.PanelHeader
                 title={this.props.widgetName}
                 onClose={pinned ? undefined : () => this.props.closeWidget()}
-                iconButtons={widgetReactIntegration.disableWidgetPinning == null
-                    ? undefined
-                    : sidebarPinnedId != null && (sidebarPinnedId !== widgetReactIntegration.getActiveWidget()) ? [] : [
-                        <Rotate degrees={pinned ? 90 : 0} key="noop">
-                            <IconButton
-                                icon="pin"
-                                ariaValue={gettext('Pin')}
-                                onClick={() => {
-                                    pinWidget();
-                                }}
-                            />
-                        </Rotate>,
-                    ]
-                }
+                iconButtons={this.getIconButtons()}
             >
                 {
                     this.props.editMode && (

--- a/scripts/apps/authoring-react/widget-layout-component.tsx
+++ b/scripts/apps/authoring-react/widget-layout-component.tsx
@@ -7,14 +7,21 @@ import {IAuthoringWidgetLayoutProps} from 'superdesk-api';
  */
 export class AuthoringWidgetLayoutComponent extends React.PureComponent<IAuthoringWidgetLayoutProps> {
     render() {
-        const {header, body, footer} = this.props;
+        const {header, body, footer, bodyPadding = 'medium'} = this.props;
+
+        // Map bodyPadding values to PanelContentBlock padding values
+        const paddingMap: Record<'none' | 'small' | 'medium', '0' | '1-5' | '3'> = {
+            none: '0',
+            small: '1-5',
+            medium: '3',
+        };
 
         return (
             <Layout.Panel side="right" open={true} size="x-small" background={this.props.background ?? 'light'}>
                 {header && <React.Fragment>{header}</React.Fragment>}
 
                 <Layout.PanelContent>
-                    <Layout.PanelContentBlock>
+                    <Layout.PanelContentBlock flex={bodyPadding === 'none'} padding={paddingMap[bodyPadding]}>
                         {body}
                     </Layout.PanelContentBlock>
                 </Layout.PanelContent>

--- a/scripts/core/interactive-article-actions-panel/action-tabs.tsx
+++ b/scripts/core/interactive-article-actions-panel/action-tabs.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {IArticleActionInteractive} from './interfaces';
+import {TabList} from 'core/ui/components/tabs';
+import {gettext} from 'core/utils';
+import {assertNever} from 'core/helpers/typescript-helpers';
+
+export function getTabLabel(id: IArticleActionInteractive): string {
+    if (id === 'send_to') {
+        return gettext('Send to');
+    } else if (id === 'fetch_to') {
+        return gettext('Fetch to');
+    } else if (id === 'duplicate_to') {
+        return gettext('Duplicate to');
+    } else if (id === 'unspike') {
+        return gettext('Unspike');
+    } else if (id === 'publish') {
+        return gettext('Publish');
+    } else if (id === 'correct') {
+        /**
+         * Display as "Publish".
+         * It's implemented as separate tab so it's easier
+         * to decouple implementation into a separate component.
+         */
+        return gettext('Publish');
+    } else {
+        assertNever(id);
+    }
+}
+
+interface IActionTabsProps {
+    tabs: Array<IArticleActionInteractive>;
+    activeTab: IArticleActionInteractive;
+    onChange(tab: IArticleActionInteractive): void;
+}
+
+/**
+ * Reusable tabs component for interactive article actions.
+ * Can be used in both the standalone panel header and the widget header.
+ */
+export const ActionTabs: React.FC<IActionTabsProps> = ({tabs, activeTab, onChange}) => {
+    return (
+        <TabList
+            tabs={tabs.map((id) => ({id, label: getTabLabel(id)}))}
+            selectedTabId={activeTab}
+            onChange={onChange}
+            data-test-id="tabs"
+        />
+    );
+};

--- a/scripts/core/interactive-article-actions-panel/actions/duplicate-to-action.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/duplicate-to-action.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import {IArticle} from 'superdesk-api';
+import {Button, ButtonGroup, ToggleBox} from 'superdesk-ui-framework/react';
+import {gettext} from 'core/utils';
+import {openArticle} from 'core/get-superdesk-api-implementation';
+import {sdApi} from 'api';
+import {getInitialDestination} from '../utils/get-initial-destination';
+import {canSendToPersonal} from '../utils/can-send-to-personal';
+import {DestinationSelect} from '../subcomponents/destination-select';
+import {ISendToDestination} from '../interfaces';
+
+export interface IDuplicateToConfig {
+    items: Array<IArticle>;
+    closeDuplicateToView(): void;
+}
+
+interface IState {
+    selectedDestination: ISendToDestination;
+}
+
+interface IRenderArgs {
+    body: JSX.Element;
+    footer: JSX.Element;
+}
+
+interface IProps extends IDuplicateToConfig {
+    children(args: IRenderArgs): JSX.Element;
+}
+
+/**
+ * Duplicate To action - provides body and footer as render props.
+ * This allows the parent to compose them into either the standalone panel or widget layout.
+ */
+export class DuplicateToAction extends React.PureComponent<IProps, IState> {
+    constructor(props: IProps) {
+        super(props);
+
+        this.state = {
+            selectedDestination: getInitialDestination(props.items, canSendToPersonal(props.items)),
+        };
+
+        this.duplicateItems = this.duplicateItems.bind(this);
+    }
+
+    duplicateItems(openAfterDuplicating?: boolean) {
+        const {selectedDestination} = this.state;
+        const {closeDuplicateToView, items} = this.props;
+
+        sdApi.article.duplicateItems(items.map(({_id}) => _id), selectedDestination).then((res) => {
+            closeDuplicateToView();
+
+            if (openAfterDuplicating) {
+                openArticle(res[0]._id, 'edit');
+            }
+        });
+    }
+
+    render() {
+        const {items} = this.props;
+
+        const body = (
+            <ToggleBox variant="simple" title={gettext('Destination')} initiallyOpen>
+                <DestinationSelect
+                    value={this.state.selectedDestination}
+                    onChange={(value) => {
+                        this.setState({
+                            selectedDestination: value,
+                        });
+                    }}
+                    includePersonalSpace={canSendToPersonal(items)}
+                />
+            </ToggleBox>
+        );
+
+        const footer = (
+            <ButtonGroup orientation="vertical">
+                {
+                    this.props.items.length === 1 && (
+                        <Button
+                            text={gettext('Duplicate and open')}
+                            onClick={() => {
+                                this.duplicateItems(true);
+                            }}
+                            size="large"
+                            type="primary"
+                            expand
+                            data-test-id="duplicate-and-open"
+                        />
+                    )
+                }
+                <Button
+                    text={gettext('Duplicate')}
+                    onClick={() => {
+                        this.duplicateItems();
+                    }}
+                    size="large"
+                    type="primary"
+                    expand
+                    data-test-id="duplicate"
+                />
+            </ButtonGroup>
+        );
+
+        return this.props.children({body, footer});
+    }
+}

--- a/scripts/core/interactive-article-actions-panel/actions/duplicate-to-tab.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/duplicate-to-tab.tsx
@@ -1,16 +1,8 @@
 import React from 'react';
-import {IArticle, IDesk} from 'superdesk-api';
-import {Button, ButtonGroup, ToggleBox} from 'superdesk-ui-framework/react';
-import {gettext} from 'core/utils';
+import {IArticle} from 'superdesk-api';
 import {PanelContent} from '../panel/panel-content';
 import {PanelFooter} from '../panel/panel-footer';
-import {openArticle} from 'core/get-superdesk-api-implementation';
-import {sdApi} from 'api';
-import {getInitialDestination} from '../utils/get-initial-destination';
-import {canSendToPersonal} from '../utils/can-send-to-personal';
-import {DestinationSelect} from '../subcomponents/destination-select';
-import {ISendToDestination} from '../interfaces';
-import {OrderedMap} from 'immutable';
+import {DuplicateToAction} from './duplicate-to-action';
 
 interface IProps {
     items: Array<IArticle>;
@@ -18,87 +10,29 @@ interface IProps {
     markupV2: boolean;
 }
 
-interface IState {
-    selectedDestination: ISendToDestination;
-}
-
-export class DuplicateToTab extends React.PureComponent<IProps, IState> {
-    constructor(props: IProps) {
-        super(props);
-
-        this.state = {
-            selectedDestination: getInitialDestination(props.items, canSendToPersonal(props.items)),
-        };
-
-        this.duplicateItems = this.duplicateItems.bind(this);
-    }
-
-    duplicateItems(
-        /**
-         * Is only supposed to be used when only one item is being duplicated
-         */
-        openAfterDuplicating?: boolean,
-    ) {
-        const {selectedDestination} = this.state;
-        const {closeDuplicateToView, items} = this.props;
-
-        sdApi.article.duplicateItems(items.map(({_id}) => _id), selectedDestination).then((res) => {
-            closeDuplicateToView();
-
-            if (openAfterDuplicating) {
-                openArticle(res[0]._id, 'edit');
-            }
-        });
-    }
-
+/**
+ * Duplicate To Tab - composes the DuplicateToAction into the panel layout.
+ */
+export class DuplicateToTab extends React.PureComponent<IProps> {
     render() {
-        const {items, markupV2} = this.props;
+        const {items, markupV2, closeDuplicateToView} = this.props;
 
         return (
-            <React.Fragment>
-                <PanelContent markupV2={markupV2}>
-                    <ToggleBox variant="simple" title={gettext('Destination')} initiallyOpen>
-                        <DestinationSelect
-                            value={this.state.selectedDestination}
-                            onChange={(value) => {
-                                this.setState({
-                                    selectedDestination: value,
-                                });
-                            }}
-                            includePersonalSpace={canSendToPersonal(items)}
-                        />
-                    </ToggleBox>
-                </PanelContent>
-
-                <PanelFooter markupV2={markupV2}>
-                    <ButtonGroup orientation="vertical">
-                        {
-                            this.props.items.length === 1 && (
-                                <Button
-                                    text={gettext('Duplicate and open')}
-                                    onClick={() => {
-                                        this.duplicateItems(true);
-                                    }}
-                                    size="large"
-                                    type="primary"
-                                    expand
-                                    data-test-id="duplicate-and-open"
-                                />
-                            )
-                        }
-                        <Button
-                            text={gettext('Duplicate')}
-                            onClick={() => {
-                                this.duplicateItems();
-                            }}
-                            size="large"
-                            type="primary"
-                            expand
-                            data-test-id="duplicate"
-                        />
-                    </ButtonGroup>
-                </PanelFooter>
-            </React.Fragment>
+            <DuplicateToAction
+                items={items}
+                closeDuplicateToView={closeDuplicateToView}
+            >
+                {({body, footer}) => (
+                    <>
+                        <PanelContent markupV2={markupV2}>
+                            {body}
+                        </PanelContent>
+                        <PanelFooter markupV2={markupV2}>
+                            {footer}
+                        </PanelFooter>
+                    </>
+                )}
+            </DuplicateToAction>
         );
     }
 }

--- a/scripts/core/interactive-article-actions-panel/actions/fetch-to-action.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/fetch-to-action.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import {IArticle} from 'superdesk-api';
+import {Button, ButtonGroup} from 'superdesk-ui-framework/react';
+import {gettext} from 'core/utils';
+import {openArticle} from 'core/get-superdesk-api-implementation';
+import {getInitialDestination} from '../utils/get-initial-destination';
+import {DestinationSelect} from '../subcomponents/destination-select';
+import {ISendToDestination} from '../interfaces';
+import {sdApi} from 'api';
+import {noop} from 'lodash';
+import {assertNever} from 'core/helpers/typescript-helpers';
+import {ToggleBox} from 'superdesk-ui-framework/react';
+
+export interface IFetchToConfig {
+    items: Array<IArticle>;
+    closeFetchToView(): void;
+    handleUnsavedChanges(items: Array<IArticle>): Promise<Array<IArticle>>;
+}
+
+interface IState {
+    selectedDestination: ISendToDestination;
+}
+
+interface IRenderArgs {
+    body: JSX.Element;
+    footer: JSX.Element;
+}
+
+interface IProps extends IFetchToConfig {
+    children(args: IRenderArgs): JSX.Element;
+}
+
+/**
+ * Fetch To action - provides body and footer as render props.
+ * This allows the parent to compose them into either the standalone panel or widget layout.
+ */
+export class FetchToAction extends React.PureComponent<IProps, IState> {
+    constructor(props: IProps) {
+        super(props);
+
+        this.state = {
+            selectedDestination: getInitialDestination(props.items, false),
+        };
+
+        this.fetchItems = this.fetchItems.bind(this);
+    }
+
+    fetchItems(openAfterFetching?: boolean) {
+        if (this.state.selectedDestination.type === 'desk') { // personal space not supported
+            sdApi.article.fetchItems(this.props.items, this.state.selectedDestination)
+                .then((res) => {
+                    this.props.closeFetchToView();
+
+                    if (openAfterFetching) {
+                        openArticle(res[0]._id, 'edit');
+                    }
+                })
+                .catch(noop);
+        }
+    }
+
+    render() {
+        const canFetch: boolean = (() => {
+            if (this.state.selectedDestination.type === 'personal-space') {
+                throw new Error('fetching to personal space is not supported');
+            } else if (this.state.selectedDestination.type === 'desk') {
+                const destinationStage = sdApi.desks.getDeskStages(
+                    this.state.selectedDestination.desk,
+                ).get(this.state.selectedDestination.stage);
+
+                if (destinationStage.is_visible) {
+                    return true;
+                } else {
+                    return sdApi.desks.getCurrentUserDesks()
+                        .map(({_id}) => _id)
+                        .includes(this.state.selectedDestination.desk);
+                }
+            } else {
+                return assertNever(this.state.selectedDestination);
+            }
+        })();
+
+        const body = (
+            <ToggleBox variant="simple" title={gettext('Destination')} initiallyOpen>
+                <DestinationSelect
+                    value={this.state.selectedDestination}
+                    onChange={(value) => {
+                        this.setState({
+                            selectedDestination: value,
+                        });
+                    }}
+                    includePersonalSpace={false}
+                />
+            </ToggleBox>
+        );
+
+        const footer = (
+            <ButtonGroup orientation="vertical">
+                {
+                    this.props.items.length === 1 && (
+                        <Button
+                            text={gettext('Fetch and open')}
+                            onClick={() => {
+                                this.fetchItems(true);
+                            }}
+                            size="large"
+                            type="primary"
+                            style="hollow"
+                            expand
+                            data-test-id="fetch-and-open"
+                            disabled={!canFetch}
+                        />
+                    )
+                }
+
+                <Button
+                    text={gettext('Fetch')}
+                    onClick={() => {
+                        this.fetchItems();
+                    }}
+                    size="large"
+                    type="primary"
+                    expand
+                    data-test-id="fetch"
+                    disabled={!canFetch}
+                />
+            </ButtonGroup>
+        );
+
+        return this.props.children({body, footer});
+    }
+}

--- a/scripts/core/interactive-article-actions-panel/actions/fetch-to-action.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/fetch-to-action.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {IArticle} from 'superdesk-api';
-import {Button, ButtonGroup} from 'superdesk-ui-framework/react';
+import {Button, ButtonGroup, ToggleBox} from 'superdesk-ui-framework/react';
 import {gettext} from 'core/utils';
 import {openArticle} from 'core/get-superdesk-api-implementation';
 import {getInitialDestination} from '../utils/get-initial-destination';
@@ -9,7 +9,6 @@ import {ISendToDestination} from '../interfaces';
 import {sdApi} from 'api';
 import {noop} from 'lodash';
 import {assertNever} from 'core/helpers/typescript-helpers';
-import {ToggleBox} from 'superdesk-ui-framework/react';
 
 export interface IFetchToConfig {
     items: Array<IArticle>;

--- a/scripts/core/interactive-article-actions-panel/actions/fetch-to-tab.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/fetch-to-tab.tsx
@@ -1,16 +1,8 @@
 import React from 'react';
 import {IArticle} from 'superdesk-api';
-import {Button, ButtonGroup, ToggleBox} from 'superdesk-ui-framework/react';
-import {gettext} from 'core/utils';
 import {PanelContent} from '../panel/panel-content';
 import {PanelFooter} from '../panel/panel-footer';
-import {openArticle} from 'core/get-superdesk-api-implementation';
-import {getInitialDestination} from '../utils/get-initial-destination';
-import {DestinationSelect} from '../subcomponents/destination-select';
-import {ISendToDestination} from '../interfaces';
-import {sdApi} from 'api';
-import {noop} from 'lodash';
-import {assertNever} from 'core/helpers/typescript-helpers';
+import {FetchToAction} from './fetch-to-action';
 
 interface IProps {
     items: Array<IArticle>;
@@ -19,107 +11,30 @@ interface IProps {
     handleUnsavedChanges(items: Array<IArticle>): Promise<Array<IArticle>>;
 }
 
-interface IState {
-    selectedDestination: ISendToDestination;
-}
-
-export class FetchToTab extends React.PureComponent<IProps, IState> {
-    constructor(props: IProps) {
-        super(props);
-
-        this.state = {
-            selectedDestination: getInitialDestination(props.items, false),
-        };
-
-        this.fetchItems = this.fetchItems.bind(this);
-    }
-
-    fetchItems(openAfterFetching?: boolean) {
-        if (this.state.selectedDestination.type === 'desk') { // personal space not supported
-            sdApi.article.fetchItems(this.props.items, this.state.selectedDestination)
-                .then((res) => {
-                    this.props.closeFetchToView();
-
-                    if (openAfterFetching) {
-                        openArticle(res[0]._id, 'edit');
-                    }
-                })
-                .catch(noop);
-        }
-    }
-
+/**
+ * Fetch To Tab - composes the FetchToAction into the panel layout.
+ */
+export class FetchToTab extends React.PureComponent<IProps> {
     render() {
-        const {markupV2} = this.props;
-
-        const canFetch: boolean = (() => {
-            if (this.state.selectedDestination.type === 'personal-space') {
-                throw new Error('fetching to personal space is not supported');
-            } else if (this.state.selectedDestination.type === 'desk') {
-                const destinationStage = sdApi.desks.getDeskStages(
-                    this.state.selectedDestination.desk,
-                ).get(this.state.selectedDestination.stage);
-
-                if (destinationStage.is_visible) {
-                    return true;
-                } else {
-                    return sdApi.desks.getCurrentUserDesks()
-                        .map(({_id}) => _id)
-                        .includes(this.state.selectedDestination.desk);
-                }
-            } else {
-                return assertNever(this.state.selectedDestination);
-            }
-        })();
+        const {items, markupV2, closeFetchToView, handleUnsavedChanges} = this.props;
 
         return (
-            <React.Fragment>
-                <PanelContent markupV2={markupV2}>
-                    <ToggleBox variant="simple" title={gettext('Destination')} initiallyOpen>
-                        <DestinationSelect
-                            value={this.state.selectedDestination}
-                            onChange={(value) => {
-                                this.setState({
-                                    selectedDestination: value,
-                                });
-                            }}
-                            includePersonalSpace={false}
-                        />
-                    </ToggleBox>
-                </PanelContent>
-
-                <PanelFooter markupV2={markupV2}>
-                    <ButtonGroup orientation="vertical">
-                        {
-                            this.props.items.length === 1 && (
-                                <Button
-                                    text={gettext('Fetch and open')}
-                                    onClick={() => {
-                                        this.fetchItems(true);
-                                    }}
-                                    size="large"
-                                    type="primary"
-                                    style="hollow"
-                                    expand
-                                    data-test-id="fetch-and-open"
-                                    disabled={!canFetch}
-                                />
-                            )
-                        }
-
-                        <Button
-                            text={gettext('Fetch')}
-                            onClick={() => {
-                                this.fetchItems();
-                            }}
-                            size="large"
-                            type="primary"
-                            expand
-                            data-test-id="fetch"
-                            disabled={!canFetch}
-                        />
-                    </ButtonGroup>
-                </PanelFooter>
-            </React.Fragment>
+            <FetchToAction
+                items={items}
+                closeFetchToView={closeFetchToView}
+                handleUnsavedChanges={handleUnsavedChanges}
+            >
+                {({body, footer}) => (
+                    <>
+                        <PanelContent markupV2={markupV2}>
+                            {body}
+                        </PanelContent>
+                        <PanelFooter markupV2={markupV2}>
+                            {footer}
+                        </PanelFooter>
+                    </>
+                )}
+            </FetchToAction>
         );
     }
 }

--- a/scripts/core/interactive-article-actions-panel/actions/publish-action.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/publish-action.tsx
@@ -1,0 +1,324 @@
+import React, {CSSProperties} from 'react';
+import {IArticle, IRestApiResponse} from 'superdesk-api';
+import {Button, ButtonGroup, ToggleBox} from 'superdesk-ui-framework/react';
+import {gettext} from 'core/utils';
+import {DestinationSelect} from '../subcomponents/destination-select';
+import {IPanelError, ISendToDestination} from '../interfaces';
+import {getCurrentDeskDestination} from '../utils/get-initial-destination';
+import {
+    IPublishingDateOptions,
+    getInitialPublishingDateOptions,
+    PublishingDateOptions,
+    getPublishingDatePatch,
+} from '../subcomponents/publishing-date-options';
+import ng from 'core/services/ng';
+import {confirmPublish} from 'apps/authoring/authoring/services/quick-publish-modal';
+import {cloneDeep} from 'lodash';
+import {
+    PublishingTargetSelect,
+    IPublishingTarget,
+    getPublishingTargetPatch,
+} from '../subcomponents/publishing-target-select';
+import {appConfig, extensions} from 'appConfig';
+import {httpRequestJsonLocal} from 'core/helpers/network';
+import {ISubscriber} from 'superdesk-interfaces/Subscriber';
+import {showModal} from '@sourcefabric/common';
+import {PreviewModal} from 'apps/publish-preview/previewModal';
+import {notify} from 'core/notify/notify';
+import {sdApi} from 'api';
+
+export interface IPublishConfig {
+    item: IArticle;
+    closePublishView(): void;
+    handleUnsavedChanges(): Promise<IArticle>;
+    onError: (error: IPanelError) => void;
+    onDataChange: (item: IArticle) => void;
+}
+
+interface IState {
+    selectedDestination: ISendToDestination;
+    publishingDateOptions: IPublishingDateOptions;
+    publishingTarget: IPublishingTarget;
+    subscribers: Array<ISubscriber> | null;
+}
+
+interface IRenderArgs {
+    body: JSX.Element;
+    footer: JSX.Element;
+    columnCount: number;
+    loading: boolean;
+}
+
+interface IProps extends IPublishConfig {
+    children(args: IRenderArgs): JSX.Element;
+}
+
+/**
+ * Publish action - provides body and footer as render props.
+ * This allows the parent to compose them into either the standalone panel or widget layout.
+ */
+export class PublishAction extends React.PureComponent<IProps, IState> {
+    constructor(props: IProps) {
+        super(props);
+
+        this.state = {
+            ...getInitialPublishingDateOptions([this.props.item]),
+            selectedDestination: getCurrentDeskDestination(this.props.item.task.desk),
+            publishingDateOptions: getInitialPublishingDateOptions([props.item]),
+            publishingTarget: {
+                target_subscribers: this.props.item.target_subscribers ?? [],
+                target_regions: this.props.item.target_regions ?? [],
+                target_types: this.props.item.target_regions ?? [],
+            },
+            subscribers: null,
+        };
+
+        this.doPublish = this.doPublish.bind(this);
+        this.doPreview = this.doPreview.bind(this);
+        this.otherDeskSelected = this.otherDeskSelected.bind(this);
+    }
+
+    otherDeskSelected(): boolean {
+        return this.state.selectedDestination.type === 'desk'
+            && this.state.selectedDestination.desk !== this.props.item.task?.desk;
+    }
+
+    doPublish(applyDestination?: boolean): void {
+        this.props.handleUnsavedChanges()
+            .then((item) => {
+                const emptyPatches: Array<Partial<IArticle>> = [{}];
+
+                const afterSending =
+                    applyDestination === true
+                    && this.state.selectedDestination.type === 'desk'
+                    && this.otherDeskSelected()
+                        ? sdApi.article.sendItems([item], this.state.selectedDestination)
+                        : Promise.resolve(emptyPatches);
+
+                afterSending.then(([patchAfterSending]) => {
+                    let itemToPublish: IArticle = {
+                        ...item,
+                        ...patchAfterSending,
+                        ...getPublishingDatePatch(item, this.state.publishingDateOptions),
+                        ...getPublishingTargetPatch(item, this.state.publishingTarget),
+                    };
+
+                    const confirmed = appConfig?.features?.confirmDueDate === true
+                        ? confirmPublish([itemToPublish])
+                        : Promise.resolve();
+
+                    confirmed.then(() => {
+                        // Cloning to prevent objects from being modified by angular
+                        sdApi.article.publishItem(
+                            cloneDeep(item),
+                            cloneDeep(itemToPublish),
+                            'publish',
+                            this.props.onError,
+                        )
+                            .then(() => {
+                                ng.get('authoringWorkspace').close();
+                                ng.get('$rootScope').$applyAsync(); // required for authoring close to take effect
+                                notify.success('Item published.');
+                            });
+                    });
+                });
+            })
+            .catch(() => {
+                // cancelled by user
+            });
+    }
+
+    doPreview() {
+        this.props.handleUnsavedChanges().then(() => {
+            showModal(({closeModal}) => (
+                <PreviewModal
+                    itemId={this.props.item._id}
+                    subscribers={this.state.subscribers}
+                    closeModal={closeModal}
+                />
+            ));
+        });
+    }
+
+    componentDidMount() {
+        httpRequestJsonLocal({
+            method: 'GET',
+            path: '/subscribers',
+        }).then((res: IRestApiResponse<ISubscriber>) => {
+            this.setState({subscribers: res._items});
+        });
+    }
+
+    render() {
+        if (this.state.subscribers == null) { // loading
+            return this.props.children({body: null, footer: null, columnCount: 1, loading: true});
+        }
+
+        const otherDeskSelected = this.otherDeskSelected();
+        const canPreview: boolean = this.state.subscribers.some(({destinations}) =>
+            (destinations ?? []).some(({preview_endpoint_url}) => (preview_endpoint_url ?? '').length > 0),
+        );
+        const publishFromEnabled = (appConfig.ui.sendAndPublish ?? true) === true;
+
+        const sectionsFromExtensions = Object.values(extensions)
+            .flatMap(({activationResult}) => activationResult?.contributions?.publishingSections ?? []);
+
+        const style: CSSProperties | undefined = sectionsFromExtensions.length > 0
+            ? {display: 'flex', alignItems: 'start', justifyContent: 'space-between', gap: 32, height: '100%'}
+            : undefined;
+
+        const childrenStyle: CSSProperties = {
+            flex: 1, // equal width for columns
+            position: 'relative',
+            height: '100%',
+        };
+
+        const body = (
+            <div style={style} data-test-id="publishing-section">
+                <div style={childrenStyle}>
+                    {
+                        publishFromEnabled && (
+                            <ToggleBox variant="simple" title={gettext('From')} initiallyOpen>
+                                <DestinationSelect
+                                    value={this.state.selectedDestination}
+                                    onChange={(value) => {
+                                        this.setState({
+                                            selectedDestination: value,
+                                        });
+
+                                        /**
+                                         * do not persist destination
+                                         * article desk isn't supposed to be changed,
+                                         * except when user chooses "publish from" option
+                                         * that sends to another desk and publishes at the same time.
+                                         * If operation is cancelled, "publish from" value must not be saved
+                                         */
+                                    }}
+                                    includePersonalSpace={false}
+
+                                    /**
+                                     * Changing the destination is only used
+                                     * to control which desk's output stage
+                                     * the published item appears in, thus
+                                     * choosing a stage would not have an impact
+                                     */
+                                    hideStages={true}
+
+                                    availableDesks={sdApi.desks.getAllDesks()
+                                        .filter((desk) => sdApi.article.canPublishOnDesk(desk.desk_type))
+                                        .toOrderedMap()
+                                    }
+                                />
+                            </ToggleBox>
+                        )
+                    }
+
+                    <PublishingDateOptions
+                        items={[this.props.item]}
+                        value={this.state.publishingDateOptions}
+                        onChange={(val) => {
+                            this.setState(
+                                {publishingDateOptions: val},
+                                () => {
+                                    this.props.onDataChange?.({
+                                        ...this.props.item,
+                                        ...getPublishingDatePatch(
+                                            this.props.item,
+                                            this.state.publishingDateOptions,
+                                        ),
+                                    });
+                                },
+                            );
+                        }}
+                        allowSettingEmbargo={appConfig.ui.publishEmbargo}
+                        allowSettingPublishSchedule={
+                            appConfig.authoring.panels.publish.publishSchedule
+                        }
+                    />
+
+                    {appConfig.authoring.panels.publish.publishingTarget && (
+                        <PublishingTargetSelect
+                            value={this.state.publishingTarget}
+                            onChange={(val) => {
+                                this.setState(
+                                    {publishingTarget: val},
+                                    () => {
+                                        this.props.onDataChange?.({
+                                            ...this.props.item,
+                                            ...getPublishingTargetPatch(
+                                                this.props.item,
+                                                this.state.publishingTarget,
+                                            ),
+                                        });
+                                    },
+                                );
+                            }}
+                        />
+                    )}
+                </div>
+
+                {
+                    sectionsFromExtensions.map((panel, i) => {
+                        const Component = panel.component;
+
+                        return (
+                            <div style={childrenStyle} key={i}>
+                                <Component item={this.props.item} />
+                            </div>
+                        );
+                    })
+                }
+            </div>
+        );
+
+        const footer = (
+            <ButtonGroup align='center' spaces='loose'>
+                {canPreview && (
+                    <Button
+                        text={gettext('Preview')}
+                        onClick={() => {
+                            this.doPreview();
+                        }}
+                        size="large"
+                        expand
+                        style="hollow"
+                    />
+                )}
+
+                {publishFromEnabled && (
+                    <Button
+                        text={gettext('Publish from')}
+                        onClick={() => {
+                            this.doPublish(true);
+                        }}
+                        disabled={!otherDeskSelected}
+                        size="large"
+                        type="primary"
+                        expand
+                        style="hollow"
+                        data-test-id="publish-from"
+                    />
+                )}
+
+                <Button
+                    text={gettext('Publish')}
+                    onClick={() => {
+                        this.doPublish();
+                    }}
+                    disabled={otherDeskSelected}
+                    size="large"
+                    type="highlight"
+                    expand
+                    data-test-id="publish"
+                />
+            </ButtonGroup>
+        );
+
+        return this.props.children({
+            body,
+            footer,
+            columnCount: 1 + sectionsFromExtensions.length,
+            loading: false,
+        });
+    }
+}

--- a/scripts/core/interactive-article-actions-panel/actions/publish-action.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/publish-action.tsx
@@ -68,7 +68,7 @@ export class PublishAction extends React.PureComponent<IProps, IState> {
             publishingTarget: {
                 target_subscribers: this.props.item.target_subscribers ?? [],
                 target_regions: this.props.item.target_regions ?? [],
-                target_types: this.props.item.target_regions ?? [],
+                target_types: this.props.item.target_types ?? [],
             },
             subscribers: null,
         };

--- a/scripts/core/interactive-article-actions-panel/actions/publish-action.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/publish-action.tsx
@@ -272,7 +272,7 @@ export class PublishAction extends React.PureComponent<IProps, IState> {
         );
 
         const footer = (
-            <ButtonGroup align='center' spaces='loose'>
+            <ButtonGroup align="center" spaces="loose">
                 {canPreview && (
                     <Button
                         text={gettext('Preview')}

--- a/scripts/core/interactive-article-actions-panel/actions/publish-tab.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/publish-tab.tsx
@@ -1,33 +1,9 @@
-import React, {CSSProperties} from 'react';
-import {IArticle, IRestApiResponse} from 'superdesk-api';
-import {Button, ToggleBox} from 'superdesk-ui-framework/react';
-import {gettext} from 'core/utils';
+import React from 'react';
+import {IArticle} from 'superdesk-api';
 import {PanelContent} from '../panel/panel-content';
 import {PanelFooter} from '../panel/panel-footer';
-import {DestinationSelect} from '../subcomponents/destination-select';
-import {IPanelError, IPropsHocInteractivePanelTab, ISendToDestination} from '../interfaces';
-import {getCurrentDeskDestination} from '../utils/get-initial-destination';
-import {
-    IPublishingDateOptions,
-    getInitialPublishingDateOptions,
-    PublishingDateOptions,
-    getPublishingDatePatch,
-} from '../subcomponents/publishing-date-options';
-import ng from 'core/services/ng';
-import {confirmPublish} from 'apps/authoring/authoring/services/quick-publish-modal';
-import {cloneDeep} from 'lodash';
-import {
-    PublishingTargetSelect,
-    IPublishingTarget,
-    getPublishingTargetPatch,
-} from '../subcomponents/publishing-target-select';
-import {appConfig, extensions} from 'appConfig';
-import {httpRequestJsonLocal} from 'core/helpers/network';
-import {ISubscriber} from 'superdesk-interfaces/Subscriber';
-import {showModal} from '@sourcefabric/common';
-import {PreviewModal} from 'apps/publish-preview/previewModal';
-import {notify} from 'core/notify/notify';
-import {sdApi} from 'api';
+import {IPanelError, IPropsHocInteractivePanelTab} from '../interfaces';
+import {PublishAction} from './publish-action';
 
 interface IProps extends IPropsHocInteractivePanelTab {
     item: IArticle;
@@ -38,279 +14,43 @@ interface IProps extends IPropsHocInteractivePanelTab {
     onDataChange: (item: IArticle) => void;
 }
 
-interface IState {
-    selectedDestination: ISendToDestination;
-    publishingDateOptions: IPublishingDateOptions;
-    publishingTarget: IPublishingTarget;
-    subscribers: Array<ISubscriber> | null;
-}
-
-export class WithPublishTab extends React.PureComponent<IProps, IState> {
-    constructor(props: IProps) {
-        super(props);
-
-        this.state = {
-            ...getInitialPublishingDateOptions([this.props.item]),
-            selectedDestination: getCurrentDeskDestination(this.props.item.task.desk),
-            publishingDateOptions: getInitialPublishingDateOptions([props.item]),
-            publishingTarget: {
-                target_subscribers: this.props.item.target_subscribers ?? [],
-                target_regions: this.props.item.target_regions ?? [],
-                target_types: this.props.item.target_regions ?? [],
-            },
-            subscribers: null,
-        };
-
-        this.doPublish = this.doPublish.bind(this);
-        this.doPreview = this.doPreview.bind(this);
-        this.otherDeskSelected = this.otherDeskSelected.bind(this);
-    }
-
-    otherDeskSelected(): boolean {
-        return this.state.selectedDestination.type === 'desk'
-            && this.state.selectedDestination.desk !== this.props.item.task?.desk;
-    }
-
-    doPublish(applyDestination?: boolean): void {
-        this.props.handleUnsavedChanges()
-            .then((item) => {
-                const emptyPatches: Array<Partial<IArticle>> = [{}];
-
-                const afterSending =
-                    applyDestination === true
-                    && this.state.selectedDestination.type === 'desk'
-                    && this.otherDeskSelected()
-                        ? sdApi.article.sendItems([item], this.state.selectedDestination)
-                        : Promise.resolve(emptyPatches);
-
-                afterSending.then(([patchAfterSending]) => {
-                    let itemToPublish: IArticle = {
-                        ...item,
-                        ...patchAfterSending,
-                        ...getPublishingDatePatch(item, this.state.publishingDateOptions),
-                        ...getPublishingTargetPatch(item, this.state.publishingTarget),
-                    };
-
-                    const confirmed = appConfig?.features?.confirmDueDate === true
-                        ? confirmPublish([itemToPublish])
-                        : Promise.resolve();
-
-                    confirmed.then(() => {
-                        // Cloning to prevent objects from being modified by angular
-                        sdApi.article.publishItem(
-                            cloneDeep(item),
-                            cloneDeep(itemToPublish),
-                            'publish',
-                            this.props.onError,
-                        )
-                            .then(() => {
-                                ng.get('authoringWorkspace').close();
-                                ng.get('$rootScope').$applyAsync(); // required for authoring close to take effect
-                                notify.success('Item published.');
-                            });
-                    });
-                });
-            })
-            .catch(() => {
-                // cancelled by user
-            });
-    }
-
-    doPreview() {
-        this.props.handleUnsavedChanges().then(() => {
-            showModal(({closeModal}) => (
-                <PreviewModal
-                    itemId={this.props.item._id}
-                    subscribers={this.state.subscribers}
-                    closeModal={closeModal}
-                />
-            ));
-        });
-    }
-
-    componentDidMount() {
-        httpRequestJsonLocal({
-            method: 'GET',
-            path: '/subscribers',
-        }).then((res: IRestApiResponse<ISubscriber>) => {
-            this.setState({subscribers: res._items});
-        });
-    }
-
+/**
+ * Publish Tab - composes the PublishAction into the panel layout.
+ * This is a wrapper component that uses the render props pattern to provide
+ * columnCount and content to the parent panel.
+ */
+export class WithPublishTab extends React.PureComponent<IProps> {
     render() {
-        if (this.state.subscribers == null) { // loading
-            return null;
-        }
+        const {item, markupV2, closePublishView, handleUnsavedChanges, onError, onDataChange} = this.props;
 
-        const {markupV2} = this.props;
-        const otherDeskSelected = this.otherDeskSelected();
-        const canPreview: boolean = this.state.subscribers.some(({destinations}) =>
-            (destinations ?? []).some(({preview_endpoint_url}) => (preview_endpoint_url ?? '').length > 0),
+        return (
+            <PublishAction
+                item={item}
+                closePublishView={closePublishView}
+                handleUnsavedChanges={handleUnsavedChanges}
+                onError={onError}
+                onDataChange={onDataChange}
+            >
+                {({body, footer, columnCount, loading}) => {
+                    if (loading) {
+                        return this.props.children({columnCount: 1, content: null});
+                    }
+
+                    return this.props.children({
+                        columnCount,
+                        content: (
+                            <>
+                                <PanelContent markupV2={markupV2}>
+                                    {body}
+                                </PanelContent>
+                                <PanelFooter markupV2={markupV2}>
+                                    {footer}
+                                </PanelFooter>
+                            </>
+                        ),
+                    });
+                }}
+            </PublishAction>
         );
-        const publishFromEnabled = (appConfig.ui.sendAndPublish ?? true) === true;
-
-        const sectionsFromExtensions = Object.values(extensions)
-            .flatMap(({activationResult}) => activationResult?.contributions?.publishingSections ?? []);
-
-        const style: CSSProperties | undefined = sectionsFromExtensions.length > 0
-            ? {display: 'flex', alignItems: 'start', justifyContent: 'space-between', gap: 32, height: '100%'}
-            : undefined;
-
-        const childrenStyle: CSSProperties = {
-            flex: 1, // equal width for columns
-            position: 'relative',
-            height: '100%',
-        };
-
-        return this.props.children({
-            columnCount: 1 + sectionsFromExtensions.length,
-            content: (
-                <React.Fragment>
-                    <PanelContent markupV2={markupV2} data-test-id="publishing-section">
-                        <div style={style}>
-                            <div style={childrenStyle}>
-                                {
-                                    publishFromEnabled && (
-                                        <ToggleBox variant="simple" title={gettext('From')} initiallyOpen>
-                                            <DestinationSelect
-                                                value={this.state.selectedDestination}
-                                                onChange={(value) => {
-                                                    this.setState({
-                                                        selectedDestination: value,
-                                                    });
-
-                                                    /**
-                                                     * do not persist destination
-                                                     * article desk isn't supposed to be changed,
-                                                     * except when user chooses "publish from" option
-                                                     * that sends to another desk and publishes at the same time.
-                                                     * If operation is cancelled, "publish from" value must not be saved
-                                                     */
-                                                }}
-                                                includePersonalSpace={false}
-
-                                                /**
-                                                 * Changing the destination is only used
-                                                 * to control which desk's output stage
-                                                 * the published item appears in, thus
-                                                 * choosing a stage would not have an impact
-                                                 */
-                                                hideStages={true}
-
-                                                availableDesks={sdApi.desks.getAllDesks()
-                                                    .filter((desk) => sdApi.article.canPublishOnDesk(desk.desk_type))
-                                                    .toOrderedMap()
-                                                }
-                                            />
-                                        </ToggleBox>
-                                    )
-                                }
-
-                                <PublishingDateOptions
-                                    items={[this.props.item]}
-                                    value={this.state.publishingDateOptions}
-                                    onChange={(val) => {
-                                        this.setState(
-                                            {publishingDateOptions: val},
-                                            () => {
-                                                this.props.onDataChange?.({
-                                                    ...this.props.item,
-                                                    ...getPublishingDatePatch(
-                                                        this.props.item,
-                                                        this.state.publishingDateOptions,
-                                                    ),
-                                                });
-                                            },
-                                        );
-                                    }}
-                                    allowSettingEmbargo={appConfig.ui.publishEmbargo}
-                                    allowSettingPublishSchedule={
-                                        appConfig.authoring.panels.publish.publishSchedule
-                                    }
-                                />
-
-                                {appConfig.authoring.panels.publish.publishingTarget && (
-                                    <PublishingTargetSelect
-                                        value={this.state.publishingTarget}
-                                        onChange={(val) => {
-                                            this.setState(
-                                                {publishingTarget: val},
-                                                () => {
-                                                    this.props.onDataChange?.({
-                                                        ...this.props.item,
-                                                        ...getPublishingTargetPatch(
-                                                            this.props.item,
-                                                            this.state.publishingTarget,
-                                                        ),
-                                                    });
-                                                },
-                                            );
-                                        }}
-                                    />
-                                )}
-                            </div>
-
-                            {
-                                sectionsFromExtensions.map((panel, i) => {
-                                    const Component = panel.component;
-
-                                    return (
-                                        <div style={childrenStyle} key={i}>
-                                            <Component item={this.props.item} />
-                                        </div>
-                                    );
-                                })
-                            }
-
-                        </div>
-                    </PanelContent>
-
-                    <PanelFooter markupV2={markupV2}>
-                        {
-                            canPreview && (
-                                <Button
-                                    text={gettext('Preview')}
-                                    onClick={() => {
-                                        this.doPreview();
-                                    }}
-                                    size="large"
-                                    expand
-                                    style="hollow"
-                                />
-                            )
-                        }
-
-                        {
-                            publishFromEnabled && (
-                                <Button
-                                    text={gettext('Publish from')}
-                                    onClick={() => {
-                                        this.doPublish(true);
-                                    }}
-                                    disabled={!otherDeskSelected}
-                                    size="large"
-                                    type="primary"
-                                    expand
-                                    style="hollow"
-                                    data-test-id="publish-from"
-                                />
-                            )
-                        }
-
-                        <Button
-                            text={gettext('Publish')}
-                            onClick={() => {
-                                this.doPublish();
-                            }}
-                            disabled={otherDeskSelected}
-                            size="large"
-                            type="highlight"
-                            expand
-                            data-test-id="publish"
-                        />
-                    </PanelFooter>
-                </React.Fragment>
-            ),
-        });
     }
 }

--- a/scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import {IArticle} from 'superdesk-api';
+import {Button, DateTimePicker, ToggleBox} from 'superdesk-ui-framework/react';
+import {gettext, toIsoStringWithoutTimezoneOffset} from 'core/utils';
+import ng from 'core/services/ng';
+import {cloneDeep} from 'lodash';
+import {notify} from 'core/notify/notify';
+import {appConfig} from 'appConfig';
+import {getLocaleForDatePicker} from 'core/helpers/ui-framework';
+import {isValid} from 'date-fns';
+import {TimeZonePicker} from 'core/ui/components/time-zone-picker';
+import {TZDate} from '@sourcefabric/date-fns-tz';
+import {ignoreTimezone} from '../subcomponents/publishing-date-options';
+
+export interface ISendCorrectionConfig {
+    item: IArticle;
+    closePublishView(): void;
+    handleUnsavedChanges(): Promise<IArticle>;
+    onDataChange(changes: IArticle): void;
+}
+
+interface IState {
+    embargo: Date | null;
+    timeZone: string | null;
+}
+
+interface IRenderArgs {
+    body: JSX.Element;
+    footer: JSX.Element;
+}
+
+interface IProps extends ISendCorrectionConfig {
+    children(args: IRenderArgs): JSX.Element;
+}
+
+/**
+ * Send Correction action - provides body and footer as render props.
+ * This allows the parent to compose them into either the standalone panel or widget layout.
+ */
+export class SendCorrectionAction extends React.Component<IProps, IState> {
+    constructor(props: IProps) {
+        super(props);
+
+        this.state = {
+            embargo: props.item.embargo != null ? ignoreTimezone(props.item.embargo) : null,
+            timeZone: props.item.schedule_settings?.time_zone ?? null,
+        };
+
+        this.doSendCorrection = this.doSendCorrection.bind(this);
+    }
+
+    doSendCorrection(): void {
+        this.props.handleUnsavedChanges()
+            .then((item) => {
+                // Cloning to prevent objects from being modified by angular
+                ng.get('authoring').publish(
+                    cloneDeep(item),
+                    cloneDeep(item),
+                    'correct',
+                ).then(() => {
+                    ng.get('authoringWorkspace').close();
+                    notify.success('Correction sent');
+                });
+            })
+            .catch(() => {
+                // cancelled by user
+            });
+    }
+
+    render() {
+        const {embargo, timeZone} = this.state;
+
+        const body = (
+            <React.Fragment>
+                <ToggleBox variant="simple" title={gettext('Embargo')} initiallyOpen>
+                    <DateTimePicker
+                        value={embargo}
+                        valueType="date"
+                        locale={{
+                            type: 'full',
+                            payload: getLocaleForDatePicker(),
+                        }}
+                        dateFormat={appConfig.view.dateformat}
+                        onChange={(val) => {
+                            const isValidDate = isValid(val);
+                            const isDateBeingReset = val === null;
+
+                            if (isValidDate || isDateBeingReset) {
+                                this.setState(
+                                    {
+                                        embargo: val,
+                                        timeZone: timeZone ?? appConfig.default_timezone,
+                                    },
+                                    () => {
+                                        this.props.onDataChange({
+                                            ...this.props.item,
+                                            embargo: val == null
+                                                ? null
+                                                : toIsoStringWithoutTimezoneOffset(new TZDate(val)),
+                                            schedule_settings: {
+                                                ...this.props.item.schedule_settings,
+                                                time_zone: this.state.timeZone,
+                                            },
+                                        });
+                                    },
+                                );
+                            }
+                        }}
+                    />
+                </ToggleBox>
+
+                {embargo != null && (
+                    <ToggleBox variant="simple" title={gettext('Time zone')} initiallyOpen>
+                        <TimeZonePicker
+                            value={timeZone}
+                            onChange={(val) => {
+                                this.setState(
+                                    {timeZone: val},
+                                    () => {
+                                        this.props.onDataChange({
+                                            ...this.props.item,
+                                            schedule_settings: {
+                                                ...this.props.item.schedule_settings,
+                                                time_zone: val,
+                                            },
+                                        });
+                                    },
+                                );
+                            }}
+                        />
+
+                        {timeZone == null && (
+                            <div style={{paddingBlockStart: 5}}>
+                                {gettext('If not set, the UTC+0 time zone is assumed.')}
+                            </div>
+                        )}
+                    </ToggleBox>
+                )}
+            </React.Fragment>
+        );
+
+        const footer = (
+            <Button
+                text={gettext('Send correction')}
+                onClick={() => {
+                    this.doSendCorrection();
+                }}
+                size="large"
+                type="highlight"
+                expand
+            />
+        );
+
+        return this.props.children({body, footer});
+    }
+}

--- a/scripts/core/interactive-article-actions-panel/actions/send-correction-tab.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/send-correction-tab.tsx
@@ -1,18 +1,8 @@
 import React from 'react';
 import {IArticle} from 'superdesk-api';
-import {Button, DateTimePicker, ToggleBox} from 'superdesk-ui-framework/react';
-import {gettext, toIsoStringWithoutTimezoneOffset} from 'core/utils';
 import {PanelContent} from '../panel/panel-content';
 import {PanelFooter} from '../panel/panel-footer';
-import ng from 'core/services/ng';
-import {cloneDeep} from 'lodash';
-import {notify} from 'core/notify/notify';
-import {appConfig} from 'appConfig';
-import {getLocaleForDatePicker} from 'core/helpers/ui-framework';
-import {isValid} from 'date-fns';
-import {TimeZonePicker} from 'core/ui/components/time-zone-picker';
-import {TZDate} from '@sourcefabric/date-fns-tz';
-import {ignoreTimezone} from '../subcomponents/publishing-date-options';
+import {SendCorrectionAction} from './send-correction-action';
 
 interface IProps {
     item: IArticle;
@@ -22,126 +12,31 @@ interface IProps {
     onDataChange(changes: IArticle): void;
 }
 
-interface IState {
-    embargo: Date | null;
-    timeZone: string | null;
-}
-
-export class SendCorrectionTab extends React.Component<IProps, IState> {
-    constructor(props: IProps) {
-        super(props);
-
-        this.state = {
-            embargo: props.item.embargo != null ? ignoreTimezone(props.item.embargo) : null,
-            timeZone: props.item.schedule_settings?.time_zone ?? null,
-        };
-
-        this.doSendCorrection = this.doSendCorrection.bind(this);
-    }
-
-    doSendCorrection(): void {
-        this.props.handleUnsavedChanges()
-            .then((item) => {
-                // Cloning to prevent objects from being modified by angular
-                ng.get('authoring').publish(
-                    cloneDeep(item),
-                    cloneDeep(item),
-                    'correct',
-                ).then(() => {
-                    ng.get('authoringWorkspace').close();
-                    notify.success('Correction sent');
-                });
-            })
-            .catch(() => {
-                // cancelled by user
-            });
-    }
-
+/**
+ * Send Correction Tab - composes the SendCorrectionAction into the panel layout.
+ */
+export class SendCorrectionTab extends React.Component<IProps> {
     render() {
-        const {markupV2} = this.props;
-        const {embargo, timeZone} = this.state;
+        const {item, markupV2, closePublishView, handleUnsavedChanges, onDataChange} = this.props;
 
         return (
-            <React.Fragment>
-                <PanelContent markupV2={markupV2}>
-                    <ToggleBox variant="simple" title={gettext('Embargo')} initiallyOpen>
-                        <DateTimePicker
-                            value={embargo}
-                            valueType="date"
-                            locale={{
-                                type: 'full',
-                                payload: getLocaleForDatePicker(),
-                            }}
-                            dateFormat={appConfig.view.dateformat}
-                            onChange={(val) => {
-                                const isValidDate = isValid(val);
-                                const isDateBeingReset = val === null;
-
-                                if (isValidDate || isDateBeingReset) {
-                                    this.setState(
-                                        {
-                                            embargo: val,
-                                            timeZone: timeZone ?? appConfig.default_timezone,
-                                        },
-                                        () => {
-                                            this.props.onDataChange({
-                                                ...this.props.item,
-                                                embargo: val == null
-                                                    ? null
-                                                    : toIsoStringWithoutTimezoneOffset(new TZDate(val)),
-                                                schedule_settings: {
-                                                    ...this.props.item.schedule_settings,
-                                                    time_zone: this.state.timeZone,
-                                                },
-                                            });
-                                        },
-                                    );
-                                }
-                            }}
-                        />
-                    </ToggleBox>
-
-                    {embargo != null && (
-                        <ToggleBox variant="simple" title={gettext('Time zone')} initiallyOpen>
-                            <TimeZonePicker
-                                value={timeZone}
-                                onChange={(val) => {
-                                    this.setState(
-                                        {timeZone: val},
-                                        () => {
-                                            this.props.onDataChange({
-                                                ...this.props.item,
-                                                schedule_settings: {
-                                                    ...this.props.item.schedule_settings,
-                                                    time_zone: val,
-                                                },
-                                            });
-                                        },
-                                    );
-                                }}
-                            />
-
-                            {timeZone == null && (
-                                <div style={{paddingBlockStart: 5}}>
-                                    {gettext('If not set, the UTC+0 time zone is assumed.')}
-                                </div>
-                            )}
-                        </ToggleBox>
-                    )}
-                </PanelContent>
-
-                <PanelFooter markupV2={markupV2}>
-                    <Button
-                        text={gettext('Send correction')}
-                        onClick={() => {
-                            this.doSendCorrection();
-                        }}
-                        size="large"
-                        type="highlight"
-                        expand
-                    />
-                </PanelFooter>
-            </React.Fragment>
+            <SendCorrectionAction
+                item={item}
+                closePublishView={closePublishView}
+                handleUnsavedChanges={handleUnsavedChanges}
+                onDataChange={onDataChange}
+            >
+                {({body, footer}) => (
+                    <>
+                        <PanelContent markupV2={markupV2}>
+                            {body}
+                        </PanelContent>
+                        <PanelFooter markupV2={markupV2}>
+                            {footer}
+                        </PanelFooter>
+                    </>
+                )}
+            </SendCorrectionAction>
         );
     }
 }

--- a/scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import {IArticle, IDesk, OrderedMap} from 'superdesk-api';
+import {Button, ButtonGroup, Text, ToggleBox} from 'superdesk-ui-framework/react';
+import {gettext, gettextPlural} from 'core/utils';
+import {applicationState, openArticle} from 'core/get-superdesk-api-implementation';
+import {appConfig} from 'appConfig';
+import {sdApi} from 'api';
+import {getInitialDestination} from '../utils/get-initial-destination';
+import {canSendToPersonal} from '../utils/can-send-to-personal';
+import {DestinationSelect} from '../subcomponents/destination-select';
+import {ISendToDestination} from '../interfaces';
+import {
+    IPublishingDateOptions,
+    getInitialPublishingDateOptions,
+    PublishingDateOptions,
+} from '../subcomponents/publishing-date-options';
+import {authoringApiCommon} from 'apps/authoring-bridge/authoring-api-common';
+
+export interface ISendToConfig {
+    items: Array<IArticle>;
+    closeSendToView(): void;
+    handleUnsavedChanges(items: Array<IArticle>): Promise<Array<IArticle>>;
+}
+
+interface IState {
+    selectedDestination: ISendToDestination;
+    publishingDateOptions: IPublishingDateOptions;
+}
+
+interface IRenderArgs {
+    body: JSX.Element;
+    footer: JSX.Element;
+    noDestinationsAvailable: boolean;
+}
+
+interface IProps extends ISendToConfig {
+    children(args: IRenderArgs): JSX.Element;
+}
+
+/**
+ * Send To action - provides body and footer as render props.
+ * This allows the parent to compose them into either the standalone panel or widget layout.
+ */
+export class SendToAction extends React.PureComponent<IProps, IState> {
+    private availableDesks: OrderedMap<string, IDesk>;
+
+    constructor(props: IProps) {
+        super(props);
+
+        this.availableDesks = sdApi.desks.getAllDesks()
+            .filter((desk) => desk.send_to_desk_not_allowed !== true)
+            .toOrderedMap();
+
+        this.state = {
+            selectedDestination: getInitialDestination(
+                props.items,
+                canSendToPersonal(props.items),
+                this.availableDesks,
+            ),
+            publishingDateOptions: getInitialPublishingDateOptions(props.items),
+        };
+
+        this.sendItems = this.sendItems.bind(this);
+    }
+
+    sendItems(itemToOpenAfterSending?: IArticle['_id'], sendPackageItems?: boolean) {
+        const {selectedDestination} = this.state;
+        const {closeSendToView, handleUnsavedChanges} = this.props;
+
+        return handleUnsavedChanges(this.props.items)
+            .then((items) => {
+                sdApi.article.sendItems(
+                    items,
+                    selectedDestination,
+                    sendPackageItems,
+                    this.state.publishingDateOptions,
+                ).then(() => {
+                    closeSendToView();
+
+                    if (itemToOpenAfterSending != null) {
+                        openArticle(itemToOpenAfterSending, 'edit');
+                    } else if (items.length === 1 && applicationState.articleInEditMode === items[0]._id) {
+                        authoringApiCommon.closeAuthoringForce();
+                    }
+                }).catch(() => {
+                    /**
+                     * Middleware that rejected the promise is responsible
+                     * for informing the user regarding the reason.
+                     */
+                });
+            }).catch(() => {
+                // sending cancelled by user
+            });
+    }
+
+    render() {
+        const {items} = this.props;
+        const itemToOpenAfterSending: IArticle['_id'] | null = (() => {
+            if (items.length !== 1) {
+                return null;
+            }
+
+            const item = items[0];
+
+            if (item._id !== applicationState.articleInEditMode) {
+                return item._id;
+            } else {
+                return null;
+            }
+        })();
+
+        const sendPackages = this.props.items.every(({type}) => type === 'composite');
+        const dest = this.state.selectedDestination;
+        const noDestinationsAvailable = dest.type === 'desk' && dest.desk == null;
+
+        const body = (
+            <React.Fragment>
+                <ToggleBox variant="simple" title={gettext('Destination')} initiallyOpen>
+                    <DestinationSelect
+                        availableDesks={this.availableDesks}
+                        value={this.state.selectedDestination}
+                        onChange={(value) => {
+                            this.setState({
+                                selectedDestination: value,
+                            });
+                        }}
+                        includePersonalSpace={canSendToPersonal(items)}
+                        disallowedStages={// if only one item is being sent, disallow current stage
+                            items.length === 1 && items[0]?.task?.stage != null
+                                ? [items[0].task.stage]
+                                : undefined
+                        }
+                    />
+                </ToggleBox>
+
+                {
+                    this.props.items.length === 1 && (
+                        <PublishingDateOptions
+                            items={this.props.items}
+                            value={this.state.publishingDateOptions}
+                            onChange={(val) => {
+                                this.setState({publishingDateOptions: val});
+                            }}
+                            allowSettingEmbargo={appConfig.ui.sendEmbargo}
+                            allowSettingPublishSchedule={appConfig.authoring.panels.sendTo.publishSchedule}
+                        />
+                    )
+                }
+            </React.Fragment>
+        );
+
+        const footer = (
+            <ButtonGroup orientation="vertical">
+                {
+                    itemToOpenAfterSending != null && (
+                        <Button
+                            text={gettext('Send and open')}
+                            onClick={() => {
+                                this.sendItems(itemToOpenAfterSending);
+                            }}
+                            size="large"
+                            type="primary"
+                            expand
+                            data-test-id="send-and-open"
+                        />
+                    )
+                }
+
+                <Button
+                    text={gettext('Send')}
+                    onClick={() => {
+                        this.sendItems();
+                    }}
+                    size="large"
+                    type="primary"
+                    expand
+                    data-test-id="send"
+                />
+
+                {
+                    sendPackages && (
+                        <Button
+                            text={gettextPlural(
+                                this.props.items.length,
+                                'Send package and items',
+                                'Send packages and items',
+                            )}
+                            onClick={() => {
+                                this.sendItems(undefined, true);
+                            }}
+                            size="large"
+                            type="primary"
+                            expand
+                        />
+                    )
+                }
+            </ButtonGroup>
+        );
+
+        return this.props.children({body, footer, noDestinationsAvailable});
+    }
+}

--- a/scripts/core/interactive-article-actions-panel/actions/send-to-tab.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/send-to-tab.tsx
@@ -1,22 +1,10 @@
 import React from 'react';
-import {IArticle, IDesk, OrderedMap} from 'superdesk-api';
-import {Button, ButtonGroup, Text, ToggleBox} from 'superdesk-ui-framework/react';
-import {gettext, gettextPlural} from 'core/utils';
+import {IArticle} from 'superdesk-api';
+import {Text} from 'superdesk-ui-framework/react';
+import {gettext} from 'core/utils';
 import {PanelContent} from '../panel/panel-content';
 import {PanelFooter} from '../panel/panel-footer';
-import {applicationState, openArticle} from 'core/get-superdesk-api-implementation';
-import {appConfig} from 'appConfig';
-import {sdApi} from 'api';
-import {getInitialDestination} from '../utils/get-initial-destination';
-import {canSendToPersonal} from '../utils/can-send-to-personal';
-import {DestinationSelect} from '../subcomponents/destination-select';
-import {ISendToDestination} from '../interfaces';
-import {
-    IPublishingDateOptions,
-    getInitialPublishingDateOptions,
-    PublishingDateOptions,
-} from '../subcomponents/publishing-date-options';
-import {authoringApiCommon} from 'apps/authoring-bridge/authoring-api-common';
+import {SendToAction} from './send-to-action';
 
 interface IProps {
     items: Array<IArticle>;
@@ -25,182 +13,48 @@ interface IProps {
     handleUnsavedChanges(items: Array<IArticle>): Promise<Array<IArticle>>;
 }
 
-interface IState {
-    selectedDestination: ISendToDestination;
-    publishingDateOptions: IPublishingDateOptions;
-}
-
-export class SendToTab extends React.PureComponent<IProps, IState> {
-    private availableDesks: OrderedMap<string, IDesk>;
-
-    constructor(props: IProps) {
-        super(props);
-
-        this.availableDesks = sdApi.desks.getAllDesks()
-            .filter((desk) => desk.send_to_desk_not_allowed !== true)
-            .toOrderedMap();
-
-        this.state = {
-            selectedDestination: getInitialDestination(
-                props.items,
-                canSendToPersonal(props.items),
-                this.availableDesks,
-            ),
-            publishingDateOptions: getInitialPublishingDateOptions(props.items),
-        };
-
-        this.sendItems = this.sendItems.bind(this);
-    }
-
-    sendItems(itemToOpenAfterSending?: IArticle['_id'], sendPackageItems?: boolean) {
-        const {selectedDestination} = this.state;
-        const {closeSendToView, handleUnsavedChanges} = this.props;
-
-        return handleUnsavedChanges(this.props.items)
-            .then((items) => {
-                sdApi.article.sendItems(
-                    items,
-                    selectedDestination,
-                    sendPackageItems,
-                    this.state.publishingDateOptions,
-                ).then(() => {
-                    closeSendToView();
-
-                    if (itemToOpenAfterSending != null) {
-                        openArticle(itemToOpenAfterSending, 'edit');
-                    } else if (items.length === 1 && applicationState.articleInEditMode === items[0]._id) {
-                        authoringApiCommon.closeAuthoringForce();
-                    }
-                }).catch(() => {
-                    /**
-                     * Middleware that rejected the promise is responsible
-                     * for informing the user regarding the reason.
-                     */
-                });
-            }).catch(() => {
-                // sending cancelled by user
-            });
-    }
-
+/**
+ * Send To Tab - composes the SendToAction into the panel layout.
+ */
+export class SendToTab extends React.PureComponent<IProps> {
     render() {
-        const {items, markupV2} = this.props;
-        const itemToOpenAfterSending: IArticle['_id'] | null = (() => {
-            if (items.length !== 1) {
-                return null;
-            }
-
-            const item = items[0];
-
-            if (item._id !== applicationState.articleInEditMode) {
-                return item._id;
-            } else {
-                return null;
-            }
-        })();
-
-        const sendPackages = this.props.items.every(({type}) => type === 'composite');
-        const dest = this.state.selectedDestination;
-
-        if (dest.type === 'desk' && dest.desk == null) {
-            return (
-                <div
-                    style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        justifyContent: 'center',
-                    }}
-                >
-                    <Text size="medium" align="center" weight="medium">
-                        {gettext('No destinations are available.')}
-                    </Text>
-                </div>
-            );
-        }
+        const {items, markupV2, closeSendToView, handleUnsavedChanges} = this.props;
 
         return (
-            <React.Fragment>
-                <PanelContent markupV2={markupV2}>
-                    <ToggleBox variant="simple" title={gettext('Destination')} initiallyOpen>
-                        <DestinationSelect
-                            availableDesks={this.availableDesks}
-                            value={this.state.selectedDestination}
-                            onChange={(value) => {
-                                this.setState({
-                                    selectedDestination: value,
-                                });
-                            }}
-                            includePersonalSpace={canSendToPersonal(items)}
-                            disallowedStages={// if only one item is being sent, disallow current stage
-                                items.length === 1 && items[0]?.task?.stage != null
-                                    ? [items[0].task.stage]
-                                    : undefined
-                            }
-                        />
-                    </ToggleBox>
-
-                    {
-                        this.props.items.length === 1 && (
-                            <PublishingDateOptions
-                                items={this.props.items}
-                                value={this.state.publishingDateOptions}
-                                onChange={(val) => {
-                                    this.setState({publishingDateOptions: val});
+            <SendToAction
+                items={items}
+                closeSendToView={closeSendToView}
+                handleUnsavedChanges={handleUnsavedChanges}
+            >
+                {({body, footer, noDestinationsAvailable}) => {
+                    if (noDestinationsAvailable) {
+                        return (
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    flexDirection: 'column',
+                                    justifyContent: 'center',
                                 }}
-                                allowSettingEmbargo={appConfig.ui.sendEmbargo}
-                                allowSettingPublishSchedule={appConfig.authoring.panels.sendTo.publishSchedule}
-                            />
-                        )
+                            >
+                                <Text size="medium" align="center" weight="medium">
+                                    {gettext('No destinations are available.')}
+                                </Text>
+                            </div>
+                        );
                     }
-                </PanelContent>
 
-                <PanelFooter markupV2={markupV2}>
-                    <ButtonGroup orientation="vertical">
-                        {
-                            itemToOpenAfterSending != null && (
-                                <Button
-                                    text={gettext('Send and open')}
-                                    onClick={() => {
-                                        this.sendItems(itemToOpenAfterSending);
-                                    }}
-                                    size="large"
-                                    type="primary"
-                                    expand
-                                    data-test-id="send-and-open"
-                                />
-                            )
-                        }
-
-                        <Button
-                            text={gettext('Send')}
-                            onClick={() => {
-                                this.sendItems();
-                            }}
-                            size="large"
-                            type="primary"
-                            expand
-                            data-test-id="send"
-                        />
-
-                        {
-                            sendPackages && (
-                                <Button
-                                    text={gettextPlural(
-                                        this.props.items.length,
-                                        'Send package and items',
-                                        'Send packages and items',
-                                    )}
-                                    onClick={() => {
-                                        this.sendItems(undefined, true);
-                                    }}
-                                    size="large"
-                                    type="primary"
-                                    expand
-                                />
-                            )
-                        }
-                    </ButtonGroup>
-                </PanelFooter>
-            </React.Fragment>
+                    return (
+                        <>
+                            <PanelContent markupV2={markupV2}>
+                                {body}
+                            </PanelContent>
+                            <PanelFooter markupV2={markupV2}>
+                                {footer}
+                            </PanelFooter>
+                        </>
+                    );
+                }}
+            </SendToAction>
         );
     }
 }

--- a/scripts/core/interactive-article-actions-panel/actions/unspike-action.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/unspike-action.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import {IArticle} from 'superdesk-api';
+import {Button, ToggleBox} from 'superdesk-ui-framework/react';
+import {gettext} from 'core/utils';
+import {getInitialDestination} from '../utils/get-initial-destination';
+import {DestinationSelect} from '../subcomponents/destination-select';
+import {ISendToDestination} from '../interfaces';
+import {sdApi} from 'api';
+
+export interface IUnspikeConfig {
+    items: Array<IArticle>;
+    closeUnspikeView(): void;
+}
+
+interface IState {
+    selectedDestination: ISendToDestination;
+}
+
+interface IRenderArgs {
+    body: JSX.Element;
+    footer: JSX.Element;
+}
+
+interface IProps extends IUnspikeConfig {
+    children(args: IRenderArgs): JSX.Element;
+}
+
+/**
+ * Unspike action - provides body and footer as render props.
+ * This allows the parent to compose them into either the standalone panel or widget layout.
+ */
+export class UnspikeAction extends React.PureComponent<IProps, IState> {
+    constructor(props: IProps) {
+        super(props);
+
+        this.state = {
+            selectedDestination: getInitialDestination(props.items, false),
+        };
+
+        this.doUnspike = this.doUnspike.bind(this);
+    }
+
+    doUnspike() {
+        const {selectedDestination} = this.state;
+
+        if (selectedDestination.type === 'desk') {
+            Promise.all(
+                this.props.items.map((item) => sdApi.article.doUnspike(
+                    item,
+                    selectedDestination.desk,
+                    selectedDestination.stage,
+                )),
+            ).then(() => {
+                this.props.closeUnspikeView();
+            });
+        }
+    }
+
+    render() {
+        const body = (
+            <ToggleBox variant="simple" title={gettext('Destination')} initiallyOpen>
+                <DestinationSelect
+                    value={this.state.selectedDestination}
+                    onChange={(value) => {
+                        this.setState({
+                            selectedDestination: value,
+                        });
+                    }}
+                    includePersonalSpace={false}
+                />
+            </ToggleBox>
+        );
+
+        const footer = (
+            <Button
+                text={gettext('Unspike')}
+                onClick={() => {
+                    this.doUnspike();
+                }}
+                size="large"
+                type="primary"
+                expand
+                data-test-id="unspike"
+            />
+        );
+
+        return this.props.children({body, footer});
+    }
+}

--- a/scripts/core/interactive-article-actions-panel/actions/unspike-tab.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/unspike-tab.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
-import {IArticle, IDesk} from 'superdesk-api';
-import {Button, ToggleBox} from 'superdesk-ui-framework/react';
-import {gettext} from 'core/utils';
+import {IArticle} from 'superdesk-api';
 import {PanelContent} from '../panel/panel-content';
 import {PanelFooter} from '../panel/panel-footer';
-import {getInitialDestination} from '../utils/get-initial-destination';
-import {DestinationSelect} from '../subcomponents/destination-select';
-import {ISendToDestination} from '../interfaces';
-import {sdApi} from 'api';
+import {UnspikeAction} from './unspike-action';
 
 interface IProps {
     items: Array<IArticle>;
@@ -15,69 +10,29 @@ interface IProps {
     markupV2: boolean;
 }
 
-interface IState {
-    selectedDestination: ISendToDestination;
-}
-
-export class UnspikeTab extends React.PureComponent<IProps, IState> {
-    constructor(props: IProps) {
-        super(props);
-
-        this.state = {
-            selectedDestination: getInitialDestination(props.items, false),
-        };
-
-        this.doUnspike = this.doUnspike.bind(this);
-    }
-
-    doUnspike() {
-        const {selectedDestination} = this.state;
-
-        if (selectedDestination.type === 'desk') {
-            Promise.all(
-                this.props.items.map((item) => sdApi.article.doUnspike(
-                    item,
-                    selectedDestination.desk,
-                    selectedDestination.stage,
-                )),
-            ).then(() => {
-                this.props.closeUnspikeView();
-            });
-        }
-    }
-
+/**
+ * Unspike Tab - composes the UnspikeAction into the panel layout.
+ */
+export class UnspikeTab extends React.PureComponent<IProps> {
     render() {
-        const {markupV2} = this.props;
+        const {items, markupV2, closeUnspikeView} = this.props;
 
         return (
-            <React.Fragment>
-                <PanelContent markupV2={markupV2}>
-                    <ToggleBox variant="simple" title={gettext('Destination')} initiallyOpen>
-                        <DestinationSelect
-                            value={this.state.selectedDestination}
-                            onChange={(value) => {
-                                this.setState({
-                                    selectedDestination: value,
-                                });
-                            }}
-                            includePersonalSpace={false}
-                        />
-                    </ToggleBox>
-                </PanelContent>
-
-                <PanelFooter markupV2={markupV2}>
-                    <Button
-                        text={gettext('Unspike')}
-                        onClick={() => {
-                            this.doUnspike();
-                        }}
-                        size="large"
-                        type="primary"
-                        expand
-                        data-test-id="unspike"
-                    />
-                </PanelFooter>
-            </React.Fragment>
+            <UnspikeAction
+                items={items}
+                closeUnspikeView={closeUnspikeView}
+            >
+                {({body, footer}) => (
+                    <>
+                        <PanelContent markupV2={markupV2}>
+                            {body}
+                        </PanelContent>
+                        <PanelFooter markupV2={markupV2}>
+                            {footer}
+                        </PanelFooter>
+                    </>
+                )}
+            </UnspikeAction>
         );
     }
 }

--- a/scripts/core/interactive-article-actions-panel/index-ui.tsx
+++ b/scripts/core/interactive-article-actions-panel/index-ui.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {assertNever} from 'core/helpers/typescript-helpers';
 import {SendToTab} from './actions/send-to-tab';
 import {IArticle} from 'superdesk-api';
-import {TabList} from 'core/ui/components/tabs';
 import {Button} from 'superdesk-ui-framework/react';
 import {gettext} from 'core/utils';
 import {Panel} from './panel/panel-main';
@@ -15,33 +14,11 @@ import {SendCorrectionTab} from './actions/send-correction-tab';
 import {FetchToTab} from './actions/fetch-to-tab';
 import {UnspikeTab} from './actions/unspike-tab';
 import {IArticleActionInteractive, IPanelAction} from './interfaces';
+import {ActionTabs} from './action-tabs';
 
 const singleColumnWidthRem = 40; // rem
 
 const handleUnsavedChangesDefault = (items: Array<IArticle>) => Promise.resolve(items);
-
-function getTabLabel(id: IArticleActionInteractive) {
-    if (id === 'send_to') {
-        return gettext('Send to');
-    } else if (id === 'fetch_to') {
-        return gettext('Fetch to');
-    } else if (id === 'duplicate_to') {
-        return gettext('Duplicate to');
-    } else if (id === 'unspike') {
-        return gettext('Unspike');
-    } else if (id === 'publish') {
-        return gettext('Publish');
-    } else if (id === 'correct') {
-        /**
-         * Display as "Publish".
-         * It's implemented as separate tab so it's easier
-         * to decouple implementation into a separate component.
-         */
-        return gettext('Publish');
-    } else {
-        assertNever(id);
-    }
-}
 
 export interface IPropsInteractiveArticleActionsPanelStateless extends IPanelAction {
     /**
@@ -83,15 +60,12 @@ export class InteractiveArticleActionsPanel
         const panelHeader = (
             <PanelHeader markupV2={markupV2}>
                 <div className="space-between" style={{width: '100%', paddingInlineEnd: 10}}>
-                    <TabList
-                        tabs={tabs.map((id) => ({id, label: getTabLabel(id)}))}
-                        selectedTabId={activeTab}
-                        onChange={(tab: IArticleActionInteractive) => {
-                            this.setState({
-                                activeTab: tab,
-                            });
+                    <ActionTabs
+                        tabs={tabs}
+                        activeTab={activeTab}
+                        onChange={(tab) => {
+                            this.setState({activeTab: tab});
                         }}
-                        data-test-id="tabs"
                     />
 
                     <Button

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -726,6 +726,7 @@ declare module 'superdesk-api' {
 
         // only works react based authoring
         background?: 'light' | 'grey';
+        bodyPadding?: 'none' | 'small' | 'medium'; // default is 'medium'
     }
 
     export interface IGenericSidebarComponentProps<T> {
@@ -786,6 +787,12 @@ declare module 'superdesk-api' {
         icon: string;
         component: React.ComponentClass<IArticleSideWidgetComponentType>;
         isAllowed?(article: IArticle): boolean; // enables limiting widgets depending on article data
+
+        /**
+         * Button type/color for the widget sidebar button.
+         * Requires superdesk-ui-framework support for ISideBarTab.buttonType
+         */
+        buttonType?: 'default' | 'primary' | 'highlight' | 'success' | 'warning' | 'alert';
 
         /**
          * Up to 2 symbols


### PR DESCRIPTION
### Purpose
Moves authoring actions side panel to a widget for authoring react

### What has changed
I've separated each tab to have a body and footer, so it's compatible with the authoring widget API we have. And I've created a widget entry for authoring react, so user can see the widget. 

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7447]


[SDESK-7447]: https://sofab.atlassian.net/browse/SDESK-7447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ