### PR TITLE
[STT-1585] Add cursor position character count to editor3 floating bar

### DIFF
--- a/scripts/apps/authoring/authoring/components/text-statistics.tsx
+++ b/scripts/apps/authoring/authoring/components/text-statistics.tsx
@@ -9,12 +9,12 @@ interface IProps {
     text: string;
     language?: string;
     limit?: number;
+    hideReadingTime?: boolean;
 }
 
 export class TextStatistics extends React.PureComponent<IProps> {
     render() {
         const wordCount = countWords(this.props.text);
-        const readingTime: string = getReadingTimeText(this.props.text, this.props.language);
 
         return (
             <div className="char-count__wrapper">
@@ -28,7 +28,11 @@ export class TextStatistics extends React.PureComponent<IProps> {
                     item={this.props.text}
                 />
 
-                <span className="char-count__base">{readingTime}</span>
+                {this.props.hideReadingTime !== true && (
+                    <span className="char-count__base">
+                        {getReadingTimeText(this.props.text, this.props.language)}
+                    </span>
+                )}
             </div>
         );
     }

--- a/scripts/apps/authoring/styles/authoring.scss
+++ b/scripts/apps/authoring/styles/authoring.scss
@@ -1882,8 +1882,3 @@ feature-image {
     color: $errorText;
 }
 
-.Editor3-root:has(.floating-char-count--active) {
-    .public-DraftEditor-content {
-        padding-block-start: var(--space-4);
-    }
-}

--- a/scripts/core/editor3/components/toolbar/FloatingCharacterCount.tsx
+++ b/scripts/core/editor3/components/toolbar/FloatingCharacterCount.tsx
@@ -4,6 +4,8 @@ import classNames from 'classnames';
 import {EditorState} from 'draft-js';
 import {EditorLimit} from '../../actions';
 import {TextStatistics} from 'apps/authoring/authoring/components/text-statistics';
+import {getCharsBeforeCursor, getSelectedCharsCount} from '../../helpers/cursor-position-count';
+import {gettext} from 'core/utils';
 
 interface IOwnProps {
     floating: boolean;
@@ -18,8 +20,15 @@ interface IReduxStateProps {
 type IProps = IOwnProps & IReduxStateProps;
 
 const FloatingCharacterCountComponent: React.FC<IProps> = ({editorState, limitConfig, floating, showFloatingCount}) => {
+    if (showFloatingCount !== true) {
+        return null;
+    }
+
+    const selection = editorState.getSelection();
+    const hasFocus = selection.getHasFocus();
     const hasLimit = limitConfig?.chars != null;
-    const isActive = floating && hasLimit && showFloatingCount === true;
+    const hasContent = editorState.getCurrentContent().hasText();
+    const isActive = (hasFocus || floating) && hasContent;
 
     const cx = classNames({
         'floating-char-count': true,
@@ -29,10 +38,25 @@ const FloatingCharacterCountComponent: React.FC<IProps> = ({editorState, limitCo
     return (
         <div className={cx}>
             {isActive && (
-                <TextStatistics
-                    text={editorState.getCurrentContent().getPlainText()}
-                    limit={limitConfig.chars}
-                />
+                <>
+                    <span className="char-count__base">
+                        {hasFocus && (() => {
+                            const [label, count] = selection.isCollapsed()
+                                ? [gettext('Position'), getCharsBeforeCursor(editorState)]
+                                : [gettext('Selected'), getSelectedCharsCount(editorState)];
+
+                            return `${label}: ${count} ${gettext('characters')}`;
+                        })()}
+                    </span>
+
+                    {hasLimit && (
+                        <TextStatistics
+                            text={editorState.getCurrentContent().getPlainText()}
+                            limit={limitConfig.chars}
+                            hideReadingTime
+                        />
+                    )}
+                </>
             )}
         </div>
     );

--- a/scripts/core/editor3/helpers/cursor-position-count.ts
+++ b/scripts/core/editor3/helpers/cursor-position-count.ts
@@ -1,0 +1,64 @@
+import {EditorState} from 'draft-js';
+
+/**
+ * Returns the total number of characters before the cursor position
+ * by summing the length of all blocks preceding the cursor's block,
+ * plus the offset within that block.
+ */
+export function getCharsBeforeCursor(editorState: EditorState): number {
+    const selection = editorState.getSelection();
+    const contentState = editorState.getCurrentContent();
+    const cursorKey = selection.getStartKey();
+    const cursorOffset = selection.getStartOffset();
+    const blocks = contentState.getBlocksAsArray();
+
+    let count = 0;
+
+    for (const block of blocks) {
+        if (block.getKey() === cursorKey) {
+            count += cursorOffset;
+            break;
+        }
+
+        count += block.getLength();
+    }
+
+    return count;
+}
+
+/**
+ * Returns the number of characters in the current selection range.
+ * Handles both single-block and multi-block selections.
+ */
+export function getSelectedCharsCount(editorState: EditorState): number {
+    const selection = editorState.getSelection();
+    const contentState = editorState.getCurrentContent();
+    const startKey = selection.getStartKey();
+    const endKey = selection.getEndKey();
+    const startOffset = selection.getStartOffset();
+    const endOffset = selection.getEndOffset();
+
+    if (startKey === endKey) {
+        return endOffset - startOffset;
+    }
+
+    const blocks = contentState.getBlocksAsArray();
+    let count = 0;
+    let inRange = false;
+
+    for (const block of blocks) {
+        const key = block.getKey();
+
+        if (key === startKey) {
+            count += block.getLength() - startOffset;
+            inRange = true;
+        } else if (key === endKey) {
+            count += endOffset;
+            break;
+        } else if (inRange) {
+            count += block.getLength();
+        }
+    }
+
+    return count;
+}

--- a/scripts/core/editor3/helpers/cursor-position-count.ts
+++ b/scripts/core/editor3/helpers/cursor-position-count.ts
@@ -1,5 +1,10 @@
 import {EditorState} from 'draft-js';
 
+// These functions count raw block characters to reflect actual cursor positions
+// in the editor. This intentionally differs from getEditorFieldCharactersCount
+// which trims whitespace for character limit validation. Trimming here would
+// cause reported positions to not match the visible cursor location.
+
 /**
  * Returns the total number of characters before the cursor position
  * by summing the length of all blocks preceding the cursor's block,

--- a/scripts/core/editor3/helpers/tests/cursor-position-count.spec.ts
+++ b/scripts/core/editor3/helpers/tests/cursor-position-count.spec.ts
@@ -1,4 +1,4 @@
-import {EditorState, SelectionState} from 'draft-js';
+import {EditorState} from 'draft-js';
 import * as Setup from '../../reducers/tests/suggestion_setup';
 import {getCharsBeforeCursor, getSelectedCharsCount} from '../cursor-position-count';
 

--- a/scripts/core/editor3/helpers/tests/cursor-position-count.spec.ts
+++ b/scripts/core/editor3/helpers/tests/cursor-position-count.spec.ts
@@ -1,0 +1,152 @@
+import {EditorState, SelectionState} from 'draft-js';
+import * as Setup from '../../reducers/tests/suggestion_setup';
+import {getCharsBeforeCursor, getSelectedCharsCount} from '../cursor-position-count';
+
+function makeEditor(texts: Array<string>) {
+    const rawContent = {
+        blocks: texts.map((text, i) => ({key: `block${i}`, text})),
+        entityMap: {},
+    };
+
+    return Setup.getInitialEditorState(rawContent);
+}
+
+function withSelection(
+    editorState: EditorState,
+    startBlockIndex: number,
+    startOffset: number,
+    endBlockIndex: number,
+    endOffset: number,
+): EditorState {
+    return Setup.applySelection(editorState, startBlockIndex, startOffset, endBlockIndex, endOffset);
+}
+
+function withCollapsedCursor(
+    editorState: EditorState,
+    blockIndex: number,
+    offset: number,
+): EditorState {
+    return withSelection(editorState, blockIndex, offset, blockIndex, offset);
+}
+
+function withReversedSelection(
+    editorState: EditorState,
+    startBlockIndex: number,
+    startOffset: number,
+    endBlockIndex: number,
+    endOffset: number,
+): EditorState {
+    const content = editorState.getCurrentContent();
+    const blocks = content.getBlocksAsArray();
+    const startBlock = blocks[startBlockIndex];
+    const endBlock = blocks[endBlockIndex];
+
+    const selection = editorState.getSelection().merge({
+        anchorKey: endBlock.getKey(),
+        anchorOffset: endOffset,
+        focusKey: startBlock.getKey(),
+        focusOffset: startOffset,
+        isBackward: true,
+    });
+
+    return EditorState.acceptSelection(editorState, selection);
+}
+
+describe('editor3.helpers.cursor-position-count', () => {
+    describe('getCharsBeforeCursor', () => {
+        it('returns 0 for empty editor with collapsed selection at offset 0', () => {
+            const editorState = withCollapsedCursor(makeEditor(['']), 0, 0);
+
+            expect(getCharsBeforeCursor(editorState)).toBe(0);
+        });
+
+        it('returns the block offset for a single-block collapsed selection in the middle', () => {
+            const editorState = withCollapsedCursor(makeEditor(['hello world']), 0, 5);
+
+            expect(getCharsBeforeCursor(editorState)).toBe(5);
+        });
+
+        it('sums lengths of previous blocks plus current offset for multi-block content', () => {
+            // 'aaa' = 3, 'bbbb' = 4, cursor at offset 2 in third block
+            const editorState = withCollapsedCursor(makeEditor(['aaa', 'bbbb', 'ccccc']), 2, 2);
+
+            expect(getCharsBeforeCursor(editorState)).toBe(3 + 4 + 2);
+        });
+
+        it('does not count block separators or newlines between blocks', () => {
+            // cursor at start of second block — count should be length of first block only
+            const editorState = withCollapsedCursor(makeEditor(['hello', 'world']), 1, 0);
+
+            expect(getCharsBeforeCursor(editorState)).toBe(5);
+        });
+
+        it('returns total raw character count when cursor is at end of document', () => {
+            const editorState = withCollapsedCursor(makeEditor(['aaa', 'bb', 'c']), 2, 1);
+
+            expect(getCharsBeforeCursor(editorState)).toBe(3 + 2 + 1);
+        });
+
+        it('handles empty blocks before cursor', () => {
+            // 'aaa' = 3, '' = 0, cursor at offset 2 in third block
+            const editorState = withCollapsedCursor(makeEditor(['aaa', '', 'bbb']), 2, 2);
+
+            expect(getCharsBeforeCursor(editorState)).toBe(3 + 0 + 2);
+        });
+    });
+
+    describe('getSelectedCharsCount', () => {
+        it('returns endOffset - startOffset for a single-block selection', () => {
+            const editorState = withSelection(makeEditor(['hello world']), 0, 2, 0, 7);
+
+            expect(getSelectedCharsCount(editorState)).toBe(5);
+        });
+
+        it('counts tail of first block + head of last block for two-block selection', () => {
+            // 'hello' selected from offset 3 = 2 chars, 'world' selected to offset 3 = 3 chars
+            const editorState = withSelection(makeEditor(['hello', 'world']), 0, 3, 1, 3);
+
+            expect(getSelectedCharsCount(editorState)).toBe(2 + 3);
+        });
+
+        it('counts tail + full middle blocks + head for multi-block selection', () => {
+            // 'aaaa' from offset 2 = 2, 'bbb' full = 3, 'cc' to offset 1 = 1
+            const editorState = withSelection(makeEditor(['aaaa', 'bbb', 'cc']), 0, 2, 2, 1);
+
+            expect(getSelectedCharsCount(editorState)).toBe(2 + 3 + 1);
+        });
+
+        it('returns the same length for a reversed (backward) selection', () => {
+            const texts = ['hello', 'world'];
+            const forward = withSelection(makeEditor(texts), 0, 2, 1, 3);
+            const backward = withReversedSelection(makeEditor(texts), 0, 2, 1, 3);
+
+            expect(getSelectedCharsCount(backward)).toBe(getSelectedCharsCount(forward));
+        });
+
+        it('handles selection spanning empty blocks', () => {
+            // 'aaa' from offset 1 = 2, '' = 0, 'bbb' to offset 2 = 2
+            const editorState = withSelection(makeEditor(['aaa', '', 'bbb']), 0, 1, 2, 2);
+
+            expect(getSelectedCharsCount(editorState)).toBe(2 + 0 + 2);
+        });
+
+        it('handles selection ending at an empty last block', () => {
+            // 'hello' from offset 2 = 3, '' to offset 0 = 0
+            const editorState = withSelection(makeEditor(['hello', '']), 0, 2, 1, 0);
+
+            expect(getSelectedCharsCount(editorState)).toBe(3 + 0);
+        });
+
+        it('returns 0 for a collapsed selection', () => {
+            const editorState = withCollapsedCursor(makeEditor(['hello']), 0, 3);
+
+            expect(getSelectedCharsCount(editorState)).toBe(0);
+        });
+
+        it('selects entire document when spanning from start to end', () => {
+            const editorState = withSelection(makeEditor(['aaa', 'bb', 'c']), 0, 0, 2, 1);
+
+            expect(getSelectedCharsCount(editorState)).toBe(3 + 2 + 1);
+        });
+    });
+});

--- a/scripts/core/editor3/styles.scss
+++ b/scripts/core/editor3/styles.scss
@@ -44,28 +44,26 @@ $editor-styleButton-size: 			3rem;
 }
 
 .Editor3-root .floating-char-count {
-	padding: 0 var(--space-1-5);
+	position: absolute;
+	inset-block-start: 100%;
+	inset-inline: 0;
+	z-index: 1;
+	padding: 0 var(--space--2);
 	border-block-start: 1px solid $editor-neutral-border;
-	border-block-end: 1px solid var(--sd-shadow-outline);
-	min-height: 0;
 	opacity: 0;
-	transition: all .2s ease;
+	pointer-events: none;
+	transition: opacity .2s ease;
 	display: flex;
 	align-items: center;
-	justify-content: flex-end;
+	justify-content: space-between;
 	font-weight: 400;
-	position: absolute;
-	inset-block-end: 0;
-	inset-inline: 0;
-	transform: translateY(100%);
 	background-color: $editor-neutral-bg;
-	z-index: 1;
 	box-shadow: 0px 1px 2px lch(0% 0 0 / 0.4);
 
 	&.floating-char-count--active {
-		min-height: var(--space-4);
-		padding: var(--space-0-5) var(--space-1-5);
+		padding: calc(0.2 * var(--base-increment)) var(--space--1);
 		opacity: 1;
+		pointer-events: auto;
 	}
 }
 
@@ -75,9 +73,7 @@ $editor-styleButton-size: 			3rem;
 	padding: 0;
 	position: relative;
 	transition: box-shadow 0.3s ease, border-color 0.3s ease;
-	&.no-toolbar {
-		padding-block-start: 5px;
-	}
+
 	iframe {
 		width: 97%;
 	}
@@ -302,7 +298,7 @@ $editor-styleButton-size: 			3rem;
 					margin: 0;
 					padding: 0;
 				}
-	
+
 				position: relative;
 				border: 1px solid var(--sd-editor-colour__controls-border);
 				padding: var(--space--1);
@@ -440,7 +436,7 @@ $editor-styleButton-size: 			3rem;
 
 .Editor3-editor .public-DraftEditorPlaceholder-root,
 .Editor3-editor .public-DraftEditor-content {
-	padding: var(--space--1-5) var(--space--2) 0 var(--space--2);
+	padding: var(--space--2) var(--space--2) 0 var(--space--2);
 	transition: padding 0.2s ease;
 	transform-origin: top center;
 	span[style*="super"] {
@@ -463,7 +459,7 @@ $editor-styleButton-size: 			3rem;
 }
 
 .Editor3-editor .public-DraftEditor-content {
-	min-height: 20px;
+	min-height: var(--space--4);
 
 	[data-block="true"] {
         border-block-end: 1.5em solid transparent;
@@ -560,6 +556,7 @@ $editor-styleButton-size: 			3rem;
 }
 
 .Editor3-controls {
+	position: relative;
 	width: 100%;
 	min-width: 300px;
 	font-family: $baseFontFamily;


### PR DESCRIPTION
### Purpose
Show the cursor position (or selection length) in characters inside the editor3 floating bar, giving writers immediate feedback about where they are in the text.

### What has changed
  - New helper `cursor-position-count.ts` with functions to calculate characters before cursor and selected character count
  - `FloatingCharacterCount` now activates on editor focus (not just toolbar scroll), showing cursor position on the left and text
  statistics on the right
  - When the toolbar is in sticky/floating mode, the bar remains visible even after focus is lost
  - Bar is hidden when the editor is empty
  - Bar is gated behind the existing `showFloatingCount` content profile setting
  - `TextStatistics` gains an optional `hideReadingTime` prop, used in the floating bar to avoid duplication with the miniToolbar below
  - Bar uses absolute positioning over the editor content to avoid layout shifts
  - Unit tests covering all cursor position and selection count scenarios

### Steps to test
- Go to Content Profiles and enable "Show Floating Character Count" for body_html field
- Open an article and click into the editor field
- Verify the floating bar appears below the toolbar showing `Position: X characters`
- Move the cursor around and confirm the position updates
- Select text and confirm it switches to `Selected: X characters`
- Scroll down so the toolbar becomes sticky (the bar should remain visible)
- Click outside the editor. Observe the cursor count disappears 
- Verify the bar does not appear on an empty editor
- Verify the bar does not appear on fields where "Show Floating Character Count" is not enabled

### Screenshots
<img width="850" alt="image" src="https://github.com/user-attachments/assets/2e4757f3-0da3-47dd-886a-c884aa905c72" />


Resolves: [STT-1585]


[STT-1585]: https://sofab.atlassian.net/browse/STT-1585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ