### PR TITLE
[SDANSA-567] - Make Send to the default tab in the Publishing pane

### DIFF
--- a/scripts/core/interactive-article-actions-panel/index-ui.tsx
+++ b/scripts/core/interactive-article-actions-panel/index-ui.tsx
@@ -7,7 +7,7 @@ import {Button} from 'superdesk-ui-framework/react';
 import {gettext} from 'core/utils';
 import {Panel} from './panel/panel-main';
 import {PanelHeader} from './panel/panel-header';
-import {authoringReactViewEnabled} from 'appConfig';
+import {authoringReactViewEnabled, appConfig} from 'appConfig';
 import {DuplicateToTab} from './actions/duplicate-to-tab';
 import {WithPublishTab} from './actions/publish-tab';
 import {logger} from 'core/services/logger';
@@ -63,8 +63,14 @@ export class InteractiveArticleActionsPanel
     constructor(props: IPropsInteractiveArticleActionsPanelStateless) {
         super(props);
 
+        const configuredDefaultTab = appConfig.authoring_actions_default_tab;
+        const initialActiveTab =
+            configuredDefaultTab != null && props.tabs.includes(configuredDefaultTab)
+                ? configuredDefaultTab
+                : props.activeTab;
+
         this.state = {
-            activeTab: props.activeTab,
+            activeTab: initialActiveTab,
         };
     }
 

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -3506,6 +3506,9 @@ declare module 'superdesk-api' {
 
         default_timezone: string;
 
+        /** allow setting default tab to open in authoring sidebar */
+        authoring_actions_default_tab?: 'publish' | 'send_to';
+
         // TANSA SERVER CONFIG
         tansa?: {
             base_url: string;


### PR DESCRIPTION
This PR cherry-picked from STT-1484 into release/2.10 used by ANSA:
- Added new key in client config to support default tab in authoring actions to be "send_to" 

Note: This relates to this [PR](https://github.com/superdesk/superdesk-ansa/pull/32) in ANSA

Resolves: [SDANSA-567](https://sofab.atlassian.net/browse/SDANSA-567)

[SDANSA-567]: https://sofab.atlassian.net/browse/SDANSA-567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ