### PR TITLE
[SDESK-7882] Hide translations field from vocabulary items editor

### DIFF
--- a/scripts/apps/vocabularies/controllers/VocabularyEditController.tsx
+++ b/scripts/apps/vocabularies/controllers/VocabularyEditController.tsx
@@ -295,6 +295,7 @@ export function VocabularyEditController(
 
     if ($scope.schema) {
         $scope.schemaFields = Object.keys($scope.schema)
+            .filter((key) => key !== 'translations')
             .sort()
             .map((key) => angular.extend(
                 {key: key},
@@ -304,7 +305,7 @@ export function VocabularyEditController(
 
     $scope.schemaFields = $scope.schemaFields
         || Object.keys($scope.model)
-            .filter((key) => key !== 'is_active')
+            .filter((key) => key !== 'is_active' && key !== 'translations')
             .map((key) => ({key: key, label: key, type: key}));
 
     $scope.itemsValidation = {valid: true};


### PR DESCRIPTION
Filter out the translations key from schema fields in the CV items editor. When translations was present in a vocabulary's schema or item data (e.g. from imports or manual DB edits), it rendered as `[object Object]` in a text input. Editing that field corrupted the translations dict by splitting the string representation character-by-character.

Resolves: [SDESK-7882]


[SDESK-7882]: https://sofab.atlassian.net/browse/SDESK-7882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ