### PR TITLE
[SDBELGA-1043] Register article actions from extensions in the authoring topbar (`markForUser`)

### DIFF
--- a/scripts/extensions/markForUser/src/extension.tsx
+++ b/scripts/extensions/markForUser/src/extension.tsx
@@ -33,6 +33,7 @@ const extension: IExtension = {
             ];
             const result: IExtensionActivationResult = {
                 contributions: {
+                    getAuthoringActions: getActionsInitialize(superdesk),
                     globalMenuHorizontal: [getMarkedForMeComponent(superdesk)],
                     articleListItemWidgets: [getDisplayMarkedUserComponent(superdesk)],
                     authoringTopbarWidgets: [


### PR DESCRIPTION
### Purpose
After the "Authoring actions rework" (f829161f9), the "Mark for user" action stopped appearing in the authoring topbar. The action was still working correctly in monitoring and search list views, making it hard to spot the regression.

### What has changed
The rework introduced a new API path (`contributions.getAuthoringActions`) for the authoring topbar and switched `AuthoringTopbarDirective` to read from it exclusively. Extensions registering under `contributions.entities.article.getActions` (the original path, still used by list views) were silently dropped from the topbar.

The `markForUser` extension now registers its action getter under both paths, restoring the "Mark for user" action in the authoring topbar while keeping it working in monitoring and search list views.

### Steps to test
1. Create an article in monitoring screen
2. From the article edit screen click 3 dots menu (More Actions)
3. Observe the "Mark for User" actions is available and working in the menu

### Screenshots
<img width="680" height="641" alt="image" src="https://github.com/user-attachments/assets/9d27d509-c046-4cc5-bcd6-6169e98723e7" />


Resolves: [SDBELGA-1043]



[SDBELGA-1043]: https://sofab.atlassian.net/browse/SDBELGA-1043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ