### PR TITLE
Link opening the original in a new tab, renamed to Original

### DIFF
--- a/po/superdesk.pot
+++ b/po/superdesk.pot
@@ -9190,10 +9190,6 @@ msgstr ""
 msgid "Last Year"
 msgstr ""
 
-#: scripts/apps/authoring/preview/fullPreview.tsx:124
-msgid "Download original"
-msgstr ""
-
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/PreviewArticle.tsx:71
 #: scripts/apps/authoring/preview/fullPreview.tsx:77
 msgid "Last modified"
@@ -11275,6 +11271,7 @@ msgstr ""
 #: scripts/apps/authoring/views/change-image.html:125
 #: scripts/apps/authoring/views/change-image.html:232
 #: scripts/apps/authoring/views/change-image.html:92
+#: scripts/apps/authoring/preview/fullPreview.tsx:124
 msgid "Original"
 msgstr ""
 

--- a/scripts/apps/authoring/preview/fullPreview.tsx
+++ b/scripts/apps/authoring/preview/fullPreview.tsx
@@ -112,18 +112,14 @@ export class FullPreview extends React.Component<IProps, IState> {
                         item.type === 'picture' && hideMedia !== true && item.renditions?.baseImage?.href != null
                             ? (
                                 <div className="d-flex flex-col justify-start">
-                                    <button
+                                    <a
                                         className="btn btn--hollow btn--tertiary btn--small mb-1 ms-auto"
-                                        onClick={() => {
-                                            const a = document.createElement('a');
-
-                                            a.href = item.renditions.original.href;
-                                            a.download = item.renditions.original.href.split('/').pop();
-                                            a.click();
-                                        }}
+                                        href={item.renditions.original.href}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
                                     >
-                                        {gettext('Download original')}
-                                    </button>
+                                        {gettext('Original')}
+                                    </a>
                                     <img src={item.renditions.baseImage.href} />
 
                                     <MediaMetadataView


### PR DESCRIPTION
### Purpose
Replacing the button with link opening the original in a new tab.  Renamed _Download original_ to _Original_, reflected in the translations as well. 

Resolves: [SDESK-7892](https://sofab.atlassian.net/browse/SDESK-7892)


[SDESK-7892]: https://sofab.atlassian.net/browse/SDESK-7892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ