### PR TITLE
STT-1584: As STT journalist I want to add company and person tags with keyboard shortcuts

### DIFF
--- a/scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx
+++ b/scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx
@@ -31,7 +31,10 @@ export const getEditor3PlainTextFormattingOptions = (): Dictionary<PLAINTEXT_FOR
     'lowercase': gettext('lowercase'),
 });
 
-type IEnhancedTag = ISuperdeskGlobalConfig['authoring']['customEditorTags'][0] & {editor3Style: string}
+type IEnhancedTag = ISuperdeskGlobalConfig['authoring']['customEditorTags'][0] & {
+    editor3Style: string;
+    tooltip?: string;
+}
 
 export const customEditorTags: Array<IEnhancedTag> = (appConfig.authoring?.customEditorTags ?? []).map((item) => {
     return {

--- a/scripts/core/editor3/components/Editor3Component.tsx
+++ b/scripts/core/editor3/components/Editor3Component.tsx
@@ -416,6 +416,34 @@ export class Editor3Component extends React.Component<IPropsEditor3Component, IS
             onCreateChangeStyleSuggestion,
         } = this.props;
 
+        const canEditInSuggestingMode = (editorState, author) =>
+            Suggestions.allowEditSuggestionOnLeft(editorState, author) ||
+            Suggestions.allowEditSuggestionOnRight(editorState, author);
+
+        const toggleInlineStyleOrSuggest = (
+            editorState,
+            style: string,
+            suggestingMode: boolean,
+            author,
+            onCreateChangeStyleSuggestion: (style: string, active: boolean) => void,
+        ) => {
+            const active = editorState.getCurrentInlineStyle().has(style);
+
+            if (suggestingMode) {
+                if (!canEditInSuggestingMode(editorState, author)) {
+                    return {handled: true as const};
+                }
+
+                onCreateChangeStyleSuggestion(style, active);
+                return {handled: true as const};
+            }
+
+            return {
+                handled: false as const,
+                newState: RichUtils.toggleInlineStyle(editorState, style),
+            };
+        };
+
         if (singleLine && command === 'split-block') {
             return 'handled';
         }
@@ -505,37 +533,33 @@ export class Editor3Component extends React.Component<IPropsEditor3Component, IS
                 break;
             }
             case 'toggle-company-tag': {
-                const style = 'EDITOR_TAG_company';
-                const inlineStyles = editorState.getCurrentInlineStyle();
-                const active = inlineStyles.has(style);
+                const res = toggleInlineStyleOrSuggest(
+                    editorState,
+                    'EDITOR_TAG_company',
+                    suggestingMode,
+                    author,
+                    onCreateChangeStyleSuggestion,
+                );
 
-                if (suggestingMode) {
-                    if (!Suggestions.allowEditSuggestionOnLeft(editorState, author)
-                        && !Suggestions.allowEditSuggestionOnRight(editorState, author)) {
-                        return 'handled';
-                    }
-                    onCreateChangeStyleSuggestion(style, active);
+                if (res.handled) {
                     return 'handled';
                 }
-
-                newState = RichUtils.toggleInlineStyle(editorState, style);
+                newState = res.newState;
                 break;
             }
             case 'toggle-person-tag': {
-                const style = 'EDITOR_TAG_person';
-                const inlineStyles = editorState.getCurrentInlineStyle();
-                const active = inlineStyles.has(style);
+                const res = toggleInlineStyleOrSuggest(
+                    editorState,
+                    'EDITOR_TAG_person',
+                    suggestingMode,
+                    author,
+                    onCreateChangeStyleSuggestion,
+                );
 
-                if (suggestingMode) {
-                    if (!Suggestions.allowEditSuggestionOnLeft(editorState, author)
-                        && !Suggestions.allowEditSuggestionOnRight(editorState, author)) {
-                        return 'handled';
-                    }
-                    onCreateChangeStyleSuggestion(style, active);
+                if (res.handled) {
                     return 'handled';
                 }
-
-                newState = RichUtils.toggleInlineStyle(editorState, style);
+                newState = res.newState;
                 break;
             }
             case 'backspace': {

--- a/scripts/core/editor3/components/Editor3Component.tsx
+++ b/scripts/core/editor3/components/Editor3Component.tsx
@@ -352,11 +352,27 @@ export class Editor3Component extends React.Component<IPropsEditor3Component, IS
             const notAllowBold = key === 'b' && editorFormat.indexOf('bold') === -1;
             const notAllowItalic = key === 'i' && editorFormat.indexOf('italic') === -1;
             const notAllowUnderline = key === 'u' && editorFormat.indexOf('underline') === -1;
+            const notAllowCompanyTag = key === '3' &&
+                editorFormat.indexOf('EDITOR_TAG_company' as RICH_FORMATTING_OPTION) === -1;
+            const notAllowPersonTag = key === '6' &&
+                editorFormat.indexOf('EDITOR_TAG_person' as RICH_FORMATTING_OPTION) === -1;
 
-            if (notAllowBold || notAllowItalic || notAllowUnderline) {
+            if (notAllowBold || notAllowItalic || notAllowUnderline || notAllowCompanyTag || notAllowPersonTag) {
                 e.preventDefault();
                 return '';
             }
+        }
+
+        // Ctrl/Cmd + 3 for Company tag
+        if (key === '3' && modifierKey) {
+            e.preventDefault();
+            return 'toggle-company-tag';
+        }
+
+        // Ctrl/Cmd + 6 for Person tag
+        if (key === '6' && modifierKey) {
+            e.preventDefault();
+            return 'toggle-person-tag';
         }
 
         // Cmd/Ctrl + Alt + - for ndash
@@ -486,6 +502,40 @@ export class Editor3Component extends React.Component<IPropsEditor3Component, IS
                     thinSpaceContentState,
                     'insert-characters',
                 );
+                break;
+            }
+            case 'toggle-company-tag': {
+                const style = 'EDITOR_TAG_company';
+                const inlineStyles = editorState.getCurrentInlineStyle();
+                const active = inlineStyles.has(style);
+
+                if (suggestingMode) {
+                    if (!Suggestions.allowEditSuggestionOnLeft(editorState, author)
+                        && !Suggestions.allowEditSuggestionOnRight(editorState, author)) {
+                        return 'handled';
+                    }
+                    onCreateChangeStyleSuggestion(style, active);
+                    return 'handled';
+                }
+
+                newState = RichUtils.toggleInlineStyle(editorState, style);
+                break;
+            }
+            case 'toggle-person-tag': {
+                const style = 'EDITOR_TAG_person';
+                const inlineStyles = editorState.getCurrentInlineStyle();
+                const active = inlineStyles.has(style);
+
+                if (suggestingMode) {
+                    if (!Suggestions.allowEditSuggestionOnLeft(editorState, author)
+                        && !Suggestions.allowEditSuggestionOnRight(editorState, author)) {
+                        return 'handled';
+                    }
+                    onCreateChangeStyleSuggestion(style, active);
+                    return 'handled';
+                }
+
+                newState = RichUtils.toggleInlineStyle(editorState, style);
                 break;
             }
             case 'backspace': {

--- a/scripts/core/editor3/components/toolbar/StyleButton.tsx
+++ b/scripts/core/editor3/components/toolbar/StyleButton.tsx
@@ -66,7 +66,20 @@ export default class StyleButton extends React.Component<IPropsStyleButton> {
             'Editor3-activeButton': active,
         });
 
-        const customTags = Object.fromEntries(customEditorTags.map(({editor3Style, label}) => [editor3Style, label]));
+        const customTags = Object.fromEntries(
+            customEditorTags.map(({editor3Style, label}) => {
+                // Add keyboard shortcuts to tooltips for company and person tags
+                let tooltip = label;
+
+                if (editor3Style === 'EDITOR_TAG_company') {
+                    tooltip = `${label} (Ctrl+3)`;
+                } else if (editor3Style === 'EDITOR_TAG_person') {
+                    tooltip = `${label} (Ctrl+6)`;
+                }
+
+                return [editor3Style, tooltip];
+            }),
+        );
 
         const styleTooltips = {
             ...customTags,

--- a/scripts/core/editor3/components/toolbar/StyleButton.tsx
+++ b/scripts/core/editor3/components/toolbar/StyleButton.tsx
@@ -67,17 +67,9 @@ export default class StyleButton extends React.Component<IPropsStyleButton> {
         });
 
         const customTags = Object.fromEntries(
-            customEditorTags.map(({editor3Style, label}) => {
-                // Add keyboard shortcuts to tooltips for company and person tags
-                let tooltip = label;
-
-                if (editor3Style === 'EDITOR_TAG_company') {
-                    tooltip = `${label} (Ctrl+3)`;
-                } else if (editor3Style === 'EDITOR_TAG_person') {
-                    tooltip = `${label} (Ctrl+6)`;
-                }
-
-                return [editor3Style, tooltip];
+            customEditorTags.map(({editor3Style, label, tooltip}) => {
+                // Use configured tooltip if provided, otherwise fallback to label
+                return [editor3Style, tooltip || label];
             }),
         );
 

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -3758,6 +3758,7 @@ declare module 'superdesk-api' {
                 icon: string;
                 label: string;
                 borderColor: 'tag-color-1' | 'tag-color-2';
+                tooltip?: string;
             }>;
             timeToRead?: any;
             lineLength?: number;


### PR DESCRIPTION
### Purpose
This PR adds shortcuts for the Company and Person tags in the editor. 

### What has changed
- Add Ctrl+3 shortcut for Company tags (EDITOR_TAG_company)
- Add Ctrl+6 shortcut for Person tags (EDITOR_TAG_person)
- Update tooltips to show shortcuts: 'Yritys (Ctrl+3)' and 'Henkilö (Ctrl+6)'

### Steps to test
1. Open the editor for a content profile whose body html has company and person tags enabled
2. Start typing and hit Ctrl+3 to enable Company tags or Ctrl+6 to enable Person tags
3. Observe that the icons also are enabled when clicked
4. Observe that also on hovering, the tooltip on the icons also show the shortcuts

### Screenshots
<img width="600" height="272" alt="2026-03-04_10-56-52" src="https://github.com/user-attachments/assets/8aa61a8a-b1db-420f-a3b9-9263b45aa82d" />

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [STT-1584](https://sofab.atlassian.net/browse/STT-1584)


[STT-1584]: https://sofab.atlassian.net/browse/STT-1584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ