### PR TITLE
[STT-1590] Apply custom editor tag styles in article preview

### DIFF
--- a/scripts/apps/authoring/preview/field-types/html.tsx
+++ b/scripts/apps/authoring/preview/field-types/html.tsx
@@ -1,4 +1,5 @@
 import {sdApi} from 'api';
+import {applyCustomEditorTagStyles, CUSTOM_EDITOR_TAG_ATTR} from 'core/editor3/components/customStyleMap';
 import React from 'react';
 
 interface IProps {
@@ -8,6 +9,10 @@ interface IProps {
 export function adjustHTMLForPreview(html: string): string {
     const parsed: HTMLElement =
     new DOMParser().parseFromString(html, 'text/html').body;
+
+    parsed.querySelectorAll(`[${CUSTOM_EDITOR_TAG_ATTR}]`).forEach((element) => {
+        applyCustomEditorTagStyles(element as HTMLElement, element.getAttribute(CUSTOM_EDITOR_TAG_ATTR));
+    });
 
     parsed.querySelectorAll('[data-custom-block-type]').forEach((element) => {
         const customBlockType = element.getAttribute('data-custom-block-type');

--- a/scripts/core/editor3/components/customStyleMap.tsx
+++ b/scripts/core/editor3/components/customStyleMap.tsx
@@ -27,6 +27,17 @@ export const customEditorTagStyleMap: Record<string, React.CSSProperties> = Obje
     ]),
 );
 
+export function applyCustomEditorTagStyles(element: HTMLElement, tagId: string): void {
+    const style = customEditorTagStyleMap[tagId];
+
+    if (style != null) {
+        element.style.display = 'inline-block';
+        for (const [prop, value] of Object.entries(style)) {
+            element.style[prop] = value as string;
+        }
+    }
+}
+
 export const customStyleMap = {
     ...Object.fromEntries(
         Object.entries(customEditorTagStyleMap).map(([style, props]) => [


### PR DESCRIPTION
### Purpose
This pull request introduces enhancements to the HTML preview rendering in the authoring app, specifically to support custom editor tag styling. The main improvements are the addition of a utility function for applying custom styles and its integration into the HTML preview adjustment logic.

### What has changed
* Added `applyCustomEditorTagStyles` function to `customStyleMap.tsx` to apply styles from `customEditorTagStyleMap` directly to HTML elements based on their tag ID.
* Updated `adjustHTMLForPreview` in `html.tsx` to use `applyCustomEditorTagStyles` for elements with the custom editor tag attribute, ensuring correct styling in the preview.

### Steps to test
- Create an article item with at least one Editor3 field
- Enter some content and mark some content with Company and Person tags
- Save it. Close it and open Preview
- Observe that the styles for the custom tags is preserved

### Screenshots
<img width="850" alt="image" src="https://github.com/user-attachments/assets/fe93dc4b-a305-438a-82d1-bec9630ca203" />

Resolves: [STT-1590]


[STT-1590]: https://sofab.atlassian.net/browse/STT-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ