### PR TITLE
[SDANSA-576] Show seconds in publish schedule when configured

### DIFF
--- a/scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx
+++ b/scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx
@@ -127,6 +127,7 @@ export class PublishingDateOptions extends React.PureComponent<IProps> {
                         <DateTimePicker
                             value={embargo}
                             valueType="date"
+                            allowSeconds={appConfig.view.timeformat.includes('ss')}
                             locale={{
                                 type: 'full',
                                 payload: getLocaleForDatePicker(),
@@ -154,6 +155,7 @@ export class PublishingDateOptions extends React.PureComponent<IProps> {
                         <DateTimePicker
                             value={publishSchedule}
                             valueType="date"
+                            allowSeconds={appConfig.view.timeformat.includes('ss')}
                             locale={{
                                 type: 'full',
                                 payload: getLocaleForDatePicker(),

--- a/scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx
+++ b/scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx
@@ -115,6 +115,7 @@ export class PublishingDateOptions extends React.PureComponent<IProps> {
 
         const canSetEmbargo = this.props.allowSettingEmbargo && sdApi.user.hasPrivilege('embargo');
         const canSetPublishSchedule = this.props.allowSettingPublishSchedule;
+        const allowSeconds = appConfig.authoring?.panels?.publish?.allowSeconds ?? false;
 
         if (items.length !== 1) {
             return null;
@@ -127,7 +128,7 @@ export class PublishingDateOptions extends React.PureComponent<IProps> {
                         <DateTimePicker
                             value={embargo}
                             valueType="date"
-                            allowSeconds={appConfig.view.timeformat.includes('ss')}
+                            allowSeconds={allowSeconds}
                             locale={{
                                 type: 'full',
                                 payload: getLocaleForDatePicker(),
@@ -155,7 +156,7 @@ export class PublishingDateOptions extends React.PureComponent<IProps> {
                         <DateTimePicker
                             value={publishSchedule}
                             valueType="date"
-                            allowSeconds={appConfig.view.timeformat.includes('ss')}
+                            allowSeconds={allowSeconds}
                             locale={{
                                 type: 'full',
                                 payload: getLocaleForDatePicker(),

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -3623,6 +3623,7 @@ declare module 'superdesk-api' {
 
             panels?: {
                 publish?: {
+                    allowSeconds?: boolean;
                     publishSchedule?: boolean
                     publishingTarget?: boolean;
                 }


### PR DESCRIPTION
### Purpose
This PR now allows the publish schedule date/time picker to show seconds when the configured view time format includes seconds.

### What has changed
- Updated the publish schedule and embargo DateTimePicker components to pass allowSeconds only when `appConfig.view.timeformat.includes('ss')`.

### Steps to test
1. Set `appConfig.view.timeformat` to `HH:mm:ss` like the way it is set for ANSA
2. Open the article publish schedule panel.
3. Verify the time picker shows seconds.
4. Change `appConfig.view.timeformat` to `HH:mm`.
5. Reload the app and verify the seconds field is no longer shown.

### Screenshots
<img width="396" height="120" alt="2026-04-01_14-43-32" src="https://github.com/user-attachments/assets/e175c39b-f45e-43a5-ba9e-c6b724ee6e15" />

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDANSA-576](https://sofab.atlassian.net/browse/SDANSA-576)


[SDANSA-576]: https://sofab.atlassian.net/browse/SDANSA-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ