### PR TITLE
[SDANSA-580] - Publish button missing from the Action bar in Personal space

### DIFF
--- a/scripts/api/article.ts
+++ b/scripts/api/article.ts
@@ -75,20 +75,24 @@ function canPublish(item: IArticle): boolean {
         return false;
     }
 
-    if (sdApi.navigation.isPersonalSpace() && appConfig?.features?.publishFromPersonal !== true) {
+    if (sdApi.navigation.isPersonalSpace()) {
+        if (appConfig?.features?.publishFromPersonal !== true) {
+            return false;
+        }
+
+        return true;
+    }
+
+    const deskId = item?.task?.desk;
+
+    if (deskId == null) {
         return false;
-    } else {
-        const deskId = item?.task?.desk;
+    }
 
-        if (deskId == null) {
-            return false;
-        }
+    const desk = sdApi.desks.getAllDesks().get(deskId);
 
-        const desk = sdApi.desks.getAllDesks().get(deskId);
-
-        if (desk.desk_type === 'authoring' && appConfig?.features?.noPublishOnAuthoringDesk === true) {
-            return false;
-        }
+    if (desk.desk_type === 'authoring' && appConfig?.features?.noPublishOnAuthoringDesk === true) {
+        return false;
     }
 
     return true;


### PR DESCRIPTION
### Purpose
This PR fixes the Publish button not appearing in the Action bar when selecting items in Personal space, even though `publishFromPersonal: true` is configured in SDANSA config

### What has changed
- Updated `canPublish()` to restructure the logic so that personal space items return early when `publishFromPersonal: true`, without falling through to the desk check. 

### Steps to test
1. Ensure `publishFromPersonal: true` is set in superdesk.config.js 
2. Navigate to Personal Space 
3. Create or select an article and verify the publish button appears in the Action bar 
4. Click Publish and confirm the item publishes successfully
5. Set `publishFromPersonal: false` and confirm the Publish button is hidden in Personal space

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I reviewed my code
- [X] I tested all affected functionality and made sure it works

Resolves: [SDANSA-580](https://sofab.atlassian.net/browse/SDANSA-580)


[SDANSA-580]: https://sofab.atlassian.net/browse/SDANSA-580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ