### PR TITLE
[STT-1569] Preserve custom tag styles when pasting between editors

### DIFF
--- a/scripts/core/editor3/components/Editor3Component.tsx
+++ b/scripts/core/editor3/components/Editor3Component.tsx
@@ -50,6 +50,7 @@ import {gettext, isMacOS} from 'core/utils';
 import {canAddArticleEmbed} from './article-embed/can-add-article-embed';
 import {addInternalEventListener} from 'core/internal-events';
 import {IconButton, Spacer} from 'superdesk-ui-framework/react';
+import {hashString} from '../helpers/hashString';
 
 export const EVENT_TYPES_TRIGGER_DROP_ZONE = [
     ...MEDIA_TYPES_TRIGGER_DROP_ZONE,
@@ -68,6 +69,7 @@ const VALID_MEDIA_TYPES = [
 ];
 
 export const EDITOR_GLOBAL_REFS = 'editor3-refs';
+export const EDITOR_COPY_METADATA = '__editor3-copy-metadata';
 const editor3AutocompleteClassName = 'editor3-autocomplete';
 
 /**
@@ -619,6 +621,12 @@ export class Editor3Component extends React.Component<IPropsEditor3Component, IS
         this.removeListeners.push(
             addInternalEventListener('editor3SpellcheckerActionWasExecuted', this.spellcheck),
         );
+
+        // Native DOM listener is required here. Using DraftJS's `onCopy` prop would
+        // replace its internal copy handler, preventing it from storing the selected
+        // blocks in its internal clipboard. The native listener fires
+        // after DraftJS's handler, so both run.
+        this.div?.addEventListener('copy', this.storeCopyOrigin);
     }
 
     handleRefs(editor: IEditor3) {
@@ -636,12 +644,38 @@ export class Editor3Component extends React.Component<IPropsEditor3Component, IS
     componentWillUnmount() {
         $(this.div).off();
 
+        this.div?.removeEventListener('copy', this.storeCopyOrigin);
+
         delete window[EDITOR_GLOBAL_REFS][this.editorKey];
 
         for (const fn of this.removeListeners) {
             fn();
         }
     }
+
+    /**
+     * Stores the origin of the copy event in a window variable so that `handlePastedText`
+     * can determine whether the paste originates from an editor in this window.
+     *
+     * We cannot rely on the editor key embedded in clipboard HTML because Chrome and Safari
+     * omits the `data-editor` attribute from copied HTML (Firefox keeps it). Instead
+     * we store a hash of the copied plain text alongside the editor key. On paste,
+     * handlePastedText recomputes the hash from the text it receives and compares:
+     * a match means the clipboard was not replaced by an external application after
+     * the copy, so the source editor's internal DraftJS clipboard is still valid.
+     */
+    private storeCopyOrigin = () => {
+        if (this.editorKey == null) {
+            return;
+        }
+
+        const text = window.getSelection()?.toString() || '';
+
+        window[EDITOR_COPY_METADATA] = {
+            editorKey: this.editorKey,
+            contentHash: hashString(text),
+        };
+    };
 
     componentDidUpdate(prevProps: IPropsEditor3Component) {
         if (window.hasOwnProperty('instgrm')) {

--- a/scripts/core/editor3/components/Editor3Component.tsx
+++ b/scripts/core/editor3/components/Editor3Component.tsx
@@ -658,7 +658,7 @@ export class Editor3Component extends React.Component<IPropsEditor3Component, IS
      * can determine whether the paste originates from an editor in this window.
      *
      * We cannot rely on the editor key embedded in clipboard HTML because Chrome and Safari
-     * omits the `data-editor` attribute from copied HTML (Firefox keeps it). Instead
+     * omit the `data-editor` attribute from copied HTML (Firefox keeps it). Instead
      * we store a hash of the copied plain text alongside the editor key. On paste,
      * handlePastedText recomputes the hash from the text it receives and compares:
      * a match means the clipboard was not replaced by an external application after

--- a/scripts/core/editor3/components/customStyleMap.tsx
+++ b/scripts/core/editor3/components/customStyleMap.tsx
@@ -12,11 +12,26 @@ const getUiFrameworkColor = (borderColor: typeof appConfig.authoring.customEdito
     }
 };
 
+export const CUSTOM_EDITOR_TAG_ATTR = 'custom-editor-tag-id';
+
+/**
+ * CSS fingerprint properties for custom editor tag styles.
+ * These are the properties used to identify custom tag styles in clipboard HTML
+ * when pasting across editors or windows. Excludes presentational-only properties
+ * like `display` that are too generic to serve as unique identifiers.
+ */
+export const customEditorTagStyleMap: Record<string, React.CSSProperties> = Object.fromEntries(
+    customEditorTags.map(({editor3Style, borderColor}) => [
+        editor3Style,
+        {borderBlockEnd: `4px double ${getUiFrameworkColor(borderColor)}`},
+    ]),
+);
+
 export const customStyleMap = {
     ...Object.fromEntries(
-        customEditorTags.map(({editor3Style, borderColor}) => [
-            editor3Style,
-            {display: 'inline-block', borderBlockEnd: `4px double ${getUiFrameworkColor(borderColor)}`},
+        Object.entries(customEditorTagStyleMap).map(([style, props]) => [
+            style,
+            {display: 'inline-block', ...props},
         ]),
     ),
 

--- a/scripts/core/editor3/components/handlePastedText.ts
+++ b/scripts/core/editor3/components/handlePastedText.ts
@@ -25,9 +25,22 @@ function removeMediaFromHtml(htmlString): string {
 }
 
 /**
+ * Returns true when the current clipboard text was copied from an editor in this
+ * window. Checks both the content hash (guards against stale metadata from a
+ * previous copy) and that the source editor is still mounted in EDITOR_GLOBAL_REFS.
+ */
+export function isCopySourceInThisWindow(text: string): boolean {
+    const copyMetadata = window[EDITOR_COPY_METADATA];
+
+    return copyMetadata != null
+        && copyMetadata.contentHash === hashString(text)
+        && window[EDITOR_GLOBAL_REFS]?.[copyMetadata.editorKey] != null;
+}
+
+/**
  * Handles paste when the source is another Editor3 instance in the same window.
  *
- * Uses the window-scoped EDITOR_COPY_SOURCE variable set by Editor3Component's
+ * Uses the window-scoped EDITOR_COPY_METADATA variable set by Editor3Component's
  * native copy listener to identify the source editor. The content hash is checked
  * first to ensure the clipboard was not replaced after the copy event fired.
  *
@@ -38,7 +51,7 @@ function removeMediaFromHtml(htmlString): string {
  * Returns 'not-handled' for cross-window pastes (source editor not in this
  * window's EDITOR_GLOBAL_REFS).
  */
-function pasteContentFromOpenEditor(
+export function pasteContentFromOpenEditor(
     text: string,
     editorState: EditorState,
     editorKey: string,
@@ -140,15 +153,8 @@ export function handlePastedText(text: string, _html: string): DraftHandleValue 
     // use its internal clipboard, preserving all inline styles. For cross-window paste
     // we fall through to processPastedHtml. EDITOR_COPY_METADATA is used instead of
     // html.includes(editorKey) because Chrome omits data-editor from clipboard HTML.
-    if (htmlComesFromDraftjsEditor(html, false)) {
-        const copyMetadata = window[EDITOR_COPY_METADATA];
-        const isSourceInThisWindow = copyMetadata != null
-            && copyMetadata.contentHash === hashString(text)
-            && window[EDITOR_GLOBAL_REFS]?.[copyMetadata.editorKey] != null;
-
-        if (isSourceInThisWindow) {
-            return 'not-handled';
-        }
+    if (htmlComesFromDraftjsEditor(html, false) && isCopySourceInThisWindow(text)) {
+        return 'not-handled';
     }
 
     return processPastedHtml(html || text, editorState, onChange, editorFormat);

--- a/scripts/core/editor3/components/handlePastedText.ts
+++ b/scripts/core/editor3/components/handlePastedText.ts
@@ -88,10 +88,7 @@ export function pasteContentFromOpenEditor(
         return 'not-handled';
     }
 
-    const blocksArray = [];
-
-    internalClipboard.forEach((b) => blocksArray.push(b));
-
+    const blocksArray = Array.from<ContentBlock>(internalClipboard);
     const contentState = ContentState.createFromBlockArray(blocksArray);
     const editorWithContent = insertContentInState(editorState, contentState, editorFormat);
 

--- a/scripts/core/editor3/components/handlePastedText.ts
+++ b/scripts/core/editor3/components/handlePastedText.ts
@@ -8,8 +8,9 @@ import {sanitizeContent, inlineStyles} from '../helpers/inlineStyles';
 import {getAllCustomDataFromEditor, setAllCustomDataForEditor} from '../helpers/editor3CustomData';
 import {getCurrentAuthor} from '../helpers/author';
 import {htmlComesFromDraftjsEditor} from '../helpers/htmlComesFromDraftjsEditor';
-import {EDITOR_GLOBAL_REFS} from 'core/editor3/components/Editor3Component';
+import {EDITOR_GLOBAL_REFS, EDITOR_COPY_METADATA} from 'core/editor3/components/Editor3Component';
 import {escape as escapeHtml} from 'lodash';
+import {hashString} from '../helpers/hashString';
 
 function removeMediaFromHtml(htmlString): string {
     const element = document.createElement('div');
@@ -23,41 +24,67 @@ function removeMediaFromHtml(htmlString): string {
     return element.innerHTML;
 }
 
+/**
+ * Handles paste when the source is another Editor3 instance in the same window.
+ *
+ * Uses the window-scoped EDITOR_COPY_SOURCE variable set by Editor3Component's
+ * native copy listener to identify the source editor. The content hash is checked
+ * first to ensure the clipboard was not replaced after the copy event fired.
+ *
+ * When the source editor is confirmed, its DraftJS internal clipboard is used
+ * directly, which preserves all inline styles (custom tags, subscript, superscript,
+ * etc.) that would otherwise survive only partially through an HTML round-trip.
+ *
+ * Returns 'not-handled' for cross-window pastes (source editor not in this
+ * window's EDITOR_GLOBAL_REFS).
+ */
 function pasteContentFromOpenEditor(
-    html: string,
+    text: string,
     editorState: EditorState,
     editorKey: string,
     onChange: (e: EditorState) => void,
     editorFormat: Array<string>,
 ): DraftHandleValue {
-    if (html.includes(editorKey)) { // comes from the same editor
+    const copyMetadata = window[EDITOR_COPY_METADATA];
+
+    if (copyMetadata == null) {
         return 'not-handled';
     }
 
-    for (const key in window[EDITOR_GLOBAL_REFS]) {
-        if (html.includes(key)) {
-            const editor = window[EDITOR_GLOBAL_REFS][key];
+    const currentHash = hashString(text);
 
-            if (editor) {
-                const internalClipboard = editor.getClipboard();
-
-                if (internalClipboard) {
-                    const blocksArray = [];
-
-                    internalClipboard.forEach((b) => blocksArray.push(b));
-
-                    const contentState = ContentState.createFromBlockArray(blocksArray);
-                    const editorWithContent = insertContentInState(editorState, contentState, editorFormat);
-
-                    onChange(editorWithContent);
-
-                    return 'handled';
-                }
-            }
-        }
+    if (copyMetadata.contentHash !== currentHash) {
+        return 'not-handled';
     }
 
-    return 'not-handled';
+    const sourceEditorKey = copyMetadata.editorKey;
+
+    if (sourceEditorKey === editorKey) {
+        return 'not-handled';
+    }
+
+    const editor = window[EDITOR_GLOBAL_REFS]?.[sourceEditorKey];
+
+    if (editor == null) {
+        return 'not-handled';
+    }
+
+    const internalClipboard = editor.getClipboard();
+
+    if (internalClipboard == null) {
+        return 'not-handled';
+    }
+
+    const blocksArray = [];
+
+    internalClipboard.forEach((b) => blocksArray.push(b));
+
+    const contentState = ContentState.createFromBlockArray(blocksArray);
+    const editorWithContent = insertContentInState(editorState, contentState, editorFormat);
+
+    onChange(editorWithContent);
+
+    return 'handled';
 }
 
 // preserve line breaks when pasting or forcing plain text
@@ -105,12 +132,23 @@ export function handlePastedText(text: string, _html: string): DraftHandleValue 
     }
 
     if (html &&
-        pasteContentFromOpenEditor(html, editorState, this.editorKey, onChange, editorFormat) === 'handled') {
+        pasteContentFromOpenEditor(text, editorState, this.editorKey, onChange, editorFormat) === 'handled') {
         return 'handled';
     }
 
+    // Defer to DraftJS only when the source editor is in this window so it can then
+    // use its internal clipboard, preserving all inline styles. For cross-window paste
+    // we fall through to processPastedHtml. EDITOR_COPY_METADATA is used instead of
+    // html.includes(editorKey) because Chrome omits data-editor from clipboard HTML.
     if (htmlComesFromDraftjsEditor(html, false)) {
-        return 'not-handled';
+        const copyMetadata = window[EDITOR_COPY_METADATA];
+        const isSourceInThisWindow = copyMetadata != null
+            && copyMetadata.contentHash === hashString(text)
+            && window[EDITOR_GLOBAL_REFS]?.[copyMetadata.editorKey] != null;
+
+        if (isSourceInThisWindow) {
+            return 'not-handled';
+        }
     }
 
     return processPastedHtml(html || text, editorState, onChange, editorFormat);

--- a/scripts/core/editor3/components/tests/handlePastedText.spec.tsx
+++ b/scripts/core/editor3/components/tests/handlePastedText.spec.tsx
@@ -1,7 +1,14 @@
 
-import {EditorState, ContentState, SelectionState, convertFromRaw} from 'draft-js';
+import {EditorState, ContentState, ContentBlock, CharacterMetadata, SelectionState, convertFromRaw} from 'draft-js';
+import {List, OrderedSet} from 'immutable';
 import {cursorAtEndPosition, cursorAtPosition} from './utils';
-import {insertContentInState, createHtmlFromText} from '../handlePastedText';
+import {
+    insertContentInState,
+    createHtmlFromText,
+    pasteContentFromOpenEditor,
+} from '../handlePastedText';
+import {EDITOR_COPY_METADATA, EDITOR_GLOBAL_REFS} from '../Editor3Component';
+import {hashString} from 'core/editor3/helpers/hashString';
 import {getAnnotationsFromContentState} from 'core/editor3/helpers/editor3CustomData';
 import {getContentStateFromHtml} from 'core/editor3/html/from-html';
 import {htmlComesFromDraftjsEditor} from 'core/editor3/helpers/htmlComesFromDraftjsEditor';
@@ -129,5 +136,100 @@ describe('editor3.handlePastedText', () => {
         const tableData = entity.getData().data;
         expect(tableData.numRows).toBe(6);
         expect(tableData.numCols).toBe(4);
+    });
+});
+
+describe('pasteContentFromOpenEditor', () => {
+    const destEditorKey = 'dest-editor';
+    const srcEditorKey = 'src-editor';
+    const text = 'pasted text';
+    let editorState: EditorState;
+    let onChangeCalled: boolean;
+    let onChange: (e: EditorState) => void;
+
+    beforeEach(() => {
+        editorState = EditorState.createWithContent(ContentState.createFromText(''));
+        onChangeCalled = false;
+        onChange = () => {
+            onChangeCalled = true;
+        };
+    });
+
+    afterEach(() => {
+        delete window[EDITOR_COPY_METADATA];
+        delete window[EDITOR_GLOBAL_REFS];
+    });
+
+    it('returns not-handled when there is no copy metadata', () => {
+        expect(pasteContentFromOpenEditor(text, editorState, destEditorKey, onChange, [])).toBe('not-handled');
+    });
+
+    it('returns not-handled when the content hash does not match', () => {
+        window[EDITOR_COPY_METADATA] = {editorKey: srcEditorKey, contentHash: hashString('something else')};
+
+        expect(pasteContentFromOpenEditor(text, editorState, destEditorKey, onChange, [])).toBe('not-handled');
+    });
+
+    it('returns not-handled when source and destination are the same editor', () => {
+        window[EDITOR_COPY_METADATA] = {editorKey: destEditorKey, contentHash: hashString(text)};
+
+        expect(pasteContentFromOpenEditor(text, editorState, destEditorKey, onChange, [])).toBe('not-handled');
+    });
+
+    it('returns not-handled when the source editor is not registered in this window', () => {
+        window[EDITOR_COPY_METADATA] = {editorKey: srcEditorKey, contentHash: hashString(text)};
+        window[EDITOR_GLOBAL_REFS] = {};
+
+        expect(pasteContentFromOpenEditor(text, editorState, destEditorKey, onChange, [])).toBe('not-handled');
+    });
+
+    it('returns not-handled when the source editor has no internal clipboard', () => {
+        window[EDITOR_COPY_METADATA] = {editorKey: srcEditorKey, contentHash: hashString(text)};
+        window[EDITOR_GLOBAL_REFS] = {[srcEditorKey]: {getClipboard: () => null}};
+
+        expect(pasteContentFromOpenEditor(text, editorState, destEditorKey, onChange, [])).toBe('not-handled');
+    });
+
+    it('returns handled and calls onChange when source is a valid same-window editor', () => {
+        const block = new ContentBlock({key: 'b1', text: 'clipboard content', type: 'unstyled'});
+        const mockEditor = {getClipboard: () => List([block])};
+
+        window[EDITOR_COPY_METADATA] = {editorKey: srcEditorKey, contentHash: hashString(text)};
+        window[EDITOR_GLOBAL_REFS] = {[srcEditorKey]: mockEditor};
+
+        const result = pasteContentFromOpenEditor(text, editorState, destEditorKey, onChange, []);
+
+        expect(result).toBe('handled');
+        expect(onChangeCalled).toBe(true);
+    });
+
+    it('preserves custom tag inline styles from the source editor internal clipboard', () => {
+        // Simulates same-window paste where the source editor has a custom tag style applied.
+        // The internal clipboard path must preserve these styles intact; an HTML round-trip
+        // would lose them because the CSS fingerprint is not in the inlineStyleRanges.
+        let resultEditorState: EditorState | null = null;
+        const styledChar = CharacterMetadata.create({style: OrderedSet(['EDITOR_TAG_PEOPLE'])});
+        const block = new ContentBlock({
+            key: 'b1',
+            text: 'tagged text',
+            type: 'unstyled',
+            characterList: List(Array(11).fill(styledChar)),
+        });
+        const mockEditor = {getClipboard: () => List([block])};
+
+        window[EDITOR_COPY_METADATA] = {editorKey: srcEditorKey, contentHash: hashString(text)};
+        window[EDITOR_GLOBAL_REFS] = {[srcEditorKey]: mockEditor};
+
+        pasteContentFromOpenEditor(
+            text, editorState, destEditorKey,
+            (s) => { resultEditorState = s; },
+            ['EDITOR_TAG_PEOPLE'],
+        );
+
+        const pastedBlock = resultEditorState.getCurrentContent().getBlocksAsArray()
+            .find((b) => b.getText() === 'tagged text');
+
+        expect(pastedBlock).toBeDefined();
+        expect(pastedBlock.getInlineStyleAt(0).has('EDITOR_TAG_PEOPLE')).toBe(true);
     });
 });

--- a/scripts/core/editor3/helpers/hashString.ts
+++ b/scripts/core/editor3/helpers/hashString.ts
@@ -1,4 +1,4 @@
-/** Fast non-cryptographic djb2-style hash. Collisions are acceptable. */
+/** Fast non-cryptographic string hash. Collisions are acceptable. */
 export function hashString(str: string): number {
     let hash = 0;
 

--- a/scripts/core/editor3/helpers/hashString.ts
+++ b/scripts/core/editor3/helpers/hashString.ts
@@ -1,0 +1,13 @@
+/** Fast non-cryptographic djb2-style hash. Collisions are acceptable. */
+export function hashString(str: string): number {
+    let hash = 0;
+
+    for (let i = 0; i < str.length; i++) {
+        const char = str.charCodeAt(i);
+
+        hash = ((hash << 5) - hash) + char;
+        hash = hash & hash;
+    }
+
+    return hash;
+}

--- a/scripts/core/editor3/html/from-html/index.ts
+++ b/scripts/core/editor3/html/from-html/index.ts
@@ -89,7 +89,7 @@ function getCssToEditorStyleMap(): Map<string, Map<string, string>> {
  * Marker positions are returned in original-text coordinates, sorted end-to-start
  * so they can be safely deleted without shifting earlier indices.
  */
-function extractCustomTagRanges(text: string): {
+export function extractCustomTagRanges(text: string): {
     styles: Array<IStyleRange>;
     markerRanges: Array<ITextRange>;
 } {
@@ -155,14 +155,16 @@ class HTMLParser {
     media: any;
     associations: any;
     tree: any;
+    private cssTagStyleMap: Map<string, Map<string, string>>;
 
-    constructor(html, associations = {}) {
+    constructor(html, associations = {}, cssTagStyleMap?: Map<string, Map<string, string>>) {
         this.iframes = {};
         this.scripts = {};
         this.figures = {};
         this.tables = {};
         this.media = {};
         this.associations = associations;
+        this.cssTagStyleMap = cssTagStyleMap ?? getCssToEditorStyleMap();
 
         this.tree = $('<div></div>');
 
@@ -174,16 +176,14 @@ class HTMLParser {
      * and normalises them to the custom-editor-tag-id attribute format.
      */
     private normalizeCssTagSpans() {
-        const cssMap = getCssToEditorStyleMap();
-
-        if (cssMap.size === 0) {
+        if (this.cssTagStyleMap.size === 0) {
             return;
         }
 
         this.tree.find('span[style]').each((_, node) => {
             const el = node as HTMLElement;
 
-            for (const [propName, valueMap] of cssMap) {
+            for (const [propName, valueMap] of this.cssTagStyleMap) {
                 const value = el.style[propName]?.toLowerCase().trim();
 
                 if (value && valueMap.has(value)) {
@@ -589,11 +589,15 @@ class HTMLParser {
     }
 }
 
-export function getContentStateFromHtml(html: string, associations: object = {}): ContentState {
+export function getContentStateFromHtml(
+    html: string,
+    associations: object = {},
+    cssTagStyleMap?: Map<string, Map<string, string>>,
+): ContentState {
     if (html.length < 1) {
         return ContentState.createFromText('');
     } else {
-        return new HTMLParser(html, associations).contentState();
+        return new HTMLParser(html, associations, cssTagStyleMap).contentState();
     }
 }
 

--- a/scripts/core/editor3/html/from-html/index.ts
+++ b/scripts/core/editor3/html/from-html/index.ts
@@ -8,8 +8,125 @@ import {
     ContentState,
     convertFromHTML,
     convertToRaw,
+    Modifier,
+    SelectionState,
 } from 'draft-js';
 import {CustomEditor3Entity} from 'core/editor3/constants';
+import {customEditorTagStyleMap, CUSTOM_EDITOR_TAG_ATTR} from '../../components/customStyleMap';
+
+interface IStyleRange {
+    styleName: string;
+    start: number;
+    end: number;
+}
+
+interface ITextRange {
+    start: number;
+    end: number;
+}
+
+// Private Use Unicode characters used as markers during HTML→ContentState conversion.
+// These survive DraftJS's convertFromHTML as plain text, letting us track inline style ranges.
+const TAG_OPEN = '\uE000'; // precedes style name
+const TAG_SEP = '\uE001'; // separates style name from content
+const TAG_CLOSE = '\uE002'; // follows content
+const TAG_REGEX = new RegExp(`${TAG_OPEN}([^${TAG_SEP}]+)${TAG_SEP}([^${TAG_OPEN}]*)${TAG_CLOSE}`, 'g');
+
+/**
+ * Builds a reverse map from CSS property+value → editor3 style name.
+ *
+ * Keyed by property name (camelCase), then by value (lowercased). Two entries
+ * are added per value: the raw string from customEditorTagStyleMap (Firefox
+ * clipboard preserves CSS variables) and the browser-computed value resolved
+ * via a temporary DOM element (Chrome resolves CSS variables, e.g. lch(...)).
+ *
+ * Iterates all properties in customEditorTagStyleMap so adding a new custom tag
+ * style with a different fingerprint property is handled automatically.
+ */
+let cssToEditorStyleMap: Map<string, Map<string, string>> | null = null;
+
+function getCssToEditorStyleMap(): Map<string, Map<string, string>> {
+    if (cssToEditorStyleMap != null) {
+        return cssToEditorStyleMap;
+    }
+
+    const map = new Map<string, Map<string, string>>();
+    const probe = document.createElement('span');
+
+    document.body.appendChild(probe);
+
+    for (const [styleName, cssProps] of Object.entries(customEditorTagStyleMap)) {
+        for (const [propName, rawValue] of Object.entries(cssProps)) {
+            if (!map.has(propName)) {
+                map.set(propName, new Map());
+            }
+
+            const valueMap = map.get(propName);
+            const rawLower = (rawValue as string).toLowerCase();
+
+            valueMap.set(rawLower, styleName);
+            probe.style[propName] = rawValue;
+
+            const computed = getComputedStyle(probe)[propName]?.toLowerCase().trim();
+
+            if (computed && computed !== rawLower) {
+                valueMap.set(computed, styleName);
+            }
+
+            probe.style[propName] = '';
+        }
+    }
+
+    document.body.removeChild(probe);
+    cssToEditorStyleMap = map;
+
+    return map;
+}
+
+/**
+ * Parses a block's text containing TAG markers into clean text + style ranges.
+ * Ranges are returned in clean-text coordinates.
+ * Marker positions are returned in original-text coordinates, sorted end-to-start
+ * so they can be safely deleted without shifting earlier indices.
+ */
+function extractCustomTagRanges(text: string): {
+    styles: Array<IStyleRange>;
+    markerRanges: Array<ITextRange>;
+} {
+    const styles: Array<IStyleRange> = [];
+    const markerRanges: Array<ITextRange> = [];
+
+    let cleanOffset = 0;
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    TAG_REGEX.lastIndex = 0;
+
+    while ((match = TAG_REGEX.exec(text)) !== null) {
+        const before = text.slice(lastIndex, match.index);
+
+        cleanOffset += before.length;
+
+        const styleName = match[1];
+        const content = match[2];
+        const start = cleanOffset;
+
+        cleanOffset += content.length;
+        styles.push({styleName, start, end: cleanOffset});
+
+        const openEnd = match.index + 1 + styleName.length + 1; // TAG_OPEN + name + TAG_SEP
+        const closeStart = match.index + match[0].length - 1;
+
+        markerRanges.push({start: match.index, end: openEnd});
+        markerRanges.push({start: closeStart, end: closeStart + 1});
+
+        lastIndex = match.index + match[0].length;
+    }
+
+    markerRanges.sort((a, b) => b.start - a.start);
+
+    return {styles, markerRanges};
+}
 
 /**
  * @ngdoc class
@@ -50,6 +167,94 @@ class HTMLParser {
         this.tree = $('<div></div>');
 
         this.createTree(html);
+    }
+
+    /**
+     * Finds spans styled with custom editor tag CSS (from browser clipboard)
+     * and normalises them to the custom-editor-tag-id attribute format.
+     */
+    private normalizeCssTagSpans() {
+        const cssMap = getCssToEditorStyleMap();
+
+        if (cssMap.size === 0) {
+            return;
+        }
+
+        this.tree.find('span[style]').each((_, node) => {
+            const el = node as HTMLElement;
+
+            for (const [propName, valueMap] of cssMap) {
+                const value = el.style[propName]?.toLowerCase().trim();
+
+                if (value && valueMap.has(value)) {
+                    el.setAttribute(CUSTOM_EDITOR_TAG_ATTR, valueMap.get(value));
+                    el.removeAttribute('style');
+                    break;
+                }
+            }
+        });
+    }
+
+    /**
+     * Replaces <span custom-editor-tag-id="X">content</span> with PUA marker
+     * text nodes so the style information survives convertFromHTML.
+     */
+    private markCustomTagSpans() {
+        this.tree.find(`[${CUSTOM_EDITOR_TAG_ATTR}]`).each((_, node) => {
+            const $node = $(node);
+            const styleName = $node.attr(CUSTOM_EDITOR_TAG_ATTR);
+
+            $node.prepend(document.createTextNode(TAG_OPEN + styleName + TAG_SEP));
+            $node.append(document.createTextNode(TAG_CLOSE));
+            $node.contents().unwrap();
+        });
+    }
+
+    /**
+     * Post-processes the ContentState to remove PUA markers and apply the
+     * corresponding inline styles to the covered character ranges.
+     */
+    private applyCustomTagStyles(initialState: ContentState): ContentState {
+        let contentState = initialState;
+
+        for (const block of contentState.getBlocksAsArray()) {
+            const text = block.getText();
+
+            if (!text.includes(TAG_OPEN)) {
+                continue;
+            }
+
+            const blockKey = block.getKey();
+            const {styles, markerRanges} = extractCustomTagRanges(text);
+
+            for (const {start, end} of markerRanges) {
+                const sel = new SelectionState({
+                    anchorKey: blockKey,
+                    anchorOffset: start,
+                    focusKey: blockKey,
+                    focusOffset: end,
+                    isBackward: false,
+                    hasFocus: false,
+                });
+
+                contentState = Modifier.removeRange(contentState, sel, 'forward');
+            }
+
+            for (const {styleName, start, end} of styles) {
+                const sel = new SelectionState({
+                    anchorKey: blockKey,
+                    anchorOffset: start,
+                    focusKey: blockKey,
+                    focusOffset: end,
+                    isBackward: false,
+                    hasFocus: false,
+                });
+
+                contentState = Modifier.applyInlineStyle(contentState, sel, styleName);
+            }
+        }
+
+        return contentState;
     }
 
     /**
@@ -178,14 +383,15 @@ class HTMLParser {
      */
     contentState(): ContentState {
         const processBlock = this.processBlock.bind(this);
-        const html = this.tree.html();
 
-        if (html.trim() === '') {
-            // if html is empty then create an empty content state
+        if (this.tree.html().trim() === '') {
             return ContentState.createFromText('');
         }
 
-        const conversionResult = convertFromHTML(html);
+        this.normalizeCssTagSpans();
+        this.markCustomTagSpans();
+
+        const conversionResult = convertFromHTML(this.tree.html());
 
         let contentState = ContentState.createFromBlockArray(
             conversionResult.contentBlocks,
@@ -193,6 +399,7 @@ class HTMLParser {
         );
 
         contentState = this.processLinks(contentState);
+        contentState = this.applyCustomTagStyles(contentState);
 
         return ContentState.createFromBlockArray(
             contentState.getBlocksAsArray().map(processBlock),

--- a/scripts/core/editor3/html/tests/from-html.spec.ts
+++ b/scripts/core/editor3/html/tests/from-html.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 /* tslint:disable:max-line-length */
-import {getContentStateFromHtml} from '../from-html';
+import {getContentStateFromHtml, extractCustomTagRanges} from '../from-html';
 import {convertFromRaw, ContentState, ContentBlock, convertToRaw} from 'draft-js';
 import {getRawContentStateWithoutBlockAndEntityKeys} from 'core/editor3/helpers/draftInsertEntity.spec';
 
@@ -95,6 +95,31 @@ describe('core.editor3.html.from-html', () => {
         expect(contentState.getPlainText()).toEqual('');
     });
 
+    it('should apply inline style from custom-editor-tag-id attribute', () => {
+        const {blocks} = blocksFor('<p><span custom-editor-tag-id="MY_STYLE">tagged</span> text</p>');
+
+        expect(blocks[0].getText()).toBe('tagged text');
+        expect(blocks[0].getInlineStyleAt(0).has('MY_STYLE')).toBe(true); // first char of span
+        expect(blocks[0].getInlineStyleAt(5).has('MY_STYLE')).toBe(true); // last char of span
+        expect(blocks[0].getInlineStyleAt(6).has('MY_STYLE')).toBe(false); // space after span
+        expect(blocks[0].getInlineStyleAt(7).has('MY_STYLE')).toBe(false); // outside span
+    });
+
+    it('should recognize custom tag spans by CSS and preserve their inline style', () => {
+        const cssTagStyleMap = new Map([
+            ['borderBlockEnd', new Map([['4px double blue', 'EDITOR_TAG_PEOPLE']])],
+        ]);
+        const html = '<p><span style="border-block-end: 4px double blue">tagged</span> plain</p>';
+        const contentState = getContentStateFromHtml(html, {}, cssTagStyleMap);
+        const block = contentState.getBlocksAsArray()[0];
+
+        expect(block.getText()).toBe('tagged plain');
+        expect(block.getInlineStyleAt(0).has('EDITOR_TAG_PEOPLE')).toBe(true); // first char of span
+        expect(block.getInlineStyleAt(5).has('EDITOR_TAG_PEOPLE')).toBe(true); // last char of span
+        expect(block.getInlineStyleAt(6).has('EDITOR_TAG_PEOPLE')).toBe(false); // space after span
+        expect(block.getInlineStyleAt(7).has('EDITOR_TAG_PEOPLE')).toBe(false); // outside span
+    });
+
     it('should parse Google Docs special paste', () => {
         const {blocks} = blocksFor('<b style="font-weight:normal;" id="docs-internal-guid-63c0f3a6-072a-245e-c39d-3f61398cba2c"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;margin-left: 21.25984251968504pt;text-indent: 14.173228346456693pt;text-align: justify;"><span style="font-size:12pt;font-family:Roboto;color:#333333;background-color:transparent;font-weight:700;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">bold</span></p><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;margin-left: 21.25984251968504pt;text-indent: 14.173228346456693pt;text-align: justify;"><span style="font-size:12pt;font-family:Roboto;color:#333333;background-color:transparent;font-weight:400;font-style:italic;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">italic</span></p><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;margin-left: 21.25984251968504pt;text-indent: 14.173228346456693pt;text-align: justify;"><span style="font-size:12pt;font-family:Roboto;color:#333333;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:underline;-webkit-text-decoration-skip:none;text-decoration-skip-ink:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">underline</span></p><br></b>');
 
@@ -172,5 +197,62 @@ describe('core.editor3.html.from-html', () => {
                 },
             },
         });
+    });
+});
+
+describe('extractCustomTagRanges', () => {
+    const O = '\uE000'; // TAG_OPEN
+    const S = '\uE001'; // TAG_SEP
+    const C = '\uE002'; // TAG_CLOSE
+
+    it('handles a single span in the middle of text', () => {
+        const {styles} = extractCustomTagRanges(`before ${O}STYLE${S}tagged${C} after`);
+
+        expect(styles).toEqual([{styleName: 'STYLE', start: 7, end: 13}]);
+    });
+
+    it('handles multiple non-adjacent spans', () => {
+        const {styles} = extractCustomTagRanges(`${O}S1${S}foo${C} ${O}S2${S}bar${C}`);
+
+        expect(styles).toEqual([
+            {styleName: 'S1', start: 0, end: 3},
+            {styleName: 'S2', start: 4, end: 7},
+        ]);
+    });
+
+    it('handles adjacent spans with no text between them', () => {
+        const {styles} = extractCustomTagRanges(`${O}S1${S}abc${C}${O}S2${S}def${C}`);
+
+        expect(styles).toEqual([
+            {styleName: 'S1', start: 0, end: 3},
+            {styleName: 'S2', start: 3, end: 6},
+        ]);
+    });
+
+    it('handles a span at the very start with trailing text', () => {
+        const {styles} = extractCustomTagRanges(`${O}STYLE${S}hello${C} world`);
+
+        expect(styles).toEqual([{styleName: 'STYLE', start: 0, end: 5}]);
+    });
+
+    it('handles a span at the very end', () => {
+        const {styles} = extractCustomTagRanges(`leading ${O}STYLE${S}end${C}`);
+
+        expect(styles).toEqual([{styleName: 'STYLE', start: 8, end: 11}]);
+    });
+
+    it('returns marker ranges sorted end-to-start for safe deletion', () => {
+        const {markerRanges} = extractCustomTagRanges(`${O}S1${S}ab${C} ${O}S2${S}cd${C}`);
+
+        for (let i = 1; i < markerRanges.length; i++) {
+            expect(markerRanges[i - 1].start).toBeGreaterThan(markerRanges[i].start);
+        }
+    });
+
+    it('returns empty arrays when there are no markers', () => {
+        const {styles, markerRanges} = extractCustomTagRanges('plain text');
+
+        expect(styles).toEqual([]);
+        expect(markerRanges).toEqual([]);
     });
 });

--- a/scripts/core/editor3/html/tests/to-html.spec.ts
+++ b/scripts/core/editor3/html/tests/to-html.spec.ts
@@ -9,6 +9,7 @@ import {ContentState, convertToRaw, convertFromRaw} from 'draft-js';
 import {getInitialContent} from 'core/editor3/store';
 import {editor3StateToHtml} from '../to-html/editor3StateToHtml';
 import {CustomEditor3Entity} from 'core/editor3/constants';
+import {CUSTOM_EDITOR_TAG_ATTR} from '../../components/customStyleMap';
 
 describe('core.editor3.html.to-html snapshots', () => {
     beforeEach(window.module('superdesk.apps.spellcheck'));
@@ -450,5 +451,47 @@ describe('core.editor3.html.to-html.AtomicBlockParser', () => {
 
         expect(html).toBe('<table><tbody><tr><td></td><td></td><td></td></tr>' +
             '<tr><td></td><td></td><td></td></tr></tbody></table>');
+    });
+});
+
+describe('editor3StateToHtml custom tag styles', () => {
+    it('emits a span with custom-editor-tag-id attribute for custom tag inline styles', () => {
+        // Uses tagStylesOverride to bypass appConfig.authoring.customEditorTags
+        // which is unavailable in the test environment.
+        const rawState: any = {
+            blocks: [{
+                key: 'b1',
+                text: 'tagged plain',
+                type: 'unstyled',
+                depth: 0,
+                inlineStyleRanges: [{offset: 0, length: 6, style: 'EDITOR_TAG_PEOPLE'}],
+                entityRanges: [],
+                data: {},
+            }],
+            entityMap: {},
+        };
+        const contentState = convertFromRaw(rawState);
+        const html = editor3StateToHtml(contentState, [], new Set(['EDITOR_TAG_PEOPLE']));
+
+        expect(html).toBe(`<p><span ${CUSTOM_EDITOR_TAG_ATTR}="EDITOR_TAG_PEOPLE">tagged</span> plain</p>`);
+    });
+
+    it('does not emit custom-editor-tag-id when the style is not in tagStyles', () => {
+        const rawState: any = {
+            blocks: [{
+                key: 'b1',
+                text: 'hello',
+                type: 'unstyled',
+                depth: 0,
+                inlineStyleRanges: [{offset: 0, length: 5, style: 'EDITOR_TAG_PEOPLE'}],
+                entityRanges: [],
+                data: {},
+            }],
+            entityMap: {},
+        };
+        const contentState = convertFromRaw(rawState);
+        const html = editor3StateToHtml(contentState, [], new Set());
+
+        expect(html).not.toContain(CUSTOM_EDITOR_TAG_ATTR);
     });
 });

--- a/scripts/core/editor3/html/to-html/editor3StateToHtml.ts
+++ b/scripts/core/editor3/html/to-html/editor3StateToHtml.ts
@@ -4,6 +4,7 @@ import {getAnnotationsFromContentState} from 'core/editor3/helpers/editor3Custom
 import {stateToHTML} from 'draft-js-export-html';
 import {trimStartExact, trimEndExact} from 'core/helpers/utils';
 import {customEditorTags} from 'apps/workspace/content/components/get-content-profiles-form-config';
+import {CUSTOM_EDITOR_TAG_ATTR} from '../../components/customStyleMap';
 
 export const editor3StateToHtml = (
     contentState: ContentState,
@@ -75,7 +76,7 @@ export const editor3StateToHtml = (
                 return {
                     element: 'span',
                     attributes: {
-                        'custom-editor-tag-id': styleValue,
+                        [CUSTOM_EDITOR_TAG_ATTR]: styleValue,
                     },
                 };
             }

--- a/scripts/core/editor3/html/to-html/editor3StateToHtml.ts
+++ b/scripts/core/editor3/html/to-html/editor3StateToHtml.ts
@@ -9,10 +9,11 @@ import {CUSTOM_EDITOR_TAG_ATTR} from '../../components/customStyleMap';
 export const editor3StateToHtml = (
     contentState: ContentState,
     disabled: Array<string> = [], // A set of disabled elements (ie. ['table'] will ignore
+    tagStylesOverride?: Set<string>,
 ): string => {
     const annotationsByStyleName = getAnnotationsFromContentState(contentState)
         .reduce((accumulator, item) => ({...accumulator, [item.styleName]: item}), {});
-    const tagStyles = new Set(customEditorTags.map(({editor3Style}) => editor3Style));
+    const tagStyles = tagStylesOverride ?? new Set(customEditorTags.map(({editor3Style}) => editor3Style));
 
     let options = {
         inlineStyles: {

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -16,6 +16,7 @@
             "dom",
             "es2020"
         ],
+        "downlevelIteration": true,
         "jsx": "react"
     }
 }


### PR DESCRIPTION
### Description
When copying text between two editor3 instances (including across separate browser windows), inline styles coming from custom editor tags were lost on paste. 

### What was the problem:
When pasting from another window, editor3 receives raw HTML from the browser clipboard. Custom tag styles are represented as CSS (e.g. `border-block-end: 4px double ...`) in that HTML. The parser had no way to recognize those CSS values and convert them back into the internal DraftJS inline style names, so the styles were silently dropped.

### What has changed:
- The HTML parser now recognizes pasted CSS matching any configured custom tag style and converts it back to the corresponding DraftJS inline style. Both raw CSS variable values (as Firefox preserves them) and browser-computed values (as Chrome resolves them) are handled.
- Because DraftJS's `convertFromHTML` strips inline styles, the recognized spans are first converted to [PUA](https://en.wikipedia.org/wiki/Private_Use_Areas) Unicode marker characters that survive the conversion, then the markers are stripped and the inline styles are applied to the correct character ranges in post-processing.
- The cross-window paste identity check now validates that the clipboard text hash matches the stored copy metadata, preventing stale metadata from interfering.
- Tests cover: the full CSS→inline style pipeline, `extractCustomTagRanges` boundary cases, `editor3StateToHtml` custom tag emission, and the `pasteContentFromOpenEditor` paste path including style preservation.

Resolves: [STT-1569]


[STT-1569]: https://sofab.atlassian.net/browse/STT-1569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ