### PR TITLE
Sdesk 7891 add download original button to the image preview

### DIFF
--- a/po/superdesk.pot
+++ b/po/superdesk.pot
@@ -9190,6 +9190,10 @@ msgstr ""
 msgid "Last Year"
 msgstr ""
 
+#: scripts/apps/authoring/preview/fullPreview.tsx:124
+msgid "Download original"
+msgstr ""
+
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/PreviewArticle.tsx:71
 #: scripts/apps/authoring/preview/fullPreview.tsx:77
 msgid "Last modified"

--- a/scripts/apps/authoring/preview/fullPreview.tsx
+++ b/scripts/apps/authoring/preview/fullPreview.tsx
@@ -111,8 +111,8 @@ export class FullPreview extends React.Component<IProps, IState> {
                     {
                         item.type === 'picture' && hideMedia !== true && item.renditions?.baseImage?.href != null
                             ? (
-                                <div class="d-flex flex-col justify-start">
-                                    <button class="btn btn--hollow btn--tertiary btn--small mb-1 ms-auto"
+                                <div className="d-flex flex-col justify-start">
+                                    <button className="btn btn--hollow btn--tertiary btn--small mb-1 ms-auto"
                                         onClick={() => {
                                             const a = document.createElement('a');
                                             a.href = item.renditions.original.href;

--- a/scripts/apps/authoring/preview/fullPreview.tsx
+++ b/scripts/apps/authoring/preview/fullPreview.tsx
@@ -112,9 +112,11 @@ export class FullPreview extends React.Component<IProps, IState> {
                         item.type === 'picture' && hideMedia !== true && item.renditions?.baseImage?.href != null
                             ? (
                                 <div className="d-flex flex-col justify-start">
-                                    <button className="btn btn--hollow btn--tertiary btn--small mb-1 ms-auto"
+                                    <button
+                                        className="btn btn--hollow btn--tertiary btn--small mb-1 ms-auto"
                                         onClick={() => {
                                             const a = document.createElement('a');
+
                                             a.href = item.renditions.original.href;
                                             a.download = item.renditions.original.href.split('/').pop();
                                             a.click();

--- a/scripts/apps/authoring/preview/fullPreview.tsx
+++ b/scripts/apps/authoring/preview/fullPreview.tsx
@@ -122,7 +122,7 @@ export class FullPreview extends React.Component<IProps, IState> {
                                             a.click();
                                         }}
                                     >
-                                        Download original
+                                        {gettext('Download original')}
                                     </button>
                                     <img src={item.renditions.baseImage.href} />
 

--- a/scripts/apps/authoring/preview/fullPreview.tsx
+++ b/scripts/apps/authoring/preview/fullPreview.tsx
@@ -111,7 +111,17 @@ export class FullPreview extends React.Component<IProps, IState> {
                     {
                         item.type === 'picture' && hideMedia !== true && item.renditions?.baseImage?.href != null
                             ? (
-                                <div>
+                                <div class="d-flex flex-col justify-start">
+                                    <button class="btn btn--hollow btn--tertiary btn--small mb-1 ms-auto"
+                                        onClick={() => {
+                                            const a = document.createElement('a');
+                                            a.href = item.renditions.original.href;
+                                            a.download = item.renditions.original.href.split('/').pop();
+                                            a.click();
+                                        }}
+                                    >
+                                        Download original
+                                    </button>
                                     <img src={item.renditions.baseImage.href} />
 
                                     <MediaMetadataView


### PR DESCRIPTION
### Purpose
Newly reenabled image preview lightbox is displaying `baseImage` instead of the `original`, hence _Download original_ button is to be added. 

### What has changed
Button is added above the image.

### Screenshots
<img width="1376" height="1213" alt="Screenshot_20260331_165827" src="https://github.com/user-attachments/assets/1f573728-5a5b-4039-9a47-6f7b1c2c07e1" />

Resolves: [SDESK-7891](https://sofab.atlassian.net/browse/SDESK-7891)


[SDESK-7891]: https://sofab.atlassian.net/browse/SDESK-7891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ