### PR TITLE
[SDBELGA-1054] Fix default author role for items created from assignments

### DIFF
--- a/scripts/apps/authoring/authoring/controllers/PopulateAuthorsController.ts
+++ b/scripts/apps/authoring/authoring/controllers/PopulateAuthorsController.ts
@@ -14,7 +14,8 @@ interface IScope extends ng.IScope {
     autosave(item: IArticle): any;
 }
 
-const isNewItem = (item: IArticle): boolean => item._current_version === 0;
+const isNewItem = (item: IArticle): boolean =>
+    item._current_version === 0 || (item.authors || []).length === 0;
 
 /**
  * It will populate item.authors with current user when item is opened for authoring.
@@ -40,9 +41,7 @@ export function PopulateAuthorsController($scope: IScope, roles: IRolesService, 
                 .then((userRole) => {
                     if (isNewItem($scope.item) && userRole.author_role) {
                         addAuthor(userRole.author_role, itemAuthors);
-                    }
-
-                    if (!isNewItem($scope.item) && userRole.editor_role) {
+                    } else if (userRole.editor_role) {
                         addAuthor(userRole.editor_role, itemAuthors);
                     }
                 });


### PR DESCRIPTION
### Purpose
Items created via "Start Working" from assignments were incorrectly assigned the editor_role instead of author_role. This happened because the backend creates the item before the frontend opens it, so _current_version is already > 0 and the isNewItem check failed.

Fixed by extending isNewItem to also treat items with no existing authors as new, and changing the two independent if blocks to if/else to prevent the first addAuthor call from mutating state that the second check evaluates.

Resolves: [SDBELGA-1054]


[SDBELGA-1054]: https://sofab.atlassian.net/browse/SDBELGA-1054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ