### PR TITLE
keep headline on top in media preview

### DIFF
--- a/scripts/apps/archive/views/preview.html
+++ b/scripts/apps/archive/views/preview.html
@@ -105,7 +105,7 @@
         <div class="core-content">
 
             <p class="title preview-headline"
-              order="{{editor['headline'].order}}"
+              order="{{selected.preview.type === 'text' ? editor['headline'].order : '0' }}"
               ng-if="selected.preview.headline && selected.preview.type !== 'composite'"
               ng-class="{condensed: !lock}"
               sd-html-preview="selected.preview.headline"


### PR DESCRIPTION
it was using profile order but the media preview itself is not in the profile config so can't be moved around.

SDANSA-581

### Purpose
<!--- Explain what this PR accomplishes. Why are we changing this? -->

### What has changed
<!--- Explain what has changed and how -->

### Steps to test
<!---
Try to explain in a few steps how to test and what things to look out for.
-->

<!-- [For UI changes]
### Screenshots
-->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I reviewed my code
- [ ] I tested all affected functionality and made sure it works

Resolves: [issue-number]
