### PR TITLE
[SDESK-7885] Fix image preview not showing

### DIFF
--- a/scripts/apps/archive/directives/MediaPreview.ts
+++ b/scripts/apps/archive/directives/MediaPreview.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import {checkRenditions, getAssociationsByFieldId} from 'apps/authoring/authoring/controllers/AssociationController';
 import {IVocabulary} from 'superdesk-api';
 import {appConfig} from 'appConfig';
-import {gettext} from 'core/utils';
+import {previewItems} from 'apps/authoring/preview/fullPreviewMultiple';
 
 /**
  * @ngdoc directive
@@ -86,7 +86,7 @@ export function MediaPreview(api, $rootScope, desks, superdesk, content, storage
              * @description Preview the item (picture, story).
              */
             scope.preview = function(item) {
-                superdesk.intent('preview', 'item', item);
+                previewItems([item]);
             };
 
             /**

--- a/scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts
@@ -7,6 +7,7 @@ import {isPublished} from 'apps/archive/utils';
 import {resetFieldMetadata} from 'core/editor3/helpers/fieldsMeta';
 import {appConfig} from 'appConfig';
 import {gettext} from 'core/utils';
+import {previewItems} from 'apps/authoring/preview/fullPreviewMultiple';
 import {formatDatelineText} from '../helpers';
 import {getMonthNamesShort} from 'core/helpers/locale';
 
@@ -136,7 +137,7 @@ export function ArticleEditDirective(
                 };
 
                 scope.preview = function(item) {
-                    superdesk.intent('preview', 'item', item);
+                    previewItems([item]);
                 };
 
                 elem.on('drop dragdrop', (event) => {

--- a/scripts/apps/monitoring/directives/WidgetGroup.ts
+++ b/scripts/apps/monitoring/directives/WidgetGroup.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 
 import {WidgetItemList as WidgetItemListComponent} from 'apps/search/components';
 import {IActivityService} from 'core/activity/activity';
+import {previewItems} from 'apps/authoring/preview/fullPreviewMultiple';
 
 WidgetGroup.$inject = [
     'search',
@@ -66,7 +67,7 @@ export function WidgetGroup(search, api, superdesk, desks, cards, $timeout, $q,
             };
 
             scope.preview = function(item) {
-                superdesk.intent('preview', 'item', item);
+                previewItems([item]);
             };
 
             scope.edit = function(item) {

--- a/scripts/apps/packaging/directives/PackageItemPreview.ts
+++ b/scripts/apps/packaging/directives/PackageItemPreview.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import {isPublished, isKilled} from 'apps/archive/utils';
 import {AuthoringWorkspaceService} from 'apps/authoring/authoring/services/AuthoringWorkspaceService';
+import {previewItems} from 'apps/authoring/preview/fullPreviewMultiple';
 
 PackageItemPreview.$inject = ['api', 'lock', 'superdesk', 'authoringWorkspace', '$sce',
     'desks', 'vocabularies'];
@@ -99,7 +100,7 @@ export function PackageItemPreview(api, lock, superdesk, authoringWorkspace: Aut
             });
 
             scope.preview = function(item) {
-                superdesk.intent('preview', 'item', item);
+                previewItems([item]);
             };
 
             scope.open = function(item) {

--- a/scripts/apps/packaging/tests/packaging.spec.ts
+++ b/scripts/apps/packaging/tests/packaging.spec.ts
@@ -1,4 +1,5 @@
 import {AuthoringWorkspaceService} from 'apps/authoring/authoring/services/AuthoringWorkspaceService';
+import * as fullPreviewMultiple from 'apps/authoring/preview/fullPreviewMultiple';
 
 describe('packaging', () => {
     beforeEach(window.module('superdesk.apps.packaging'));
@@ -60,11 +61,11 @@ describe('packaging', () => {
             scope = elem.isolateScope();
         }));
 
-        it('can preview item', inject(($rootScope, $q, superdesk) => {
-            spyOn(superdesk, 'intent').and.returnValue($q.when());
+        it('can preview item', inject(($rootScope) => {
+            spyOn(fullPreviewMultiple, 'previewItems');
             scope.preview(item);
             $rootScope.$apply();
-            expect(superdesk.intent).toHaveBeenCalledWith('preview', 'item', item);
+            expect(fullPreviewMultiple.previewItems).toHaveBeenCalledWith([item]);
         }));
 
         it('can open item', inject(($rootScope, $q, authoringWorkspace: AuthoringWorkspaceService) => {


### PR DESCRIPTION
Replace `superdesk.intent('preview', 'item', item)` with `previewItems()` from `fullPreviewMultiple.tsx` in all remaining callers.

The intent call has been broken since `ItemPreviewContainer` was removed in a82d4aa (Nov 2021). No activity is registered for action "preview" + type "item", so the intent always rejected with undefined.

Affected files:
- MediaPreview.ts
- WidgetGroup.ts
- PackageItemPreview.ts
- ArticleEditDirective.ts

Resolves: [SDESK-7885]


[SDESK-7885]: https://sofab.atlassian.net/browse/SDESK-7885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ