### PR TITLE
[STT-1624] - Stories with a scheduled time in the past are not shown as published

### DIFF
--- a/scripts/apps/search/components/fields/state.tsx
+++ b/scripts/apps/search/components/fields/state.tsx
@@ -5,12 +5,16 @@ import {ITEM_STATE} from 'apps/archive/constants';
 import {openArticle} from 'core/get-superdesk-api-implementation';
 import {StateLabel} from 'superdesk-ui-framework';
 import {IArticle} from 'superdesk-api';
+import moment from 'moment-timezone';
+
+function isScheduledTimeInFuture(item: IArticle): boolean {
+    const scheduledTime = item.schedule_settings?.utc_publish_schedule;
+
+    return scheduledTime != null && moment(scheduledTime).isAfter(moment.utc());
+}
 
 export function getStateLabel(item: IArticle) {
-    const hasScheduledPublishTime = item.schedule_settings?.utc_publish_schedule != null;
-
-    // We treat items that have a set scheduled publish time as `scheduled`, regardless if they're published or not
-    if (hasScheduledPublishTime) {
+    if (isScheduledTimeInFuture(item)) {
         return ITEM_STATE.SCHEDULED;
     }
 
@@ -58,14 +62,13 @@ export const StatusInfo = (props: IStateComponentProps) => {
         openArticle(item._id, 'view');
     };
 
-    const scheduledPublishTime = item.schedule_settings?.utc_publish_schedule;
     const handleClick = clickable && item.state === 'being_corrected'
         ? openItem
         : undefined;
 
     return (
         <StateLabel
-            state={scheduledPublishTime != null ? ITEM_STATE.SCHEDULED : item.state}
+            state={isScheduledTimeInFuture(item) ? ITEM_STATE.SCHEDULED : item.state}
             text={getStateLabel(item)}
             onClick={handleClick}
         />


### PR DESCRIPTION
### Purpose
This PR fixes a bug where once the scheduled time has passed and the story is published, it should display the actual state `Published` and not `Scheduled`

### What has changed
- Added helper function to compare the scheduled publish time and current time
- Updated `getStateLabel()` and `StatusInfo` component to

### Steps to test
1. Create a new story and set a scheduled publish time in the future and publish
2. Verify the story shows "Scheduled" label in the list view while waiting for the scheduled time
3. After schedule time has passed, verify the story now shows "Published" label in the list view


### Checklist
- [X] I reviewed my code
- [X] I tested all affected functionality and made sure it works

Resolves: [STT-1624](https://sofab.atlassian.net/browse/STT-1624)


[STT-1624]: https://sofab.atlassian.net/browse/STT-1624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ