### PR TITLE
[SDBELGA-1044] Restore autofocus on the search field in the Mark for user modal

### DIFF
--- a/scripts/core/ui/components/SelectUser.tsx
+++ b/scripts/core/ui/components/SelectUser.tsx
@@ -13,6 +13,8 @@ interface IState {
 }
 
 export class SelectUser extends SuperdeskReactComponent<IPropsSelectUser, IState> {
+    private treeSelectRef = React.createRef<TreeSelect<IUser>>();
+
     static getDerivedStateFromProps(props: IPropsSelectUser, state: IState): Partial<IState> | null {
         if (props.selectedUserId !== state.selectedUser?._id) {
             const users = store.getState().entities.users;
@@ -32,6 +34,17 @@ export class SelectUser extends SuperdeskReactComponent<IPropsSelectUser, IState
         };
     }
 
+    componentDidMount() {
+        if (this.props.autoFocus) {
+            // dropdownInitiallyOpen opens the dropdown via setState in TreeSelect's componentDidMount.
+            // We defer inputFocus by one tick to ensure that re-render has completed
+            // and the search input is in the DOM before attempting to focus it.
+            setTimeout(() => {
+                this.treeSelectRef.current?.inputFocus();
+            }, 0);
+        }
+    }
+
     render() {
         const users = store.getState().entities.users;
 
@@ -47,6 +60,8 @@ export class SelectUser extends SuperdeskReactComponent<IPropsSelectUser, IState
 
         return (
             <TreeSelect
+                ref={this.treeSelectRef}
+                dropdownInitiallyOpen={this.props.autoFocus === true}
                 kind="synchronous"
                 label={gettext('Select a user')}
                 inlineLabel={true}


### PR DESCRIPTION
### Purpose
The autofocus was originally implemented in 02bb57825 using `SelectWithTemplate` which natively supported `autoFocus` and `autoOpen` props. When `SelectUser` was migrated to `TreeSelect` in 17efc4f4d, those props were dropped and never re-implemented, silently breaking the behaviour.

`TreeSelect` does not support `autoFocus` directly. The fix opens the dropdown immediately via `dropdownInitiallyOpen` and defers the `inputFocus` call by one tick to ensure the search input is in the DOM after TreeSelect's internal setState re-render completes.

### What has changed
* Added a `treeSelectRef` using `React.createRef` to manage the focus of the `TreeSelect` component.
* Implemented the `componentDidMount` lifecycle method to trigger input focus on the search field when `autoFocus` is enabled, ensuring the input is present in the DOM before focusing.
* Passed the `ref` and `dropdownInitiallyOpen` props to `TreeSelect`, enabling the dropdown to open and the input to be focused when `autoFocus` is set.

### Screenshots
<img width="850" alt="image" src="https://github.com/user-attachments/assets/6d9fa0f2-0781-48c4-8ac6-dcf03c62af04" />


Resolves: [SDBELGA-1044]


[SDBELGA-1044]: https://sofab.atlassian.net/browse/SDBELGA-1044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ