### PR TITLE
SDESK-7894: Display Publishing shortcuts on opening authoring 

### DIFF
--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -235,21 +235,34 @@ export function AuthoringDirective(
                 getLabelForFieldId = _getLabelForFieldId;
 
                 $scope.$watch('item', () => {
-                    $scope.toDeskEnabled = appConfig.features?.customAuthoringTopbar?.toDesk
-                        && !sdApi.navigation.isPersonalSpace()
+                    $scope.toDeskAvailable = appConfig.features?.customAuthoringTopbar?.toDesk
+                        && !sdApi.navigation.isPersonalSpace();
+
+                    $scope.toDeskEnabled = $scope.toDeskAvailable
                         && authoringApiCommon.checkShortcutButtonAvailability($scope.item, $scope.dirty);
 
-                    $scope.closeAndContinueEnabled = sdApi.article.showCloseAndContinue($scope.item, $scope.dirty);
+                    $scope.closeAndContinueAvailable = appConfig.features?.customAuthoringTopbar?.closeAndContinue
+                        && !sdApi.navigation.isPersonalSpace();
 
-                    $scope.publishEnabled = appConfig.features?.customAuthoringTopbar?.publish
-                        && sdApi.article.canPublishOnDesk($scope.deskType)
+                    $scope.closeAndContinueEnabled = $scope.closeAndContinueAvailable
+                        && sdApi.article.showCloseAndContinue($scope.item, $scope.dirty);
+
+                    $scope.publishAvailable = appConfig.features?.customAuthoringTopbar?.publish
+                        && sdApi.article.canPublishOnDesk($scope.deskType);
+
+                    $scope.publishEnabled = $scope.publishAvailable
                         && authoringApiCommon.checkShortcutButtonAvailability(
                             $scope.item,
                             false,
                             sdApi.navigation.isPersonalSpace(),
                         );
 
-                    $scope.publishAndContinueEnabled = sdApi.article.showPublishAndContinue($scope.item, $scope.dirty);
+                    $scope.publishAndContinueAvailable = appConfig.features?.customAuthoringTopbar?.publishAndContinue
+                        && !sdApi.navigation.isPersonalSpace()
+                        && sdApi.article.canPublishOnDesk($scope.deskType);
+
+                    $scope.publishAndContinueEnabled = $scope.publishAndContinueAvailable
+                        && sdApi.article.showPublishAndContinue($scope.item, $scope.dirty);
                 }, true);
             });
 
@@ -642,8 +655,8 @@ export function AuthoringDirective(
             }
 
             $scope.showCustomButtons = () => {
-                return $scope.toDeskEnabled || $scope.closeAndContinueEnabled
-                    || $scope.publishAndContinueEnabled || $scope.publishEnabled || $scope.sendAndDuplicateEnabled;
+                return $scope.toDeskAvailable || $scope.closeAndContinueAvailable
+                    || $scope.publishAndContinueAvailable || $scope.publishAvailable || $scope.sendAndDuplicateEnabled;
             };
 
             $scope.saveAndContinue = function(customButtonAction, showConfirm) {

--- a/scripts/apps/authoring/views/authoring-topbar.html
+++ b/scripts/apps/authoring/views/authoring-topbar.html
@@ -49,8 +49,9 @@
         ng-show="_editable && itemActions.save && (action === 'edit' || isCorrection(item))"
       >
         <button
-                ng-if="toDeskEnabled"
+                ng-if="toDeskAvailable"
                 class="btn sd-overflow-ellipsis btn--custom"
+                ng-disabled="!toDeskEnabled"
                 ng-click="saveAndContinue(sendToNextStage, false)"
                 aria-label="{{ 'To Desk' | translate }}"
                 title="{{ :: 'To Desk' | translate }}">
@@ -59,8 +60,9 @@
         </button>
 
         <button
-                ng-if="closeAndContinueEnabled"
+                ng-if="closeAndContinueAvailable"
                 class="btn sd-overflow-ellipsis btn--custom"
+                ng-disabled="!closeAndContinueEnabled"
                 ng-click="saveAndContinue(closeAndContinue, false)"
                 aria-label="{{ 'Close and Continue' | translate }}"
                 title="{{ 'Close and Continue' | translate }}">
@@ -69,9 +71,10 @@
         </button>
 
         <button
-                ng-if="publishEnabled"
+                ng-if="publishAvailable"
                 class="btn btn--custom btn--publish"
                 type="submit"
+                ng-disabled="!publishEnabled"
                 ng-click="saveAndContinue(publish, true)"
                 aria-label="{{ :: 'Publish' | translate }}"
                 title="{{ :: 'Publish' | translate }}">
@@ -91,8 +94,9 @@
         </button>
 
         <button
-                ng-if="publishAndContinueEnabled"
+                ng-if="publishAndContinueAvailable"
                 class="btn sd-overflow-ellipsis btn--custom btn--publish-plus"
+                ng-disabled="!publishAndContinueEnabled"
                 ng-click="saveAndContinue(publishAndContinue, true)"
                 aria-label="{{ :: 'Publish and Continue' | translate }}"
                 title="{{ :: 'Publish and Continue' | translate }}">


### PR DESCRIPTION
### Purpose
This PR allows for publishing shortcuts to be displayed immediately when the authoring view opens while keeping them disabled until actionable. Just like the save and cancel button.

### What has changed
- Publishing shortcut buttons now render immediately when the authoring view opens, but remain disabled until the item is ready to be acted upon.

### Steps to test
1. Start a new article
2. On opening the authoring view, confirm that the shortcut buttons (To Desk, Publish, Publish & Continue, Close & Continue) are visible but disabled
3. Type something to trigger autosave and confirm the buttons become enabled/active.
4. Click Publish or Publish & Continue and confirm it saves first, then performs the action.
5. Repeat on an existing article and buttons should be visible and enabled immediately.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I reviewed my code
- [X] I tested all affected functionality and made sure it works

Resolves: [SDESK-7894](https://sofab.atlassian.net/browse/SDESK-7894)


[SDESK-7894]: https://sofab.atlassian.net/browse/SDESK-7894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ