### PR TITLE
Add AI-assisted PO translation workflow

### DIFF
--- a/.github/skills/translate-po/SKILL.md
+++ b/.github/skills/translate-po/SKILL.md
@@ -12,14 +12,15 @@ Use this skill when asked to update translations in `superdesk-client-core`.
 - Target language code, for example `es`
 - Target PO file, for example `po/es.po`
 - Source of truth: `po/superdesk.pot`
-- Optional glossary file, for example `docs/i18n/es-glossary.md`
+- Optional glossary file, normally `docs/i18n/<lang>-glossary.md` when it exists
 - Translation rules: `docs/i18n/translation-rules.md`
+- Optional internal batch size for large translation sets
 
 ## Environment requirements
 
 Before doing any translation work, ensure the environment is ready:
 
-1. Use Node.js 22.
+1. Use Node.js 20 or newer. Prefer the repo's configured Node.js version when it is easy to use, but do not spend time upgrading from Node.js 20+ only for this workflow.
 2. Install project dependencies:
 
 ```bash
@@ -45,7 +46,7 @@ Assume `po/superdesk.pot` was prepared by a human developer in a complete local 
 npm run gettext-update-po -- <lang>
 ```
 
-2. Fill only empty `msgstr` and `msgstr[n]` entries in `po/<lang>.po`.
+2. Fill empty `msgstr` and `msgstr[n]` entries in `po/<lang>.po`. Use internal batches only when the number of pending entries is too large to handle safely in one pass.
 
 3. Validate the result:
 
@@ -54,6 +55,22 @@ grunt nggettext_compile
 ```
 
 4. Prepare a pull request against `develop`.
+
+## Internal batching
+
+The final result should be a single pull request, not one pull request per batch.
+
+Use internal batches only when the pending translation set is large enough that one pass would reduce quality or risk context loss.
+
+- use `npm run gettext-next-batch -- <lang> --limit 50` to inspect the next deterministic batch when batching is needed
+- if batching is needed, process at most `50` safe untranslated active entries at a time unless the prompt provides a different batch size
+- after each internal batch, re-check placeholders, plural structures, whitespace, and glossary consistency for the entries just changed
+- run validation after each successful internal batch when practical, and fix only issues introduced in that batch
+- commit each successful internal batch separately within the same pull request so review and rollback are easier
+- continue with the next internal batch in the same agent session until there are no more safe empty entries, or until continuing would reduce quality
+- if the session cannot safely finish the full file, keep the partial work in the same PR and report exactly where the agent stopped
+- do not translate obsolete `#~` entries
+- do not create separate PRs for each internal batch unless the user explicitly asks for that
 
 ## Sync safety checks
 
@@ -89,18 +106,9 @@ Skip the entry and leave it unchanged if it is:
 
 - Do not introduce leading or trailing spaces in translated text.
 - Do not introduce double spaces unless they are already required by the source.
-- Do not add spaces before punctuation marks in Spanish.
+- Do not add spaces before punctuation marks in the target language.
 - Do not add unnecessary spaces inside parentheses, quotes, or around slashes.
-- Preserve placeholder text exactly, but make the surrounding Spanish punctuation and spacing natural.
+- Preserve placeholder text exactly, but make the surrounding punctuation and spacing natural for the target language.
 - Before saving, re-read each changed entry once focusing only on whitespace and punctuation.
 
-## Current Spanish configuration
-
-For the current Spanish workflow:
-
-- target language: `es`
-- target file: `po/es.po`
-- glossary: `docs/i18n/es-glossary.md`
-- rules: `docs/i18n/translation-rules.md`
-
-When asked to update Spanish translations, use this skill together with the Spanish glossary and rules.
+When asked to update translations, use this skill together with `docs/i18n/translation-rules.md` and the glossary for the target language when one exists.

--- a/docs/i18n/ai-agent-instructions.md
+++ b/docs/i18n/ai-agent-instructions.md
@@ -8,11 +8,12 @@ Follow these rules when updating translations in `superdesk-client-core`.
 - Target language code: `<lang>`
 - Target PO file: `po/<lang>.po`
 - Optional excluded PO files: any locale-specific files that the workflow marks as out of scope
-- Optional glossary: a language-specific glossary file if one exists
+- Optional glossary: `docs/i18n/<lang>-glossary.md` if one exists
+- Optional internal batch size for large translation sets
 
 ## Environment Requirements
 
-- Use Node.js 22.
+- Use Node.js 20 or newer. Prefer the repo's configured Node.js version when it is easy to use, but do not spend time upgrading from Node.js 20+ only for this workflow.
 - Install project dependencies with `npm ci`.
 - Ensure GNU gettext tools are installed and available:
   - `msgmerge`
@@ -29,7 +30,22 @@ Assume `po/superdesk.pot` was prepared outside the agent flow.
 
 1. Use the existing `po/superdesk.pot` on the branch as the source of truth.
 2. Assume `npm run gettext-update-po -- <lang>` has structurally synced `po/<lang>.po`.
-3. Only then fill missing translations in `po/<lang>.po`.
+3. Only then fill missing translations in `po/<lang>.po`. Use internal batches only when the number of pending entries is too large to handle safely in one pass.
+
+## Internal Batching
+
+The expected output is one pull request for the target language.
+
+- Use internal batches only when the pending translation set is large enough that one pass would reduce quality or risk context loss.
+- Use `npm run gettext-next-batch -- <lang> --limit 50` to inspect the next deterministic batch when batching is needed.
+- If batching is needed, process at most `50` safe active untranslated entries at a time unless the prompt provides a different batch size.
+- After each internal batch, review only the entries just changed for placeholder preservation, plural structure, whitespace, punctuation, and glossary consistency.
+- Run validation after each successful internal batch when practical, and fix only issues introduced in that batch.
+- Commit each successful internal batch separately within the same pull request so review and rollback are easier.
+- Continue in the same agent session until no more safe empty entries remain, or until continuing would reduce quality.
+- If the full file cannot be completed safely, keep the partial work in the same PR and report where translation stopped.
+- Do not translate obsolete `#~` entries.
+- Do not create separate PRs per internal batch unless explicitly requested.
 
 ## Sync Safety Checks
 
@@ -66,7 +82,7 @@ Skip the entry and leave it unchanged if it is:
 - Do not add double spaces unless the source requires them.
 - Do not add spaces before punctuation marks.
 - Do not add unnecessary spaces inside parentheses, quotes, or around slashes.
-- Preserve placeholders exactly, but keep surrounding Spanish spacing natural.
+- Preserve placeholders exactly, but keep surrounding spacing natural for the target language.
 - Re-read changed translations once with a whitespace-only review before finishing.
 
 ## Validation Mindset

--- a/docs/i18n/ja-glossary.md
+++ b/docs/i18n/ja-glossary.md
@@ -1,0 +1,74 @@
+# Japanese Glossary
+
+Use clear, concise Japanese for UI labels. Prefer consistency over stylistic variation.
+
+This glossary is a starting point for AI-assisted draft translations. Japanese terminology should still be reviewed by a fluent Japanese speaker before release.
+
+## Core Terms
+
+- article -> 記事
+- item -> アイテム
+- content -> コンテンツ
+- headline -> 見出し
+- slugline -> スラッグライン
+- byline -> 署名
+- desk -> デスク
+- stage -> ステージ
+- workspace -> ワークスペース
+- assignment -> アサインメント
+- planning -> プランニング
+- event -> イベント
+- coverage -> 取材
+- vocabulary -> ボキャブラリー
+- dictionary -> 辞書
+- template -> テンプレート
+- preview -> プレビュー
+- publish -> 公開
+- unpublish -> 公開を取り消す
+- schedule -> スケジュール
+- save -> 保存
+- close -> 閉じる
+- cancel -> キャンセル
+- delete -> 削除
+- filter -> フィルター
+- search -> 検索
+- settings -> 設定
+- user -> ユーザー
+- language -> 言語
+- translation -> 翻訳
+- ingest -> 取り込み
+- source -> ソース
+- subscriber -> 配信先
+- package -> パッケージ
+- rundown -> ランダウン
+
+## Tone
+
+- Keep UI labels short and direct.
+- Prefer common product UI wording over literal translation.
+- Use polite but concise Japanese for messages.
+- Keep product names such as `Superdesk` untranslated.
+- Use Japanese punctuation where natural, such as `。`, `、`, `：`, and `？`.
+- Avoid unnecessary spaces between Japanese text and punctuation.
+
+## Consistency Rules
+
+- Preserve established translations already present in `po/ja.po` once that file exists, unless a correction is separately approved.
+- Do not translate placeholders, field identifiers, internal codes, or product names.
+- Preserve all `{{...}}` placeholders exactly, including spaces inside placeholders.
+- Avoid adding spaces around placeholders unless the surrounding Japanese text requires it for readability.
+- If a source term is ambiguous, leave it for manual review instead of forcing a glossary match.
+- If an English editorial term is commonly used as-is in product context, prefer the glossary katakana form.
+
+## Review-Required Terms
+
+These terms are context-sensitive. Use the glossary default only when the UI context is clear; otherwise skip the entry for human review.
+
+- desk -> デスク
+- stage -> ステージ
+- slugline -> スラッグライン
+- assignment -> アサインメント
+- planning -> プランニング
+- coverage -> 取材
+- rundown -> ランダウン
+- subscriber -> 配信先

--- a/docs/i18n/translation-workflow.md
+++ b/docs/i18n/translation-workflow.md
@@ -16,7 +16,7 @@ This is the manual GitHub Copilot agent workflow for AI-assisted translations in
 npm run gettext-update-po -- es
 ```
 
-5. The agent fills empty `msgstr` and `msgstr[n]` entries in `po/es.po`, using `po/superdesk.pot` as the source of truth.
+5. The agent fills empty `msgstr` and `msgstr[n]` entries in `po/es.po`, using `po/superdesk.pot` as the source of truth. If there are too many pending entries to handle safely in one pass, the agent works in internal batches during the same session, commits each successful batch separately when practical, and still prepares one PR.
 
 6. The agent validates with existing tooling:
 
@@ -33,6 +33,7 @@ grunt nggettext_compile
 - Read `po/superdesk.pot` as the source of truth.
 - Update only `po/es.po`.
 - Translate only empty entries in `po/es.po`.
+- Use internal batches only when the pending translation set is large, but keep the result in a single PR.
 - Do not prune obsolete entries during the agent-driven sync step.
 - Never modify runtime JSON files directly.
 - Never edit `msgid`.
@@ -43,6 +44,7 @@ grunt nggettext_compile
 ## Notes
 
 - `npm run gettext-update-po -- <lang>` is generic and can be reused for other existing top-level PO files later.
+- `npm run gettext-next-batch -- <lang> --limit 50` can be used to inspect the next deterministic batch of untranslated entries when batching is needed.
 - The current examples use Spanish (`es`), but the agent workflow and skill are designed to work for other supported languages too.
 - The primary trigger is manual: ask the GitHub Copilot agent to perform the translation update.
 - `npm run gettext-extract` is intentionally outside the agent flow and should be run by a human developer when the POT needs to be refreshed.

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
   },
   "scripts": {
     "gettext-extract": "grunt gettext:extract",
+    "gettext-next-batch": "node ./tasks/gettext-next-batch.js",
     "gettext-update-po": "node ./tasks/gettext-update-po.js",
     "postinstall": "node ./tasks/patch-package.js && node tasks/generate-placeholder-file-for-extension-styles.js",
     "test": "npm run lint && npm run unit && npm run verify-client-api-changes",

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,0 +1,21776 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: scripts/core/lang/missing-translations-strings.ts:32
+msgid "\"GENRE 'null value not allowed'"
+msgstr "「GENREにnull値は許可されていません」"
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:199
+msgid "\"Name\" is a required field"
+msgstr "「名前」は必須フィールドです"
+
+#: ../superdesk-planning/client/components/ContentProfiles/utils.ts:16
+msgid "\"{{fieldName}}\" field is required by the system"
+msgstr "「{{fieldName}}」フィールドはシステムで必須です"
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:204
+msgid "\"{{language}}\" translation is required"
+msgstr "「{{language}}」の翻訳は必須です"
+
+#: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:240
+msgid "\"{{x}}\" field is required"
+msgstr "「{{x}}」フィールドは必須です"
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:74
+msgid ""
+"'' is currently managing featured stories. This feature can only be accessed "
+"by one user at a time."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:23
+msgid "'ABSTRACT is a required field'"
+msgstr "「ABSTRACTは必須フィールドです」"
+
+#: scripts/core/lang/missing-translations-strings.ts:24
+msgid "'ANPA_CATEGORY is a required field'"
+msgstr "「ANPA_CATEGORYは必須フィールドです」"
+
+#: scripts/core/lang/missing-translations-strings.ts:23
+msgid "'BYLINE is a required field'"
+msgstr "「BYLINEは必須フィールドです」"
+
+#: scripts/core/lang/missing-translations-strings.ts:33
+msgid "'CATEGORY is a required field'"
+msgstr "「CATEGORYは必須フィールドです」"
+
+#: scripts/core/lang/missing-translations-strings.ts:32
+msgid "'DATELINE is a required field'"
+msgstr "「DATELINEは必須フィールドです」"
+
+#: scripts/core/lang/missing-translations-strings.ts:22
+msgid "'GENRE is a required field'"
+msgstr "「GENREは必須フィールドです」"
+
+#: scripts/core/lang/missing-translations-strings.ts:25
+msgid "'GENRE null value not allowed'"
+msgstr "「GENREにnull値は許可されていません」"
+
+#: scripts/core/lang/missing-translations-strings.ts:24
+msgid "'HEADLINE is a required field'"
+msgstr "「HEADLINEは必須フィールドです」"
+
+#: scripts/core/lang/missing-translations-strings.ts:30
+msgid "'PLACE is a required field'"
+msgstr "「PLACEは必須フィールドです」"
+
+#: scripts/core/lang/missing-translations-strings.ts:43
+msgid "'PRIORITY is a required field'"
+msgstr "「PRIORITYは必須フィールドです」"
+
+#: scripts/core/lang/missing-translations-strings.ts:24
+msgid "'SLUGLINE is a required field'"
+msgstr "「SLUGLINEは必須フィールドです」"
+
+#: scripts/core/lang/missing-translations-strings.ts:23
+msgid "'SUBJECT is a required field'"
+msgstr "「SUBJECTは必須フィールドです」"
+
+#: scripts/core/lang/missing-translations-strings.ts:43
+msgid "'URGENCY is a required field'"
+msgstr "「URGENCYは必須フィールドです」"
+
+#: scripts/core/lang/missing-translations-strings.ts:34
+msgid "'must be of list type'\""
+msgstr "「リスト型でなければなりません」"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:37
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:146
+msgid "'not scheduled yet'"
+msgstr "「未スケジュール」"
+
+#: scripts/apps/highlights/services/HighlightsService.ts:16
+msgid "(Global)"
+msgstr "(グローバル)"
+
+#: scripts/apps/contacts/components/ListTypeIcon.tsx:13
+msgid "(Private)"
+msgstr "(プライベート)"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:269
+msgid "(advanced mode)"
+msgstr "(詳細モード)"
+
+#: scripts/apps/monitoring/views/monitoring-group-header.html:44
+msgid "(as defined for all groups)"
+msgstr "(全グループの定義通り)"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:237
+msgid "(custom text field)"
+msgstr "(カスタムテキストフィールド)"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:238
+msgid "(custom vocabulary)"
+msgstr "(カスタムボキャブラリー)"
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:170
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:170
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:199
+msgid "(disabled)"
+msgstr "(無効)"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:97
+#: scripts/extensions/broadcasting/dist/src/rundowns/manage-rundown-items.js:97
+#: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:176
+msgid "(empty)"
+msgstr "(空)"
+
+#: scripts/apps/search/MultiImageEdit.ts:290
+#: scripts/apps/search/MultiImageEdit.ts:311
+msgid "(multiple values)"
+msgstr "(複数の値)"
+
+#: scripts/core/ui/views/sd-timezone.html:12
+msgid "(no matches)"
+msgstr "(一致なし)"
+
+#: scripts/apps/authoring/compare-versions/views/compare-versions.html:17
+msgid "* choose article version from dropdown menu"
+msgstr "* ドロップダウンメニューから記事バージョンを選択"
+
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:127
+msgid "* fields are required"
+msgstr "* 印のフィールドは必須です"
+
+#: scripts/apps/publish/views/email-config.html:3
+msgid "*at least one visible or hidden recipient needed"
+msgstr "*表示または非表示の受信者が少なくとも1人必要です"
+
+#: ../superdesk-analytics/client/utils.js:193
+msgid "1 day"
+msgstr "1日"
+
+#: ../superdesk-analytics/client/utils.js:199
+msgid "1 hour"
+msgstr "1時間"
+
+#: scripts/core/ArticlesListByQueryWithFilters.tsx:316
+msgid "1 item selected"
+msgid_plural "{{number}} items selected"
+msgstr[0] "{{number}}件選択中"
+
+#: ../superdesk-analytics/client/utils.js:205
+msgid "1 minute"
+msgstr "1分"
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:22
+msgid "1 month"
+msgstr "1か月"
+
+#: ../superdesk-planning/client/components/fields/with-more-items.tsx:52
+msgid "1 more item"
+msgid_plural "{{n}} more items"
+msgstr[0] "他{{n}}件"
+
+#: ../superdesk-analytics/client/utils.js:210
+msgid "1 second"
+msgstr "1秒"
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:270
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:270
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:446
+msgid "1 tag can not be displayed"
+msgid_plural "{{n}} tags can not be displayed"
+msgstr[0] "{{n}}件のタグを表示できません"
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:20
+msgid "1 week"
+msgstr "1週間"
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:24
+msgid "1 year"
+msgstr "1年"
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:27
+msgid "10 years"
+msgstr "10年"
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:186
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:186
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:196
+msgid "100MB"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:97
+msgid "108h"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:183
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:183
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:193
+msgid "10MB"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:44
+#: ../superdesk-planning/client/utils/filters.ts:81
+msgid "10th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:28
+msgid "10th update"
+msgstr "第10版"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:45
+#: ../superdesk-planning/client/utils/filters.ts:83
+msgid "11th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:28
+msgid "11th update"
+msgstr "第11版"
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:17
+msgid "12 Hours"
+msgstr "12時間"
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:204
+msgid "12:00am"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:46
+#: ../superdesk-planning/client/utils/filters.ts:85
+msgid "12th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:29
+msgid "12th update"
+msgstr "第12版"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:47
+#: ../superdesk-planning/client/utils/filters.ts:87
+msgid "13th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:29
+msgid "13th update"
+msgstr "第13版"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:48
+#: ../superdesk-planning/client/utils/filters.ts:89
+msgid "14th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:29
+msgid "14th update"
+msgstr "第14版"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:49
+#: ../superdesk-planning/client/utils/filters.ts:91
+msgid "15th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:29
+msgid "15th update"
+msgstr "第15版"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:50
+#: ../superdesk-planning/client/utils/filters.ts:93
+msgid "16th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:29
+msgid "16th update"
+msgstr "第16版"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:51
+msgid "17th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:29
+msgid "17th update"
+msgstr "第17版"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:52
+msgid "18th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:30
+msgid "18th update"
+msgstr "第18版"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:53
+#: ../superdesk-planning/client/utils/filters.ts:99
+msgid "19th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:30
+msgid "19th update"
+msgstr "第19版"
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:189
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:189
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:199
+msgid "1GB"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:181
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:181
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:191
+msgid "1MB"
+msgstr ""
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:21
+msgid "2 weeks"
+msgstr "2週間"
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:25
+msgid "2 years"
+msgstr "2年"
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:105
+msgid "200 minimum"
+msgstr "最低200"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:54
+#: ../superdesk-planning/client/utils/filters.ts:101
+msgid "20th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:30
+msgid "20th update"
+msgstr "第20版"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:55
+#: ../superdesk-planning/client/utils/filters.ts:103
+msgid "21st"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:56
+#: ../superdesk-planning/client/utils/filters.ts:105
+msgid "22nd"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:57
+#: ../superdesk-planning/client/utils/filters.ts:107
+msgid "23rd"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:19
+msgid "24 Hours"
+msgstr "24時間"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:58
+#: ../superdesk-planning/client/utils/filters.ts:109
+msgid "24th"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:187
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:187
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:197
+msgid "250MB"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:184
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:184
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:194
+msgid "25MB"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:59
+#: ../superdesk-planning/client/utils/filters.ts:111
+msgid "25th"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:60
+#: ../superdesk-planning/client/utils/filters.ts:113
+msgid "26th"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:61
+#: ../superdesk-planning/client/utils/filters.ts:115
+msgid "27th"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:62
+#: ../superdesk-planning/client/utils/filters.ts:117
+msgid "28th"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:36
+#: ../superdesk-planning/client/utils/filters.ts:65
+msgid "2nd"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:27
+msgid "2nd update"
+msgstr "第2版"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:37
+#: ../superdesk-planning/client/utils/filters.ts:67
+msgid "3rd"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:27
+msgid "3rd update"
+msgstr "第3版"
+
+#: scripts/core/lang/missing-translations-strings.ts:25
+msgid "412: Can't publish as item state is draft"
+msgstr "412: アイテムの状態が下書きのため公開できません"
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:20
+msgid "48 Hours"
+msgstr "48時間"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:38
+#: ../superdesk-planning/client/utils/filters.ts:69
+msgid "4th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:27
+msgid "4th update"
+msgstr "第4版"
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:26
+msgid "5 years"
+msgstr "5年"
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:188
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:188
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:198
+msgid "500MB"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:185
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:185
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:195
+msgid "50MB"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:182
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:182
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:192
+msgid "5MB"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:39
+#: ../superdesk-planning/client/utils/filters.ts:71
+msgid "5th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:27
+msgid "5th update"
+msgstr "第5版"
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:16
+msgid "6 Hours"
+msgstr "6時間"
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:23
+msgid "6 months"
+msgstr "6か月"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:40
+#: ../superdesk-planning/client/utils/filters.ts:73
+msgid "6th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:28
+msgid "6th update"
+msgstr "第6版"
+
+#: ../superdesk-planning/client/utils/filters.ts:95
+msgid "70th"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:41
+#: ../superdesk-planning/client/utils/filters.ts:75
+msgid "7th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:28
+msgid "7th update"
+msgstr "第7版"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:42
+#: ../superdesk-planning/client/utils/filters.ts:77
+msgid "8th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:28
+msgid "8th update"
+msgstr "第8版"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:43
+#: ../superdesk-planning/client/utils/filters.ts:79
+msgid "9th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:28
+msgid "9th update"
+msgstr "第9版"
+
+#: scripts/apps/desks/views/desk-config-modal.html:249
+msgid ": OFF"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:252
+msgid ": ON"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:206
+msgid ":00am"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:208
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:210
+msgid ":00pm"
+msgstr ""
+
+#: scripts/apps/workspace/content/views/profile-settings.html:85
+msgid ""
+"<button class=\"sd-alert__close\" ng-click=\"showInfoLabel = false\"></"
+"button>\n"
+"                    Please note that only one content profile per content "
+"type other than text is allowed. If the content type is disabled, the limit "
+"is already reached."
+msgstr ""
+
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-parameters.html:1
+msgid ""
+"<p>Generate a report showing usage of the Planning module.<br></p>\n"
+"    <p>This provides a statistics on who is and who isn't creating items in "
+"the Planning module</p>"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:6
+msgid ""
+"<sd-spinner ng-if=\"isSaving\" data-test-id=\"loading-indicator\" data-"
+"size=\"'mini'\"></sd-spinner>\n"
+"                    Save"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:183
+msgid ""
+"<sd-spinner ng-if=\"saveTopbarLoading\" data-test-id=\"loading-indicator\" "
+"data-size=\"'mini'\"></sd-spinner>\n"
+"        <span translate>Save</span>"
+msgstr ""
+
+#: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:216
+msgid "A content profile with this name already exists."
+msgstr "この名前のコンテンツプロファイルは既に存在します。"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:274
+msgid "A desk is required"
+msgstr "デスクは必須です"
+
+#: scripts/core/auth/reset-password.html:43
+msgid ""
+"A link was sent to the specified email address. Please use it to reset your "
+"password. It is valid a limited amount of time."
+msgstr "指定されたメールアドレスにリンクが送信されました。パスワードのリセットにご利用ください。有効期限があります。"
+
+#: ../superdesk-planning/client/api/locations.ts:30
+msgid "A location matching this one already exists"
+msgstr "一致するロケーションが既に存在します"
+
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:107
+msgid "A new template will be created"
+msgstr "新しいテンプレートが作成されます"
+
+#: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:226
+msgid "A user is required"
+msgstr "ユーザーは必須です"
+
+#: scripts/apps/search/views/search-parameters.html:218
+msgid "AAP Image Keyword"
+msgstr "AAP画像キーワード"
+
+#: scripts/core/lang/missing-translations-strings.ts:47
+msgid "ABSTRACT is too long"
+msgstr "ABSTRACTが長すぎます"
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:66
+msgid "ADD WORD"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:35
+msgid "AMP"
+msgstr ""
+
+#: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:88
+#: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:97
+msgid "AND"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/Categories.tsx:26
+#: ../superdesk-planning/client/components/fields/preview/index.ts:65
+#: ../superdesk-planning/client/utils/contentProfiles.ts:287
+#: scripts/apps/content-filters/views/production-test-view.html:23
+#: scripts/apps/search/services/SearchService.ts:69
+msgid "ANPA Category"
+msgstr "ANPAカテゴリー"
+
+#: ../superdesk-planning/client/components/fields/list/Categories.tsx:19
+msgid "ANPA Category:"
+msgstr "ANPAカテゴリー："
+
+#: scripts/core/lang/missing-translations-strings.ts:31
+msgid "ANPA Take Key"
+msgstr "ANPAテイクキー"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx:109
+msgid "ASSOCIATED XMP FILE"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:242
+msgid "ATTACHED FILE {{ index }} is required"
+msgstr "添付ファイル{{ index }}は必須です"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx:95
+msgid "ATTACHMENTS"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:107
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:88
+msgid "Abbreviation"
+msgstr "略語"
+
+#: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:157
+msgid "Abbreviation already exists. Do you want to overwrite it?"
+msgstr "略語は既に存在します。上書きしますか？"
+
+#: scripts/apps/dictionaries/views/settings.html:33
+msgid "Abbreviations Dictionary"
+msgstr "略語辞書"
+
+#: scripts/core/menu/views/menu.html:115
+msgid "About Superdesk"
+msgstr "Superdeskについて"
+
+#: scripts/apps/authoring-react/field-adapters/abstract.ts:20
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-panel.tsx:164
+#: scripts/apps/authoring/views/theme-select.html:45
+#: scripts/apps/authoring/views/theme-select.html:96
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:378
+#: scripts/apps/workspace/content/constants.ts:8
+msgid "Abstract"
+msgstr "要約"
+
+#: scripts/apps/authoring/views/theme-select.html:47
+#: scripts/apps/authoring/views/theme-select.html:98
+msgid "Abstract example"
+msgstr "要約の例"
+
+#: scripts/apps/dashboard/views/workspace.html:9
+#: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:160
+msgid "Accept"
+msgstr "承認"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Accepted.tsx:15
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:173
+#: scripts/apps/authoring-react/article-widgets/suggestions.tsx:73
+#: scripts/apps/authoring/track-changes/views/suggestions-widget.html:8
+msgid "Accepted"
+msgstr "承認済み"
+
+#: scripts/apps/authoring/track-changes/views/suggestions-widget.html:37
+msgid "Accepted by"
+msgstr "承認者"
+
+#: scripts/apps/authoring-react/article-widgets/suggestions.tsx:126
+msgid "Accepted by {{user}}"
+msgstr "{{user}}が承認"
+
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:33
+msgid "Access Key ID"
+msgstr "アクセスキーID"
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/accreditation-deadline.tsx:24
+#: ../superdesk-planning/client/components/fields/preview/index.ts:188
+#: ../superdesk-planning/client/components/fields/resources/events.ts:108
+#: ../superdesk-planning/client/utils/contentProfiles.ts:347
+msgid "Accreditation Deadline"
+msgstr "認定締切"
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:73
+#: ../superdesk-planning/client/components/fields/preview/index.ts:284
+#: ../superdesk-planning/client/components/fields/resources/events.ts:97
+#: ../superdesk-planning/client/utils/contentProfiles.ts:345
+msgid "Accreditation Info"
+msgstr "認定情報"
+
+#: scripts/apps/monitoring/views/desk-notifications.html:28
+msgid "Acknowledge"
+msgstr "確認"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:16
+#: scripts/apps/publish/views/publish-queue.html:117
+msgid "Action"
+msgstr "アクション"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/index.tsx:318
+#: ../superdesk-planning/client/components/Events/EventItem.tsx:132
+#: ../superdesk-planning/client/components/ItemActionsMenu/ActionsMenuPopup.tsx:56
+#: ../superdesk-planning/client/components/ItemActionsMenu/index.tsx:70
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:84
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:87
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:88
+#: ../superdesk-planning/client/components/Planning/PlanningItem.tsx:157
+#: ../superdesk-planning/client/constants/tooltips.ts:34
+#: scripts/apps/authoring/authoring/constants.ts:12
+#: scripts/apps/desks/views/settings.html:29
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:2
+#: scripts/apps/monitoring/views/item-actions-menu.html:16
+#: scripts/apps/search/components/actions-menu/MenuItems.tsx:272
+#: scripts/apps/templates/views/templates.html:34
+#: scripts/apps/workspace/content/views/profile-settings.html:41
+#: scripts/apps/workspace/content/views/profile-settings.html:45
+#: scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx:120
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:71
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:79
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:305
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:145
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:165
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:71
+#: scripts/extensions/broadcasting/dist/src/rundowns/manage-rundown-items.js:79
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:305
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:145
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:165
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:128
+#: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:140
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:472
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:264
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:311
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:127
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:127
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:150
+msgid "Actions"
+msgstr "アクション"
+
+#: scripts/apps/authoring-react/subcomponents/authoring-actions-menu.tsx:42
+#: scripts/apps/authoring-react/subcomponents/authoring-actions-menu.tsx:71
+msgid "Actions menu"
+msgstr "アクションメニュー"
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:16
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:243
+#: scripts/apps/contacts/services/ContactsService.ts:61
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:22
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:138
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:23
+#: scripts/apps/publish/directives/SubscribersDirective.ts:435
+#: scripts/apps/publish/directives/SubscribersDirective.ts:65
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:44
+#: scripts/apps/users/controllers/UserListController.ts:155
+#: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:467
+#: scripts/apps/workspace/content/views/profile-settings.html:168
+#: scripts/apps/workspace/content/views/profile-settings.html:61
+msgid "Active"
+msgstr "有効"
+
+#: scripts/apps/workspace/content/views/profile-settings.html:22
+msgid "Active only"
+msgstr "有効のみ"
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:424
+msgid "Active until {{end}}"
+msgstr "{{end}}まで有効"
+
+#: scripts/apps/users/views/activity-feed.html:4
+#: scripts/core/lang/missing-translations-strings.ts:44
+msgid "Activity Stream"
+msgstr "アクティビティストリーム"
+
+#: scripts/core/lang/missing-translations-strings.ts:44
+msgid "Activity stream widget"
+msgstr "アクティビティストリームウィジェット"
+
+#: ../superdesk-planning/client/components/fields/editor/AdHocPlanning.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:41
+msgid "Ad Hoc Planning"
+msgstr "アドホックプランニング"
+
+#: scripts/apps/authoring-react/fields/date/config.tsx:109
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:239
+#: scripts/apps/authoring/metadata/views/metadata-target-publishing.html:14
+#: scripts/apps/content-filters/views/manage-filters.html:81
+#: scripts/apps/content-filters/views/manage-filters.html:93
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:27
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:75
+#: scripts/apps/templates/views/template-editor-modal.html:158
+#: scripts/core/editor3/highlightsConfig.ts:26
+#: scripts/core/interactive-article-actions-panel/subcomponents/controlled-vocabulary-select.tsx:65
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:350
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:350
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:98
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:98
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:615
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:217
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:71
+#: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:71
+#: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:153
+#: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/editor.js:35
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/editor.js:35
+#: scripts/extensions/broadcasting/src/authoring-fields/subitems/editor.tsx:79
+msgid "Add"
+msgstr "追加"
+
+#: ../superdesk-planning/client/utils/confirmAddingRelatedItems.tsx:56
+msgid "Add 1 item"
+msgid_plural "Add {{n}} items"
+msgstr[0] "{{n}}件追加"
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:96
+msgid "Add Abbreviation"
+msgstr "略語を追加"
+
+#: ../superdesk-planning/client/constants/planning.ts:140
+msgid "Add As Event"
+msgstr "イベントとして追加"
+
+#: ../superdesk-planning/client/components/Contacts/ContactEditor.tsx:88
+#: ../superdesk-planning/client/components/Contacts/ContactField.tsx:126
+msgid "Add Contact"
+msgstr "連絡先を追加"
+
+#: ../superdesk-planning/client/components/Editor/bookmarks/AddCoverageBookmark.tsx:56
+#: ../superdesk-planning/client/components/Editor/bookmarks/AddCoverageBookmark.tsx:92
+msgid "Add Coverage"
+msgstr "取材を追加"
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:323
+msgid "Add Coverage To Workflow"
+msgstr "ワークフローに取材を追加"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:267
+msgid "Add Coverages"
+msgstr "取材を追加"
+
+#: ../superdesk-analytics/client/utils.js:176
+msgid "Add Featuremedia"
+msgstr "フィーチャーメディアを追加"
+
+#: scripts/extensions/sams/dist/src/containers/FileUploadModal.js:232
+#: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:232
+#: scripts/extensions/sams/src/containers/FileUploadModal.tsx:288
+msgid "Add File"
+msgstr "ファイルを追加"
+
+#: scripts/apps/content-filters/views/manage-filters.html:116
+msgid "Add Filter Statement"
+msgstr "フィルター条件を追加"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:28
+msgid "Add Gallery"
+msgstr "ギャラリーを追加"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:29
+msgid "Add Image"
+msgstr "画像を追加"
+
+#: scripts/apps/ingest/views/dashboard/ingest-sources-list.html:1
+msgid "Add Ingest Sources"
+msgstr "取り込みソースを追加"
+
+#: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:436
+msgid "Add Item"
+msgstr "アイテムを追加"
+
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:7
+#: scripts/apps/content-filters/views/manage-filters.html:6
+#: scripts/apps/desks/views/settings.html:15
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:6
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:6
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:25
+#: scripts/apps/products/views/products.html:16
+#: scripts/apps/publish/views/subscribers.html:26
+#: scripts/apps/search-providers/views/search-provider-config.html:5
+#: scripts/apps/templates/views/templates.html:21
+#: scripts/apps/users/views/settings-roles.html:6
+#: scripts/apps/vocabularies/views/vocabulary-config.html:14
+#: scripts/apps/vocabularies/views/vocabulary-config.html:19
+#: scripts/apps/vocabularies/views/vocabulary-config.html:25
+#: scripts/apps/vocabularies/views/vocabulary-config.html:31
+#: scripts/apps/vocabularies/views/vocabulary-config.html:37
+#: scripts/apps/vocabularies/views/vocabulary-config.html:43
+#: scripts/apps/vocabularies/views/vocabulary-config.html:49
+#: scripts/apps/vocabularies/views/vocabulary-config.html:8
+#: scripts/apps/workspace/content/views/profile-settings.html:26
+#: scripts/extensions/sams/dist/src/components/sets/manageSetsModal.js:103
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/manageSetsModal.js:103
+#: scripts/extensions/sams/src/components/sets/manageSetsModal.tsx:107
+msgid "Add New"
+msgstr "新規追加"
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:4
+msgid "Add New Abbreviations Dictionary"
+msgstr "新しい略語辞書を追加"
+
+#: scripts/apps/content-filters/views/manage-filters.html:33
+msgid "Add New Content Filter"
+msgstr "新しいコンテンツフィルターを追加"
+
+#: scripts/apps/workspace/content/views/profile-settings.html:79
+msgid "Add New Content Profile"
+msgstr "新しいコンテンツプロファイルを追加"
+
+#: scripts/apps/desks/views/desk-config-modal.html:4
+msgid "Add New Desk"
+msgstr "新しいデスクを追加"
+
+#: scripts/apps/publish/views/subscribers.html:227
+msgid "Add New Destination"
+msgstr "新しい送信先を追加"
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:5
+msgid "Add New Dictionary"
+msgstr "新しい辞書を追加"
+
+#: ../superdesk-planning/client/components/GeoLookupInput/CreateNewGeoLookup.tsx:129
+msgid "Add New Event Location"
+msgstr "新しいイベントロケーションを追加"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:215
+msgid "Add New Filter"
+msgstr "新しいフィルターを追加"
+
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:43
+msgid "Add New Filter Condition"
+msgstr "新しいフィルター条件を追加"
+
+#: scripts/apps/products/views/products-config-modal.html:3
+msgid "Add New Product"
+msgstr "新しいプロダクトを追加"
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:31
+msgid "Add New Rule Set"
+msgstr "新しいルールセットを追加"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:31
+msgid "Add New Scheme"
+msgstr "新しいスキームを追加"
+
+#: scripts/apps/search-providers/directive.ts:24
+#: scripts/apps/search-providers/views/search-provider-config.html:28
+msgid "Add New Search Provider"
+msgstr "新しい検索プロバイダーを追加"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:58
+msgid "Add New Source"
+msgstr "新しいソースを追加"
+
+#: scripts/apps/publish/views/subscribers.html:69
+msgid "Add New Subscriber"
+msgstr "新しい配信先を追加"
+
+#: scripts/apps/templates/views/template-editor-modal.html:4
+msgid "Add New Template"
+msgstr "新しいテンプレートを追加"
+
+#: ../superdesk-planning/client/components/Editor/bookmarks/AddPlanningBookmark.tsx:30
+msgid "Add Planning Item"
+msgstr "プランニングアイテムを追加"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:84
+msgid "Add Rule"
+msgstr "ルールを追加"
+
+#: scripts/apps/ingest/views/dashboard/dashboard.html:4
+msgid "Add Sources"
+msgstr "ソースを追加"
+
+#: scripts/apps/dashboard/views/workspace.html:99
+msgid "Add This Widget"
+msgstr "このウィジェットを追加"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/TimeInputs.tsx:95
+msgid "Add Time"
+msgstr "時間を追加"
+
+#: scripts/apps/authoring/authoring/article-url-fields.tsx:103
+msgid "Add URL"
+msgstr "URLを追加"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageArrayInput.tsx:165
+#: ../superdesk-planning/client/components/fields/editor/Coverages.tsx:139
+msgid "Add a coverage"
+msgstr "取材を追加"
+
+#: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:239
+msgid "Add a new location"
+msgstr "新しいロケーションを追加"
+
+#: scripts/apps/authoring-react/multi-edit-modal.tsx:318
+msgid "Add article"
+msgstr "記事を追加"
+
+#: ../superdesk-planning/client/components/AddToPlanningModal/index.tsx:72
+msgid ""
+"Add article to Planning - select an existing Planning Item or create a new "
+"one"
+msgstr "記事をプランニングに追加 - 既存のプランニングアイテムを選択するか新規作成"
+
+#: ../superdesk-planning/client/components/Planning/PlanningItem.tsx:317
+#: ../superdesk-planning/client/components/Planning/PlanningItem.tsx:322
+msgid "Add as coverage"
+msgstr "取材として追加"
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:278
+#: ../superdesk-planning/client/utils/events.tsx:717
+msgid "Add as related event"
+msgid_plural "Add as related events"
+msgstr[0] "関連イベントとして追加"
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:181
+#: ../superdesk-planning/client/utils/planning.tsx:818
+msgid "Add as related planning"
+msgid_plural "Add as related plannings"
+msgstr[0] "関連プランニングとして追加"
+
+#: scripts/apps/authoring/media/views/media-metadata-editor-directive.html:122
+#: scripts/apps/authoring/views/authoring-header.html:614
+msgid "Add author"
+msgstr "著者を追加"
+
+#: scripts/apps/authoring/views/item-association.html:110
+msgid "Add caption"
+msgstr "キャプションを追加"
+
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:55
+msgid "Add content slugline"
+msgstr "コンテンツのスラッグラインを追加"
+
+#: ../superdesk-planning/client/constants/planning.ts:144
+#: ../superdesk-planning/client/constants/planning.ts:147
+msgid "Add coverage"
+msgstr "取材を追加"
+
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:58
+msgid "Add description"
+msgstr "説明を追加"
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:50
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:50
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:74
+msgid "Add entity"
+msgstr "エンティティを追加"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:113
+msgid "Add field after"
+msgstr "後にフィールドを追加"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:69
+msgid "Add field before"
+msgstr "前にフィールドを追加"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-filter.html:8
+msgid "Add filter"
+msgstr "フィルターを追加"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldList.tsx:43
+msgid "Add first field"
+msgstr "最初のフィールドを追加"
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupList.tsx:113
+msgid "Add first group"
+msgstr "最初のグループを追加"
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupElementTemplate.tsx:80
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupList.tsx:92
+msgid "Add group after"
+msgstr "後にグループを追加"
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupElementTemplate.tsx:43
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupList.tsx:55
+msgid "Add group before"
+msgstr "前にグループを追加"
+
+#: scripts/validate-instance-configuration.tsx:59
+msgid "Add it via Settings > Metadata"
+msgstr "設定 > メタデータから追加してください"
+
+#: scripts/apps/packaging/views/search.html:10
+msgid "Add items"
+msgstr "アイテムを追加"
+
+#: ../superdesk-planning/client/components/fields/editor/EventLinks.tsx:77
+#: scripts/core/editor3/highlightsConfig.ts:112
+msgid "Add link"
+msgstr "リンクを追加"
+
+#: scripts/apps/authoring/metadata/views/meta-place-directive.html:2
+#: scripts/apps/authoring/metadata/views/metadata-tags.html:3
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:11
+#: scripts/apps/dictionaries/views/settings.html:10
+#: scripts/core/ui/components/Form/SelectMetaTermsInput/index.tsx:103
+#: scripts/core/ui/views/sd-multi-select.html:3
+msgid "Add new"
+msgstr "新規追加"
+
+#: scripts/apps/workspace/content/components/new-field-select.tsx:34
+msgid "Add new field"
+msgstr "新しいフィールドを追加"
+
+#: scripts/apps/dashboard/views/workspace.html:69
+msgid "Add new widget"
+msgstr "新しいウィジェットを追加"
+
+#: ../superdesk-planning/client/components/Editor/bookmarks/AddPlanningBookmark.tsx:42
+msgid "Add planning item"
+msgstr "プランニングアイテムを追加"
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:65
+msgid "Add rule"
+msgstr "ルールを追加"
+
+#: scripts/extensions/datetimeField/dist/src/config.js:54
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:54
+#: scripts/extensions/datetimeField/src/config.tsx:109
+msgid "Add step"
+msgstr "ステップを追加"
+
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:66
+msgid "Add task description"
+msgstr "タスクの説明を追加"
+
+#: ../superdesk-planning/client/actions/agenda.ts:166
+msgid "Add these  events to the planning list?"
+msgstr "これらのイベントをプランニングリストに追加しますか？"
+
+#: ../superdesk-planning/client/actions/agenda.ts:165
+msgid "Add this event to the planning list?"
+msgstr "このイベントをプランニングリストに追加しますか？"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:251
+msgid "Add this item to all recurring events or just this one?"
+msgstr "このアイテムをすべての繰り返しイベントに追加しますか？それともこのイベントのみですか？"
+
+#: scripts/apps/authoring/views/item-association.html:100
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:56
+msgid "Add title"
+msgstr "タイトルを追加"
+
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:268
+msgid "Add to Current Package"
+msgstr "現在のパッケージに追加"
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningItem.tsx:111
+msgid "Add to Feature Stories"
+msgstr "特集記事に追加"
+
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:129
+#: ../superdesk-planning/client/planning-extension/src/extension.ts:175
+#: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:165
+msgid "Add to Planning"
+msgstr "プランニングに追加"
+
+#: scripts/apps/packaging/index.ts:74
+msgid "Add to current"
+msgstr "現在に追加"
+
+#: scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx:67
+msgid "Add to dictionary"
+msgstr "辞書に追加"
+
+#: ../superdesk-planning/client/constants/planning.ts:145
+msgid "Add to featured stories"
+msgstr "特集記事に追加"
+
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:283
+msgid "Add to highlight"
+msgstr "ハイライトに追加"
+
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:138
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:129
+#: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:52
+msgid "Add to workflow"
+msgstr "ワークフローに追加"
+
+#: scripts/apps/authoring-react/fields/urls/editor.tsx:85
+msgid "Add url"
+msgstr "URLを追加"
+
+#: scripts/apps/dashboard/views/workspace.html:13
+#: scripts/apps/dashboard/views/workspace.html:14
+msgid "Add widget"
+msgstr "ウィジェットを追加"
+
+#: scripts/apps/authoring-react/fields/attachments/difference-row.tsx:25
+msgid "Added"
+msgstr "追加済み"
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:90
+msgid "Added to featured stories"
+msgstr "特集記事に追加しました"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:236
+msgid "Added to workflow"
+msgstr "ワークフローに追加しました"
+
+#: scripts/apps/relations/services/RelationsService.ts:46
+msgid ""
+"Adding ingested items as related is not allowed due to configuration options"
+msgstr "設定により、取り込みアイテムを関連アイテムとして追加することはできません"
+
+#: scripts/apps/relations/services/RelationsService.ts:29
+msgid ""
+"Adding published items as related is not allowed due to configuration options"
+msgstr "設定により、公開済みアイテムを関連アイテムとして追加することはできません"
+
+#: scripts/apps/relations/services/RelationsService.ts:36
+msgid ""
+"Adding related items that are not published is not allowed due to "
+"configuration options"
+msgstr "設定により、未公開のアイテムを関連アイテムとして追加することはできません"
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:227
+#: ../superdesk-planning/client/components/Locations/LocationsList.tsx:112
+#: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:49
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:24
+msgid "Address"
+msgstr "住所"
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:541
+msgid "Address line 1"
+msgstr "住所1"
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:553
+msgid "Address line 2"
+msgstr "住所2"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:30
+msgid "Adjust"
+msgstr "調整"
+
+#: scripts/apps/authoring/views/change-image.html:239
+msgid "Adjust colours"
+msgstr "色を調整"
+
+#: scripts/core/menu/views/menu.html:95
+msgid "Admin tools"
+msgstr "管理ツール"
+
+#: scripts/apps/users/components/UserAvatar.tsx:92
+#: scripts/apps/users/views/edit-form.html:169
+#: scripts/apps/users/views/edit-form.html:67
+msgid "Administrator"
+msgstr "管理者"
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:14
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:14
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-panel.html:14
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-panel.html:14
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-panel.html:14
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-panel.html:14
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-panel.html:14
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-panel.html:14
+msgid "Advanced"
+msgstr "詳細"
+
+#: scripts/apps/search/views/search-panel.html:8
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:215
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:215
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:233
+msgid "Advanced Search"
+msgstr "詳細検索"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentFilterPanel.tsx:104
+#: ../superdesk-planning/client/components/Main/SearchPanel.tsx:113
+#: ../superdesk-planning/client/components/Main/ToggleFiltersButton.tsx:14
+#: ../superdesk-planning/client/components/Main/ToggleFiltersButton.tsx:15
+msgid "Advanced filters"
+msgstr "詳細フィルター"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageAddButton/CoveragesMenuPopup.tsx:66
+msgid "Advanced mode"
+msgstr "詳細モード"
+
+#: scripts/apps/search/views/search-panel.html:58
+msgid "Advanced search"
+msgstr "詳細検索"
+
+#: scripts/apps/search/views/search-panel.html:2
+msgid "Advanced search panel"
+msgstr "詳細検索パネル"
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:10
+msgid "Africa/Abidjan"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:11
+msgid "Africa/Accra"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:12
+msgid "Africa/Cairo"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:13
+msgid "Africa/Casablanca"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:14
+msgid "Africa/Dakar"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:15
+msgid "Africa/Johannesburg"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:16
+msgid "Africa/Khartoum"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:17
+msgid "Africa/Kinshasa"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:18
+msgid "Africa/Lagos"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:19
+msgid "Africa/Nairobi"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:20
+msgid "Africa/Tunis"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:38
+msgid "After"
+msgstr "後"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/createPlanningForm.tsx:46
+msgid "Agenda"
+msgstr "アジェンダ"
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:240
+msgid "Agenda assigned to the planning item."
+msgstr "プランニングアイテムに割り当てられたアジェンダ。"
+
+#: ../superdesk-planning/client/components/fields/agendas.tsx:29
+msgid "Agenda:"
+msgstr "アジェンダ："
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:201
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/agendas-field.ts:27
+#: ../superdesk-planning/client/components/fields/editor/Agendas.tsx:42
+#: ../superdesk-planning/client/components/fields/preview/index.ts:50
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.js:77
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.js:77
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.tsx:106
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx:88
+#: ../superdesk-planning/client/utils/contentProfiles.ts:307
+msgid "Agendas"
+msgstr "アジェンダ"
+
+#: scripts/extensions/ai-widget/dist/src/ai-assistant.js:21
+#: scripts/extensions/ai-widget/dist/src/ai-assistant.js:90
+#: scripts/extensions/ai-widget/dist/src/extension.js:40
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/ai-assistant.js:21
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/ai-assistant.js:90
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/extension.js:40
+#: scripts/extensions/ai-widget/src/ai-assistant.tsx:159
+#: scripts/extensions/ai-widget/src/ai-assistant.tsx:66
+#: scripts/extensions/ai-widget/src/extension.ts:44
+msgid "Ai Assistant"
+msgstr "AIアシスタント"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/airing-info-block.js:24
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/airing-info-block.js:24
+#: scripts/extensions/broadcasting/src/rundowns/components/airing-info-block.tsx:63
+msgid "Air date"
+msgstr "放送日"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/airing-info-block.js:20
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/airing-info-block.js:20
+#: scripts/extensions/broadcasting/src/rundowns/components/airing-info-block.tsx:45
+msgid "Air time"
+msgstr "放送時間"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:89
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:97
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:37
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:89
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:97
+#: scripts/extensions/broadcasting/dist/src/rundowns/manage-rundown-items.js:37
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:191
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:217
+#: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:69
+msgid "Airtime"
+msgstr "放送時間"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:38
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:47
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/applied-filters.js:38
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/filtering-inputs.js:37
+#: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:86
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:84
+msgid "Airtime date from"
+msgstr "放送日（開始）"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:46
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:52
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/applied-filters.js:46
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/filtering-inputs.js:42
+#: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:104
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:99
+msgid "Airtime date to"
+msgstr "放送日（終了）"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:22
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:24
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/applied-filters.js:22
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/filtering-inputs.js:24
+#: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:50
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:43
+msgid "Airtime time from"
+msgstr "放送時間（開始）"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:30
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:34
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/applied-filters.js:30
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/filtering-inputs.js:29
+#: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:68
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:60
+msgid "Airtime time to"
+msgstr "放送時間（終了）"
+
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:18
+msgid "Alert"
+msgstr "アラート"
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/tag-popover.js:16
+#: scripts/extensions/auto-tagging-widget/dist/src/tag-popover.js:16
+#: scripts/extensions/auto-tagging-widget/src/tag-popover.tsx:26
+msgid "Aliases:"
+msgstr "別名："
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:31
+msgid "Align Center"
+msgstr "中央揃え"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:32
+msgid "Align Justify"
+msgstr "両端揃え"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:33
+msgid "Align Left"
+msgstr "左揃え"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:34
+msgid "Align Right"
+msgstr "右揃え"
+
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:76
+#: scripts/apps/contacts/services/ContactsService.ts:55
+#: scripts/apps/contacts/services/ContactsService.ts:60
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:139
+#: scripts/apps/publish/directives/SubscribersDirective.ts:71
+#: scripts/apps/templates/constants.ts:8
+#: scripts/apps/users/controllers/UserListController.ts:160
+#: scripts/core/ArticlesListByQueryWithFilters.tsx:178
+msgid "All"
+msgstr "すべて"
+
+#: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:32
+msgid "All Calendars"
+msgstr "すべてのカレンダー"
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:303
+msgid "All Coverage has been cancelled"
+msgstr "すべての取材がキャンセルされました"
+
+#: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:25
+msgid "All Coverages Assigned"
+msgstr "すべての取材が割り当て済み"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:64
+#: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:12
+msgid "All Day"
+msgstr "終日"
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:136
+msgid "All Day Toggle"
+msgstr "終日切り替え"
+
+#: ../superdesk-planning/client/components/Assignments/DesksSubNavDropDown.tsx:21
+msgid "All Desks"
+msgstr "すべてのデスク"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:283
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:368
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:114
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:253
+#: ../superdesk-planning/client/constants/events.ts:175
+msgid "All Events"
+msgstr "すべてのイベント"
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:241
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:97
+msgid "All Events & Planning"
+msgstr "すべてのイベントとプランニング"
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:173
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:270
+msgid "All Planning Items"
+msgstr "すべてのプランニングアイテム"
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:180
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:215
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:180
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:215
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:210
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:268
+msgid "All Sets"
+msgstr "すべてのセット"
+
+#: scripts/apps/search/components/fields/authors.tsx:107
+msgid "All authors"
+msgstr "すべての著者"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelPlanningCoveragesForm.tsx:139
+msgid "All coverages cancelled:"
+msgstr "すべての取材がキャンセル："
+
+#: ../superdesk-planning/client/components/Events/EventDateTime.tsx:134
+msgid "All day"
+msgstr "終日"
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:122
+msgid "All featured planning items are currently selected"
+msgstr "すべての特集プランニングアイテムが選択されています"
+
+#: scripts/core/menu/notifications/views/notifications.html:12
+msgid "All good so far"
+msgstr "問題ありません"
+
+#: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:72
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:72
+#: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:55
+msgid "All item types"
+msgstr "すべてのアイテムタイプ"
+
+#: scripts/core/itemList/LazyLoader.tsx:226
+msgid "All items have been loaded"
+msgstr "すべてのアイテムが読み込まれました"
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:327
+msgid "All items were published successfully."
+msgstr "すべてのアイテムが正常に公開されました。"
+
+#: ../superdesk-planning/client/components/WorkqueueContainer/index.tsx:25
+msgid "All open items"
+msgstr "すべての未完了アイテム"
+
+#: scripts/apps/authoring/views/opened-articles.html:2
+msgid "All opened items"
+msgstr "すべての開いているアイテム"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:282
+msgid "All planning"
+msgstr "すべてのプランニング"
+
+#: scripts/apps/users/views/list.html:14
+msgid "All user types"
+msgstr "すべてのユーザータイプ"
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:267
+msgid "Allow Multiple Items"
+msgstr "複数アイテムを許可"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:189
+msgid "Allow Remove Ingested Items"
+msgstr "取り込みアイテムの削除を許可"
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:78
+msgid "Allow adding items that are in progress"
+msgstr "進行中のアイテムの追加を許可"
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:94
+msgid "Allow adding items that are published"
+msgstr "公開済みのアイテムの追加を許可"
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:68
+msgid "Allow audio"
+msgstr "音声を許可"
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:362
+msgid "Allow field to be toggled"
+msgstr "フィールドの切り替えを許可"
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:38
+msgid "Allow picture"
+msgstr "画像を許可"
+
+#: scripts/apps/authoring-react/fields/dropdown/config-main.tsx:122
+msgid "Allow selecting multiple values"
+msgstr "複数の値の選択を許可"
+
+#: scripts/extensions/predefinedTextField/dist/src/config.js:80
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:80
+#: scripts/extensions/predefinedTextField/src/config.tsx:152
+msgid "Allow switching to free text input"
+msgstr "自由テキスト入力への切り替えを許可"
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:58
+msgid "Allow video"
+msgstr "動画を許可"
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:258
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:156
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:258
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:156
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:355
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:164
+msgid "Allowed Desks"
+msgstr "許可されたデスク"
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:15
+msgid "Alt Text"
+msgstr "代替テキスト"
+
+#: scripts/apps/workspace/content/constants.ts:9
+msgid "Alt text"
+msgstr "代替テキスト"
+
+#: scripts/apps/authoring-react/fields/media/media-metadata.tsx:15
+#: scripts/apps/authoring/media/MediaMetadataView.tsx:30
+#: scripts/apps/authoring/views/item-carousel.html:104
+#: scripts/core/editor3/components/media/MediaBlock.tsx:204
+msgid "Alt text:"
+msgstr "代替テキスト："
+
+#: scripts/apps/authoring-react/article-widgets/demo-widget.tsx:27
+msgid "Alter slugline"
+msgstr "スラッグラインを変更"
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:21
+msgid "America/Anchorage"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:22
+msgid "America/Argentina/Buenos Aires"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:23
+msgid "America/Bogota"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:24
+msgid "America/Caracas"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:25
+msgid "America/Chicago"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:26
+msgid "America/Edmonton"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:27
+msgid "America/Guatemala"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:28
+msgid "America/Halifax"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:29
+msgid "America/Havana"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:30
+msgid "America/La Paz"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:31
+msgid "America/Lima"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:32
+msgid "America/Los Angeles"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:33
+msgid "America/Manaus"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:34
+msgid "America/Mexico City"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:35
+msgid "America/Montevideo"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:36
+msgid "America/New York"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:37
+msgid "America/Phoenix"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:38
+msgid "America/Santiago"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:39
+msgid "America/Sao Paulo"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:40
+msgid "America/Tegucigalpa"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:41
+msgid "America/Tijuana"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:42
+msgid "America/Toronto"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:43
+msgid "America/Vancouver"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:44
+msgid "America/Winnipeg"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:395
+msgid "An Item can't have both Embargo and Publish Schedule."
+msgstr "アイテムにエンバーゴと公開スケジュールの両方を設定することはできません。"
+
+#: ../superdesk-planning/client/actions/agenda.ts:47
+msgid "An agenda with this name already exists"
+msgstr "この名前のアジェンダは既に存在します"
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:84
+msgid "An error occured when testing config."
+msgstr "設定のテスト中にエラーが発生しました。"
+
+#: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:46
+msgid "An error occured, please try again."
+msgstr "エラーが発生しました。もう一度お試しください。"
+
+#: scripts/apps/publish-preview/previewModal.tsx:66
+msgid "An error occurred while trying to preview the item."
+msgstr "アイテムのプレビュー中にエラーが発生しました。"
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:230
+msgid "An update can not be created"
+msgstr "更新を作成できません"
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:52
+msgid "An update can not be created for an item which is not published yet."
+msgstr "未公開のアイテムの更新は作成できません。"
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:41
+msgid ""
+"An update for this version of the item already exists. To create another "
+"update, find the latest version of the item."
+msgstr "このバージョンのアイテムの更新は既に存在します。別の更新を作成するには、アイテムの最新バージョンを見つけてください。"
+
+#: ../superdesk-analytics/client/index.js:94
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:36
+msgid "Analytics"
+msgstr "アナリティクス"
+
+#: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:121
+#: scripts/core/editor3/components/toolbar/index.tsx:410
+#: scripts/core/editor3/highlightsConfig.ts:19
+msgid "Annotation"
+msgstr "注釈"
+
+#: scripts/core/editor3/components/annotations/AnnotationInput.tsx:265
+msgid "Annotation Body"
+msgstr "注釈本文"
+
+#: scripts/core/editor3/components/annotations/AnnotationInput.tsx:250
+msgid "Annotation Type"
+msgstr "注釈タイプ"
+
+#: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:66
+msgid ""
+"Annotation Types information is not available. Please check your metadata "
+"configuration."
+msgstr "注釈タイプの情報が利用できません。メタデータの設定を確認してください。"
+
+#: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:124
+msgid "Annotation type"
+msgstr "注釈タイプ"
+
+#: scripts/apps/archive/views/html-preview.html:2
+#: scripts/apps/authoring-react/article-widgets/metadata/AnnotationsPreview.tsx:20
+msgid "Annotations"
+msgstr "注釈"
+
+#: scripts/extensions/annotationsLibrary/dist/src/extension.js:70
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/extension.js:70
+#: scripts/extensions/annotationsLibrary/src/extension.tsx:101
+msgid "Annotations Library"
+msgstr "注釈ライブラリ"
+
+#: scripts/extensions/annotationsLibrary/dist/src/extension.js:59
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/extension.js:59
+#: scripts/extensions/annotationsLibrary/src/extension.tsx:89
+msgid "Annotations library"
+msgstr "注釈ライブラリ"
+
+#: scripts/apps/dashboard/workspace-tasks/views/desk-stages.html:6
+msgid "Any"
+msgstr "すべて"
+
+#: scripts/apps/archive/views/metadata-view.html:162
+msgid "Aperture"
+msgstr "絞り値"
+
+#: scripts/apps/users/views/user-preferences.html:21
+#: scripts/apps/users/views/user-preferences.html:255
+msgid "Appearance"
+msgstr "外観"
+
+#: scripts/apps/publish/views/subscribers.html:244
+msgid "Applied Global Block Filters"
+msgstr "適用済みグローバルブロックフィルター"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:161
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:75
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:140
+#: scripts/apps/authoring/views/change-image.html:163
+#: scripts/apps/authoring/views/change-image.html:200
+#: scripts/core/helpers/generic-array-list-page-component.tsx:126
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines.js:32
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:73
+#: scripts/extensions/ai-widget/dist/src/headlines/headlines.js:32
+#: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:73
+#: scripts/extensions/ai-widget/src/headlines/headlines.tsx:70
+#: scripts/extensions/ai-widget/src/translations/translations-body.tsx:173
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:240
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:243
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:563
+msgid "Apply"
+msgstr "適用"
+
+#: scripts/apps/master-desk/components/FilterPanelComponent.tsx:171
+msgid "Apply Filters"
+msgstr "フィルターを適用"
+
+#: scripts/apps/vocabularies/components/UploadConfigModal.tsx:80
+msgid "Apply config"
+msgstr "設定を適用"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:244
+msgid "Apply the changes to all recurring planning items or just this one?"
+msgstr "この変更をすべての繰り返しプランニングアイテムに適用しますか？それともこのアイテムのみですか？"
+
+#: scripts/apps/publish/views/email-config.html:38
+msgid "Apply watermark"
+msgstr "透かしを適用"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:37
+#: scripts/apps/production-api-keys/config.ts:23
+#: scripts/core/lang/missing-translations-strings.ts:15
+msgid "Archive"
+msgstr "アーカイブ"
+
+#: scripts/apps/workspace/content/constants.ts:11
+msgid "Archive description"
+msgstr "アーカイブの説明"
+
+#: scripts/apps/search/views/item-repo.html:6
+msgid "Archived"
+msgstr "アーカイブ済み"
+
+#: scripts/apps/content-filters/views/manage-filters.html:54
+msgid "Archived Block"
+msgstr "アーカイブブロック"
+
+#: scripts/core/lang/missing-translations-strings.ts:15
+msgid "Archived Management"
+msgstr "アーカイブ管理"
+
+#: scripts/apps/archive/views/preview.html:46
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/archived-from.tsx:8
+#: scripts/apps/authoring/views/authoring-topbar.html:35
+msgid "Archived from"
+msgstr "アーカイブ元"
+
+#: scripts/apps/search/components/ItemContainer.tsx:14
+msgid "Archived from {{desk}}"
+msgstr "{{desk}}からアーカイブ"
+
+#: ../superdesk-planning/client/components/ConfirmationModal.tsx:162
+msgid "Are you sure ?"
+msgstr "よろしいですか？"
+
+#: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:214
+#: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:226
+msgid "Are you sure to remove this subscription?"
+msgstr "このサブスクリプションを削除してもよろしいですか？"
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:348
+msgid "Are you sure you want to delete Ingest Source?"
+msgstr "取り込みソースを削除してもよろしいですか？"
+
+#: scripts/apps/search-providers/directive.ts:87
+msgid "Are you sure you want to delete Search Provider?"
+msgstr "検索プロバイダーを削除してもよろしいですか？"
+
+#: scripts/apps/highlights/controllers/HighlightsConfig.ts:66
+msgid "Are you sure you want to delete configuration?"
+msgstr "設定を削除してもよろしいですか？"
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:84
+msgid "Are you sure you want to delete content filter?"
+msgstr "コンテンツフィルターを削除してもよろしいですか？"
+
+#: scripts/apps/workspace/services/WorkspaceService.ts:19
+msgid "Are you sure you want to delete current workspace?"
+msgstr "現在のワークスペースを削除してもよろしいですか？"
+
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:120
+msgid "Are you sure you want to delete filter condition?"
+msgstr "フィルター条件を削除してもよろしいですか？"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:47
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:61
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:132
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:47
+#: scripts/extensions/broadcasting/dist/src/rundowns/manage-rundown-items.js:61
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:132
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:88
+#: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:118
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:245
+msgid "Are you sure you want to delete it?"
+msgstr "削除してもよろしいですか？"
+
+#: scripts/apps/products/controllers/ProductsConfigController.ts:201
+msgid "Are you sure you want to delete product?"
+msgstr "プロダクトを削除してもよろしいですか？"
+
+#: scripts/apps/ingest/directives/IngestRulesContent.ts:61
+msgid "Are you sure you want to delete rule set?"
+msgstr "ルールセットを削除してもよろしいですか？"
+
+#: scripts/apps/search/directives/SavedSearches.ts:112
+msgid "Are you sure you want to delete saved search?"
+msgstr "保存済み検索を削除してもよろしいですか？"
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/store/sets/actions.js:95
+#: scripts/extensions/sams/dist/src/store/sets/actions.js:95
+#: scripts/extensions/sams/src/store/sets/actions.ts:113
+msgid "Are you sure you want to delete the Set \"{{name}}\"?"
+msgstr "セット「{{name}}」を削除してもよろしいですか？"
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/store/assets/actions.js:324
+#: scripts/extensions/sams/dist/src/store/assets/actions.js:324
+#: scripts/extensions/sams/src/store/assets/actions.ts:383
+msgid "Are you sure you want to delete the asset \"{{name}}\"?"
+msgstr "アセット「{{name}}」を削除してもよろしいですか？"
+
+#: ../superdesk-analytics/client/saved_reports/directives/SavedReportList.js:122
+msgid "Are you sure you want to delete the saved report?"
+msgstr "保存済みレポートを削除してもよろしいですか？"
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsList.js:204
+msgid "Are you sure you want to delete the scheduled report?"
+msgstr "スケジュール済みレポートを削除してもよろしいですか？"
+
+#: scripts/apps/templates/directives/TemplatesDirective.ts:363
+msgid "Are you sure you want to delete the template?"
+msgstr "テンプレートを削除してもよろしいですか？"
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/store/assets/actions.js:331
+#: scripts/extensions/sams/dist/src/store/assets/actions.js:331
+#: scripts/extensions/sams/src/store/assets/actions.ts:392
+msgid "Are you sure you want to delete these {{length}} assets"
+msgstr "これら{{length}}件のアセットを削除してもよろしいですか"
+
+#: scripts/apps/ingest/directives/IngestRoutingContent.ts:239
+msgid "Are you sure you want to delete this scheme rule?"
+msgstr "このスキームルールを削除してもよろしいですか？"
+
+#: scripts/apps/ingest/directives/IngestRoutingContent.ts:238
+msgid "Are you sure you want to delete this scheme?"
+msgstr "このスキームを削除してもよろしいですか？"
+
+#: scripts/apps/users/directives/UserRolesDirective.ts:89
+msgid "Are you sure you want to delete user role?"
+msgstr "ユーザーロールを削除してもよろしいですか？"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:1028
+#: ../superdesk-planning/client/actions/events/ui.ts:995
+msgid "Are you sure you want to mark this event as complete?"
+msgstr "このイベントを完了にしてもよろしいですか？"
+
+#: scripts/apps/archive/index.tsx:498
+msgid "Are you sure you want to spike the item?"
+msgstr "このアイテムをスパイクしてもよろしいですか？"
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:188
+msgid "Are you sure you want to spike the items?"
+msgstr "これらのアイテムをスパイクしてもよろしいですか？"
+
+#: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:64
+msgid "Are you sure you want to unpublish item \"{{headline}}\"?"
+msgstr "アイテム「{{headline}}」の公開を取り消してもよろしいですか？"
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:53
+msgid "Are you sure you want to unpublish item \"{{label}}\"?"
+msgstr "アイテム「{{label}}」の公開を取り消してもよろしいですか？"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:96
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:236
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:32
+msgid "Area"
+msgstr "エリア"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:38
+msgid "Arrow Left"
+msgstr "左矢印"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:39
+msgid "Arrow Right"
+msgstr "右矢印"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:40
+msgid "Arrow Small"
+msgstr "小矢印"
+
+#: scripts/apps/users/views/user-preferences.html:103
+msgid "Article Defaults"
+msgstr "記事のデフォルト"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:215
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:297
+msgid "Article Template"
+msgstr "記事テンプレート"
+
+#: scripts/apps/archive/views/preview.html:17
+msgid "Article Type"
+msgstr "記事タイプ"
+
+#: scripts/apps/search/components/TypeIcon.tsx:39
+#: scripts/apps/search/components/TypeIcon.tsx:50
+msgid "Article Type {{type}}"
+msgstr "記事タイプ{{type}}"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:107
+msgid "Article Type(s)"
+msgstr "記事タイプ"
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/RelatedArticlesListComponent.tsx:105
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/RelatedArticlesListComponent.tsx:122
+msgid "Article Type: text"
+msgstr "記事タイプ：テキスト"
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/RelatedArticlesListComponent.tsx:100
+msgid "Article Type: {{articleType}}"
+msgstr "記事タイプ：{{articleType}}"
+
+#: ../superdesk-planning/client/utils/assignments.ts:504
+#: scripts/apps/authoring/authoring/directives/AuthoringHeaderDirective.ts:70
+#: scripts/apps/search/components/ListTypeIcon.tsx:56
+#: scripts/apps/search/components/TypeIcon.tsx:49
+#: scripts/core/directives/FiletypeIconDirective.ts:39
+msgid "Article Type: {{type}}"
+msgstr "記事タイプ：{{type}}"
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:577
+msgid ""
+"Article cannot be published. Please accept or reject all suggestions first."
+msgstr "記事を公開できません。先にすべての提案を承認または却下してください。"
+
+#: scripts/apps/users/views/user-preferences.html:16
+msgid "Article defaults"
+msgstr "記事のデフォルト"
+
+#: scripts/apps/authoring-react/packages.tsx:116
+msgid "Article is not linked to any packages"
+msgstr "記事はどのパッケージにもリンクされていません"
+
+#: scripts/apps/search/components/fields/scheduledDateTime.tsx:23
+msgid "Article is scheduled for {{schedule}}"
+msgstr "記事は{{schedule}}に公開予定です"
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:304
+msgid "Article preview"
+msgstr "記事プレビュー"
+
+#: ../superdesk-planning/client/actions/multiSelect.ts:236
+msgid "Article was created."
+msgstr "記事が作成されました。"
+
+#: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:49
+msgid "Article {{slug}} is already marked for this highlight"
+msgstr "記事{{slug}}は既にこのハイライトに登録されています"
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:168
+#: ../superdesk-planning/client/components/OrderBar/OrderDirectionIcon.tsx:16
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:41
+#: scripts/apps/search/views/item-sortbar.html:20
+#: scripts/core/ui/components/SortBar/index.tsx:65
+msgid "Ascending"
+msgstr "昇順"
+
+#: ../superdesk-analytics/client/charts/views/chart-form-options.html:50
+msgid "Ascending Order"
+msgstr "昇順"
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:45
+msgid "Asia/Almaty"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:46
+msgid "Asia/Baghdad"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:47
+msgid "Asia/Baku"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:48
+msgid "Asia/Bangkok"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:49
+msgid "Asia/Beirut"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:50
+msgid "Asia/Colombo"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:51
+msgid "Asia/Dhaka"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:52
+msgid "Asia/Dili"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:53
+msgid "Asia/Dubai"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:54
+msgid "Asia/Irkutsk"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:55
+msgid "Asia/Jakarta"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:56
+msgid "Asia/Jerusalem"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:57
+msgid "Asia/Kabul"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:58
+msgid "Asia/Karachi"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:59
+msgid "Asia/Kathmandu"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:60
+msgid "Asia/Krasnoyarsk"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:61
+msgid "Asia/Kuala Lumpur"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:62
+msgid "Asia/Manila"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:63
+msgid "Asia/Novosibirsk"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:64
+msgid "Asia/Pyongyang"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:65
+msgid "Asia/Rangoon"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:66
+msgid "Asia/Riyadh"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:67
+msgid "Asia/Seoul"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:68
+msgid "Asia/Singapore"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:69
+msgid "Asia/Tashkent"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:70
+msgid "Asia/Tehran"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:71
+msgid "Asia/Tokyo"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:72
+msgid "Asia/Vladivostok"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:73
+msgid "Asia/Yakutsk"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:74
+msgid "Asia/Yekaterinburg"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:130
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:130
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:130
+msgid "Asset Preview"
+msgstr "アセットプレビュー"
+
+#: scripts/extensions/sams/dist/src/api/assets.js:438
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:438
+#: scripts/extensions/sams/src/api/assets.ts:554
+msgid "Asset deleted successfully"
+msgstr "アセットが正常に削除されました"
+
+#: scripts/extensions/sams/dist/src/api/assets.js:460
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:460
+#: scripts/extensions/sams/src/api/assets.ts:577
+msgid "Asset updated successfully"
+msgstr "アセットが正常に更新されました"
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/notifications/assets.js:30
+#: scripts/extensions/sams/dist/src/notifications/assets.js:30
+#: scripts/extensions/sams/src/notifications/assets.ts:43
+msgid "Asset was deleted by another user."
+msgstr "アセットは別のユーザーによって削除されました。"
+
+#: scripts/apps/publish/views/http-push-config.html:10
+#: scripts/apps/publish/views/http-push-config.html:9
+msgid "Assets URL"
+msgstr "アセットURL"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:216
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:42
+msgid "Assign"
+msgstr "割り当て"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:131
+msgid "Assign \"{{calendar}}\" Calendar to Series"
+msgstr "「{{calendar}}」カレンダーをシリーズに割り当て"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:134
+msgid "Assign Calendar"
+msgstr "カレンダーを割り当て"
+
+#: scripts/apps/authoring-react/fields/media/media-metadata.tsx:27
+#: scripts/apps/authoring/media/MediaMetadataView.tsx:21
+#: scripts/apps/authoring/views/item-carousel.html:116
+#: scripts/apps/authoring/views/item-carousel.html:47
+#: scripts/apps/authoring/views/item-carousel.html:76
+#: scripts/core/editor3/components/media/MediaBlock.tsx:216
+#: scripts/core/editor3/components/media/MediaBlock.tsx:258
+#: scripts/core/editor3/components/media/MediaBlock.tsx:298
+msgid "Assign rights:"
+msgstr "権限を割り当て："
+
+#: ../superdesk-planning/client/constants/planning.ts:143
+msgid "Assign to agenda"
+msgstr "アジェンダに割り当て"
+
+#: ../superdesk-planning/client/constants/events.ts:168
+msgid "Assign to calendar"
+msgstr "カレンダーに割り当て"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/State.tsx:29
+#: ../superdesk-planning/client/utils/index.ts:385
+msgid "Assigned"
+msgstr "割り当て済み"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:205
+#: ../superdesk-planning/client/utils/assignments.ts:205
+msgid "Assigned Provider"
+msgstr "割り当て済みプロバイダー"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:107
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:124
+msgid "Assigned by {{name}}"
+msgstr "{{name}}が割り当て"
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:27
+msgid "Assigned desks"
+msgstr "割り当て済みデスク"
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:74
+msgid "Assigned to agenda '{{ agenda }}'"
+msgstr "アジェンダ「{{ agenda }}」に割り当て済み"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:25
+msgid "Assigned to provider"
+msgstr "プロバイダーに割り当て済み"
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:195
+msgid "Assigned to:"
+msgstr "割り当て先："
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:114
+msgid "Assigned:"
+msgstr "割り当て済み："
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/index.tsx:225
+msgid "Assigned: {{ name }}"
+msgstr "割り当て：{{ name }}"
+
+#: ../superdesk-planning/client/components/Coverages/CoveragePreview/CoveragePreviewTopBar.tsx:53
+msgid "Assignee"
+msgstr "担当者"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:254
+#: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:271
+msgid "Assignee:"
+msgstr "担当者："
+
+#: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:44
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:78
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:83
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:187
+#: ../superdesk-planning/client/planning-extension/src/extension.ts:245
+#: ../superdesk-planning/client/utils/index.ts:585
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:8
+#: scripts/apps/search/views/item-preview.html:24
+msgid "Assignment"
+msgstr "アサインメント"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:243
+#: ../superdesk-planning/client/components/fields/editor/AssignmentPriority.tsx:28
+msgid "Assignment Priority"
+msgstr "アサインメント優先度"
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:192
+msgid "Assignment does not exist"
+msgstr "アサインメントが存在しません"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:50
+msgid "Assignment for"
+msgstr "アサインメント対象"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:144
+msgid "Assignment has been cancelled, unable to reassign"
+msgstr "アサインメントがキャンセルされたため、再割り当てできません"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:145
+msgid "Assignment has been cancelled, unable to remove"
+msgstr "アサインメントがキャンセルされたため、削除できません"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:141
+msgid "Assignment has been completed, unable to reassign"
+msgstr "アサインメントが完了したため、再割り当てできません"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:142
+msgid "Assignment has been completed, unable to remove"
+msgstr "アサインメントが完了したため、削除できません"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:147
+msgid "Assignment is locked, unable to reassign"
+msgstr "アサインメントがロックされているため、再割り当てできません"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:148
+msgid "Assignment is locked, unable to remove"
+msgstr "アサインメントがロックされているため、削除できません"
+
+#: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:123
+msgid "Assignment locked"
+msgstr "アサインメントがロックされています"
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:464
+msgid "Assignment priority has been updated."
+msgstr "アサインメントの優先度が更新されました。"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:97
+msgid "Assignment removed"
+msgstr "アサインメントが削除されました"
+
+#: ../superdesk-planning/client/actions/assignments/api.ts:362
+msgid "Assignment reverted."
+msgstr "アサインメントが元に戻されました。"
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:78
+#: ../superdesk-planning/client/components/Assignments/SubNavBar.tsx:62
+#: ../superdesk-planning/client/controllers/AssignmentController.tsx:45
+#: ../superdesk-planning/client/index.ts:59
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/assignments-overview/index.js:95
+#: ../superdesk-planning/client/planning-extension/src/assignments-overview/index.tsx:132
+#: ../superdesk-planning/index.ts:21 scripts/apps/master-desk/MasterDesk.tsx:40
+#: scripts/apps/production-api-keys/config.ts:29
+msgid "Assignments"
+msgstr "アサインメント"
+
+#: ../superdesk-planning/client/apps/Assignments/AssignmentsUi.tsx:14
+#: ../superdesk-planning/client/apps/Assignments/FulfilAssignmentUi.tsx:14
+msgid "Assignments Content"
+msgstr "アサインメントコンテンツ"
+
+#: ../superdesk-planning/client/components/fields/editor/XMPFile.tsx:53
+msgid "Associate an XMP file"
+msgstr "XMPファイルを関連付け"
+
+#: scripts/apps/search/components/Associations.tsx:40
+msgid "Associated"
+msgstr "関連付け済み"
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:315
+msgid "Associated Event"
+msgstr "関連イベント"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/index.tsx:210
+#: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:233
+msgid "Associated Events"
+msgstr "関連イベント"
+
+#: scripts/apps/search/constants.ts:19
+msgid "Associated Feature Media"
+msgstr "関連フィーチャーメディア"
+
+#: ../superdesk-planning/client/components/Coverages/CoveragePreview/index.tsx:151
+msgid "Associated XMP File"
+msgstr "関連XMPファイル"
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:94
+msgid "Associated an event"
+msgstr "イベントを関連付けました"
+
+#: scripts/apps/publish/views/ftp-config.html:38
+msgid "Associated/featuremedia path"
+msgstr "関連/フィーチャーメディアパス"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:66
+msgid "At least 2 languages must be selected"
+msgstr "少なくとも2つの言語を選択してください"
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:198
+msgid "At least one of [{{list}}] is required."
+msgstr "[{{list}}]のうち少なくとも1つは必須です。"
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:146
+msgid ""
+"At least two versions are needed for comparison. This article has only one."
+msgstr "比較には少なくとも2つのバージョンが必要です。この記事にはバージョンが1つしかありません。"
+
+#: scripts/extensions/sams/dist/src/components/assets/selectAssetModal.js:153
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/selectAssetModal.js:153
+#: scripts/extensions/sams/src/components/assets/selectAssetModal.tsx:172
+msgid "Attach Asset(s)"
+msgstr "アセットを添付"
+
+#: scripts/apps/authoring/attachments/AttachmentsWidgetComponent.tsx:112
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:123
+msgid "Attach files"
+msgstr "ファイルを添付"
+
+#: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:212
+#: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:209
+#: ../superdesk-planning/client/components/UI/FileReadOnlyList.tsx:73
+#: ../superdesk-planning/client/components/fields/editor/EventAttachments.tsx:100
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:60
+msgid "Attached Files"
+msgstr "添付ファイル"
+
+#: ../superdesk-planning/client/components/Coverages/CoveragePreview/index.tsx:165
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:104
+msgid "Attached files"
+msgstr "添付ファイル"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:43
+#: scripts/core/editor3/components/links/LinkInput.tsx:72
+msgid "Attachment"
+msgstr "添付ファイル"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:44
+msgid "Attachment Large"
+msgstr "添付ファイル（大）"
+
+#: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/planning-attachments/index.tsx:24
+#: scripts/apps/authoring-react/field-adapters/attachments.ts:16
+#: scripts/apps/authoring-react/fields/attachments/index.tsx:22
+#: scripts/apps/authoring/attachments/attachments.ts:11
+#: scripts/apps/authoring/views/article-edit.html:729
+#: scripts/apps/workspace/content/constants.ts:12
+msgid "Attachments"
+msgstr "添付ファイル"
+
+#: scripts/apps/authoring-react/fields/attachments/index.tsx:41
+msgid "Attachments (authoring-react)"
+msgstr "添付ファイル（authoring-react）"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:45
+#: ../superdesk-planning/client/utils/index.ts:597
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:239
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:241
+#: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:60
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:113
+#: scripts/extensions/sams/dist/src/utils/assets.js:113
+#: scripts/extensions/sams/src/utils/assets.ts:146
+msgid "Audio"
+msgstr "音声"
+
+#: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:75
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:75
+#: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:58
+msgid "Audio only"
+msgstr "音声のみ"
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:75
+msgid "Australia/Adelaide"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:76
+msgid "Australia/Melbourne"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:77
+msgid "Australia/Perth"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:78
+msgid "Australia/Sydney"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:269
+msgid "Authentication Token"
+msgstr "認証トークン"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:646
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:120
+#: scripts/apps/archive/views/preview.html:50
+#: scripts/apps/users/views/edit-form.html:170
+#: scripts/apps/users/views/edit-form.html:66
+msgid "Author"
+msgstr "著者"
+
+#: scripts/apps/users/views/edit-form.html:20
+#: scripts/apps/users/views/edit-form.html:249
+msgid "Author info"
+msgstr "著者情報"
+
+#: scripts/apps/users/views/settings-roles.html:61
+msgid "Author roles controlled vocabullary is missing."
+msgstr "著者ロールの統制語彙が見つかりません。"
+
+#: scripts/apps/authoring-react/toolbar/version-header.tsx:43
+msgid "Author:"
+msgstr "著者："
+
+#: scripts/apps/authoring/authoring/index.ts:205
+#: scripts/apps/authoring/compare-versions/index.ts:27
+#: scripts/apps/authoring/multiedit/multiedit.ts:465
+#: scripts/apps/authoring/views/authoring.html:2
+msgid "Authoring"
+msgstr "オーサリング"
+
+#: scripts/apps/desks/views/desk-config-modal.html:106
+msgid ""
+"Authoring desks are for content creation, and items within it are protected "
+"from accidental publication. Publishing is only permitted  from production "
+"desks."
+msgstr "オーサリングデスクはコンテンツ作成用で、その中のアイテムは誤公開から保護されます。公開はプロダクションデスクからのみ許可されます。"
+
+#: scripts/apps/authoring-react/field-adapters/authors.tsx:80
+#: scripts/apps/search/components/fields/authors.tsx:113
+#: scripts/apps/workspace/content/constants.ts:13
+msgid "Authors"
+msgstr "著者"
+
+#: scripts/apps/users/views/list.html:15
+msgid "Authors only"
+msgstr "著者のみ"
+
+#: scripts/apps/templates/views/templates.html:61
+msgid "Automated item creation"
+msgstr "アイテムの自動作成"
+
+#: scripts/apps/templates/views/template-editor-modal.html:144
+msgid "Automatically create item"
+msgstr "アイテムを自動作成"
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:39
+msgid "Automatically insert items from"
+msgstr "アイテムを自動挿入"
+
+#: scripts/extensions/availability-manager/dist/src/extension.js:36
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/extension.js:37
+#: scripts/extensions/availability-manager/src/extension.ts:55
+msgid "Availability"
+msgstr "可用性"
+
+#: scripts/extensions/availability-manager/dist/src/extension.js:49
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/extension.js:51
+#: scripts/extensions/availability-manager/src/extension.ts:73
+msgid "Availability Management"
+msgstr "可用性管理"
+
+#: scripts/extensions/availability-manager/dist/src/extension.js:17
+#: scripts/extensions/availability-manager/dist/src/extension.js:20
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/extension.js:17
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/extension.js:20
+#: scripts/extensions/availability-manager/src/extension.ts:19
+#: scripts/extensions/availability-manager/src/extension.ts:28
+msgid ""
+"Availability manager extension could not start because vocabulary \"{{id}}\" "
+"is missing"
+msgstr "ボキャブラリー「{{id}}」がないため、可用性マネージャー拡張機能を開始できませんでした"
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/availability-settings.js:189
+#: scripts/extensions/availability-manager/dist/src/settings/availability-settings.js:189
+#: scripts/extensions/availability-manager/src/settings/availability-settings.tsx:326
+msgid "Availability schedule"
+msgstr "可用性スケジュール"
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:54
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:74
+#: scripts/extensions/availability-manager/dist/src/utils.js:54
+#: scripts/extensions/availability-manager/dist/src/utils.js:74
+#: scripts/extensions/availability-manager/src/utils.ts:57
+#: scripts/extensions/availability-manager/src/utils.ts:77
+msgid "Available"
+msgstr "利用可能"
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:70
+#: scripts/extensions/availability-manager/dist/src/utils.js:70
+#: scripts/extensions/availability-manager/src/utils.ts:73
+msgid "Available all day"
+msgstr "終日利用可能"
+
+#: scripts/apps/dashboard/world-clock/configuration.html:28
+msgid "Available clocks"
+msgstr "利用可能なクロック"
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:209
+msgid "Available in user/desk preferences"
+msgstr "ユーザー/デスク設定で利用可能"
+
+#: scripts/apps/authoring-react/toolbar/translate-modal.tsx:108
+msgid "Available languages"
+msgstr "利用可能な言語"
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningList.tsx:92
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:167
+msgid "Available selections"
+msgstr "利用可能な選択肢"
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:279
+#: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:30
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:24
+msgid "Average"
+msgstr "平均"
+
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:33
+#: scripts/apps/dashboard/views/workspace.html:89
+#: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:70
+#: scripts/apps/search/views/saved-search-manage-subscribers.html:128
+#: scripts/core/itemList/views/relatedItem-list-widget.html:66
+#: scripts/core/ui/components/content-create-dropdown/more-templates.tsx:43
+msgid "Back"
+msgstr "戻る"
+
+#: scripts/apps/search/views/search-panel.html:5
+msgid "Back / Cancel"
+msgstr "戻る/キャンセル"
+
+#: ../superdesk-planning/client/components/Assignments/SubNavBar.tsx:51
+msgid "Back to group list view"
+msgstr "グループリスト表示に戻る"
+
+#: scripts/apps/monitoring/views/monitoring-view.html:10
+msgid "Back to original view"
+msgstr "元の表示に戻る"
+
+#: scripts/extensions/annotationsLibrary/dist/src/AnnotationSelectSingleItem.js:13
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.js:13
+#: scripts/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.tsx:30
+msgid "Back to results"
+msgstr "結果に戻る"
+
+#: scripts/apps/users/views/edit.html:3
+msgid "Back to users list"
+msgstr "ユーザーリストに戻る"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:46
+msgid "Backward Thin"
+msgstr "戻る（細）"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:47
+msgid "Ban Circle"
+msgstr "禁止"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:87
+msgid "Bar"
+msgstr "バー"
+
+#: scripts/apps/authoring/comments/views/comments-widget.html:24
+msgid "Be the first one..."
+msgstr "最初の投稿者になりましょう..."
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:178
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:181
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:361
+msgid "Before airtime"
+msgstr "放送前"
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:7
+msgid ""
+"Before you start using your new newsroom, please tell us a little about "
+"yourself:"
+msgstr "新しいニュースルームの使用を開始する前に、あなたについて少し教えてください："
+
+#: scripts/apps/search/components/fields/state.tsx:41
+msgid "Being Corrected"
+msgstr "修正中"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:48
+msgid "Bell"
+msgstr "ベル"
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:39
+msgid "Better"
+msgstr "より良い"
+
+#: scripts/apps/users/views/edit-form.html:286
+msgid "Biography"
+msgstr "経歴"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:46
+msgid "Black"
+msgstr "黒"
+
+#: scripts/apps/search/views/search-parameters.html:258
+msgid "Black&White"
+msgstr "白黒"
+
+#: scripts/apps/authoring/packages/views/packages-widget.html:15
+#: scripts/apps/packaging/views/sd-package-item-preview.html:20
+msgid "Blank headline received"
+msgstr "空の見出しを受信しました"
+
+#: scripts/apps/content-filters/views/manage-filters.html:58
+msgid "Block API"
+msgstr "ブロックAPI"
+
+#: scripts/apps/products/views/products-config-modal.html:71
+msgid "Blocking"
+msgstr "ブロック中"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:56
+msgid "Blue"
+msgstr "青"
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:57
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:166
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-panel.tsx:196
+#: scripts/apps/authoring/views/theme-select.html:105
+#: scripts/apps/authoring/views/theme-select.html:54
+msgid "Body"
+msgstr "本文"
+
+#: scripts/apps/authoring-react/field-adapters/body_html.ts:22
+#: scripts/apps/workspace/content/constants.ts:15
+#: scripts/core/lang/missing-translations-strings.ts:31
+msgid "Body HTML"
+msgstr "本文HTML"
+
+#: scripts/apps/authoring-react/field-adapters/body_footer.ts:37
+#: scripts/apps/workspace/content/constants.ts:14
+msgid "Body footer"
+msgstr "本文フッター"
+
+#: scripts/apps/authoring-react/field-adapters/body_footer.ts:36
+msgid "Body footer / Helplines / Contact Information"
+msgstr "本文フッター/ヘルプライン/連絡先情報"
+
+#: scripts/apps/authoring/views/theme-select.html:107
+#: scripts/apps/authoring/views/theme-select.html:56
+msgid "Body text example"
+msgstr "本文テキストの例"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:49
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:32
+msgid "Bold"
+msgstr "太字"
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:75
+msgid "Bold (Ctrl+B)"
+msgstr "太字（Ctrl+B）"
+
+#: scripts/apps/authoring-react/fields/boolean/index.ts:23
+msgid "Boolean"
+msgstr "ブール値"
+
+#: ../superdesk-planning/client/utils/eventsplanning.ts:23
+#: ../superdesk-planning/client/utils/eventsplanning.ts:26
+#: scripts/apps/publish/directives/SubscribersDirective.ts:66
+#: scripts/apps/publish/views/subscribers.html:149
+msgid "Both"
+msgstr "両方"
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:200
+msgid ""
+"Both start and end date need to be filled in (or cleared) to save the "
+"subscriber."
+msgstr "配信先を保存するには、開始日と終了日の両方を入力（またはクリア）する必要があります。"
+
+#: scripts/apps/authoring/views/change-image.html:242
+msgid "Brightness"
+msgstr "明るさ"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:50
+#: scripts/core/lang/missing-translations-strings.ts:15
+msgid "Broadcast"
+msgstr "ブロードキャスト"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:51
+msgid "Broadcast Create"
+msgstr "ブロードキャスト作成"
+
+#: scripts/extensions/broadcasting/dist/src/extension.js:19
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/extension.js:19
+#: scripts/extensions/broadcasting/src/extension.ts:20
+msgid "Broadcasting"
+msgstr "ブロードキャスト中"
+
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:38
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:40
+msgid "Browse"
+msgstr "参照"
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:546
+msgid "Building, Suite, Unit, Apartment, Floor, etc."
+msgstr "建物、スイート、ユニット、アパートメント、階など"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:52
+msgid "Business"
+msgstr "ビジネス"
+
+#: scripts/core/lang/missing-translations-strings.ts:31
+msgid "By"
+msgstr "作成者"
+
+#: scripts/apps/users/views/user-preferences.html:143
+msgid ""
+"By selecting the categories you are interested in, the system will only "
+"display these in a menu for setting the content item's categories (along "
+"with any of its existing categories)."
+msgstr "興味のあるカテゴリーを選択すると、コンテンツアイテムのカテゴリー設定メニューにはそれらのカテゴリーと既存のカテゴリーのみが表示されます。"
+
+#: scripts/apps/users/views/user-preferences.html:185
+msgid ""
+"By selecting the desks as your preferred desks, they appear first in the "
+"order when sending or publishing items."
+msgstr "デスクを優先デスクとして選択すると、アイテムの送信や公開時にそれらが先頭に表示されます。"
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:362
+#: scripts/apps/authoring-react/field-adapters/byline.ts:20
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:155
+#: scripts/apps/master-desk/components/FilterPanelComponent.tsx:156
+#: scripts/apps/search/views/search-parameters.html:48
+#: scripts/apps/users/views/edit-form.html:268
+#: scripts/apps/workspace/content/constants.ts:16
+msgid "Byline"
+msgstr "署名"
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:244
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:244
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:314
+msgid "Bytes"
+msgstr "バイト"
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/correct-action.tsx:11
+#: scripts/apps/authoring/views/authoring-topbar.html:131
+msgid "C"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/close-and-continue.tsx:26
+#: scripts/apps/authoring/views/authoring-topbar.html:68
+msgid "C & C"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/cancel-authoring.tsx:12
+msgid "CANCEL"
+msgstr ""
+
+#: scripts/apps/publish/views/email-config.html:20
+msgid "CID"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/planning.ts:232
+msgid "COVERAGE SCHEDULE is required"
+msgstr "取材スケジュールは必須です"
+
+#: ../superdesk-planning/client/validators/planning.ts:256
+msgid "COVERAGE SCHEDULED DATE cannot be in the past"
+msgstr "取材予定日は過去の日付にできません"
+
+#: scripts/apps/workspace/views/workspace-dropdown.html:32
+msgid "CREATE NEW WORKSPACE"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/views/chart.html:26
+msgid "CSV File"
+msgstr "CSVファイル"
+
+#: scripts/apps/workspace/views/workspace-dropdown.html:20
+msgid "CUSTOM WORKSPACES"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:53
+msgid "Calendar"
+msgstr "カレンダー"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:54
+msgid "Calendar List"
+msgstr "カレンダーリスト"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:922
+msgid "Calendar assigned to the event"
+msgstr "イベントに割り当てられたカレンダー"
+
+#: ../superdesk-planning/client/components/fields/calendars.tsx:52
+msgid "Calendar:"
+msgstr "カレンダー："
+
+#: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:37
+msgid "Calendar: {{activeCalendarName}}"
+msgstr "カレンダー：{{activeCalendarName}}"
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:143
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/calendars.ts:36
+#: ../superdesk-planning/client/components/fields/preview/index.ts:58
+#: ../superdesk-planning/client/components/fields/resources/events.ts:133
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.js:76
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.js:82
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.tsx:94
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx:96
+#: ../superdesk-planning/client/utils/contentProfiles.ts:277
+msgid "Calendars"
+msgstr "カレンダー"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:89
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:89
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:117
+msgid "Camera"
+msgstr "カメラ"
+
+#: scripts/core/itemList/views/relatedItem-list-widget.html:20
+msgid "Can be associated as a take"
+msgstr "テイクとして関連付け可能"
+
+#: scripts/core/itemList/views/relatedItem-list-widget.html:19
+msgid "Can be associated as an update"
+msgstr "更新として関連付け可能"
+
+#: scripts/apps/workspace/content/views/profile-settings.html:172
+msgid "Can be embedded"
+msgstr "埋め込み可能"
+
+#: scripts/core/editor3/components/article-embed/can-add-article-embed.ts:35
+msgid "Can not embed to item which itself can be embedded."
+msgstr "埋め込み可能なアイテムには埋め込みできません。"
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:48
+msgid "Can not update a broadcast version of the story."
+msgstr "ブロードキャスト版の記事を更新できません。"
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:112
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:58
+#: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:31
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:205
+#: ../superdesk-planning/client/api/coverages.ts:35
+#: ../superdesk-planning/client/api/coverages.ts:56
+#: ../superdesk-planning/client/components/Assignments/EditCoverageAssignmentModal.tsx:101
+#: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:106
+#: ../superdesk-planning/client/components/ConfirmationModal.tsx:118
+#: ../superdesk-planning/client/components/Contacts/ActionBar.tsx:14
+#: ../superdesk-planning/client/components/Contacts/ContactEditor.tsx:93
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:156
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:69
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:402
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:191
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:148
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:260
+#: ../superdesk-planning/client/components/FulFilAssignmentModal/index.tsx:97
+#: ../superdesk-planning/client/components/GeoLookupInput/CreateNewGeoLookup.tsx:175
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:173
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:184
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:197
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:361
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:52
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DateInputPopup.tsx:270
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:199
+#: ../superdesk-planning/client/components/UI/SubNav/SlidingToolBar.tsx:44
+#: ../superdesk-planning/client/components/UI/SubNav/SlidingToolBar.tsx:49
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:130
+#: ../superdesk-planning/client/constants/events.ts:159
+#: ../superdesk-planning/client/utils/confirmAddingRelatedItems.tsx:54
+#: scripts/api/article-fetch.tsx:94 scripts/api/article-send.tsx:86
+#: scripts/apps/archive/show-spike-dialog.tsx:56
+#: scripts/apps/archive/views/archived-kill.html:16
+#: scripts/apps/archive/views/export.html:33
+#: scripts/apps/archive/views/resend-configuration.html:28
+#: scripts/apps/authoring-react/authoring-swtich.tsx:22
+#: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:152
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:33
+#: scripts/apps/authoring-react/toolbar/export-modal.tsx:118
+#: scripts/apps/authoring-react/toolbar/highlights-modal.tsx:96
+#: scripts/apps/authoring-react/toolbar/mark-for-desks/mark-for-desks-modal.tsx:68
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:60
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:157
+#: scripts/apps/authoring-react/toolbar/translate-modal.tsx:130
+#: scripts/apps/authoring/attachments/AttachmentsEditorModal.tsx:46
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:130
+#: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:129
+#: scripts/apps/authoring/authoring/components/publish-warning-confirm-modal.tsx:30
+#: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:46
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:594
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:49
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:61
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:73
+#: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:30
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:22
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-dropdown.html:15
+#: scripts/apps/authoring/views/authoring-topbar.html:235
+#: scripts/apps/authoring/views/change-image.html:162
+#: scripts/apps/authoring/views/change-image.html:193
+#: scripts/apps/authoring/views/change-image.html:199
+#: scripts/apps/authoring/views/change-image.html:80
+#: scripts/apps/authoring/views/confirm-media-associated.html:19
+#: scripts/apps/authoring/views/theme-select.html:118
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:258
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:104
+#: scripts/apps/content-filters/views/manage-filters.html:155
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:12
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:87
+#: scripts/apps/desks/views/desk-config-modal.html:272
+#: scripts/apps/desks/views/desk-config-modal.html:281
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:132
+#: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:96
+#: scripts/apps/highlights/views/highlights_config_modal.html:54
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:26
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:74
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:126
+#: scripts/apps/ingest/views/settings/ingest-routing-filter.html:32
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:70
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:260
+#: scripts/apps/monitoring/views/aggregate-settings.html:156
+#: scripts/apps/products/views/products-config-modal.html:93
+#: scripts/apps/publish-preview/previewModal.tsx:89
+#: scripts/apps/publish/views/publish-queue.html:144
+#: scripts/apps/publish/views/publish-queue.html:91
+#: scripts/apps/publish/views/subscribers.html:330
+#: scripts/apps/search-providers/views/search-provider-config.html:125
+#: scripts/apps/search/views/item-globalsearch.html:20
+#: scripts/apps/search/views/multi-image-edit.html:15
+#: scripts/apps/search/views/save-search.html:30
+#: scripts/apps/search/views/saved-search-subscribe.html:31
+#: scripts/apps/templates/views/create-template.html:50
+#: scripts/apps/templates/views/template-editor-modal.html:222
+#: scripts/apps/users/views/edit-form.html:400
+#: scripts/apps/users/views/edit-form.html:5
+#: scripts/apps/users/views/settings-roles.html:87
+#: scripts/apps/users/views/user-preferences.html:5
+#: scripts/apps/users/views/user-privileges.html:6
+#: scripts/apps/vocabularies/components/UploadConfigModal.tsx:75
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:92
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:322
+#: scripts/apps/workspace/content/views/profile-settings.html:130
+#: scripts/apps/workspace/content/views/profile-settings.html:188
+#: scripts/apps/workspace/views/edit-workspace-modal.html:38
+#: scripts/core/ArticlesListByQueryWithFilters.tsx:310
+#: scripts/core/activity/views/activity-chooser.html:9
+#: scripts/core/editor3/components/annotations/AnnotationInput.tsx:284
+#: scripts/core/editor3/components/comments/CommentInput.tsx:94
+#: scripts/core/editor3/components/comments/CommentPopup.tsx:221
+#: scripts/core/editor3/components/links/LinkInput.tsx:218
+#: scripts/core/editor3/components/links/LinkInput.tsx:244
+#: scripts/core/prompt-modal.tsx:35 scripts/core/services/modalService.tsx:152
+#: scripts/core/ui/components/Form/DateInput/DateInputPopup.tsx:252
+#: scripts/core/ui/components/Form/TimeInput/TimeInputPopup.tsx:147
+#: scripts/core/ui/components/IgnoreCancelSaveDialog.tsx:64
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:266
+#: scripts/core/ui/components/Modal/ModalPrompt.tsx:50
+#: scripts/core/ui/components/SubNav/SlidingToolBar.tsx:21
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:47
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:83
+#: scripts/core/ui/show-confirmation-prompt.tsx:28
+#: scripts/core/ui/views/datepicker-wrapper.html:9
+#: scripts/core/ui/views/sd-timepicker-popup.html:27
+#: scripts/extensions/annotationsLibrary/dist/src/AnnotationsSelect.js:18
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/AnnotationsSelect.js:18
+#: scripts/extensions/annotationsLibrary/src/AnnotationsSelect.tsx:38
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:260
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:260
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:72
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:72
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:415
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:179
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-workday-modal.js:107
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/manage-schedule.js:129
+#: scripts/extensions/availability-manager/dist/src/settings/edit-workday-modal.js:107
+#: scripts/extensions/availability-manager/dist/src/settings/manage-schedule.js:129
+#: scripts/extensions/availability-manager/src/settings/edit-workday-modal.tsx:165
+#: scripts/extensions/availability-manager/src/settings/manage-schedule.tsx:204
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:150
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:36
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:15
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-modal.js:52
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:150
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:36
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:15
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-modal.js:52
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:280
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:64
+#: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:34
+#: scripts/extensions/broadcasting/src/shows/create-show-modal.tsx:101
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:20
+#: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:20
+#: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:67
+#: scripts/extensions/sams/dist/src/components/assets/assetEditorPanel.js:145
+#: scripts/extensions/sams/dist/src/components/assets/selectAssetModal.js:152
+#: scripts/extensions/sams/dist/src/components/attachments/editAttachmentModal.js:131
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:220
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditorPanel.js:145
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/selectAssetModal.js:152
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/editAttachmentModal.js:131
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:220
+#: scripts/extensions/sams/src/components/assets/assetEditorPanel.tsx:125
+#: scripts/extensions/sams/src/components/assets/selectAssetModal.tsx:167
+#: scripts/extensions/sams/src/components/attachments/editAttachmentModal.tsx:125
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:237
+#: scripts/extensions/videoEditor/dist/src/VideoEditorHeader.js:10
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorHeader.js:10
+#: scripts/extensions/videoEditor/src/VideoEditorHeader.tsx:22
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:86
+msgid "Cancel Event"
+msgstr "イベントをキャンセル"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:150
+#: ../superdesk-planning/client/constants/planning.ts:138
+msgid "Cancel Planning"
+msgstr "プランニングをキャンセル"
+
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:127
+msgid "Cancel Scheduled Update"
+msgstr "スケジュール済み更新をキャンセル"
+
+#: scripts/apps/publish/views/publish-queue.html:83
+msgid "Cancel Selection"
+msgstr "選択をキャンセル"
+
+#: ../superdesk-planning/client/constants/planning.ts:139
+msgid "Cancel all Coverage(s)"
+msgstr "すべての取材をキャンセル"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:152
+msgid "Cancel all recurring events or just this one?"
+msgstr "すべての繰り返しイベントをキャンセルしますか？それともこのイベントのみですか？"
+
+#: scripts/apps/archive/index.tsx:326
+msgid "Cancel correction"
+msgstr "修正をキャンセル"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/index.tsx:264
+#: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:51
+msgid "Cancel coverage"
+msgstr "取材をキャンセル"
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:53
+msgid "Cancel planning items with Event"
+msgstr "イベントとともにプランニングアイテムをキャンセル"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:84
+msgid "Cancel {{event}}"
+msgstr "{{event}}をキャンセル"
+
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:110
+msgid "Canceling failed"
+msgstr "キャンセルに失敗しました"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/State.tsx:50
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:31
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:204
+#: ../superdesk-planning/client/utils/index.ts:374
+#: ../superdesk-planning/client/utils/index.ts:422
+msgid "Cancelled"
+msgstr "キャンセル済み"
+
+#: scripts/apps/relations/directives/RelatedItemsDirective.ts:149
+msgid "Cannot add self as related item."
+msgstr "自身を関連アイテムとして追加できません。"
+
+#: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:32
+msgid ""
+"Cannot change workflow status if the coverage is part of an expired planning "
+"item"
+msgstr "期限切れのプランニングアイテムに含まれる取材のワークフロー状態は変更できません"
+
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:35
+msgid "Cannot delete vocabulary"
+msgstr "ボキャブラリーを削除できません"
+
+#: ../superdesk-planning/client/validators/events.ts:289
+msgid "Cannot end with \".\""
+msgstr "「.」で終わることはできません"
+
+#: ../superdesk-planning/client/actions/main.ts:905
+msgid "Cannot load more data as filter type is not selected."
+msgstr "フィルタータイプが選択されていないため、データをさらに読み込めません。"
+
+#: ../superdesk-planning/client/actions/main.ts:926
+msgid "Cannot load more data. Failed to run the query."
+msgstr "データをさらに読み込めません。クエリの実行に失敗しました。"
+
+#: ../superdesk-planning/client/actions/main.ts:947
+msgid "Cannot search as filter type is not selected."
+msgstr "フィルタータイプが選択されていないため、検索できません。"
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:7
+#: scripts/core/editor3/components/media/MediaBlock.tsx:317
+msgid "Caption"
+msgstr "キャプション"
+
+#: scripts/apps/authoring/editor/views/find-replace.html:18
+msgid "Case Sensitive"
+msgstr "大文字小文字を区別"
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:96
+msgid "Case sensitive"
+msgstr "大文字小文字を区別"
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:121
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:431
+#: scripts/apps/monitoring/directives/utils.ts:32
+#: scripts/apps/users/views/user-preferences.html:17
+#: scripts/apps/workspace/content/constants.ts:17
+msgid "Categories"
+msgstr "カテゴリー"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:521
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:99
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:316
+#: scripts/apps/content-api/services/ContentAPISearchService.ts:33
+#: scripts/apps/legal-archive/services/LegalArchiveService.ts:27
+#: scripts/apps/legal-archive/tests/legal.spec.ts:69
+#: scripts/apps/search/directives/SearchFilters.ts:44
+msgid "Category"
+msgstr "カテゴリー"
+
+#: ../superdesk-analytics/client/utils.js:180
+msgid "Change Image"
+msgstr "画像を変更"
+
+#: ../superdesk-analytics/client/utils.js:177
+#: ../superdesk-analytics/client/utils.js:178
+msgid "Change POI"
+msgstr "POIを変更"
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:235
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:235
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:323
+msgid "Change Set filter"
+msgstr "セットフィルターを変更"
+
+#: scripts/apps/users/config.ts:122 scripts/apps/users/views/edit-form.html:52
+msgid "Change avatar"
+msgstr "アバターを変更"
+
+#: scripts/apps/authoring/views/change-image.html:203
+msgid "Change image settings"
+msgstr "画像設定を変更"
+
+#: scripts/core/auth/login-modal.html:86
+msgid "Change password"
+msgstr "パスワードを変更"
+
+#: scripts/apps/users/views/user-preferences.html:258
+msgid "Change the appearance of Superdesk across the whole application."
+msgstr "アプリケーション全体のSuperdeskの外観を変更します。"
+
+#: ../superdesk-analytics/client/charts/views/table.html:23
+msgid "Change the search filters and try again!"
+msgstr "検索フィルターを変更してもう一度お試しください。"
+
+#: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:167
+msgid "Change view"
+msgstr "表示を変更"
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/controllers/FeaturemediaUpdatesReportController.js:143
+#: ../superdesk-analytics/client/featuremedia_updates_report/directives/FeaturemediaUpdatesReportPreview.js:21
+msgid "Changes to Featuremedia"
+msgstr "フィーチャーメディアの変更"
+
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:181
+msgid "Changes will be lost, if they are not saved."
+msgstr "保存しないと変更が失われます。"
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorTools.js:32
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorTools.js:32
+#: scripts/extensions/videoEditor/src/VideoEditorTools.tsx:76
+msgid "Changing quality is only supported for 480p and higher quality videos."
+msgstr "画質の変更は480p以上の動画でのみサポートされています。"
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:38
+msgid "Channel has gone strangely quiet."
+msgstr "チャンネルが異常に静かです。"
+
+#: scripts/apps/desks/views/desk-config-modal.html:205
+msgid "Character limit exceeded, desk can not be created/updated."
+msgstr "文字数制限を超えました。デスクを作成/更新できません。"
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:49
+msgid "Character limit exceeded, dictionary can not be created/updated."
+msgstr "文字数制限を超えました。辞書を作成/更新できません。"
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:14
+msgid "Character limit exceeded, highlight can not be created/updated."
+msgstr "文字数制限を超えました。ハイライトを作成/更新できません。"
+
+#: scripts/apps/desks/views/desk-config-modal.html:290
+msgid "Character limit exceeded, stage can not be created/updated."
+msgstr "文字数制限を超えました。ステージを作成/更新できません。"
+
+#: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:124
+msgid "Character limit settings"
+msgstr "文字数制限設定"
+
+#: scripts/apps/authoring-react/fields/editor3/editor.tsx:384
+msgid "Character {{chars}} is not allowed"
+msgid_plural "The following characters are not allowed {{chars}}"
+msgstr[0] "次の文字は使用できません：{{chars}}"
+
+#: scripts/apps/authoring/authoring/ValidateCharacters.tsx:23
+msgid "Character {{chars}} not allowed in the {{field}}."
+msgid_plural "Characters {{chars}} not allowed in the {{field}}."
+msgstr[0] "{{field}}では次の文字は使用できません：{{chars}}"
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:55
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:55
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-panel.html:55
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-panel.html:48
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-panel.html:55
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-panel.html:55
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-panel.html:55
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-panel.html:55
+msgid "Chart"
+msgstr "グラフ"
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:23
+msgid "Chart Colours"
+msgstr "グラフの色"
+
+#: ../superdesk-analytics/client/charts/views/chart-form-options.html:26
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:24
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-preview.html:13
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-preview.html:20
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:24
+msgid "Chart Type"
+msgstr "グラフタイプ"
+
+#: scripts/core/views/sdselect.html:13
+msgid "Check all"
+msgstr "すべてチェック"
+
+#: scripts/apps/authoring-react/fields/register-fields.ts:30
+#: scripts/apps/authoring/views/authoring-topbar.html:379
+#: scripts/apps/authoring/views/authoring-topbar.html:388
+msgid "Check spelling"
+msgstr "スペルチェック"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:55
+msgid "Chevron Down Thin"
+msgstr "下向き矢印（細）"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:56
+msgid "Chevron Left Thin"
+msgstr "左向き矢印（細）"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:57
+msgid "Chevron Right Thin"
+msgstr "右向き矢印（細）"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:58
+msgid "Chevron Up Thin"
+msgstr "上向き矢印（細）"
+
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:36
+msgid "Choose entire category"
+msgstr "カテゴリー全体を選択"
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:92
+msgid ""
+"Choose existing labels or create new\n"
+"                                    ones by typing. The labels are only used "
+"to organize the controlled vocabularies\n"
+"                                    in the list. The CVs are grouped under "
+"each label. You can choose only one\n"
+"                                    label."
+msgstr ""
+
+#: scripts/apps/highlights/views/package_highlights_dropdown_directive.html:20
+msgid "Choose highlight list"
+msgstr "ハイライトリストを選択"
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:40
+#: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:40
+#: scripts/extensions/ai-widget/src/translations/translations-body.tsx:87
+msgid "Choose the language and click the translate button at the bottom"
+msgstr "言語を選択し、下部の翻訳ボタンをクリックしてください"
+
+#: scripts/apps/contacts/constants.ts:75
+#: scripts/apps/contacts/views/search-panel.html:61
+msgid "City"
+msgstr "都市"
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:252
+#: ../superdesk-planning/client/components/Locations/LocationsList.tsx:118
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:48
+msgid "City/Town"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:274
+msgid "Clean Pasted HTML"
+msgstr "貼り付けたHTMLをクリーン"
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:67
+msgid "Clean pasted HTML"
+msgstr "貼り付けたHTMLをクリーン"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentFilterPanel.tsx:126
+#: ../superdesk-planning/client/components/Main/SearchPanel.tsx:135
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:181
+#: scripts/apps/authoring/comments/views/comments-widget.html:57
+#: scripts/apps/dashboard/world-clock/configuration.html:39
+#: scripts/apps/legal-archive/views/legal_archive.html:95
+#: scripts/core/ui/components/MultiSelect.tsx:31
+#: scripts/core/ui/views/sd-timezone.html:26
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:215
+#: scripts/extensions/broadcasting/dist/src/page.js:219
+#: scripts/extensions/broadcasting/src/page.tsx:337
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:260
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:260
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:374
+msgid "Clear"
+msgstr "クリア"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:59
+msgid "Clear All"
+msgstr "すべてクリア"
+
+#: scripts/apps/search/views/search-parameters.html:261
+msgid "Clear Edge"
+msgstr "エッジをクリア"
+
+#: scripts/apps/authoring/views/article-edit.html:577
+msgid "Clear Embed"
+msgstr "埋め込みをクリア"
+
+#: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:123
+#: ../superdesk-planning/client/components/Main/SubNavBar.tsx:32
+#: scripts/apps/master-desk/components/FilterPanelComponent.tsx:178
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:807
+msgid "Clear Filters"
+msgstr "フィルターをクリア"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:60
+msgid "Clear Format"
+msgstr "書式をクリア"
+
+#: ../superdesk-planning/client/components/UI/SearchBox.tsx:118
+msgid "Clear Search"
+msgstr "検索をクリア"
+
+#: scripts/apps/master-desk/components/FilterBarComponent.tsx:34
+msgid "Clear all filters"
+msgstr "すべてのフィルターをクリア"
+
+#: scripts/apps/users/views/user-preferences.html:155
+msgid "Clear all selected"
+msgstr "選択をすべてクリア"
+
+#: ../superdesk-planning/client/components/UI/Form/DateTimeInput/index.tsx:155
+#: scripts/core/ui/components/Form/DateTimeInput/index.tsx:85
+msgid "Clear date and time"
+msgstr "日時をクリア"
+
+#: scripts/apps/authoring-react/fields/embed/editor.tsx:78
+msgid "Clear embed"
+msgstr "埋め込みをクリア"
+
+#: scripts/apps/contacts/views/search-panel.html:86
+#: scripts/apps/content-api/views/search-panel.html:22
+#: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:108
+#: scripts/apps/search/views/save-search.html:9
+msgid "Clear filters"
+msgstr "フィルターをクリア"
+
+#: scripts/apps/authoring/media/views/media-copy-metadata-directive.html:5
+msgid "Clear saved metadata"
+msgstr "保存済みメタデータをクリア"
+
+#: scripts/apps/content-filters/views/filter-search.html:43
+#: scripts/apps/monitoring/views/monitoring-view.html:86
+#: scripts/apps/publish/views/publish-queue.html:9
+#: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:356
+#: scripts/core/list/views/searchbar.html:5
+msgid "Clear search"
+msgstr "検索をクリア"
+
+#: scripts/apps/users/config.ts:93
+msgid "Clear sessions"
+msgstr "セッションをクリア"
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:365
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:365
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:646
+msgid "Click \"Run\" to generate"
+msgstr "「実行」をクリックして生成"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:106
+msgid "Click on a Scheme rules on the left to view details."
+msgstr "左側のスキームルールをクリックして詳細を表示。"
+
+#: scripts/apps/dashboard/views/workspace.html:60
+msgid "Click on the \"+\" button in the top right corner to add some widgets."
+msgstr "右上の「+」ボタンをクリックしてウィジェットを追加してください。"
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:160
+msgid "Click the Plus button to add languages"
+msgstr "プラスボタンをクリックして言語を追加"
+
+#: scripts/apps/users/views/change-avatar.html:38
+msgid ""
+"Click to capture using camera. Be sure that you allow camera accessibility."
+msgstr "クリックしてカメラで撮影。カメラへのアクセスを許可してください。"
+
+#: scripts/apps/authoring/authoring/components/video-thumbnail-editor.tsx:108
+msgid "Click to replace thumbnail"
+msgstr "クリックしてサムネイルを置換"
+
+#: scripts/apps/production-api-keys/config.ts:54
+msgid "Client ID"
+msgstr "クライアントID"
+
+#: scripts/apps/production-api-keys/config.ts:59
+msgid "Client Secret"
+msgstr "クライアントシークレット"
+
+#: scripts/apps/dashboard/world-clock/configuration.html:5
+msgid "Clock type"
+msgstr "クロックタイプ"
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:104
+#: ../superdesk-planning/client/components/Agendas/ManageAgendasModal.tsx:72
+#: ../superdesk-planning/client/components/Assignments/AssignmentFilterPanel.tsx:100
+#: ../superdesk-planning/client/components/Assignments/EditCoverageAssignmentModal.tsx:83
+#: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:63
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:380
+#: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:218
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:271
+#: ../superdesk-planning/client/components/Events/ManageEventTemplatesModal.tsx:101
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:206
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:46
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:101
+#: ../superdesk-planning/client/components/FulFilAssignmentModal/index.tsx:78
+#: ../superdesk-planning/client/components/GeoLookupInput/CreateNewGeoLookup.tsx:133
+#: ../superdesk-planning/client/components/ItemActionsMenu/ActionsMenuPopup.tsx:59
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:196
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:339
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:361
+#: ../superdesk-planning/client/components/Main/ItemEditorModal/EditorModalPanel.tsx:175
+#: ../superdesk-planning/client/components/Main/SearchPanel.tsx:109
+#: ../superdesk-planning/client/components/ModalWithForm/index.tsx:108
+#: ../superdesk-planning/client/components/ModalWithForm/index.tsx:129
+#: ../superdesk-planning/client/components/NotificationModal.tsx:45
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:140
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:210
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModalSubnav.tsx:46
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:67
+#: ../superdesk-planning/client/components/SelectItemModal.tsx:30
+#: ../superdesk-planning/client/components/WorkqueueContainer/WorkqueueItem.tsx:49
+#: ../superdesk-planning/client/components/fields/with-more-items.tsx:65
+#: ../superdesk-planning/client/constants/tooltips.ts:25
+#: scripts/apps/authoring-react/preview-article-modal.tsx:34
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/close-button.tsx:12
+#: scripts/apps/authoring-react/toolbar/highlights-management.tsx:79
+#: scripts/apps/authoring-react/toolbar/multi-edit-toolbar-action.tsx:73
+#: scripts/apps/authoring/preview/fullPreviewMultiple.tsx:67
+#: scripts/apps/authoring/views/authoring-topbar.html:174
+#: scripts/apps/authoring/views/authoring-topbar.html:175
+#: scripts/apps/authoring/views/authoring-topbar.html:179
+#: scripts/apps/authoring/views/dashboard-articles.html:4
+#: scripts/apps/authoring/views/preview-formatted.html:29
+#: scripts/apps/content-filters/views/production-test.html:10
+#: scripts/apps/ingest/directives/authenticate-ingest-provider.tsx:24
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:235
+#: scripts/apps/search-providers/directive.ts:117
+#: scripts/apps/search/components/actions-menu/Label.tsx:24
+#: scripts/apps/search/views/multi-image-edit.html:5
+#: scripts/apps/workspace/views/edit-workspace-modal.html:5
+#: scripts/core/interactive-article-actions-panel/index-ui.tsx:72
+#: scripts/core/menu/views/about.html:37 scripts/core/menu/views/about.html:5
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/working-day-view.js:27
+#: scripts/extensions/availability-manager/dist/src/settings/working-day-view.js:27
+#: scripts/extensions/availability-manager/src/settings/working-day-view.tsx:59
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:229
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:237
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:348
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:232
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:237
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:348
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:544
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:354
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:600
+#: scripts/extensions/sams/dist/src/components/sets/manageSetsModal.js:105
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:116
+#: scripts/extensions/sams/dist/src/containers/FileUploadModal.js:231
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/manageSetsModal.js:105
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:116
+#: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:231
+#: scripts/extensions/sams/src/components/sets/manageSetsModal.tsx:127
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:107
+#: scripts/extensions/sams/src/containers/FileUploadModal.tsx:283
+msgid "Close"
+msgstr "閉じる"
+
+#: scripts/apps/authoring/views/authoring-topbar.html:67
+msgid "Close & Continue"
+msgstr "閉じて続行"
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines-widget.js:48
+#: scripts/extensions/ai-widget/dist/src/headlines/headlines-widget.js:48
+#: scripts/extensions/ai-widget/src/headlines/headlines-widget.tsx:71
+msgid "Close Headlines"
+msgstr "見出しを閉じる"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:61
+msgid "Close Small"
+msgstr "閉じる（小）"
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary-widget.js:47
+#: scripts/extensions/ai-widget/dist/src/summary/summary-widget.js:47
+#: scripts/extensions/ai-widget/src/summary/summary-widget.tsx:67
+msgid "Close Summary"
+msgstr "サマリーを閉じる"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:62
+msgid "Close Thick"
+msgstr "閉じる（太）"
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-widget.js:43
+#: scripts/extensions/ai-widget/dist/src/translations/translations-widget.js:43
+#: scripts/extensions/ai-widget/src/translations/translations-widget.tsx:80
+msgid "Close Translate"
+msgstr "翻訳を閉じる"
+
+#: scripts/apps/authoring/views/authoring-topbar.html:65
+#: scripts/apps/authoring/views/authoring-topbar.html:66
+msgid "Close and Continue"
+msgstr "閉じて続行"
+
+#: scripts/apps/production-api-keys/utils.tsx:27
+msgid "Close anyway"
+msgstr "強制的に閉じる"
+
+#: scripts/apps/authoring/authoring/index.ts:469
+msgid "Close current item"
+msgstr "現在のアイテムを閉じる"
+
+#: scripts/apps/dashboard/closed-desk/index.ts:159
+msgid "Close desk widget"
+msgstr "デスクウィジェットを閉じる"
+
+#: scripts/apps/authoring/views/change-image.html:155
+msgid "Close details"
+msgstr "詳細を閉じる"
+
+#: scripts/apps/contacts/views/search-panel.html:4
+#: scripts/apps/content-api/views/search-panel.html:11
+#: scripts/apps/legal-archive/views/legal_archive.html:44
+#: scripts/apps/search/views/search-panel.html:22
+msgid "Close panel"
+msgstr "パネルを閉じる"
+
+#: scripts/apps/search/views/item-preview.html:27
+msgid "Close preview"
+msgstr "プレビューを閉じる"
+
+#: scripts/apps/production-api-keys/utils.tsx:17
+msgid "Close this panel?"
+msgstr "このパネルを閉じますか？"
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:140
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:9
+#: scripts/apps/search-providers/views/search-provider-config.html:14
+msgid "Closed"
+msgstr "クローズ"
+
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:242
+msgid "Closing failed"
+msgstr "クローズに失敗しました"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:63
+msgid "Code"
+msgstr "コード"
+
+#: ../superdesk-planning/client/components/UI/CollapseBox.tsx:175
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:64
+#: scripts/core/editor3/components/Editor3Component.tsx:901
+msgid "Collapse"
+msgstr "折りたたみ"
+
+#: scripts/apps/authoring-react/multi-edit-modal.tsx:158
+msgid "Collapse widgets"
+msgstr "ウィジェットを折りたたみ"
+
+#: scripts/apps/vocabularies/services/SchemaFactory.ts:8
+msgid "Color"
+msgstr "色"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:90
+msgid "Column"
+msgstr "列"
+
+#: scripts/apps/monitoring/views/monitoring-view.html:196
+msgid "Columns:"
+msgstr "列："
+
+#: scripts/apps/packaging/index.ts:93
+msgid "Combine with current"
+msgstr "現在のアイテムと統合"
+
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:42
+#: ../superdesk-planning/client/components/fields/editor/ItemType.tsx:18
+msgid "Combined"
+msgstr "統合済み"
+
+#: scripts/apps/publish/views/subscribers.html:158
+msgid "Comma separated values"
+msgstr "カンマ区切りの値"
+
+#: scripts/apps/products/views/products-config-modal.html:55
+msgid "Comma separated values."
+msgstr "カンマ区切りの値。"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:65
+#: scripts/core/editor3/components/comments/Comment.tsx:90
+#: scripts/core/editor3/components/toolbar/index.tsx:398
+#: scripts/core/editor3/highlightsConfig.ts:12
+msgid "Comment"
+msgstr "コメント"
+
+#: scripts/apps/authoring-react/article-widgets/comments/index.tsx:9
+#: scripts/apps/authoring-react/generic-widgets/comments/CommentsWidget.tsx:25
+#: scripts/apps/authoring-react/generic-widgets/comments/index.tsx:38
+#: scripts/apps/authoring/comments/comments.ts:146
+msgid "Comments"
+msgstr "コメント"
+
+#: ../superdesk-planning/client/components/fields/index.tsx:223
+msgid "Common"
+msgstr "共通"
+
+#: scripts/apps/monitoring/directives/utils.ts:95
+#: scripts/apps/search/views/search.html:22
+#: scripts/apps/search/views/search.html:23
+msgid "Compact View"
+msgstr "コンパクト表示"
+
+#: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:102
+msgid "Compact list"
+msgstr "コンパクトリスト"
+
+#: scripts/apps/search/constants.ts:16
+#: scripts/apps/workspace/content/constants.ts:18
+msgid "Company Codes"
+msgstr "企業コード"
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:29
+msgid "Company/Organisation"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:185
+msgid "Compare"
+msgstr "比較"
+
+#: scripts/apps/authoring/compare-versions/views/compare-versions.html:2
+msgid "Compare Versions"
+msgstr "バージョンを比較"
+
+#: scripts/apps/authoring-react/toolbar/compare-article-versions.tsx:129
+msgid "Compare article versions"
+msgstr "記事のバージョンを比較"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:148
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:132
+#: scripts/apps/authoring/views/authoring-topbar.html:286
+msgid "Compare versions"
+msgstr "バージョンを比較"
+
+#: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:124
+msgid "Comparing \"{{x}}\"(primary) to \"{{y}}\"(secondary)"
+msgstr "「{{x}}」（プライマリ）と「{{y}}」（セカンダリ）を比較"
+
+#: ../superdesk-planning/client/constants/assignments.ts:193
+msgid "Complete Assignment"
+msgstr "アサインメントを完了"
+
+#: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:28
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:66
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/State.tsx:43
+#: ../superdesk-planning/client/constants/assignments.ts:206
+#: ../superdesk-planning/client/utils/index.ts:402
+#: scripts/apps/master-desk/components/AssignmentsComponent.tsx:52
+msgid "Completed"
+msgstr "完了"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:66
+#: ../superdesk-planning/client/utils/index.ts:595
+msgid "Composite"
+msgstr "複合"
+
+#: scripts/apps/legal-archive/index.ts:38
+msgid "Confidential data"
+msgstr "機密データ"
+
+#: scripts/apps/highlights/controllers/HighlightsConfig.ts:70
+msgid "Configuration deleted."
+msgstr "設定が削除されました。"
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:79
+msgid ""
+"Configuration has changed. {{message}} Would you like to save the story to "
+"your workspace?"
+msgstr "設定が変更されました。{{message}}記事をワークスペースに保存しますか？"
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:11
+#: scripts/apps/highlights/views/highlights_config_modal.html:12
+msgid "Configuration name"
+msgstr "設定名"
+
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:89
+#: scripts/apps/authoring/views/theme-select.html:9
+msgid "Configure Editor themes"
+msgstr "エディターテーマの設定"
+
+#: scripts/extensions/predefinedTextField/dist/src/config.js:64
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:64
+#: scripts/extensions/predefinedTextField/src/config.tsx:101
+msgid "Configure predefined values"
+msgstr "定義済みの値を設定"
+
+#: scripts/apps/authoring-react/toolbar-components/integration-wrapper/configure-theme-button.tsx:13
+msgid "Configure themes"
+msgstr "テーマの設定"
+
+#: ../superdesk-planning/client/api/coverages.ts:34
+#: ../superdesk-planning/client/api/coverages.ts:55
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:191
+#: scripts/apps/archive/index.tsx:477
+#: scripts/apps/archive/show-spike-dialog.tsx:49
+#: scripts/apps/authoring-react/authoring-swtich.tsx:28
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:46
+#: scripts/apps/authoring/authoring/components/publish-warning-confirm-modal.tsx:35
+#: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:51
+#: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:101
+#: scripts/apps/search/MultiImageEdit.ts:174
+#: scripts/core/get-superdesk-api-implementation.tsx:422
+#: scripts/core/services/modalService.tsx:150 scripts/core/ui-utils.tsx:44
+#: scripts/core/ui/components/Form/TimeInput/TimeInputPopup.tsx:140
+#: scripts/core/ui/show-confirmation-prompt.tsx:36
+#: scripts/core/ui/views/datepicker-wrapper.html:8
+#: scripts/core/ui/views/sd-timepicker-popup.html:28
+msgid "Confirm"
+msgstr "確認"
+
+#: ../superdesk-planning/client/constants/assignments.ts:197
+msgid "Confirm Availability"
+msgstr "可用性を確認"
+
+#: scripts/apps/authoring/authoring/components/publish-warning-confirm-modal.tsx:24
+msgid "Confirm Publish Warnings"
+msgstr "公開警告を確認"
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:28
+#: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:41
+msgid "Confirm Unpublishing"
+msgstr "公開取り消しを確認"
+
+#: scripts/apps/authoring/views/change-image.html:194
+msgid "Confirm crop"
+msgstr "トリミングを確認"
+
+#: scripts/core/auth/login-modal.html:78
+#: scripts/core/auth/reset-password.html:51
+msgid "Confirm new password"
+msgstr "新しいパスワードを確認"
+
+#: ../superdesk-planning/client/components/ConfirmationModal.tsx:149
+msgid "Confirmation"
+msgstr "確認"
+
+#: scripts/apps/ingest/directives/authenticate-ingest-provider.tsx:20
+msgid "Connect an account"
+msgstr "アカウントを接続"
+
+#: scripts/core/notification/notification.ts:222
+msgid "Connected to Notification Server!"
+msgstr "通知サーバーに接続しました。"
+
+#: scripts/apps/publish/views/odbc-config.html:2
+#: scripts/apps/publish/views/odbc-config.html:4
+msgid "Connection string"
+msgstr "接続文字列"
+
+#: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/contact/index.tsx:23
+msgid "Contact"
+msgstr "連絡先"
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:220
+#: scripts/apps/contacts/constants.ts:72
+#: scripts/apps/contacts/views/search-panel.html:31
+msgid "Contact Type"
+msgstr "連絡先タイプ"
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:108
+msgid "Contact type \"{{ contact_type }}\" MUST have an email"
+msgstr "連絡先タイプ「{{ contact_type }}」にはメールアドレスが必要です"
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/contacts.ts:10
+#: ../superdesk-planning/client/components/fields/editor/Contacts.tsx:19
+#: ../superdesk-planning/client/components/fields/editor/CoverageContact.tsx:22
+#: ../superdesk-planning/client/components/fields/preview/Contacts.tsx:22
+#: ../superdesk-planning/client/utils/contentProfiles.ts:285
+#: ../superdesk-planning/client/utils/contentProfiles.ts:333
+#: scripts/apps/production-api-keys/config.ts:26
+msgid "Contacts"
+msgstr "連絡先"
+
+#: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:52
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:91
+#: ../superdesk-planning/client/components/Main/ItemEditor/Editor.tsx:61
+#: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:84
+#: scripts/apps/archive/index.tsx:370
+#: scripts/apps/content-filters/views/production-test-view.html:52
+#: scripts/apps/legal-archive/views/legal_archive.html:118
+#: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:74
+#: scripts/apps/packaging/views/search-widget-preview.html:5
+#: scripts/apps/search/views/item-preview.html:9
+#: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/subitems-view-edit.js:52
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.js:52
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:65
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:65
+#: scripts/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.tsx:119
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:89
+msgid "Content"
+msgstr "コンテンツ"
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:219
+msgid ""
+"Content\n"
+"                                Type"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:254
+msgid "Content API"
+msgstr "コンテンツAPI"
+
+#: scripts/apps/content-api/controllers/ContentAPIController.ts:26
+#: scripts/apps/content-api/index.ts:21
+msgid "Content API Search"
+msgstr "コンテンツAPI検索"
+
+#: scripts/core/lang/missing-translations-strings.ts:26
+msgid "Content Expiry"
+msgstr "コンテンツ有効期限"
+
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:332
+msgid "Content Fields"
+msgstr "コンテンツフィールド"
+
+#: scripts/apps/content-filters/views/manage-filters.html:107
+#: scripts/apps/ingest/views/settings/ingest-routing-filter.html:2
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:3
+#: scripts/apps/products/views/products-config-modal.html:60
+msgid "Content Filter"
+msgstr "コンテンツフィルター"
+
+#: scripts/apps/products/views/products-config-modal.html:68
+msgid "Content Filter Type"
+msgstr "コンテンツフィルタータイプ"
+
+#: scripts/apps/content-filters/index.ts:38
+#: scripts/apps/content-filters/views/filter-search-result.html:24
+#: scripts/apps/content-filters/views/settings.html:4
+msgid "Content Filters"
+msgstr "コンテンツフィルター"
+
+#: scripts/apps/monitoring/directives/utils.ts:23
+#: scripts/apps/templates/views/template-editor-modal.html:28
+#: scripts/apps/templates/views/template-editor-modal.html:38
+msgid "Content Profile"
+msgstr "コンテンツプロファイル"
+
+#: scripts/apps/workspace/content/index.ts:43
+#: scripts/apps/workspace/content/views/profile-settings.html:4
+#: scripts/core/lang/missing-translations-strings.ts:31
+msgid "Content Profiles"
+msgstr "コンテンツプロファイル"
+
+#: ../superdesk-analytics/client/content_publishing_report/index.js:44
+msgid "Content Publishing"
+msgstr "コンテンツ公開"
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:479
+msgid "Content State"
+msgstr "コンテンツ状態"
+
+#: ../superdesk-planning/client/components/fields/editor/ContentTemplate.tsx:82
+msgid "Content Template"
+msgstr "コンテンツテンプレート"
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:321
+#: scripts/apps/publish/views/publish-queue.html:107
+#: scripts/apps/workspace/content/views/profile-settings.html:98
+msgid "Content Type"
+msgstr "コンテンツタイプ"
+
+#: scripts/apps/publish/views/publish-queue.html:60
+msgid "Content Type:"
+msgstr "コンテンツタイプ："
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:395
+#: scripts/core/lang/missing-translations-strings.ts:15
+msgid "Content Types"
+msgstr "コンテンツタイプ"
+
+#: scripts/core/activity/activity.ts:27
+msgid "Content config"
+msgstr "コンテンツ設定"
+
+#: scripts/apps/users/views/settings-roles.html:65
+msgid "Content creation"
+msgstr "コンテンツ作成"
+
+#: scripts/apps/users/views/settings-roles.html:75
+msgid "Content editing"
+msgstr "コンテンツ編集"
+
+#: scripts/apps/desks/views/desk-config-modal.html:324
+msgid "Content expiry:"
+msgstr "コンテンツ有効期限："
+
+#: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:103
+msgid "Content fields"
+msgstr "コンテンツフィールド"
+
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:31
+msgid "Content filter"
+msgstr "コンテンツフィルター"
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:58
+msgid "Content filter saved."
+msgstr "コンテンツフィルターを保存しました。"
+
+#: scripts/core/activity/activity.ts:32
+msgid "Content flow"
+msgstr "コンテンツフロー"
+
+#: ../superdesk-planning/client/actions/assignments/api.ts:265
+msgid "Content items not found!"
+msgstr "コンテンツアイテムが見つかりません。"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:75
+msgid "Content linked"
+msgstr "コンテンツがリンクされました"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:72
+msgid "Content linked to coverage"
+msgstr "取材にリンクされたコンテンツ"
+
+#: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:122
+msgid "Content locked"
+msgstr "コンテンツがロックされています"
+
+#: scripts/apps/search/components/TypeIcon.tsx:26
+msgid "Content profile: {{name}}"
+msgstr "コンテンツプロファイル：{{name}}"
+
+#: scripts/apps/search/views/search-filters.html:2
+msgid "Content types"
+msgstr "コンテンツタイプ"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:95
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:77
+msgid "Content unlinked"
+msgstr "コンテンツのリンクが解除されました"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Content.tsx:24
+msgid "Content: {{ numberOfContent }}"
+msgstr "コンテンツ：{{ numberOfContent }}"
+
+#: scripts/api/article-send.tsx:93
+#: scripts/apps/desks/views/desk-config-modal.html:421
+msgid "Continue"
+msgstr "続行"
+
+#: scripts/apps/authoring/views/change-image.html:249
+msgid "Contrast"
+msgstr "コントラスト"
+
+#: scripts/apps/authoring/views/change-image.html:154
+msgid "Controls"
+msgstr "コントロール"
+
+#: scripts/core/editor3/components/toolbar/index.tsx:452
+msgid "Convert text to lowercase"
+msgstr "テキストを小文字に変換"
+
+#: scripts/core/editor3/components/toolbar/index.tsx:441
+msgid "Convert text to uppercase"
+msgstr "テキストを大文字に変換"
+
+#: ../superdesk-planning/client/constants/events.ts:163
+msgid "Convert to Recurring Event"
+msgstr "繰り返しイベントに変換"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:110
+msgid "Convert to a recurring event"
+msgstr "繰り返しイベントに変換"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:80
+msgid "Converted to recurring event"
+msgstr "繰り返しイベントに変換されました"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:92
+msgid "Copied to clipboard"
+msgstr "クリップボードにコピーしました"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:67
+#: scripts/apps/archive/index.tsx:268
+#: scripts/apps/products/views/products-config-modal.html:28
+#: scripts/apps/publish/views/subscribers.html:286
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines.js:42
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary.js:30
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:52
+#: scripts/extensions/ai-widget/dist/src/headlines/headlines.js:42
+#: scripts/extensions/ai-widget/dist/src/summary/summary.js:30
+#: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:52
+#: scripts/extensions/ai-widget/src/headlines/headlines.tsx:94
+#: scripts/extensions/ai-widget/src/summary/summary.tsx:62
+#: scripts/extensions/ai-widget/src/translations/translations-body.tsx:118
+msgid "Copy"
+msgstr "コピー"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:89
+msgid "Copy assignment Id"
+msgstr "アサインメントIDをコピー"
+
+#: scripts/apps/authoring/media/views/media-copy-metadata-directive.html:2
+msgid "Copy metadata"
+msgstr "メタデータをコピー"
+
+#: scripts/apps/production-api-keys/config.ts:64
+msgid "Copy this now, you won't be able to access it again."
+msgstr "今すぐコピーしてください。再度アクセスできなくなります。"
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:195
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:64
+msgid "Copyright"
+msgstr "著作権"
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:32
+#: scripts/apps/archive/views/metadata-view.html:173
+#: scripts/apps/workspace/content/constants.ts:19
+msgid "Copyright holder"
+msgstr "著作権所有者"
+
+#: scripts/apps/authoring-react/fields/media/media-metadata.tsx:23
+#: scripts/apps/authoring/media/MediaMetadataView.tsx:20
+#: scripts/apps/authoring/views/item-carousel.html:112
+#: scripts/apps/authoring/views/item-carousel.html:43
+#: scripts/apps/authoring/views/item-carousel.html:72
+#: scripts/core/editor3/components/media/MediaBlock.tsx:212
+#: scripts/core/editor3/components/media/MediaBlock.tsx:254
+#: scripts/core/editor3/components/media/MediaBlock.tsx:294
+msgid "Copyright holder:"
+msgstr "著作権所有者："
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:36
+#: scripts/apps/archive/views/metadata-view.html:177
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:202
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:68
+#: scripts/apps/workspace/content/constants.ts:20
+msgid "Copyright notice"
+msgstr "著作権表示"
+
+#: scripts/apps/authoring-react/fields/media/media-metadata.tsx:31
+#: scripts/apps/authoring/media/MediaMetadataView.tsx:22
+#: scripts/apps/authoring/views/item-carousel.html:120
+#: scripts/apps/authoring/views/item-carousel.html:51
+#: scripts/apps/authoring/views/item-carousel.html:80
+#: scripts/core/editor3/components/media/MediaBlock.tsx:223
+#: scripts/core/editor3/components/media/MediaBlock.tsx:265
+#: scripts/core/editor3/components/media/MediaBlock.tsx:305
+msgid "Copyright notice:"
+msgstr "著作権表示："
+
+#: scripts/apps/search/views/multi-image-edit.html:69
+msgid "Copyright:"
+msgstr "著作権："
+
+#: ../superdesk-analytics/client/utils.js:159
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/correct-action.tsx:10
+#: scripts/apps/authoring/views/authoring-topbar.html:128
+#: scripts/apps/authoring/views/authoring-topbar.html:129
+#: scripts/apps/authoring/views/authoring-topbar.html:130
+msgid "Correct"
+msgstr "修正"
+
+#: scripts/apps/authoring/authoring/index.ts:357
+msgid "Correct item"
+msgstr "アイテムを修正"
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:38
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:87
+#: scripts/apps/search/components/fields/state.tsx:39
+msgid "Corrected"
+msgstr "修正済み"
+
+#: scripts/apps/authoring/versioning/history/HistoryController.ts:182
+msgid "Corrected by"
+msgstr "修正者"
+
+#: scripts/core/interactive-article-actions-panel/index-ui.tsx:137
+msgid "Correcting multiple items from authoring pane is not supported"
+msgstr "オーサリングペインからの複数アイテムの同時修正はサポートされていません"
+
+#: scripts/apps/search/components/fields/state.tsx:40
+#: scripts/core/lang/missing-translations-strings.ts:16
+msgid "Correction"
+msgstr "修正"
+
+#: scripts/apps/authoring/versioning/history/views/history.html:165
+msgid "Correction Cancel by"
+msgstr "修正キャンセル者"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:485
+msgid "Correction cancelled by {{user}}"
+msgstr "{{user}}が修正をキャンセル"
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:467
+msgid "Correction has been removed"
+msgstr "修正が削除されました"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:495
+#: scripts/apps/authoring/versioning/history/views/history.html:171
+msgid "Correction link is removed"
+msgstr "修正リンクが削除されました"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:575
+msgid "Corrections"
+msgstr "修正"
+
+#: ../superdesk-planning/client/api/editor/item_planning.ts:125
+msgid "Could not link event - Please close the item and try linking again"
+msgstr "イベントをリンクできませんでした。アイテムを閉じてから再度リンクしてください"
+
+#: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:42
+#: scripts/core/ui/components/Form/LinkInput.tsx:27
+msgid "Could not load title"
+msgstr "タイトルを読み込めませんでした"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:1017
+#: ../superdesk-planning/client/actions/events/ui.ts:1039
+#: ../superdesk-planning/client/actions/events/ui.ts:895
+msgid "Could not obtain lock on the event."
+msgstr "イベントのロックを取得できませんでした。"
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:245
+msgid "Could not obtain lock on the planning item."
+msgstr "プランニングアイテムのロックを取得できませんでした。"
+
+#: ../superdesk-planning/client/components/editor-standalone/authoring-storage-event-http.ts:51
+msgid "Could not save event"
+msgstr "イベントを保存できませんでした"
+
+#: ../superdesk-planning/client/actions/main.ts:1654
+msgid "Could not save the item."
+msgstr "アイテムを保存できませんでした。"
+
+#: ../superdesk-planning/client/actions/assignments/api.ts:364
+msgid "Could not unlock the assignment."
+msgstr "アサインメントのロック解除ができませんでした。"
+
+#: ../superdesk-planning/client/actions/main.ts:1650
+msgid "Could not unlock the item."
+msgstr "アイテムのロック解除ができませんでした。"
+
+#: scripts/apps/highlights/services/HighlightsService.ts:126
+msgid "Couldn't mark item"
+msgstr "アイテムをマークできませんでした"
+
+#: scripts/apps/highlights/services/HighlightsService.ts:126
+msgid "Couldn't unmark item"
+msgstr "アイテムのマークを解除できませんでした"
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:288
+#: ../superdesk-planning/client/components/Locations/LocationsList.tsx:136
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:84
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:635
+#: scripts/apps/contacts/constants.ts:77
+#: scripts/apps/contacts/views/search-panel.html:75
+msgid "Country"
+msgstr "国"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:88
+#: scripts/apps/archive/views/assignment-icon.html:1
+#: scripts/apps/search/components/fields/assignment.tsx:17
+msgid "Coverage"
+msgstr "取材"
+
+#: ../superdesk-planning/client/components/Assignments/EditCoverageAssignmentModal.tsx:81
+msgid "Coverage Assignment Details"
+msgstr "取材アサインメント詳細"
+
+#: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:37
+#: ../superdesk-planning/client/components/fields/preview/index.ts:45
+msgid "Coverage Assignment Status"
+msgstr "取材アサインメント状態"
+
+#: ../superdesk-planning/client/utils/assignments.ts:206
+msgid "Coverage Contact"
+msgstr "取材連絡先"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:191
+msgid "Coverage Provider"
+msgstr "取材プロバイダー"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:133
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:266
+#: ../superdesk-planning/client/components/Coverages/CoveragePreview/CoveragePreviewTopBar.tsx:60
+msgid "Coverage Provider:"
+msgstr "取材プロバイダー："
+
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/ScheduledUpdateForm.tsx:156
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:231
+#: ../superdesk-planning/client/components/fields/editor/NewsCoverageStatus.tsx:32
+#: ../superdesk-planning/client/components/fields/preview/index.ts:205
+#: ../superdesk-planning/client/utils/contentProfiles.ts:327
+msgid "Coverage Status"
+msgstr "取材状態"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageAddButton/CoveragesMenuPopup.tsx:51
+#: ../superdesk-planning/client/components/fields/editor/CoverageType.tsx:34
+#: ../superdesk-planning/client/components/fields/preview/index.ts:70
+msgid "Coverage Type"
+msgstr "取材タイプ"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:85
+msgid "Coverage added to workflow"
+msgstr "取材がワークフローに追加されました"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:32
+msgid "Coverage assigned"
+msgstr "取材が割り当てられました"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:69
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:72
+msgid "Coverage availability"
+msgstr "取材の可用性"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:89
+msgid "Coverage availability confirmed"
+msgstr "取材の可用性が確認されました"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:93
+msgid "Coverage availability reverted"
+msgstr "取材の可用性が元に戻されました"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:68
+msgid "Coverage cancelled"
+msgstr "取材がキャンセルされました"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:105
+msgid "Coverage completed"
+msgstr "取材が完了しました"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:64
+msgid "Coverage edited"
+msgstr "取材が編集されました"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:293
+msgid "Coverage enabled"
+msgstr "取材が有効になりました"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:287
+msgid "Coverage has been added to workflow"
+msgstr "取材がワークフローに追加されました"
+
+#: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:28
+msgid "Coverage must be assigned to a desk"
+msgstr "取材はデスクに割り当てる必要があります"
+
+#: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:24
+msgid "Coverage must be in draft status"
+msgstr "取材は下書き状態でなければなりません"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:25
+msgid "Coverage of type {{ type }} created"
+msgstr "タイプ{{ type }}の取材が作成されました"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:81
+msgid "Coverage priority modified"
+msgstr "取材の優先度が変更されました"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:51
+msgid "Coverage re-assigned to"
+msgstr "取材の再割り当て先"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:30
+msgid "Coverage reassigned"
+msgstr "取材が再割り当てされました"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:52
+msgid "Coverage removed"
+msgstr "取材が削除されました"
+
+#: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:20
+msgid "Coverage was cancelled"
+msgstr "取材がキャンセルされました"
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:77
+#: ../superdesk-planning/client/components/Coverages/CoverageArrayInput.tsx:199
+#: ../superdesk-planning/client/components/Editor/bookmarks/CoveragesBookmark.tsx:119
+#: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:252
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:121
+#: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/coverages/index.tsx:27
+#: ../superdesk-planning/client/utils/contentProfiles.ts:317
+msgid "Coverages"
+msgstr "取材"
+
+#: ../superdesk-planning/client/api/planning.ts:299
+msgid "Coverages added to workflow."
+msgstr "取材がワークフローに追加されました。"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:433
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:219
+#: ../superdesk-analytics/client/utils.js:150
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:74
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:201
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:158
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:143
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:127
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:203
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:410
+#: ../superdesk-planning/client/components/Main/ItemEditorModal/EditorModalPanel.tsx:168
+#: scripts/apps/monitoring/directives/MonitoringView.ts:201
+#: scripts/apps/templates/services/TemplatesService.ts:70
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:6
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:191
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:39
+#: scripts/extensions/broadcasting/dist/src/page.js:195
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:39
+#: scripts/extensions/broadcasting/src/page.tsx:286
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:71
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:223
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:223
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:245
+msgid "Create"
+msgstr "作成"
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:420
+msgid "Create & Post"
+msgstr "作成して投稿"
+
+#: scripts/apps/archive/index.tsx:246
+msgid "Create Broadcast"
+msgstr "ブロードキャストを作成"
+
+#: ../superdesk-analytics/client/utils.js:175
+msgid "Create Highlight"
+msgstr "ハイライトを作成"
+
+#: ../superdesk-planning/client/components/GeoLookupInput/CreateNewGeoLookup.tsx:180
+msgid "Create Location"
+msgstr "ロケーションを作成"
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:189
+msgid "Create New Location"
+msgstr "新しいロケーションを作成"
+
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:45
+msgid "Create New Task"
+msgstr "新しいタスクを作成"
+
+#: scripts/apps/monitoring/index.ts:128
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:257
+msgid "Create Package"
+msgstr "パッケージを作成"
+
+#: ../superdesk-planning/client/components/Editor/EditorBookmarksBar.tsx:64
+msgid "Create Planning"
+msgstr "プランニングを作成"
+
+#: ../superdesk-planning/client/constants/events.ts:157
+msgid "Create Planning Item"
+msgstr "プランニングアイテムを作成"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:105
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:179
+msgid "Create Scheduled Export"
+msgstr "スケジュールエクスポートを作成"
+
+#: scripts/apps/monitoring/index.ts:126
+msgid "Create a broadcast"
+msgstr "ブロードキャストを作成"
+
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:49
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:50
+msgid "Create a new location"
+msgstr "新しいロケーションを作成"
+
+#: ../superdesk-planning/client/constants/events.ts:158
+msgid "Create and Open Planning Item"
+msgstr "プランニングアイテムを作成して開く"
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary.js:50
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:63
+#: scripts/extensions/ai-widget/dist/src/summary/summary.js:50
+#: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:63
+#: scripts/extensions/ai-widget/src/summary/summary.tsx:91
+#: scripts/extensions/ai-widget/src/translations/translations-body.tsx:148
+msgid "Create article"
+msgstr "記事を作成"
+
+#: scripts/apps/highlights/views/settings.html:11
+msgid "Create configuration"
+msgstr "設定を作成"
+
+#: scripts/apps/contacts/views/list.html:10
+msgid "Create contact"
+msgstr "連絡先を作成"
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:3
+msgid "Create highlight configuration"
+msgstr "ハイライト設定を作成"
+
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:45
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:55
+#: scripts/apps/authoring/workqueue/work-queue-create-new-button.tsx:10
+#: scripts/apps/relations/directives/related-items-create-new-button.tsx:11
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:166
+#: scripts/extensions/broadcasting/dist/src/page.js:170
+#: scripts/extensions/broadcasting/src/page.tsx:252
+msgid "Create new"
+msgstr "新規作成"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:183
+#: scripts/extensions/broadcasting/dist/src/page.js:187
+#: scripts/extensions/broadcasting/src/page.tsx:275
+msgid "Create new Show"
+msgstr "新しいショーを作成"
+
+#: scripts/apps/desks/views/desk-config-modal.html:292
+msgid "Create new Stage"
+msgstr "新しいステージを作成"
+
+#: scripts/apps/workspace/views/edit-workspace-modal.html:3
+msgid "Create new Workspace"
+msgstr "新しいワークスペースを作成"
+
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:110
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:114
+#: scripts/apps/monitoring/views/monitoring-view.html:126
+#: scripts/apps/workspace/content/index.ts:54
+msgid "Create new item"
+msgstr "新しいアイテムを作成"
+
+#: ../superdesk-planning/client/components/Main/ListPanel.tsx:344
+msgid "Create new items or change your search filters"
+msgstr "新しいアイテムを作成するか検索フィルターを変更してください"
+
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:109
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:113
+msgid "Create new planning item"
+msgstr "新しいプランニングアイテムを作成"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:18
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:18
+#: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:44
+msgid "Create new rundown template"
+msgstr "新しいランダウンテンプレートを作成"
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:55
+msgid "Create new schedule"
+msgstr "新しいスケジュールを作成"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-modal.js:48
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-modal.js:48
+#: scripts/extensions/broadcasting/src/shows/create-show-modal.tsx:85
+msgid "Create new show"
+msgstr "新しいショーを作成"
+
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:141
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:141
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:135
+msgid "Create new tag: \"{{ tag }}\""
+msgstr "新しいタグを作成：「{{ tag }}」"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:134
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:134
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:261
+msgid "Create new template"
+msgstr "新しいテンプレートを作成"
+
+#: scripts/apps/packaging/index.ts:50 scripts/apps/packaging/index.ts:59
+#: scripts/core/ui/components/content-create-dropdown/initial-view.tsx:199
+msgid "Create package"
+msgstr "パッケージを作成"
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:239
+msgid "Create planning"
+msgstr "プランニングを作成"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:259
+msgid "Create planning for all events or just this one?"
+msgstr "すべてのイベントにプランニングを作成しますか？それともこのイベントのみですか？"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:57
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:57
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:103
+msgid "Create rundown"
+msgstr "ランダウンを作成"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:14
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:14
+#: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:28
+msgid "Create rundown template"
+msgstr "ランダウンテンプレートを作成"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:161
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:161
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:317
+msgid "Create rundowns automatically"
+msgstr "ランダウンを自動作成"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:219
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:219
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:415
+msgid "Create template"
+msgstr "テンプレートを作成"
+
+#: scripts/apps/users/views/list.html:3
+msgid "Create user"
+msgstr "ユーザーを作成"
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:129
+#: ../superdesk-planning/client/components/AuditInformation/index.tsx:110
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:23
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:33
+#: scripts/apps/archive/views/metadata-view.html:89
+#: scripts/apps/archive/views/preview.html:6
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:370
+#: scripts/apps/authoring/authoring/created-info.tsx:49
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:167
+#: scripts/apps/authoring/suggest/SuggestView.html:21
+#: scripts/apps/authoring/suggest/SuggestView.html:69
+#: scripts/apps/contacts/services/ContactsService.ts:40
+#: scripts/apps/content-api/services/ContentAPISearchService.ts:29
+#: scripts/apps/legal-archive/services/LegalArchiveService.ts:25
+#: scripts/apps/legal-archive/tests/legal.spec.ts:67
+#: scripts/apps/production-api-keys/ProductionApiItem.tsx:36
+#: scripts/apps/search/services/SearchService.ts:67
+#: scripts/apps/users/views/list.html:37
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:146
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:146
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:112
+#: scripts/extensions/sams/dist/src/utils/ui.js:112
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:171
+#: scripts/extensions/sams/src/utils/ui.tsx:105
+msgid "Created"
+msgstr "作成済み"
+
+#: ../superdesk-planning/client/components/UI/List/CreatedUpdatedColumn.tsx:28
+msgid "Created : {{ datetime }}"
+msgstr "作成日時：{{ datetime }}"
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:154
+msgid "Created From"
+msgstr "作成日（開始）"
+
+#: scripts/core/lang/missing-translations-strings.ts:39
+msgid "Created Ingest Channel {{name}}"
+msgstr "取り込みチャンネル{{name}}を作成しました"
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:158
+msgid "Created To"
+msgstr "作成日（終了）"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:105
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:105
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:187
+msgid "Created at {{date}}"
+msgstr "{{date}}に作成"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:88
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:88
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:165
+msgid "Created at {{time}} by {{user}}"
+msgstr "{{user}}が{{time}}に作成"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:96
+#: scripts/apps/authoring/versioning/history/views/history.html:6
+msgid "Created by"
+msgstr "作成者"
+
+#: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:111
+msgid "Created by this user"
+msgstr "このユーザーが作成"
+
+#: scripts/apps/search/directives/DateFilters.ts:77
+msgid "Created from"
+msgstr "作成元"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:92
+msgid "Created from 'update repetitions'"
+msgstr "「繰り返し更新」から作成"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:104
+msgid "Created from a planning item"
+msgstr "プランニングアイテムから作成"
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:37
+msgid "Created from content"
+msgstr "コンテンツから作成"
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:32
+msgid "Created from event"
+msgstr "イベントから作成"
+
+#: scripts/apps/authoring/versioning/history/views/history.html:127
+msgid "Created from highlight"
+msgstr "ハイライトから作成"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:380
+msgid "Created from highlight({{x}}) by {{user}}"
+msgstr "{{user}}がハイライト（{{x}}）から作成"
+
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:2
+msgid "Created on"
+msgstr "作成日"
+
+#: scripts/apps/search/directives/DateFilters.ts:78
+msgid "Created to"
+msgstr "作成日（終了）"
+
+#: scripts/extensions/sams/dist/src/components/common/versionUserDateLines.js:95
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/versionUserDateLines.js:66
+#: scripts/extensions/sams/src/components/common/versionUserDateLines.tsx:36
+msgid "Created {{ datetime }}"
+msgstr "作成日時：{{ datetime }}"
+
+#: scripts/extensions/sams/dist/src/components/common/versionUserDateLines.js:96
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/versionUserDateLines.js:67
+#: scripts/extensions/sams/src/components/common/versionUserDateLines.tsx:41
+msgid "Created {{ datetime }} by"
+msgstr "{{ datetime }}に作成者："
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:129
+msgid "Creation Date"
+msgstr "作成日"
+
+#: ../superdesk-planning/client/components/fields/editor/DatesGroup.tsx:80
+msgid "Creation date"
+msgstr "作成日"
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:17
+#: scripts/apps/search/constants.ts:11
+#: scripts/apps/search/views/search-parameters.html:131
+msgid "Creator"
+msgstr "作成者"
+
+#: scripts/apps/production-api-keys/config.ts:49
+msgid "Credentials"
+msgstr "認証情報"
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:209
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:72
+msgid "Credit"
+msgstr "クレジット"
+
+#: scripts/apps/authoring-react/fields/media/media-metadata.tsx:19
+#: scripts/apps/authoring/media/MediaMetadataView.tsx:19
+#: scripts/apps/authoring/views/item-carousel.html:108
+#: scripts/apps/authoring/views/item-carousel.html:39
+#: scripts/apps/authoring/views/item-carousel.html:68
+#: scripts/core/editor3/components/media/MediaBlock.tsx:208
+#: scripts/core/editor3/components/media/MediaBlock.tsx:250
+#: scripts/core/editor3/components/media/MediaBlock.tsx:290
+msgid "Credit:"
+msgstr "クレジット："
+
+#: scripts/apps/search/views/search-filters.html:57
+msgid "Credits"
+msgstr "クレジット"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:248
+#: scripts/apps/publish/views/subscribers.html:234
+msgid "Critical Errors"
+msgstr "重大なエラー"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:68
+#: scripts/apps/authoring/views/change-image.html:205
+msgid "Crop"
+msgstr "トリミング"
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:181
+msgid "Crop coordinates are not defined for {{cropName}} picture crop."
+msgstr "{{cropName}}画像トリミングのトリミング座標が定義されていません。"
+
+#: scripts/apps/profiling/views/profiling.html:35
+msgid "Cumulative time"
+msgstr "累積時間"
+
+#: scripts/apps/profiling/views/profiling.html:36
+msgid "Cumulative time per call"
+msgstr "コールあたりの累積時間"
+
+#: ../superdesk-planning/client/constants/assignments.ts:209
+msgid "Current Assignments"
+msgstr "現在のアサインメント"
+
+#: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:78
+msgid "Current Date"
+msgstr "現在の日付"
+
+#: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:82
+msgid "Current Date (Based on Event timezone)"
+msgstr "現在の日付（イベントのタイムゾーン基準）"
+
+#: ../superdesk-planning/client/components/Events/RepeatEventSummary/index.tsx:14
+msgid "Current Repeat Summary"
+msgstr "現在の繰り返しサマリー"
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:181
+msgid "Currently Selected"
+msgstr "選択中"
+
+#: scripts/apps/search/views/multi-image-edit.html:93
+msgid "Currently editing: {{getSelectedItemsLength()}} items"
+msgstr "編集中：{{getSelectedItemsLength()}}件のアイテム"
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningSelectedList.tsx:23
+msgid "Currently selected"
+msgstr "選択中"
+
+#: scripts/core/upload/image-crop-directive.ts:254
+msgid "Currently the image size is {{width}}x{{height}})."
+msgstr "現在の画像サイズは{{width}}x{{height}}です。"
+
+#: scripts/apps/authoring/views/dashboard-articles.html:5
+msgid "Currently working on"
+msgstr "作業中"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:221
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:316
+msgid "Custom Layout"
+msgstr "カスタムレイアウト"
+
+#: scripts/core/editor3/components/toolbar/index.tsx:358
+msgid "Custom block"
+msgstr "カスタムブロック"
+
+#: scripts/apps/vocabularies/views/settings.html:22
+msgid "Custom blocks"
+msgstr "カスタムブロック"
+
+#: scripts/apps/vocabularies/views/settings.html:25
+msgid "Custom date fields"
+msgstr "カスタム日付フィールド"
+
+#: scripts/apps/vocabularies/views/settings.html:28
+msgid "Custom embed fields"
+msgstr "カスタム埋め込みフィールド"
+
+#: scripts/apps/vocabularies/views/settings.html:19
+msgid "Custom text fields"
+msgstr "カスタムテキストフィールド"
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:76
+msgid "Customer Installation No.:"
+msgstr "顧客インストール番号："
+
+#: scripts/apps/dashboard/index.ts:54
+msgid "Customize your widgets and views"
+msgstr "ウィジェットと表示をカスタマイズ"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:69
+msgid "Cut"
+msgstr "カット"
+
+#: ../superdesk-planning/client/components/Main/CalendarNavigation.tsx:46
+msgid "D"
+msgstr ""
+
+#: scripts/apps/workspace/views/workspace-dropdown.html:11
+msgid "DESKS"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:32
+msgid "DONE"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:130
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:216
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-parameters.html:25
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-preview.html:11
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:34
+msgid "Daily"
+msgstr "毎日"
+
+#: ../superdesk-planning/client/utils/filters.ts:45
+msgid "Daily @ {{ time }} to {{ desk }}"
+msgstr "毎日{{ time }}に{{ desk }}へ"
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:67
+msgid "Daily at {{hour}}"
+msgstr "毎日{{hour}}に"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:58
+msgid "Dark Blue"
+msgstr "ダークブルー"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:47
+msgid "Dark Gray"
+msgstr "ダークグレー"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:69
+msgid "Dark Magenta"
+msgstr "ダークマゼンタ"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:66
+msgid "Dark Orange"
+msgstr "ダークオレンジ"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:70
+msgid "Dark Violet"
+msgstr "ダークバイオレット"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:48
+msgid "Darker Gray"
+msgstr "より濃いグレー"
+
+#: scripts/apps/dashboard/controllers/DashboardController.ts:38
+#: scripts/apps/dashboard/index.ts:70
+#: scripts/apps/dashboard/views/workspace.html:2
+msgid "Dashboard"
+msgstr "ダッシュボード"
+
+#: scripts/apps/dashboard/views/workspace.html:59
+msgid "Dashboard is empty"
+msgstr "ダッシュボードは空です"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:419
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:16
+#: ../superdesk-analytics/client/search/views/date-filters.html:62
+#: ../superdesk-planning/client/components/UI/Form/DateInput/index.tsx:218
+#: ../superdesk-planning/client/components/fields/editor/DateOnly.tsx:26
+#: scripts/core/lang/missing-translations-strings.ts:31
+#: scripts/extensions/datetimeField/dist/src/editor.js:41
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:41
+#: scripts/extensions/datetimeField/src/editor.tsx:64
+msgid "Date"
+msgstr "日付"
+
+#: scripts/apps/authoring-react/fields/date/index.tsx:17
+msgid "Date (authoring-react)"
+msgstr "日付（authoring-react）"
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:177
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:91
+msgid "Date Created"
+msgstr "作成日"
+
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:2
+#: ../superdesk-planning/client/components/fields/preview/index.ts:142
+msgid "Date Filter"
+msgstr "日付フィルター"
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:3
+msgid "Date Filter:"
+msgstr "日付フィルター："
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:108
+#: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:16
+msgid "Date Filters"
+msgstr "日付フィルター"
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:180
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:94
+msgid "Date Updated"
+msgstr "更新日"
+
+#: scripts/apps/search/directives/DateFilters.ts:76
+msgid "Date created"
+msgstr "作成日"
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:183
+msgid "Date field is required"
+msgstr "日付フィールドは必須です"
+
+#: ../superdesk-planning/client/validators/planning.ts:253
+msgid "Date is in the past"
+msgstr "日付が過去です"
+
+#: scripts/apps/search/directives/DateFilters.ts:84
+msgid "Date modified"
+msgstr "更新日"
+
+#: ../superdesk-planning/client/apps/Planning/SubNavDatePicker.tsx:71
+#: ../superdesk-planning/client/components/UI/Form/DateInput/index.tsx:209
+msgid "Date picker"
+msgstr "日付選択"
+
+#: scripts/apps/search/constants.ts:21
+#: scripts/apps/search/directives/DateFilters.ts:92
+msgid "Date published"
+msgstr "公開日"
+
+#: scripts/apps/search/directives/DateFilters.ts:100
+msgid "Date scheduled"
+msgstr "スケジュール日"
+
+#: scripts/apps/authoring-react/fields/datetime/preview.tsx:16
+msgid "Date time (AUTHORING-REACT)"
+msgstr "日時（AUTHORING-REACT）"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:415
+msgid "Date/Time"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:113
+#: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:88
+msgid "Date:"
+msgstr "日付："
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:352
+#: scripts/apps/authoring-react/field-adapters/dateline.ts:12
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:151
+#: scripts/apps/users/views/user-preferences.html:106
+#: scripts/apps/workspace/content/constants.ts:21
+msgid "Dateline"
+msgstr "発信地"
+
+#: scripts/apps/authoring-react/fields/dateline/index.tsx:27
+msgid "Dateline (authoring-react)"
+msgstr "発信地（authoring-react）"
+
+#: ../superdesk-planning/client/components/fields/editor/DatesGroup.tsx:40
+#: ../superdesk-planning/client/components/fields/index.tsx:232
+#: ../superdesk-planning/client/utils/contentProfiles.ts:265
+msgid "Dates"
+msgstr "日付"
+
+#: scripts/extensions/datetimeField/dist/src/extension.js:20
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/extension.js:20
+#: scripts/extensions/datetimeField/src/extension.tsx:27
+msgid "Datetime"
+msgstr "日時"
+
+#: scripts/apps/authoring-react/fields/datetime/index.tsx:24
+msgid "Datetime (authoring-react)"
+msgstr "日時（authoring-react）"
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:157
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:77
+#: scripts/extensions/availability-manager/dist/src/constants.js:34
+#: scripts/extensions/availability-manager/dist/src/correspondent-availability/filters.js:84
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/constants.js:34
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/correspondent-availability/filters.js:84
+#: scripts/extensions/availability-manager/src/constants.ts:42
+#: scripts/extensions/availability-manager/src/correspondent-availability/filters.tsx:128
+msgid "Day"
+msgstr "日"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:29
+msgid "Day of the Month"
+msgstr "日（月の何日目）"
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:30
+msgid "Day(s)"
+msgstr "日"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:4
+msgid "Days"
+msgstr "日数"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:68
+msgid "Deep Pink"
+msgstr "ディープピンク"
+
+#: scripts/apps/monitoring/views/monitoring-group-header.html:31
+#: scripts/apps/monitoring/views/monitoring-group-header.html:43
+#: scripts/apps/search-providers/directive.ts:118
+msgid "Default"
+msgstr "デフォルト"
+
+#: scripts/apps/users/views/user-preferences.html:219
+msgid "Default Agenda"
+msgstr "デフォルトアジェンダ"
+
+#: scripts/apps/users/views/user-preferences.html:206
+msgid "Default Calendar"
+msgstr "デフォルトカレンダー"
+
+#: scripts/apps/desks/views/desk-config-modal.html:176
+msgid "Default Content Profile"
+msgstr "デフォルトコンテンツプロファイル"
+
+#: scripts/apps/desks/views/desk-config-modal.html:153
+msgid "Default Content Template"
+msgstr "デフォルトコンテンツテンプレート"
+
+#: scripts/apps/users/views/edit-form.html:220
+msgid "Default Desk"
+msgstr "デフォルトデスク"
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:147
+msgid "Default Duration"
+msgstr "デフォルトの期間"
+
+#: scripts/apps/users/views/user-preferences.html:232
+msgid "Default Events & Planning Filter"
+msgstr "デフォルトのイベントとプランニングフィルター"
+
+#: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:72
+msgid "Default Template"
+msgstr "デフォルトテンプレート"
+
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:96
+#: scripts/apps/authoring/views/theme-select.html:15
+msgid "Default Theme"
+msgstr "デフォルトテーマ"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:236
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:208
+msgid "Default Value"
+msgstr "デフォルト値"
+
+#: scripts/apps/users/views/settings-roles.html:54
+msgid "Default author roles"
+msgstr "デフォルトの著者ロール"
+
+#: scripts/apps/users/views/edit-form.html:18
+#: scripts/apps/users/views/edit-form.html:215
+msgid "Default desk"
+msgstr "デフォルトデスク"
+
+#: scripts/core/ui/components/content-create-dropdown/initial-view.tsx:131
+msgid "Default desk template"
+msgstr "デフォルトデスクテンプレート"
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:189
+msgid "Default language"
+msgstr "デフォルト言語"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:69
+msgid "Default language is a required field"
+msgstr "デフォルト言語は必須フィールドです"
+
+#: scripts/apps/desks/views/desk-config-modal.html:131
+msgid "Default monitoring view"
+msgstr "デフォルトモニタリング表示"
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/manage-schedule.js:128
+#: scripts/extensions/availability-manager/dist/src/settings/manage-schedule.js:128
+#: scripts/extensions/availability-manager/src/settings/manage-schedule.tsx:199
+msgid "Default schedule"
+msgstr "デフォルトスケジュール"
+
+#: scripts/apps/search-providers/views/search-provider-config.html:53
+msgid "Default view"
+msgstr "デフォルト表示"
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:106
+msgid ""
+"Defines the width of the pop-up in the\n"
+"                                    article header. A minimal value of 200 "
+"is required."
+msgstr ""
+
+#: scripts/extensions/annotationsLibrary/dist/src/GetFields.js:23
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/GetFields.js:23
+#: scripts/extensions/annotationsLibrary/src/GetFields.ts:24
+#: scripts/extensions/predefinedTextField/dist/src/config.js:21
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:21
+#: scripts/extensions/predefinedTextField/src/config.tsx:30
+msgid "Definition"
+msgstr "定義"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:204
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:305
+#: ../superdesk-planning/client/components/Events/ManageEventTemplatesModal.tsx:51
+#: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:100
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:71
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:86
+#: ../superdesk-planning/client/components/UI/Form/InputArray/index.tsx:86
+#: ../superdesk-planning/client/components/fields/common/PreviewFilterSchedule.tsx:69
+#: ../superdesk-planning/client/constants/tooltips.ts:27
+#: scripts/apps/production-api-keys/ProductionApiItem.tsx:63
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:97
+#: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:187
+#: scripts/core/editor3/components/annotations/AnnotationInput.tsx:280
+#: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:97
+#: scripts/core/editor3/components/comments/Comment.tsx:61
+#: scripts/core/editor3/components/links/LinkToolbar.tsx:59
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:250
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:59
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:130
+#: scripts/extensions/broadcasting/dist/src/rundowns/manage-rundown-items.js:59
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:130
+#: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:116
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:242
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:124
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:124
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:51
+#: scripts/extensions/sams/dist/src/utils/assets.js:51
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:116
+#: scripts/extensions/sams/src/utils/assets.ts:63
+msgid "Delete"
+msgstr "削除"
+
+#: ../superdesk-planning/client/constants/tooltips.ts:26
+msgid "Delete Agenda"
+msgstr "アジェンダを削除"
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/store/assets/actions.js:324
+#: scripts/extensions/sams/dist/src/extensions/sams/src/store/assets/actions.js:331
+#: scripts/extensions/sams/dist/src/store/assets/actions.js:324
+#: scripts/extensions/sams/dist/src/store/assets/actions.js:331
+#: scripts/extensions/sams/src/store/assets/actions.ts:384
+#: scripts/extensions/sams/src/store/assets/actions.ts:393
+msgid "Delete Asset?"
+msgstr "アセットを削除しますか？"
+
+#: ../superdesk-planning/client/constants/tooltips.ts:36
+msgid "Delete Filter"
+msgstr "フィルターを削除"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:203
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:304
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:70
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:85
+msgid "Delete Item?"
+msgstr "アイテムを削除しますか？"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:70
+msgid "Delete Rule"
+msgstr "ルールを削除"
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:33
+msgid "Delete Saved Report"
+msgstr "保存済みレポートを削除"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:114
+msgid "Delete Scheduled Export"
+msgstr "スケジュールエクスポートを削除"
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/store/sets/actions.js:95
+#: scripts/extensions/sams/dist/src/store/sets/actions.js:95
+#: scripts/extensions/sams/src/store/sets/actions.ts:114
+msgid "Delete Set?"
+msgstr "セットを削除しますか？"
+
+#: scripts/core/editor3/highlightsConfig.ts:102
+msgid "Delete empty paragraphs"
+msgstr "空の段落を削除"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:101
+msgid "Delete failed! Field is required by the system"
+msgstr "削除に失敗しました。フィールドはシステムで必須です"
+
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:248
+msgid "Delete item?"
+msgstr "アイテムを削除しますか？"
+
+#: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:226
+#: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:230
+msgid "Delete link"
+msgstr "リンクを削除"
+
+#: scripts/apps/search/views/saved-searches.html:16
+#: scripts/apps/search/views/saved-searches.html:45
+msgid "Delete search"
+msgstr "検索を削除"
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:35
+msgid "Delete this Schedule"
+msgstr "このスケジュールを削除"
+
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:87
+msgid "Delete vocabulary?"
+msgstr "ボキャブラリーを削除しますか？"
+
+#: scripts/apps/dashboard/views/workspace.html:35
+#: scripts/apps/monitoring/views/monitoring-view.html:220
+msgid "Delete workspace"
+msgstr "ワークスペースを削除"
+
+#: scripts/core/lang/missing-translations-strings.ts:40
+msgid "Deleted Ingest Channel {{name}}"
+msgstr "取り込みチャンネル{{name}}を削除しました"
+
+#: scripts/apps/publish/views/destination.html:22
+msgid "Delivery type"
+msgstr "配信タイプ"
+
+#: scripts/apps/authoring-react/article-widgets/demo-widget.tsx:10
+msgid "Demo widget"
+msgstr "デモウィジェット"
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:169
+#: ../superdesk-planning/client/components/OrderBar/OrderDirectionIcon.tsx:20
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:70
+#: scripts/apps/search/views/item-sortbar.html:21
+#: scripts/core/ui/components/SortBar/index.tsx:77
+msgid "Descending"
+msgstr "降順"
+
+#: ../superdesk-analytics/client/charts/views/chart-form-options.html:49
+msgid "Descending Order"
+msgstr "降順"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:437
+#: ../superdesk-analytics/client/utils.js:156
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/deschedule.tsx:9
+#: scripts/apps/authoring/views/authoring-topbar.html:110
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:316
+msgid "Deschedule"
+msgstr "スケジュール解除"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:113
+#: scripts/apps/authoring/versioning/history/views/history.html:17
+msgid "Descheduled by"
+msgstr "スケジュール解除者"
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:48
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:53
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:65
+#: ../superdesk-planning/client/components/fields/preview/index.ts:232
+#: ../superdesk-planning/client/components/fields/preview/index.ts:264
+#: ../superdesk-planning/client/components/fields/resources/events.ts:31
+#: ../superdesk-planning/client/components/fields/resources/planning.ts:12
+#: scripts/apps/archive/views/metadata-associateditem-view.html:11
+#: scripts/apps/archive/views/metadata-view.html:215
+#: scripts/apps/authoring-react/field-adapters/description_text.ts:22
+#: scripts/apps/authoring-react/fields/embed/editor.tsx:121
+#: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:216
+#: scripts/apps/authoring-react/fields/urls/editor.tsx:59
+#: scripts/apps/authoring/attachments/AttachmentsEditorModal.tsx:71
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:189
+#: scripts/apps/authoring/authoring/article-url-fields.tsx:89
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:209
+#: scripts/apps/authoring/views/article-edit.html:611
+#: scripts/apps/search/views/save-search-dialog.html:10
+#: scripts/apps/search/views/search-parameters.html:207
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:78
+#: scripts/apps/workspace/content/constants.ts:22
+#: scripts/apps/workspace/content/views/profile-settings.html:122
+#: scripts/apps/workspace/content/views/profile-settings.html:158
+#: scripts/core/editor3/components/embeds/EmbedBlock.tsx:174
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:67
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:67
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:158
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show.js:69
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:25
+#: scripts/extensions/broadcasting/dist/src/shows/create-show.js:69
+#: scripts/extensions/broadcasting/dist/src/shows/manage-shows.js:25
+#: scripts/extensions/broadcasting/src/shows/create-show.tsx:107
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:37
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:183
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:227
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:114
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:146
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:238
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:144
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:183
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:227
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:114
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:146
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:238
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:144
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:205
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:264
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:131
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:163
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:291
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:144
+msgid "Description"
+msgstr "説明"
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:291
+msgid "Description Long"
+msgstr "長い説明"
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:273
+msgid "Description Short"
+msgstr "短い説明"
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:305
+msgid "Description Text"
+msgstr "説明テキスト"
+
+#: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:135
+msgid "Description:"
+msgstr "説明："
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:328
+#: scripts/apps/search/views/multi-image-edit.html:33
+msgid "Deselect All"
+msgstr "すべて選択解除"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:495
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-parameters.html:9
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-preview.html:2
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:111
+#: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:171
+#: ../superdesk-planning/client/components/Coverages/CoveragePreview/CoveragePreviewTopBar.tsx:45
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:280
+#: ../superdesk-planning/client/components/fields/editor/DeskId.tsx:39
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:64
+#: scripts/apps/desks/views/actionpicker.html:4
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:39
+#: scripts/apps/templates/views/create-template.html:39
+#: scripts/apps/templates/views/template-editor-modal.html:80
+#: scripts/apps/workspace/content/constants.ts:23
+msgid "Desk"
+msgstr "デスク"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:231
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:383
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:500
+#: ../superdesk-analytics/client/desk_activity_report/index.js:45
+msgid "Desk Activity"
+msgstr "デスクアクティビティ"
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:64
+msgid "Desk Assignments"
+msgstr "デスクアサインメント"
+
+#: scripts/apps/desks/views/desk-config-modal.html:68
+msgid "Desk Email"
+msgstr "デスクメール"
+
+#: scripts/core/lang/missing-translations-strings.ts:16
+msgid "Desk Management"
+msgstr "デスク管理"
+
+#: scripts/apps/monitoring/directives/AggregateSettings.ts:56
+#: scripts/apps/workspace/content/constants.ts:66
+msgid "Desk Output"
+msgstr "デスク出力"
+
+#: scripts/apps/dashboard/closed-desk/index.ts:152
+msgid "Desk Router"
+msgstr "デスクルーター"
+
+#: scripts/apps/monitoring/directives/AggregateSettings.ts:50
+msgid "Desk Schedule Output"
+msgstr "デスクスケジュール出力"
+
+#: scripts/apps/monitoring/directives/AggregateSettings.ts:62
+msgid "Desk Sent Output"
+msgstr "デスク送信済み出力"
+
+#: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:79
+msgid "Desk Templates"
+msgstr "デスクテンプレート"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:367
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:371
+msgid "Desk Transitions"
+msgstr "デスク遷移"
+
+#: scripts/apps/desks/views/desk-config-modal.html:93
+#: scripts/apps/desks/views/settings.html:82
+msgid "Desk Type"
+msgstr "デスクタイプ"
+
+#: scripts/apps/desks/controllers/DeskConfigController.ts:63
+msgid "Desk deleted."
+msgstr "デスクが削除されました。"
+
+#: scripts/apps/desks/views/desk-config-modal.html:32
+msgid "Desk description"
+msgstr "デスクの説明"
+
+#: scripts/apps/desks/views/desk-config-modal.html:70
+msgid "Desk email address."
+msgstr "デスクのメールアドレス。"
+
+#: scripts/apps/desks/services/DesksFactory.ts:425
+msgid "Desk has been modified elsewhere. Please reload the desks."
+msgstr "デスクが他で変更されました。デスクを再読み込みしてください。"
+
+#: scripts/apps/desks/views/desk-config-modal.html:114
+msgid "Desk language"
+msgstr "デスク言語"
+
+#: scripts/apps/desks/views/settings.html:4
+msgid "Desk management"
+msgstr "デスク管理"
+
+#: scripts/apps/desks/views/desk-config-modal.html:16
+msgid "Desk name"
+msgstr "デスク名"
+
+#: scripts/apps/dashboard/closed-desk/index.ts:26
+msgid "Desk status is outdated, please refresh."
+msgstr "デスクの状態が古くなっています。更新してください。"
+
+#: scripts/apps/search/views/saved-search-manage-subscribers.html:167
+#: scripts/apps/search/views/saved-search-manage-subscribers.html:88
+msgid "Desk subscription"
+msgstr "デスクサブスクリプション"
+
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:126
+msgid "Desk template"
+msgstr "デスクテンプレート"
+
+#: scripts/apps/desks/directives/DeskeditBasic.ts:65
+msgid "Desk with name {{name}} already exists."
+msgstr "名前「{{name}}」のデスクは既に存在します。"
+
+#: scripts/apps/templates/views/templates.html:52
+msgid "Desk(s)"
+msgstr "デスク"
+
+#: ../superdesk-planning/client/components/Archive/ArchivePreview/ArchivePreviewMetadataList.tsx:24
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Desk.tsx:12
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:98
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:242
+#: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:218
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:94
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateAssignmentForm.tsx:157
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx:166
+msgid "Desk:"
+msgstr "デスク："
+
+#: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:111
+msgid "Desk: {{ desk }}"
+msgstr "デスク：{{ desk }}"
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:109
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:383
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:137
+#: scripts/apps/desks/index.ts:50
+#: scripts/apps/monitoring/views/aggregate-settings.html:8
+#: scripts/apps/production-api-keys/config.ts:24
+#: scripts/apps/search/views/search-filters.html:31
+#: scripts/apps/templates/views/template-editor-modal.html:91
+#: scripts/apps/users/views/user-preferences.html:18
+#: scripts/extensions/sams/dist/src/components/common/DesksSelectInput.js:130
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/DesksSelectInput.js:130
+#: scripts/extensions/sams/src/components/common/DesksSelectInput.tsx:109
+msgid "Desks"
+msgstr "デスク"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:196
+#: scripts/apps/publish/views/publish-queue.html:111
+#: scripts/core/interactive-article-actions-panel/actions/duplicate-to-action.tsx:62
+#: scripts/core/interactive-article-actions-panel/actions/fetch-to-action.tsx:83
+#: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:118
+#: scripts/core/interactive-article-actions-panel/actions/unspike-action.tsx:61
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:250
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:250
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:325
+msgid "Destination"
+msgstr "送信先"
+
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:14
+msgid "Destination name"
+msgstr "送信先名"
+
+#: scripts/apps/publish/views/subscribers.html:216
+msgid "Destinations"
+msgstr "送信先"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:151
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:64
+#: ../superdesk-planning/client/components/fields/index.tsx:241
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:541
+#: scripts/apps/authoring/authoring/index.ts:418
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:253
+msgid "Details"
+msgstr "詳細"
+
+#: scripts/apps/authoring/views/change-image.html:7
+msgid "Details / Metadata"
+msgstr "詳細/メタデータ"
+
+#: scripts/apps/dictionaries/index.ts:33
+msgid "Dictionaries"
+msgstr "辞書"
+
+#: scripts/core/lang/missing-translations-strings.ts:16
+msgid "Dictionaries List Management"
+msgstr "辞書リスト管理"
+
+#: scripts/apps/dictionaries/views/settings.html:23
+msgid "Dictionary"
+msgstr "辞書"
+
+#: scripts/apps/dictionaries/controllers/DictionaryConfigController.ts:93
+msgid "Dictionary deleted."
+msgstr "辞書が削除されました。"
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:36
+msgid "Dictionary file"
+msgstr "辞書ファイル"
+
+#: scripts/apps/dictionaries/views/settings.html:4
+msgid "Dictionary management"
+msgstr "辞書管理"
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:25
+msgid "Dictionary name"
+msgstr "辞書名"
+
+#: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:14
+msgid "Dictionary saved successfully"
+msgstr "辞書が正常に保存されました"
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:28
+msgid "Dictionary with name {{dictionary.name}} already exists."
+msgstr "名前「{{dictionary.name}}」の辞書は既に存在します。"
+
+#: scripts/apps/authoring-react/compare-articles/view-difference.tsx:74
+msgid ""
+"Difference view for \"{{type}}\" fields is not implemented. Latter version "
+"is being displayed."
+msgstr "「{{type}}」フィールドの差分表示は未実装です。新しいバージョンが表示されています。"
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:72
+msgid "Digital/Internet"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:45
+#: scripts/apps/archive/views/metadata-view.html:211
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:205
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:133
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:133
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:159
+msgid "Dimensions"
+msgstr "サイズ"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:192
+msgid "Disable Item Updates"
+msgstr "アイテム更新を無効化"
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:169
+msgid "Disable selection of an entire category"
+msgstr "カテゴリー全体の選択を無効化"
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:487
+msgid "Disable spellchecker"
+msgstr "スペルチェッカーを無効化"
+
+#: scripts/apps/users/config.ts:76
+msgid "Disable user"
+msgstr "ユーザーを無効化"
+
+#: ../superdesk-planning/client/components/Agendas/AgendaListItem.tsx:41
+#: ../superdesk-planning/client/utils/planning.tsx:1368
+#: scripts/apps/users/controllers/UserListController.ts:159
+msgid "Disabled"
+msgstr "無効"
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:216
+msgid "Disabled Agendas"
+msgstr "無効なアジェンダ"
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:158
+msgid "Disabled Calendars"
+msgstr "無効なカレンダー"
+
+#: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:77
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:77
+#: scripts/extensions/sams/src/components/sets/setListPanel.tsx:83
+msgid "Disabled Sets"
+msgstr "無効なセット"
+
+#: scripts/apps/desks/views/desk-config-modal.html:197
+msgid "Disallow sending items to this desk"
+msgstr "このデスクへのアイテム送信を禁止"
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:76
+msgid "Disallowed characters"
+msgstr "禁止文字"
+
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:379
+#: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:217
+msgid "Discard All"
+msgstr "すべて破棄"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:104
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:116
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:124
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:104
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:116
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:124
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:206
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:231
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:199
+msgid "Discard unsaved changes?"
+msgstr "保存されていない変更を破棄しますか？"
+
+#: scripts/core/notification/notification.ts:215
+msgid "Disconnected from Notification Server!"
+msgstr "通知サーバーから切断されました。"
+
+#: scripts/core/lang/missing-translations-strings.ts:45
+msgid ""
+"Displaying news ingest statistics. You can switch color themes or graph "
+"sources."
+msgstr "ニュース取り込み統計を表示中。カラーテーマやグラフソースを切り替えできます。"
+
+#: scripts/core/keyboard/keyboard.ts:401 scripts/core/keyboard/keyboard.ts:410
+msgid "Displays active keyboard shortcuts"
+msgstr "アクティブなキーボードショートカットを表示"
+
+#: ../superdesk-planning/client/components/fields/editor/NoContentLinking.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/Flags.tsx:30
+msgid "Do not link content updates"
+msgstr "コンテンツの更新をリンクしない"
+
+#: scripts/apps/vocabularies/constants.ts:56
+msgid "Do not show"
+msgstr "表示しない"
+
+#: scripts/apps/settings/index.ts:20
+msgid "Do some admin chores"
+msgstr "管理タスクを実行"
+
+#: scripts/apps/authoring/views/confirm-media-associated.html:3
+msgid "Do you want to add an image to this update?"
+msgstr "この更新に画像を追加しますか？"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:26
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:26
+#: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:74
+msgid "Do you want to create a rundown template for this show right away?"
+msgstr "このショーのランダウンテンプレートをすぐに作成しますか？"
+
+#: scripts/apps/archive/index.tsx:477
+msgid "Do you want to delete the item permanently?"
+msgstr "このアイテムを完全に削除しますか？"
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:167
+msgid "Do you want to delete the items permanently?"
+msgstr "これらのアイテムを完全に削除しますか？"
+
+#: ../superdesk-planning/client/actions/locations.ts:66
+msgid "Do you want to delete the location \"{{ name }}\"?"
+msgstr "ロケーション「{{ name }}」を削除しますか？"
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:391
+msgid "Do you want to deschedule articles?"
+msgstr "記事のスケジュールを解除しますか？"
+
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:264
+msgid "Do you want to link it to that assignment ?"
+msgstr "そのアサインメントにリンクしますか？"
+
+#: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:50
+msgid "Do you want to publish the article?"
+msgid_plural "Do you want to publish {{number}} articles?"
+msgstr[0] "{{number}}件の記事を公開しますか？"
+
+#: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:148
+msgid "Do you want to remove Abbreviation?"
+msgstr "略語を削除しますか？"
+
+#: scripts/apps/users/views/edit-form.html:360
+msgid "Do you want to reset the password for user {{user.full_name}} ?"
+msgstr "ユーザー{{user.full_name}}のパスワードをリセットしますか？"
+
+#: ../superdesk-planning/client/actions/multiSelect.ts:128
+msgid "Do you want to spike  item(s) ?"
+msgstr "アイテムをスパイクしますか？"
+
+#: ../superdesk-planning/client/actions/multiSelect.ts:148
+msgid "Do you want to unspike  item(s) ?"
+msgstr "アイテムのスパイクを解除しますか？"
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:122
+#: scripts/extensions/sams/dist/src/utils/assets.js:122
+#: scripts/extensions/sams/src/utils/assets.ts:152
+msgid "Document"
+msgstr "ドキュメント"
+
+#: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:76
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:76
+#: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:59
+msgid "Documents only"
+msgstr "ドキュメントのみ"
+
+#: scripts/apps/content-filters/views/manage-filters.html:147
+msgid "Does match"
+msgstr "一致する"
+
+#: scripts/apps/content-filters/views/manage-filters.html:148
+msgid "Doesn't match"
+msgstr "一致しない"
+
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:326
+msgid "Don't Fulfil Assignment"
+msgstr "アサインメントを履行しない"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:273
+msgid "Don't Save"
+msgstr "保存しない"
+
+#: ../superdesk-planning/client/components/AddToPlanningModal/index.tsx:77
+msgid "Don't add"
+msgstr "追加しない"
+
+#: scripts/core/auth/reset-password.html:70
+msgid "Don't have token? Get it."
+msgstr "トークンがありませんか？取得してください。"
+
+#: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:28
+#: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:49
+msgid "Don't save"
+msgstr "保存しない"
+
+#: scripts/apps/authoring/editor/views/find-replace.html:35
+#: scripts/apps/authoring/views/change-image.html:13
+#: scripts/apps/dashboard/views/workspace.html:83
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:11
+#: scripts/apps/desks/views/desk-config-modal.html:216
+#: scripts/apps/desks/views/desk-config-modal.html:422
+#: scripts/apps/desks/views/desk-config-modal.html:452
+#: scripts/apps/desks/views/desk-config-modal.html:477
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:129
+#: scripts/apps/monitoring/views/aggregate-settings.html:157
+#: scripts/apps/users/views/change-avatar.html:79
+#: scripts/extensions/videoEditor/dist/src/VideoEditorHeader.js:11
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorHeader.js:11
+#: scripts/extensions/videoEditor/src/VideoEditorHeader.tsx:30
+msgid "Done"
+msgstr "完了"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:71
+msgid "Dots"
+msgstr "ドット"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:72
+msgid "Dots Vertical"
+msgstr "縦ドット"
+
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:269
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:67
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:229
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:73
+#: scripts/apps/authoring/attachments/AttachmentsListItem.tsx:50
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:45
+#: scripts/extensions/sams/dist/src/utils/assets.js:45
+#: scripts/extensions/sams/src/utils/assets.ts:57
+msgid "Download"
+msgstr "ダウンロード"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:74
+msgid "Download Alternate"
+msgstr "代替ダウンロード"
+
+#: scripts/apps/vocabularies/views/vocabulary-config.html:84
+msgid "Download config"
+msgstr "設定をダウンロード"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/State.tsx:21
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:19
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:196
+#: ../superdesk-planning/client/utils/index.ts:341
+#: scripts/apps/search/components/fields/state.tsx:30
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:187
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:242
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:187
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:242
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:95
+#: scripts/extensions/sams/dist/src/utils/ui.js:95
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:225
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:306
+#: scripts/extensions/sams/src/utils/ui.tsx:76
+msgid "Draft"
+msgstr "下書き"
+
+#: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:75
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:75
+#: scripts/extensions/sams/src/components/sets/setListPanel.tsx:61
+msgid "Draft Sets"
+msgstr "下書きセット"
+
+#: scripts/apps/archive/views/upload.html:37
+msgid "Drag Your Files Here"
+msgstr "ここにファイルをドラッグ"
+
+#: ../superdesk-planning/client/components/UI/Form/FileInput.tsx:200
+#: scripts/core/ui/components/Form/FileInput.tsx:136
+#: scripts/extensions/sams/dist/src/apps/samsAttachmentsWidget.js:194
+#: scripts/extensions/sams/dist/src/apps/samsAttachmentsWidget.js:204
+#: scripts/extensions/sams/dist/src/extensions/sams/src/apps/samsAttachmentsWidget.js:194
+#: scripts/extensions/sams/dist/src/extensions/sams/src/apps/samsAttachmentsWidget.js:204
+#: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:192
+#: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:216
+msgid "Drag files here or"
+msgstr "ここにファイルをドラッグまたは"
+
+#: scripts/apps/vocabularies/components/UploadConfigModal.tsx:60
+msgid ""
+"Drag one or more files here to upload them,\n"
+"                or select files by clicking the button below"
+msgstr ""
+
+#: scripts/apps/authoring/attachments/AttachmentsWidgetComponent.tsx:126
+msgid "Drag one or more files here to upload them, or just click here."
+msgstr "ここにファイルをドラッグしてアップロード、またはここをクリックしてください。"
+
+#: scripts/apps/authoring/attachments/AttachmentsWidgetComponent.tsx:104
+msgid ""
+"Drag one or more files here to upload them, or just click the button below."
+msgstr "ここにファイルをドラッグしてアップロード、または下のボタンをクリックしてください。"
+
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:101
+msgid "Drop events here"
+msgstr "ここにイベントをドロップ"
+
+#: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:87
+msgid "Drop files here to upload"
+msgstr "ここにファイルをドロップしてアップロード"
+
+#: scripts/apps/users/views/change-avatar.html:29
+msgid "Drop it here"
+msgstr "ここにドロップ"
+
+#: scripts/apps/relations/views/related-items.html:11
+#: scripts/core/ui/components/drop-zone-3.tsx:128
+msgid "Drop items here"
+msgstr "ここにアイテムをドロップ"
+
+#: scripts/apps/authoring/views/item-association.html:11
+#: scripts/apps/authoring/views/item-carousel.html:10
+#: scripts/core/ui/components/drop-zone-3.tsx:127
+msgid "Drop items here or click to upload"
+msgstr "ここにアイテムをドロップまたはクリックしてアップロード"
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:184
+msgid "Drop planning items here"
+msgstr "ここにプランニングアイテムをドロップ"
+
+#: scripts/apps/authoring-react/fields/dropdown/index.ts:21
+msgid "Dropdown (authoring-react)"
+msgstr "ドロップダウン（authoring-react）"
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:174
+msgid "Dropped item is not a planning item"
+msgstr "ドロップされたアイテムはプランニングアイテムではありません"
+
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:164
+msgid "Dropped item is not an event"
+msgstr "ドロップされたアイテムはイベントではありません"
+
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/ScheduledUpdateForm.tsx:169
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:235
+#: ../superdesk-planning/client/components/fields/editor/CoverageSchedule.tsx:27
+#: ../superdesk-planning/client/components/fields/preview/index.ts:197
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:75
+msgid "Due"
+msgstr "期限"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:26
+msgid "Due Date"
+msgstr "期限日"
+
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:34
+msgid "Due date"
+msgstr "期限日"
+
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:38
+msgid "Due time"
+msgstr "期限時間"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:142
+#: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:172
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:119
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateAssignmentForm.tsx:128
+msgid "Due:"
+msgstr "期限："
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:435
+#: ../superdesk-analytics/client/utils.js:169
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:372
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/index.tsx:217
+#: ../superdesk-planning/client/constants/events.ts:156
+#: ../superdesk-planning/client/constants/planning.ts:137
+#: scripts/apps/archive/index.tsx:168 scripts/apps/archive/index.tsx:196
+#: scripts/apps/archive/index.tsx:214
+#: scripts/apps/authoring/authoring/constants.ts:13
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:228
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:242
+#: scripts/core/interactive-article-actions-panel/actions/duplicate-to-action.tsx:92
+msgid "Duplicate"
+msgstr "複製"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/index.tsx:230
+msgid "Duplicate As"
+msgstr "名前を付けて複製"
+
+#: scripts/core/lang/missing-translations-strings.ts:16
+msgid "Duplicate Content within a Desk"
+msgstr "デスク内のコンテンツを複製"
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:55
+msgid "Duplicate ID: {{x}}"
+msgstr "重複ID：{{x}}"
+
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:239
+msgid "Duplicate In Place"
+msgstr "その場で複製"
+
+#: scripts/apps/archive/index.tsx:172
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:225
+msgid "Duplicate To"
+msgstr "複製先"
+
+#: scripts/apps/monitoring/index.ts:125
+msgid "Duplicate an item"
+msgstr "アイテムを複製"
+
+#: scripts/core/interactive-article-actions-panel/actions/duplicate-to-action.tsx:80
+msgid "Duplicate and open"
+msgstr "複製して開く"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:96
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:78
+msgid "Duplicate created"
+msgstr "複製が作成されました"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:171
+#: scripts/apps/authoring/versioning/history/views/history.html:52
+msgid "Duplicate created by"
+msgstr "複製作成者"
+
+#: scripts/apps/archive/index.tsx:151
+msgid "Duplicate in place"
+msgstr "その場で複製"
+
+#: scripts/core/interactive-article-actions-panel/action-tabs.tsx:13
+msgid "Duplicate to"
+msgstr "複製先"
+
+#: scripts/apps/archive/index.tsx:200
+msgid "Duplicate to personal"
+msgstr "個人スペースに複製"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:100
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:82
+msgid "Duplicated"
+msgstr "複製済み"
+
+#: ../superdesk-analytics/client/utils.js:152
+msgid "Duplicated From"
+msgstr "複製元"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:146
+#: scripts/apps/authoring/versioning/history/views/history.html:30
+msgid "Duplicated by"
+msgstr "複製者"
+
+#: scripts/apps/search/views/item-preview.html:15
+msgid "Duplicates"
+msgstr "複製"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:63
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:95
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/duration-label.js:11
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:95
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/duration-label.js:11
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:124
+#: scripts/extensions/broadcasting/src/rundowns/components/duration-label.tsx:21
+msgid "Duration"
+msgstr "期間"
+
+#: scripts/apps/authoring-react/fields/duration/index.tsx:20
+msgid "Duration (authoring-react)"
+msgstr "期間（authoring-react）"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:54
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:60
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/applied-filters.js:54
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/filtering-inputs.js:50
+#: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:122
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:119
+msgid "Duration from"
+msgstr "期間（開始）"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:62
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:65
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/applied-filters.js:62
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/filtering-inputs.js:55
+#: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:140
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:132
+msgid "Duration to"
+msgstr "期間（終了）"
+
+#: ../superdesk-planning/client/validators/events.ts:87
+msgid "END DATE cannot be in the past"
+msgstr "終了日は過去の日付にできません"
+
+#: ../superdesk-planning/client/validators/events.ts:20
+msgid "END DATE is a required field"
+msgstr "終了日は必須フィールドです"
+
+#: ../superdesk-planning/client/validators/events.ts:60
+msgid "END DATE should be after START DATE"
+msgstr "終了日は開始日より後でなければなりません"
+
+#: ../superdesk-planning/client/validators/events.ts:41
+msgid "END TIME is a required field"
+msgstr "終了時間は必須フィールドです"
+
+#: ../superdesk-planning/client/validators/events.ts:57
+msgid "END TIME should be after START TIME"
+msgstr "終了時間は開始時間より後でなければなりません"
+
+#: ../superdesk-planning/client/validators/events.ts:290
+msgid "EXTERNAL LINK {{ index }} cannot end with \".\""
+msgstr "外部リンク{{ index }}は「.」で終わることはできません"
+
+#: ../superdesk-planning/client/validators/events.ts:284
+msgid ""
+"EXTERNAL LINK {{ index }} must start with \"http://\", \"https://\" or \"www."
+"\""
+msgstr "外部リンク{{ index }}は「http://」、「https://」または「www.」で始まる必要があります"
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:35
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:16
+#: scripts/apps/archive/views/metadata-associateditem-view.html:19
+msgid "Ed Note"
+msgstr "編集メモ"
+
+#: scripts/apps/authoring-react/field-adapters/ednote.ts:20
+#: scripts/apps/workspace/content/constants.ts:24
+msgid "Ed. Note"
+msgstr "編集メモ"
+
+#: ../superdesk-planning/client/components/Agendas/AgendaListItem.tsx:57
+#: ../superdesk-planning/client/components/Events/ManageEventTemplatesModal.tsx:42
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:42
+#: ../superdesk-planning/client/components/ExportTemplates/ExportTemplateItem.tsx:31
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:428
+#: ../superdesk-planning/client/components/Main/ItemEditorModal/EditorModalPanel.tsx:168
+#: ../superdesk-planning/client/components/fields/common/PreviewFilterSchedule.tsx:58
+#: ../superdesk-planning/client/constants/events.ts:166
+#: ../superdesk-planning/client/constants/planning.ts:141
+#: ../superdesk-planning/client/constants/tooltips.ts:24
+#: scripts/apps/authoring-react/fields/linked-items/editor.tsx:48
+#: scripts/apps/authoring-react/fields/package-items/editor.tsx:45
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/edit-button.tsx:11
+#: scripts/apps/authoring/attachments/AttachmentsListItem.tsx:60
+#: scripts/apps/authoring/authoring/index.ts:222
+#: scripts/apps/authoring/views/authoring-topbar.html:105
+#: scripts/apps/desks/views/settings.html:37
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:104
+#: scripts/apps/production-api-keys/ProductionApiItem.tsx:50
+#: scripts/apps/search/components/WidgetItem.tsx:107
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:115
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:116
+#: scripts/apps/templates/views/templates.html:36
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:4
+#: scripts/apps/vocabularies/views/vocabulary-config.html:92
+#: scripts/apps/workspace/content/views/profile-settings.html:47
+#: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:92
+#: scripts/core/editor3/components/comments/Comment.tsx:56
+#: scripts/core/editor3/components/links/LinkToolbar.tsx:58
+#: scripts/extensions/annotationsLibrary/dist/src/annotations-library-page.js:35
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/annotations-library-page.js:35
+#: scripts/extensions/annotationsLibrary/src/annotations-library-page.tsx:69
+#: scripts/extensions/annotationsLibrary/src/annotations-library-page.tsx:70
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/working-day-view.js:18
+#: scripts/extensions/availability-manager/dist/src/settings/working-day-view.js:18
+#: scripts/extensions/availability-manager/src/settings/working-day-view.tsx:36
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:32
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:146
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:250
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:45
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:124
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:159
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:62
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:32
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:146
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:253
+#: scripts/extensions/broadcasting/dist/src/rundowns/manage-rundown-items.js:45
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:124
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:159
+#: scripts/extensions/broadcasting/dist/src/shows/manage-shows.js:62
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:72
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:269
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:579
+#: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:98
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:236
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:296
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:88
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:89
+#: scripts/extensions/predefinedTextField/dist/src/config.js:37
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:37
+#: scripts/extensions/predefinedTextField/src/config.tsx:55
+#: scripts/extensions/predefinedTextField/src/config.tsx:56
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:111
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:111
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:57
+#: scripts/extensions/sams/dist/src/utils/assets.js:57
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:102
+#: scripts/extensions/sams/src/utils/assets.ts:69
+msgid "Edit"
+msgstr "編集"
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:8
+msgid "Edit \"' + schedule.name + '\" Schedule"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:5
+msgid "Edit \"{{name}}\" Desk"
+msgstr "デスク「{{name}}」を編集"
+
+#: scripts/apps/products/views/products-config-modal.html:4
+msgid "Edit \"{{name}}\" Product"
+msgstr "プロダクト「{{name}}」を編集"
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:4
+msgid "Edit \"{{name}}\" highlight"
+msgstr "ハイライト「{{name}}」を編集"
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:7
+msgid "Edit Abbreviations Dictionary"
+msgstr "略語辞書を編集"
+
+#: ../superdesk-planning/client/constants/tooltips.ts:23
+msgid "Edit Agenda"
+msgstr "アジェンダを編集"
+
+#: scripts/apps/authoring/attachments/AttachmentsEditorModal.tsx:41
+#: scripts/extensions/sams/dist/src/components/attachments/editAttachmentModal.js:122
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/editAttachmentModal.js:122
+#: scripts/extensions/sams/src/components/attachments/editAttachmentModal.tsx:102
+msgid "Edit Attachment"
+msgstr "添付ファイルを編集"
+
+#: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:76
+#: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:77
+msgid "Edit Contact"
+msgstr "連絡先を編集"
+
+#: scripts/apps/content-filters/views/manage-filters.html:20
+#: scripts/apps/content-filters/views/manage-filters.html:32
+msgid "Edit Content Filter"
+msgstr "コンテンツフィルターを編集"
+
+#: scripts/apps/workspace/content/views/profile-settings.html:47
+msgid "Edit Content Profile"
+msgstr "コンテンツプロファイルを編集"
+
+#: scripts/apps/authoring/views/change-image.html:4
+msgid "Edit Crops"
+msgstr "トリミングを編集"
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:8
+msgid "Edit Dictionary"
+msgstr "辞書を編集"
+
+#: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:114
+msgid "Edit Event"
+msgstr "イベントを編集"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:96
+#: ../superdesk-planning/client/constants/tooltips.ts:35
+msgid "Edit Filter"
+msgstr "フィルターを編集"
+
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:23
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:42
+msgid "Edit Filter Condition"
+msgstr "フィルター条件を編集"
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:109
+msgid "Edit Ingest Source"
+msgstr "取り込みソースを編集"
+
+#: scripts/apps/ingest/views/dashboard/ingest-sources-list.html:6
+msgid "Edit Ingest Sources"
+msgstr "取り込みソースを編集"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:75
+msgid "Edit Line"
+msgstr "行を編集"
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:190
+msgid "Edit Location"
+msgstr "ロケーションを編集"
+
+#: scripts/apps/authoring/authoring/index.ts:254
+msgid "Edit Media Metadata"
+msgstr "メディアメタデータを編集"
+
+#: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:148
+msgid "Edit Planning"
+msgstr "プランニングを編集"
+
+#: ../superdesk-planning/client/constants/assignments.ts:194
+msgid "Edit Priority"
+msgstr "優先度を編集"
+
+#: scripts/apps/users/views/settings-roles.html:29
+msgid "Edit Role"
+msgstr "ロールを編集"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:67
+msgid "Edit Rule"
+msgstr "ルールを編集"
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:30
+msgid "Edit Rule set"
+msgstr "ルールセットを編集"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:262
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:262
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:404
+msgid "Edit Rundown"
+msgstr "ランダウンを編集"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:106
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:180
+msgid "Edit Scheduled Export"
+msgstr "スケジュールエクスポートを編集"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:30
+msgid "Edit Scheme"
+msgstr "スキームを編集"
+
+#: scripts/apps/search-providers/views/search-provider-config.html:16
+#: scripts/apps/search-providers/views/search-provider-config.html:27
+msgid "Edit Search Provider"
+msgstr "検索プロバイダーを編集"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:57
+msgid "Edit Source"
+msgstr "ソースを編集"
+
+#: scripts/apps/publish/views/subscribers.html:50
+#: scripts/apps/publish/views/subscribers.html:68
+msgid "Edit Subscriber"
+msgstr "配信先を編集"
+
+#: scripts/apps/templates/views/templates.html:36
+msgid "Edit Template"
+msgstr "テンプレートを編集"
+
+#: scripts/core/lang/missing-translations-strings.ts:17
+msgid "Edit Unique Name"
+msgstr "ユニーク名を編集"
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditor.js:486
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditor.js:486
+#: scripts/extensions/videoEditor/src/VideoEditor.tsx:680
+msgid "Edit Video"
+msgstr "動画を編集"
+
+#: scripts/apps/monitoring/index.ts:121
+msgid "Edit an item"
+msgstr "アイテムを編集"
+
+#: scripts/apps/monitoring/index.ts:124
+msgid "Edit an item in a new Window"
+msgstr "新しいウィンドウでアイテムを編集"
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-workday-modal.js:106
+#: scripts/extensions/availability-manager/dist/src/settings/edit-workday-modal.js:106
+#: scripts/extensions/availability-manager/src/settings/edit-workday-modal.tsx:161
+msgid "Edit availability"
+msgstr "可用性を編集"
+
+#: scripts/apps/highlights/views/settings.html:19
+msgid "Edit configuration"
+msgstr "設定を編集"
+
+#: scripts/apps/authoring-react/fields/media/media-carousel/image.tsx:104
+#: scripts/apps/authoring/views/article-edit.html:301
+#: scripts/apps/authoring/views/change-image.html:9
+#: scripts/apps/authoring/views/item-association.html:77
+#: scripts/apps/authoring/views/item-carousel.html:100
+#: scripts/core/editor3/components/media/MediaBlock.tsx:192
+msgid "Edit crops"
+msgstr "トリミングを編集"
+
+#: scripts/apps/desks/views/settings.html:34
+msgid "Edit desk"
+msgstr "デスクを編集"
+
+#: scripts/apps/dictionaries/views/settings.html:54
+msgid "Edit dictionary"
+msgstr "辞書を編集"
+
+#: scripts/core/editor3/components/embeds/EmbedBlock.tsx:83
+msgid "Edit embed"
+msgstr "埋め込みを編集"
+
+#: scripts/apps/authoring-react/fields/media/media-carousel/image.tsx:94
+#: scripts/apps/authoring/views/article-edit.html:300
+#: scripts/apps/authoring/views/change-image.html:3
+#: scripts/apps/authoring/views/change-image.html:8
+#: scripts/apps/authoring/views/item-association.html:76
+#: scripts/apps/authoring/views/item-carousel.html:99
+#: scripts/core/editor3/components/media/MediaBlock.tsx:182
+msgid "Edit image"
+msgstr "画像を編集"
+
+#: scripts/apps/authoring/authoring/index.ts:241
+msgid "Edit in new Window"
+msgstr "新しいウィンドウで編集"
+
+#: scripts/apps/authoring-react/fields/linked-items/editor.tsx:54
+#: scripts/apps/authoring-react/fields/package-items/editor.tsx:51
+msgid "Edit in new window"
+msgstr "新しいウィンドウで編集"
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:492
+#: ../superdesk-planning/client/constants/events.ts:167
+#: ../superdesk-planning/client/constants/planning.ts:142
+#: ../superdesk-planning/client/constants/tooltips.ts:32
+msgid "Edit in popup"
+msgstr "ポップアップで編集"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:374
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:374
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:649
+msgid "Edit item"
+msgstr "アイテムを編集"
+
+#: scripts/core/editor3/highlightsConfig.ts:124
+msgid "Edit link"
+msgstr "リンクを編集"
+
+#: scripts/apps/authoring-react/fields/media/media-carousel/audio.tsx:85
+#: scripts/apps/authoring-react/fields/media/media-carousel/image.tsx:84
+#: scripts/apps/authoring-react/fields/media/media-carousel/video.tsx:84
+#: scripts/apps/authoring/views/article-edit.html:299
+#: scripts/apps/authoring/views/article-edit.html:327
+#: scripts/apps/authoring/views/article-edit.html:348
+#: scripts/apps/authoring/views/item-association.html:42
+#: scripts/apps/authoring/views/item-association.html:62
+#: scripts/apps/authoring/views/item-association.html:75
+#: scripts/apps/authoring/views/item-carousel.html:56
+#: scripts/apps/authoring/views/item-carousel.html:85
+#: scripts/apps/authoring/views/item-carousel.html:98
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:101
+#: scripts/apps/search/views/multi-image-edit.html:2
+#: scripts/core/editor3/components/media/MediaBlock.tsx:172
+#: scripts/core/editor3/components/media/MediaBlock.tsx:332
+msgid "Edit metadata"
+msgstr "メタデータを編集"
+
+#: scripts/apps/products/views/product-test.html:35
+#: scripts/apps/products/views/products.html:31
+msgid "Edit product"
+msgstr "プロダクトを編集"
+
+#: scripts/apps/users/views/settings-roles.html:17
+msgid "Edit role"
+msgstr "ロールを編集"
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:19
+msgid "Edit rule set"
+msgstr "ルールセットを編集"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:19
+msgid "Edit scheme"
+msgstr "スキームを編集"
+
+#: scripts/apps/search/views/saved-searches.html:15
+#: scripts/apps/search/views/saved-searches.html:44
+msgid "Edit search"
+msgstr "検索を編集"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:46
+msgid "Edit source"
+msgstr "ソースを編集"
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:28
+msgid "Edit this Schedule"
+msgstr "このスケジュールを編集"
+
+#: scripts/extensions/videoEditor/dist/src/extension.js:15
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/extension.js:15
+#: scripts/extensions/videoEditor/src/extension.tsx:22
+msgid "Edit video"
+msgstr "動画を編集"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:27
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:41
+msgid "Edited"
+msgstr "編集済み"
+
+#: scripts/apps/workspace/content/views/profile-settings.html:138
+msgid "Editing"
+msgstr "編集中"
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:124
+msgid "Editor 3"
+msgstr "エディター3"
+
+#: scripts/apps/authoring-react/fields/editor3/index.tsx:57
+msgid "Editor3 (authoring-react)"
+msgstr "エディター3（authoring-react）"
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:295
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:147
+msgid "Editorial Note"
+msgstr "編集メモ"
+
+#: ../superdesk-planning/client/components/Archive/ArchivePreview/ArchivePreviewMetadataList.tsx:33
+msgid "Editorial Note:"
+msgstr "編集メモ："
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:348
+msgid "Editorial note"
+msgstr "編集メモ"
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:253
+msgid "Ednote"
+msgstr "編集メモ"
+
+#: scripts/apps/contacts/constants.ts:70
+#: scripts/apps/contacts/views/search-panel.html:47
+#: scripts/apps/users/views/list.html:36
+#: scripts/core/auth/reset-password.html:13
+msgid "Email"
+msgstr "メール"
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:14
+msgid "Email Address"
+msgstr "メールアドレス"
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:21
+msgid "Email this report"
+msgstr "このレポートをメール送信"
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:405
+#: scripts/apps/search/components/fields/embargo.tsx:46
+#: scripts/apps/workspace/content/constants.ts:25
+#: scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx:75
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx:126
+msgid "Embargo"
+msgstr "エンバーゴ"
+
+#: scripts/apps/archive/views/metadata-view.html:132
+msgid "Embargo Timestamp"
+msgstr "エンバーゴタイムスタンプ"
+
+#: scripts/apps/search/components/fields/embargo.tsx:23
+msgid "Embargo until {{date}}"
+msgstr "{{date}}までエンバーゴ"
+
+#: scripts/apps/search/components/fields/embargo.tsx:30
+msgid "Embargo: {{text}}"
+msgstr "エンバーゴ：{{text}}"
+
+#: scripts/apps/authoring-react/fields/embed/index.tsx:18
+msgid "Embed (authoring-react)"
+msgstr "埋め込み（authoring-react）"
+
+#: scripts/apps/authoring-react/fields/embed/editor.tsx:106
+msgid "Embed code"
+msgstr "埋め込みコード"
+
+#: scripts/core/editor3/components/BaseUnstyledComponent.tsx:103
+msgid "Embedding articles is not configured for this content profile field"
+msgstr "このコンテンツプロファイルフィールドでは記事の埋め込みが設定されていません"
+
+#: scripts/core/editor3/components/article-embed/article-embed.tsx:24
+msgid "Embedding from:"
+msgstr "埋め込み元："
+
+#: scripts/core/editor3/actions/editor3.tsx:75
+msgid "Embedding is not allowed for this editor"
+msgstr "このエディターでは埋め込みは許可されていません"
+
+#: scripts/core/lang/missing-translations-strings.ts:14
+msgid "Enable Feature Preview"
+msgstr "機能プレビューを有効化"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:204
+msgid "Enable if config can't be tested on REST server."
+msgstr "REST サーバーで設定をテストできない場合に有効にしてください。"
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:488
+msgid "Enable spellchecker"
+msgstr "スペルチェッカーを有効化"
+
+#: scripts/apps/users/config.ts:108
+msgid "Enable user"
+msgstr "ユーザーを有効化"
+
+#: ../superdesk-planning/client/components/Agendas/ManageAgendasModal.tsx:31
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/availability-settings.js:129
+#: scripts/extensions/availability-manager/dist/src/settings/availability-settings.js:129
+#: scripts/extensions/availability-manager/src/settings/availability-settings.tsx:200
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:232
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:232
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:268
+msgid "Enabled"
+msgstr "有効"
+
+#: scripts/apps/publish/views/subscribers.html:96
+msgid "End Date"
+msgstr "終了日"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:23
+msgid "End Time (exclusive)"
+msgstr "終了時間（排他）"
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:177
+msgid "End date cannot be greater than today"
+msgstr "終了日は本日より後にできません"
+
+#: ../superdesk-planning/client/validators/events.ts:84
+msgid "End date is in the past"
+msgstr "終了日が過去です"
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:162
+msgid "End date is required"
+msgstr "終了日は必須です"
+
+#: ../superdesk-planning/client/validators/profile.ts:49
+#: ../superdesk-planning/client/validators/profile.ts:50
+msgid "End date must be set"
+msgstr "終了日を設定してください"
+
+#: ../superdesk-planning/client/validators/events.ts:59
+msgid "End date should be after start date"
+msgstr "終了日は開始日より後でなければなりません"
+
+#: ../superdesk-planning/client/validators/events.ts:56
+msgid "End time should be after start time"
+msgstr "終了時間は開始時間より後でなければなりません"
+
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:3
+msgid "Endpoint URL"
+msgstr "エンドポイントURL"
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:133
+msgid "Ends"
+msgstr "終了"
+
+#: scripts/apps/publish-preview/previewModal.tsx:67
+msgid ""
+"Ensure correct preview endpoint is configured or contact endpoint "
+"maintainers."
+msgstr "正しいプレビューエンドポイントが設定されていることを確認するか、エンドポイントの管理者に連絡してください。"
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:163
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:535
+msgid "Enter Desk Actions"
+msgstr "デスクアクションに入る"
+
+#: scripts/core/editor3/components/embeds/EmbedInput.tsx:164
+msgid "Enter URL or code to embed"
+msgstr "埋め込むURLまたはコードを入力"
+
+#: scripts/core/auth/login-modal.html:75
+#: scripts/core/auth/reset-password.html:48
+msgid "Enter new password"
+msgstr "新しいパスワードを入力"
+
+#: scripts/apps/users/views/change-avatar.html:44
+msgid "Enter web url"
+msgstr "WebURLを入力"
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:36
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:36
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:58
+msgid "Entity"
+msgstr "エンティティ"
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:60
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:60
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:135
+msgid "Entity type"
+msgstr "エンティティタイプ"
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:83
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:83
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:195
+msgid "Entity type is required."
+msgstr "エンティティタイプは必須です。"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:76
+msgid "Envelope"
+msgstr "封筒"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:243
+msgid "Error"
+msgstr "エラー"
+
+#: scripts/api/highlights.ts:44 scripts/api/highlights.ts:48
+msgid "Error creating highlight."
+msgstr "ハイライトの作成中にエラーが発生しました。"
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:339
+#: scripts/apps/search/controllers/get-multi-actions.tsx:381
+msgid "Error on item:"
+msgstr "アイテムのエラー："
+
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:21
+msgid "Error sending as"
+msgstr "送信エラー"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:74
+msgid "Error sending as {{name}} to {{destination}} at {{date}}"
+msgstr "{{date}}に{{name}}として{{destination}}への送信エラー"
+
+#: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:28
+msgid "Error. Dictionary not saved."
+msgstr "エラー。辞書が保存されませんでした。"
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:626
+msgid "Error. Item not published."
+msgstr "エラー。アイテムが公開されませんでした。"
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:322
+msgid "Error. Item not updated."
+msgstr "エラー。アイテムが更新されませんでした。"
+
+#: scripts/apps/search/directives/SavedSearches.ts:119
+msgid "Error. Saved search not deleted."
+msgstr "エラー。保存済み検索が削除されませんでした。"
+
+#: scripts/apps/search/directives/SaveSearch.ts:83
+msgid "Error. Search could not be saved."
+msgstr "エラー。検索を保存できませんでした。"
+
+#: scripts/apps/users/controllers/SessionsDeleteCommand.ts:15
+msgid "Error. Sessions could not be cleared."
+msgstr "エラー。セッションをクリアできませんでした。"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:315
+#: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:270
+msgid "Error. The Desk Activity report could not be generated!"
+msgstr "エラー。デスクアクティビティレポートを生成できませんでした。"
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:223
+msgid "Error. The Planning Usage Report could not be generated!"
+msgstr "エラー。プランニング使用状況レポートを生成できませんでした。"
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:240
+msgid "Error. The Production Time report could not be generated!"
+msgstr "エラー。製作時間レポートを生成できませんでした。"
+
+#: ../superdesk-analytics/client/content_publishing_report/controllers/ContentPublishingReportController.js:275
+#: ../superdesk-analytics/client/featuremedia_updates_report/controllers/FeaturemediaUpdatesReportController.js:216
+#: ../superdesk-analytics/client/publishing_performance_report/controllers/PublishingPerformanceReportController.ts:280
+#: ../superdesk-analytics/client/update_time_report/controllers/UpdateTimeReportController.js:243
+msgid "Error. The Publishing Report could not be generated!"
+msgstr "エラー。公開レポートを生成できませんでした。"
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/controller.js:246
+msgid "Error. The report could not be generated."
+msgstr "エラー。レポートを生成できませんでした。"
+
+#: scripts/apps/users/controllers/UserDeleteCommand.ts:24
+msgid "Error. User Profile cannot be disabled."
+msgstr "エラー。ユーザープロファイルを無効にできません。"
+
+#: scripts/apps/users/controllers/UserEnableCommand.ts:21
+msgid "Error. User Profile cannot be enabled."
+msgstr "エラー。ユーザープロファイルを有効にできません。"
+
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:120
+msgid "Error. Vocabulary not saved."
+msgstr "エラー。ボキャブラリーが保存されませんでした。"
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:199
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:107
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:110
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:126
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:145
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:148
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:64
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:69
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:72
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:90
+#: scripts/apps/content-filters/controllers/ProductionTestController.ts:107
+#: scripts/apps/content-filters/controllers/ProductionTestController.ts:109
+#: scripts/apps/desks/controllers/DeskConfigController.ts:104
+#: scripts/apps/desks/controllers/DeskConfigController.ts:67
+#: scripts/apps/desks/directives/DeskeditPeople.ts:64
+#: scripts/apps/desks/directives/DeskeditStages.ts:239
+#: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:22
+#: scripts/apps/ingest/directives/IngestRoutingContent.ts:54
+#: scripts/apps/ingest/directives/IngestRulesContent.ts:52
+#: scripts/apps/products/controllers/ProductsConfigController.ts:180
+#: scripts/apps/products/controllers/ProductsConfigController.ts:185
+#: scripts/apps/products/controllers/ProductsConfigController.ts:187
+#: scripts/apps/products/controllers/ProductsConfigController.ts:206
+#: scripts/apps/products/controllers/ProductsConfigController.ts:257
+#: scripts/apps/publish/controllers/PublishQueueController.ts:180
+#: scripts/apps/publish/directives/SubscribersDirective.ts:219
+#: scripts/apps/search-providers/directive.ts:59
+#: scripts/apps/templates/directives/TemplatesDirective.ts:369
+#: scripts/apps/templates/helpers.ts:6 scripts/apps/templates/helpers.ts:9
+#: scripts/apps/users/controllers/UserDeleteCommand.ts:20
+#: scripts/apps/users/controllers/UserDeleteCommand.ts:22
+#: scripts/apps/users/controllers/UserEnableCommand.ts:17
+#: scripts/apps/users/controllers/UserEnableCommand.ts:19
+#: scripts/apps/users/directives/UserRolesDirective.ts:66
+msgid "Error:"
+msgstr "エラー："
+
+#: scripts/apps/search-providers/directive.ts:62
+msgid "Error: A Search Provider with type  already exists."
+msgstr "エラー：同じタイプの検索プロバイダーが既に存在します。"
+
+#: scripts/apps/products/controllers/ProductsConfigController.ts:208
+msgid "Error: Failed to delete product."
+msgstr "エラー：プロダクトの削除に失敗しました。"
+
+#: scripts/apps/content-filters/controllers/ProductionTestController.ts:111
+msgid "Error: Failed to fetch production test results."
+msgstr "エラー：本番テスト結果の取得に失敗しました。"
+
+#: scripts/apps/publish/controllers/PublishQueueController.ts:183
+msgid "Error: Failed to re-schedule"
+msgstr "エラー：再スケジュールに失敗しました"
+
+#: scripts/apps/search-providers/directive.ts:66
+msgid "Error: Failed to save Search Provider."
+msgstr "エラー：検索プロバイダーの保存に失敗しました。"
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:228
+msgid "Error: Failed to save Subscriber."
+msgstr "エラー：配信先の保存に失敗しました。"
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:151
+msgid "Error: Failed to save content filter."
+msgstr "エラー：コンテンツフィルターの保存に失敗しました。"
+
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:112
+msgid "Error: Failed to save filter condition."
+msgstr "エラー：フィルター条件の保存に失敗しました。"
+
+#: scripts/apps/templates/helpers.ts:13
+msgid "Error: Failed to save template."
+msgstr "エラー：テンプレートの保存に失敗しました。"
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:76
+msgid "Error: Failed to test content filter."
+msgstr "エラー：コンテンツフィルターのテストに失敗しました。"
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:74
+msgid "Error: Internal error in Filter testing"
+msgstr "エラー：フィルターテストの内部エラー"
+
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:105
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:67
+#: scripts/apps/products/controllers/ProductsConfigController.ts:183
+msgid "Error: Name needs to be unique"
+msgstr "エラー：名前は一意でなければなりません"
+
+#: scripts/core/itemList/itemList.ts:110
+msgid "Error: Slugline required."
+msgstr "エラー：スラッグラインは必須です。"
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:225
+msgid "Error: Subscriber must have at least one destination."
+msgstr "エラー：配信先には少なくとも1つの送信先が必要です。"
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:222
+msgid "Error: Subscriber with Name  already exists."
+msgstr "エラー：同じ名前の配信先が既に存在します。"
+
+#: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:24
+msgid "Error: The dictionary already exists."
+msgstr "エラー：辞書は既に存在します。"
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:359
+msgid "Error: Unable to delete Ingest Source"
+msgstr "エラー：取り込みソースを削除できません"
+
+#: scripts/apps/search-providers/directive.ts:98
+msgid "Error: Unable to delete Search Provider."
+msgstr "エラー：検索プロバイダーを削除できません。"
+
+#: scripts/api/article.ts:422
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:100
+msgid "Error: Unique Name is not unique."
+msgstr "エラー：ユニーク名が一意ではありません。"
+
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:111
+msgid "Error: {{ message }}"
+msgstr "エラー：{{ message }}"
+
+#: scripts/apps/users/directives/UserEditDirective.ts:272
+msgid "Error: {{error}}"
+msgstr "エラー：{{error}}"
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:316
+#: scripts/apps/authoring/authoring/services/LockService.ts:20
+#: scripts/extensions/sams/dist/src/api/assets.js:446
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:446
+#: scripts/extensions/sams/src/api/assets.ts:562
+msgid "Error: {{message}}"
+msgstr "エラー：{{message}}"
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/api.js:25
+#: scripts/extensions/sams/dist/src/utils/api.js:25
+#: scripts/extensions/sams/src/utils/api.ts:25
+msgid "Error[04002]: Invalid search query"
+msgstr "エラー[04002]：無効な検索クエリ"
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/api.js:46
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/api.js:56
+#: scripts/extensions/sams/dist/src/utils/api.js:46
+#: scripts/extensions/sams/dist/src/utils/api.js:56
+#: scripts/extensions/sams/src/utils/api.ts:42
+#: scripts/extensions/sams/src/utils/api.ts:53
+msgid "Error[{{number}}]: {{description}}"
+msgstr "エラー[{{number}}]：{{description}}"
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/api.js:33
+#: scripts/extensions/sams/dist/src/utils/api.js:33
+#: scripts/extensions/sams/src/utils/api.ts:30
+msgid "Error[{{number}}]: {{error}} not unique"
+msgstr "エラー[{{number}}]：{{error}}が一意ではありません"
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/api.js:39
+#: scripts/extensions/sams/dist/src/utils/api.js:39
+#: scripts/extensions/sams/src/utils/api.ts:35
+msgid "Error[{{number}}]: {{error}} requried"
+msgstr "エラー[{{number}}]：{{error}}は必須です"
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/validation-errors.js:14
+#: scripts/extensions/availability-manager/dist/src/validation-errors.js:14
+#: scripts/extensions/availability-manager/src/validation-errors.tsx:19
+msgid "Errors"
+msgstr "エラー"
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:79
+msgid "Europe/Athens"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:80
+msgid "Europe/Belgrade"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:81
+msgid "Europe/Berlin"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:82
+msgid "Europe/Brussels"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:83
+msgid "Europe/Bucharest"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:84
+msgid "Europe/Dublin"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:85
+msgid "Europe/Helsinki"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:86
+msgid "Europe/Istanbul"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:87
+msgid "Europe/Kiev"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:88
+msgid "Europe/Lisbon"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:89
+msgid "Europe/London"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:90
+msgid "Europe/Madrid"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:91
+msgid "Europe/Minsk"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:92
+msgid "Europe/Moscow"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:93
+msgid "Europe/Paris"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:94
+msgid "Europe/Prague"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:95
+msgid "Europe/Rome"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:96
+msgid "Europe/Sofia"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:97
+msgid "Europe/Stockholm"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:40
+#: ../superdesk-planning/client/components/ItemIcon.tsx:23
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:53
+#: ../superdesk-planning/client/components/Main/ItemEditorModal/EditorModalPanel.tsx:169
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:77
+#: ../superdesk-planning/client/utils/history.tsx:75
+#: ../superdesk-planning/client/utils/index.ts:581
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:17
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:17
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:25
+msgid "Event"
+msgstr "イベント"
+
+#: ../superdesk-planning/client/utils/events.tsx:479
+msgid "Event \"{{name}}\" is already added as related"
+msgstr "イベント「{{name}}」は既に関連として追加されています"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:43
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:57
+msgid "Event Cancelled"
+msgstr "イベントキャンセル済み"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:59
+msgid "Event Cancelled:"
+msgstr "イベントキャンセル済み："
+
+#: ../superdesk-planning/client/components/Planning/PlanningEditor/PlanningEditorHeader.tsx:61
+#: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:187
+#: ../superdesk-planning/client/components/StateLabel/index.tsx:61
+#: ../superdesk-planning/client/components/fields/state.tsx:45
+msgid "Event Completed"
+msgstr "イベント完了"
+
+#: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/event-dates/index.tsx:23
+msgid "Event Date"
+msgstr "イベント日"
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/event-dates.ts:18
+msgid "Event Dates"
+msgstr "イベント日程"
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/Editor.tsx:187
+#: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:126
+msgid "Event Details"
+msgstr "イベント詳細"
+
+#: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:225
+msgid "Event Ends"
+msgstr "イベント終了"
+
+#: ../superdesk-planning/client/api/contentProfiles.ts:212
+msgid "Event Fields"
+msgstr "イベントフィールド"
+
+#: ../superdesk-planning/client/components/Events/EventEditor/index.tsx:182
+msgid "Event Name"
+msgstr "イベント名"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:47
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:65
+msgid "Event Postponed"
+msgstr "イベント延期"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:41
+msgid "Event Postponed:"
+msgstr "イベント延期："
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:39
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:53
+msgid "Event Rescheduled"
+msgstr "イベント再スケジュール"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:51
+msgid "Event Rescheduled from"
+msgstr "イベント再スケジュール元"
+
+#: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:206
+msgid "Event Starts"
+msgstr "イベント開始"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:60
+msgid "Event cancelled"
+msgstr "イベントがキャンセルされました"
+
+#: ../superdesk-planning/client/validators/events.ts:154
+msgid "Event duration is greater than {{maxDuration}} days."
+msgstr "イベントの期間が{{maxDuration}}日を超えています。"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:136
+msgid "Event has been cancelled"
+msgstr "イベントがキャンセルされました"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:151
+msgid "Event has been postponed"
+msgstr "イベントが延期されました"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:324
+msgid "Event has been rescheduled"
+msgstr "イベントが再スケジュールされました"
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:77
+msgid "Event has to be created before adding related plannings"
+msgstr "関連プランニングを追加するには先にイベントを作成する必要があります"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:84
+msgid "Event repetitions modified"
+msgstr "イベントの繰り返しが変更されました"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:522
+msgid "Event repetitions updated"
+msgstr "イベントの繰り返しが更新されました"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:31
+msgid "Event spiked"
+msgstr "イベントがスパイクされました"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:507
+msgid "Event time has been updated"
+msgstr "イベント時間が更新されました"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:76
+msgid "Event time modified"
+msgstr "イベント時間が変更されました"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:35
+msgid "Event unspiked"
+msgstr "イベントのスパイクが解除されました"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:234
+msgid "Event will be changed to a multi-day event!"
+msgstr "イベントが複数日イベントに変更されます。"
+
+#: ../superdesk-planning/client/components/fields/editor/DatesGroup.tsx:44
+msgid "Event/Planning date"
+msgstr ""
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:75
+#: ../superdesk-planning/client/components/fields/editor/ItemType.tsx:21
+#: ../superdesk-planning/client/components/fields/index.tsx:235
+#: ../superdesk-planning/client/utils/eventsplanning.ts:17
+#: ../superdesk-planning/client/utils/eventsplanning.ts:19
+#: scripts/apps/production-api-keys/config.ts:28
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:18
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:18
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:26
+msgid "Events"
+msgstr "イベント"
+
+#: ../superdesk-planning/client/components/Main/FiltersBox.tsx:39
+msgid "Events & Planning"
+msgstr "イベントとプランニング"
+
+#: ../superdesk-planning/client/apps/Planning/AddToPlanningUi.tsx:34
+#: ../superdesk-planning/client/apps/Planning/PlanningUi.tsx:21
+msgid "Events and Planning content"
+msgstr "イベントとプランニングコンテンツ"
+
+#: ../superdesk-planning/client/components/Main/FiltersBox.tsx:45
+msgid "Events only"
+msgstr "イベントのみ"
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:101
+msgid "Every"
+msgstr "毎"
+
+#: ../superdesk-planning/client/utils/filters.ts:163
+#: ../superdesk-planning/client/utils/filters.ts:180
+msgid "Every Hour"
+msgstr "毎時"
+
+#: scripts/apps/search/views/edit-time-interval.html:4
+msgid "Every day"
+msgstr "毎日"
+
+#: scripts/apps/search/views/edit-time-interval.html:18
+msgid "Every hour"
+msgstr "毎時"
+
+#: ../superdesk-planning/client/utils/events.tsx:1402
+msgid "Every {{interval}} day(s)"
+msgstr "{{interval}}日ごと"
+
+#: ../superdesk-planning/client/utils/events.tsx:1395
+msgid "Every {{interval}} month(s) on day {{day}}"
+msgstr "{{interval}}か月ごとの{{day}}日"
+
+#: ../superdesk-planning/client/utils/events.tsx:1405
+msgid "Every {{interval}} week(s)"
+msgstr "{{interval}}週間ごと"
+
+#: ../superdesk-planning/client/utils/events.tsx:1388
+msgid "Every {{interval}} year(s) on {{date}}"
+msgstr "{{interval}}年ごとの{{date}}"
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:6
+msgid "Exact"
+msgstr "完全一致"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:78
+msgid "Exclamation Sign"
+msgstr "感嘆符"
+
+#: ../superdesk-analytics/client/search/views/preview-source-filter.html:6
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:102
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:131
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:15
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:160
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:189
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:218
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:247
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:276
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:318
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:347
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:44
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:73
+msgid "Exclude"
+msgstr "除外"
+
+#: ../superdesk-planning/client/components/fields/editor/ExcludeRescheduledAndCancelled.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:79
+msgid "Exclude Rescheduled And Cancelled"
+msgstr "再スケジュール済みとキャンセル済みを除外"
+
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:304
+msgid "Exclude Rewrites"
+msgstr "書き直しを除外"
+
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:173
+msgid "Exclude Spike"
+msgstr "スパイクを除外"
+
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:359
+msgid "Exclude all locked items"
+msgstr "すべてのロック済みアイテムを除外"
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:67
+msgid "Exclude rewrites"
+msgstr "書き直しを除外"
+
+#: scripts/apps/search/views/search-parameters.html:151
+msgid "Exclude spiked content"
+msgstr "スパイク済みコンテンツを除外"
+
+#: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:151
+msgid "Existing Locations"
+msgstr "既存のロケーション"
+
+#: scripts/apps/authoring/multiedit/views/multiedit.html:3
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:87
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:39
+msgid "Exit"
+msgstr "終了"
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:173
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:556
+msgid "Exit Desk Actions"
+msgstr "デスクアクションから退出"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:79
+#: scripts/core/editor3/components/Editor3Component.tsx:901
+msgid "Expand"
+msgstr "展開"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:80
+msgid "Expand Thin"
+msgstr "展開（細）"
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:108
+msgid "Expandable"
+msgstr "展開可能"
+
+#: scripts/apps/publish/views/subscribers.html:304
+msgid "Expire in:"
+msgstr "有効期限："
+
+#: ../superdesk-planning/client/components/fields/state.tsx:55
+#: ../superdesk-planning/client/utils/index.ts:430
+msgid "Expired"
+msgstr "期限切れ"
+
+#: scripts/apps/archive/views/metadata-view.html:98
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:277
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:92
+msgid "Expiry"
+msgstr "有効期限"
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:82
+msgid "Expiry Date:"
+msgstr "有効期限日："
+
+#: scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx:64
+msgid "Explanation"
+msgstr "説明"
+
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:266
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:142
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:222
+#: scripts/apps/archive/index.tsx:342 scripts/apps/archive/views/export.html:32
+#: scripts/apps/archive/views/export.html:4
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:183
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/export-highlight.tsx:18
+#: scripts/apps/authoring-react/toolbar/export-modal.tsx:112
+#: scripts/apps/authoring-react/toolbar/export-modal.tsx:82
+#: scripts/apps/authoring/views/authoring-topbar.html:208
+#: scripts/apps/authoring/views/authoring-topbar.html:307
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:113
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:287
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:287
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:452
+msgid "Export"
+msgstr "エクスポート"
+
+#: ../superdesk-analytics/client/charts/views/chart.html:23
+msgid "Export Chart As..."
+msgstr "グラフをエクスポート..."
+
+#: ../superdesk-analytics/client/utils.js:174
+msgid "Export Highlight"
+msgstr "ハイライトをエクスポート"
+
+#: ../superdesk-planning/client/components/fields/editor/ExportTemplate.tsx:48
+msgid "Export Template"
+msgstr "テンプレートをエクスポート"
+
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:255
+msgid "Export as article"
+msgstr "記事としてエクスポート"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:353
+#: scripts/apps/authoring/versioning/history/views/history.html:116
+msgid "Exported by"
+msgstr "エクスポート者"
+
+#: scripts/apps/archive/views/metadata-view.html:163
+msgid "Exposure time"
+msgstr "露出時間"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:81
+msgid "External"
+msgstr "外部"
+
+#: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:237
+#: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:116
+msgid "External Links"
+msgstr "外部リンク"
+
+#: ../superdesk-planning/client/components/Events/EventEditor/index.tsx:172
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:61
+msgid "External Reference"
+msgstr "外部参照"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:82
+msgid "Eye Open"
+msgstr "目（開）"
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:107
+msgid "FR"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:27
+msgid "FTP File Extension"
+msgstr "FTPファイル拡張子"
+
+#: scripts/apps/publish/views/ftp-config.html:22
+msgid "FTP Server Path"
+msgstr "FTPサーバーパス"
+
+#: scripts/apps/publish/views/ftp-config.html:39
+msgid "FTP Server Path for Associated media items"
+msgstr "関連メディアアイテム用FTPサーバーパス"
+
+#: scripts/apps/publish/views/ftp-config.html:4
+msgid "FTP Server URL"
+msgstr "FTPサーバーURL"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:83
+#: scripts/apps/users/views/edit-form.html:295
+msgid "Facebook"
+msgstr "Facebook"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:84
+msgid "Facebook Circle"
+msgstr "Facebook（丸）"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:923
+msgid "Failed to add Calendar to the Event"
+msgstr "イベントへのカレンダー追加に失敗しました"
+
+#: ../superdesk-planning/client/api/planning.ts:306
+msgid "Failed to add coverages to workflow"
+msgstr "ワークフローへの取材追加に失敗しました"
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:328
+#: ../superdesk-planning/client/actions/planning/ui.ts:369
+msgid "Failed to add planning item added as featured story"
+msgstr "特集記事としてのプランニングアイテム追加に失敗しました"
+
+#: scripts/apps/archive/directives/ArchivedItemKill.ts:33
+#: scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.ts:97
+msgid "Failed to apply kill template to the item."
+msgstr "アイテムへのキルテンプレート適用に失敗しました。"
+
+#: scripts/apps/archive/related-item-widget/relatedItem.ts:188
+msgid "Failed to associate update: {{message}}"
+msgstr "更新の関連付けに失敗しました：{{message}}"
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:307
+msgid "Failed to cancel all coverage!"
+msgstr "すべての取材のキャンセルに失敗しました。"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:140
+msgid "Failed to cancel the Event!"
+msgstr "イベントのキャンセルに失敗しました。"
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:289
+msgid "Failed to cancel the Planning Item!"
+msgstr "プランニングアイテムのキャンセルに失敗しました。"
+
+#: scripts/core/auth/login-modal-directive.ts:80
+msgid "Failed to change the password."
+msgstr "パスワードの変更に失敗しました。"
+
+#: scripts/apps/authoring/authoring/services/MultiEditUnsavedChangesService.ts:78
+msgid "Failed to check for unsaved changes"
+msgstr "未保存の変更の確認に失敗しました"
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:710
+msgid "Failed to create an archive item."
+msgstr "アーカイブアイテムの作成に失敗しました。"
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsModal.js:102
+msgid "Failed to create the Report Schedule!"
+msgstr "レポートスケジュールの作成に失敗しました。"
+
+#: scripts/extensions/sams/dist/src/api/sets.js:46
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:46
+#: scripts/extensions/sams/src/api/sets.ts:59
+msgid "Failed to create the Set"
+msgstr "セットの作成に失敗しました"
+
+#: ../superdesk-planning/client/api/locations.ts:33
+msgid "Failed to create the location"
+msgstr "ロケーションの作成に失敗しました"
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:197
+msgid "Failed to create/update Events and Planning view filter"
+msgstr "イベントとプランニングの表示フィルターの作成/更新に失敗しました"
+
+#: scripts/extensions/sams/dist/src/api/assets.js:449
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:449
+#: scripts/extensions/sams/src/api/assets.ts:564
+msgid "Failed to delete the Asset"
+msgstr "アセットの削除に失敗しました"
+
+#: scripts/extensions/sams/dist/src/api/sets.js:84
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:84
+#: scripts/extensions/sams/src/api/sets.ts:104
+msgid "Failed to delete the Set"
+msgstr "セットの削除に失敗しました"
+
+#: ../superdesk-planning/client/api/locations.ts:91
+msgid "Failed to delete the location"
+msgstr "ロケーションの削除に失敗しました"
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:194
+msgid "Failed to delete the saved report"
+msgstr "保存済みレポートの削除に失敗しました"
+
+#: scripts/apps/authoring/authoring/services/MultiEditUnsavedChangesService.ts:60
+msgid "Failed to discard some changes"
+msgstr "一部の変更の破棄に失敗しました"
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:258
+msgid "Failed to duplicate the item"
+msgstr "アイテムの複製に失敗しました"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:61
+#: ../superdesk-analytics/client/charts/services/ChartManager.js:30
+msgid "Failed to export the chart;"
+msgstr "グラフのエクスポートに失敗しました。"
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:239
+msgid "Failed to fetch all filters"
+msgstr "すべてのフィルターの取得に失敗しました"
+
+#: ../superdesk-planning/client/controllers/AssignmentPreviewController.tsx:107
+#: ../superdesk-planning/client/controllers/AssignmentPreviewController.tsx:73
+msgid "Failed to fetch assignment information."
+msgstr "アサインメント情報の取得に失敗しました。"
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:242
+msgid "Failed to fetch featured stories!"
+msgstr "特集記事の取得に失敗しました。"
+
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:72
+msgid "Failed to fetch item from archive"
+msgstr "アーカイブからのアイテム取得に失敗しました"
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:633
+msgid "Failed to fetch planning item."
+msgstr "プランニングアイテムの取得に失敗しました。"
+
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:115
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:65
+msgid "Failed to find an Assignment to link to!"
+msgstr "リンク先のアサインメントが見つかりませんでした。"
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:407
+msgid "Failed to generate picture crops."
+msgstr "画像トリミングの生成に失敗しました。"
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:260
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:474
+msgid "Failed to generate update: {{message}}"
+msgstr "更新の生成に失敗しました：{{message}}"
+
+#: scripts/extensions/sams/dist/src/api/assets.js:348
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:348
+#: scripts/extensions/sams/src/api/assets.ts:437
+msgid "Failed to get Assets"
+msgstr "アセットの取得に失敗しました"
+
+#: scripts/apps/authoring/authoring/services/LockService.ts:21
+msgid "Failed to get a lock on the item!"
+msgstr "アイテムのロック取得に失敗しました。"
+
+#: scripts/extensions/sams/src/api/assets.ts:406
+msgid "Failed to get asset \"\""
+msgstr "アセットの取得に失敗しました"
+
+#: scripts/extensions/sams/dist/src/api/assets.js:305
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:305
+#: scripts/extensions/sams/src/api/assets.ts:389
+msgid "Failed to get assets counts for sets"
+msgstr "セットのアセット数の取得に失敗しました"
+
+#: scripts/extensions/sams/dist/src/api/assets.js:408
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:408
+#: scripts/extensions/sams/src/api/assets.ts:519
+msgid "Failed to get binary for asset"
+msgstr "アセットのバイナリ取得に失敗しました"
+
+#: scripts/extensions/sams/dist/src/api/assets.js:427
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:427
+#: scripts/extensions/sams/src/api/assets.ts:541
+msgid "Failed to get compressed binaries for assets"
+msgstr "アセットの圧縮バイナリ取得に失敗しました"
+
+#: scripts/apps/ingest/controllers/ExternalSourceController.ts:29
+msgid "Failed to get item."
+msgstr "アイテムの取得に失敗しました。"
+
+#: scripts/extensions/sams/dist/src/api/assets.js:527
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:527
+#: scripts/extensions/sams/src/api/assets.ts:648
+msgid "Failed to get tags"
+msgstr "タグの取得に失敗しました"
+
+#: ../superdesk-planning/client/actions/autosave.ts:76
+msgid "Failed to get the autosave entry"
+msgstr "自動保存エントリの取得に失敗しました"
+
+#: ../superdesk-planning/client/actions/main.ts:1528
+msgid "Failed to get the queue item"
+msgstr "キューアイテムの取得に失敗しました"
+
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:254
+msgid "Failed to link to requested assignment!"
+msgstr "リクエストされたアサインメントへのリンクに失敗しました。"
+
+#: scripts/extensions/sams/dist/src/api/sets.js:23
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:23
+#: scripts/extensions/sams/src/api/sets.ts:30
+msgid "Failed to load all sets"
+msgstr "すべてのセットの読み込みに失敗しました"
+
+#: scripts/extensions/sams/dist/src/api/storageDestinations.js:23
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/storageDestinations.js:23
+#: scripts/extensions/sams/src/api/storageDestinations.ts:34
+msgid "Failed to load all storage destinations"
+msgstr "すべてのストレージ送信先の読み込みに失敗しました"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:352
+msgid "Failed to load duplicated Event."
+msgstr "複製されたイベントの読み込みに失敗しました。"
+
+#: ../superdesk-planning/client/api/locks.ts:80
+msgid "Failed to load item locks"
+msgstr "アイテムロックの読み込みに失敗しました"
+
+#: ../superdesk-planning/client/api/locks.ts:73
+msgid "Failed to load locked items"
+msgstr "ロック済みアイテムの読み込みに失敗しました"
+
+#: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:229
+#: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:286
+msgid "Failed to load the item."
+msgstr "アイテムの読み込みに失敗しました。"
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:241
+msgid "Failed to load the saved report!"
+msgstr "保存済みレポートの読み込みに失敗しました。"
+
+#: ../superdesk-planning/client/actions/autosave.ts:32
+msgid "Failed to load {{ itemType }} autosaves."
+msgstr "{{ itemType }}の自動保存の読み込みに失敗しました。"
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:277
+#: ../superdesk-planning/client/actions/planning/ui.ts:330
+msgid "Failed to lock featured story action!"
+msgstr "特集記事アクションのロックに失敗しました。"
+
+#: ../superdesk-planning/client/api/locks.ts:226
+msgid "Failed to lock item"
+msgstr "アイテムのロックに失敗しました"
+
+#: scripts/extensions/sams/dist/src/api/assets.js:486
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:486
+#: scripts/extensions/sams/src/api/assets.ts:604
+msgid "Failed to lock the Asset"
+msgstr "アセットのロックに失敗しました"
+
+#: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:273
+msgid "Failed to lock the item."
+msgstr "アイテムのロックに失敗しました。"
+
+#: ../superdesk-planning/client/actions/main.ts:485
+msgid "Failed to post the {{ itemType }}"
+msgstr "{{ itemType }}の投稿に失敗しました"
+
+#: ../superdesk-planning/client/actions/main.ts:447
+msgid "Failed to post, could not find the item type!"
+msgstr "投稿に失敗しました。アイテムタイプが見つかりません。"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:155
+msgid "Failed to postpone the Event!"
+msgstr "イベントの延期に失敗しました。"
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/publish-and-continue.tsx:25
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:671
+msgid "Failed to publish and continue."
+msgstr "公開と続行に失敗しました。"
+
+#: scripts/extensions/sams/dist/src/api/assets.js:249
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:249
+#: scripts/extensions/sams/src/api/assets.ts:330
+msgid "Failed to query Assets"
+msgstr "アセットのクエリに失敗しました"
+
+#: ../superdesk-planning/client/actions/autosave.ts:199
+msgid "Failed to remove autosave. Not found"
+msgstr "自動保存の削除に失敗しました。見つかりません"
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:279
+msgid "Failed to remove link: {{message}}"
+msgstr "リンクの削除に失敗しました：{{message}}"
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:327
+#: ../superdesk-planning/client/actions/planning/ui.ts:368
+msgid "Failed to remove planning item as featured story"
+msgstr "特集記事からのプランニングアイテム削除に失敗しました"
+
+#: ../superdesk-planning/client/actions/events/api.ts:762
+msgid "Failed to remove the file from event."
+msgstr "イベントからのファイル削除に失敗しました。"
+
+#: ../superdesk-planning/client/actions/planning/api.ts:728
+msgid "Failed to remove the file from planning."
+msgstr "プランニングからのファイル削除に失敗しました。"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:365
+msgid "Failed to reschedule the Event!"
+msgstr "イベントの再スケジュールに失敗しました。"
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:544
+msgid "Failed to revert the assignment."
+msgstr "アサインメントの取り消しに失敗しました。"
+
+#: ../superdesk-planning/client/actions/main.ts:896
+msgid "Failed to run the query"
+msgstr "クエリの実行に失敗しました"
+
+#: scripts/apps/contacts/directives/ContactsSearchResultsDirective.ts:80
+#: scripts/apps/content-api/directives/ContentAPISearchResultsDirective.ts:77
+#: scripts/apps/search/directives/SearchResults.ts:293
+msgid "Failed to run the query!"
+msgstr "クエリの実行に失敗しました。"
+
+#: ../superdesk-planning/client/actions/main.ts:986
+msgid "Failed to run the query.."
+msgstr "クエリの実行に失敗しました..."
+
+#: ../superdesk-planning/client/actions/autosave.ts:141
+msgid "Failed to save autosave item."
+msgstr "自動保存アイテムの保存に失敗しました。"
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:357
+msgid "Failed to save featured story record!"
+msgstr "特集記事レコードの保存に失敗しました。"
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:169
+msgid "Failed to save report"
+msgstr "レポートの保存に失敗しました"
+
+#: scripts/apps/authoring/authoring/services/MultiEditUnsavedChangesService.ts:72
+msgid "Failed to save some articles"
+msgstr "一部の記事の保存に失敗しました"
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsModal.js:103
+msgid "Failed to save the Report Schedule!"
+msgstr "レポートスケジュールの保存に失敗しました。"
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:461
+msgid "Failed to save the area of interest:"
+msgstr "注目エリアの保存に失敗しました："
+
+#: scripts/apps/authoring/tests/changeImage.spec.ts:94
+msgid "Failed to save the area of interest: Failed to call picture_crop."
+msgstr "注目エリアの保存に失敗しました：picture_cropの呼び出しに失敗しました。"
+
+#: scripts/apps/authoring/tests/changeImage.spec.ts:128
+msgid "Failed to save the area of interest: Failed to call picture_renditions."
+msgstr "注目エリアの保存に失敗しました：picture_renditionsの呼び出しに失敗しました。"
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:469
+msgid "Failed to save the assignment."
+msgstr "アサインメントの保存に失敗しました。"
+
+#: ../superdesk-planning/client/actions/events/api.ts:833
+msgid "Failed to save the event template"
+msgstr "イベントテンプレートの保存に失敗しました"
+
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:190
+#: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:135
+msgid "Failed to save the profile!"
+msgstr "プロファイルの保存に失敗しました。"
+
+#: ../superdesk-planning/client/actions/main.ts:351
+msgid "Failed to save the {{itemType}}!"
+msgstr "{{itemType}}の保存に失敗しました。"
+
+#: ../superdesk-planning/client/actions/main.ts:293
+msgid "Failed to save, could not find the item {{itemType}}!"
+msgstr "保存に失敗しました。アイテム{{itemType}}が見つかりません。"
+
+#: ../superdesk-analytics/client/email_report/services/EmailReportService.js:69
+msgid "Failed to send report email!"
+msgstr "レポートメールの送信に失敗しました。"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:69
+#: ../superdesk-planning/client/actions/events/ui.ts:86
+msgid "Failed to spike the event(s)"
+msgstr "イベントのスパイクに失敗しました"
+
+#: ../superdesk-planning/client/api/locks.ts:354
+#: ../superdesk-planning/client/api/locks.ts:396
+msgid "Failed to unlock item"
+msgstr "アイテムのロック解除に失敗しました"
+
+#: scripts/extensions/sams/dist/src/api/assets.js:504
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:504
+#: scripts/extensions/sams/src/api/assets.ts:623
+msgid "Failed to unlock the Asset"
+msgstr "アセットのロック解除に失敗しました"
+
+#: ../superdesk-planning/client/actions/main.ts:408
+msgid "Failed to unpost the {{ itemType }}"
+msgstr "{{ itemType }}の投稿取り消しに失敗しました"
+
+#: ../superdesk-planning/client/actions/main.ts:385
+msgid "Failed to unpost, could not find the item type!"
+msgstr "投稿取り消しに失敗しました。アイテムタイプが見つかりません。"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:526
+msgid "Failed to update Event repetitions"
+msgstr "イベント繰り返しの更新に失敗しました"
+
+#: scripts/extensions/sams/dist/src/api/assets.js:365
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:365
+#: scripts/extensions/sams/src/api/assets.ts:464
+msgid "Failed to update asset."
+msgstr "アセットの更新に失敗しました。"
+
+#: ../superdesk-planning/client/api/locations.ts:69
+msgid "Failed to update location"
+msgstr "ロケーションの更新に失敗しました"
+
+#: scripts/extensions/sams/dist/src/api/assets.js:468
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:468
+#: scripts/extensions/sams/src/api/assets.ts:585
+msgid "Failed to update the Asset"
+msgstr "アセットの更新に失敗しました"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:511
+msgid "Failed to update the Event time!"
+msgstr "イベント時間の更新に失敗しました。"
+
+#: scripts/extensions/sams/dist/src/api/sets.js:66
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:66
+#: scripts/extensions/sams/src/api/sets.ts:85
+msgid "Failed to update the Set"
+msgstr "セットの更新に失敗しました"
+
+#: scripts/extensions/sams/dist/src/api/assets.js:43
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:43
+#: scripts/extensions/sams/src/api/assets.ts:61
+msgid "Failed to upload file."
+msgstr "ファイルのアップロードに失敗しました。"
+
+#: ../superdesk-planning/client/components/fields/editor/EventAttachments.tsx:62
+#: scripts/extensions/sams/dist/src/containers/FileUploadModal.js:208
+#: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:208
+#: scripts/extensions/sams/src/containers/FileUploadModal.tsx:240
+msgid "Failed to upload files"
+msgstr "ファイルのアップロードに失敗しました"
+
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:34
+#: ../superdesk-planning/client/components/fields/preview/base/utils.ts:17
+msgid "False"
+msgstr "偽"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:85
+msgid "Fast Forward"
+msgstr "早送り"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:86
+msgid "Fast Rewind"
+msgstr "巻き戻し"
+
+#: scripts/apps/workspace/content/constants.ts:26
+msgid "Feature Image"
+msgstr "フィーチャー画像"
+
+#: scripts/apps/search/views/search-parameters.html:175
+#: scripts/apps/workspace/content/constants.ts:27
+msgid "Feature Media"
+msgstr "フィーチャーメディア"
+
+#: scripts/core/lang/missing-translations-strings.ts:17
+msgid "Feature Preview"
+msgstr "機能プレビュー"
+
+#: scripts/apps/authoring-react/field-adapters/feature_media.ts:21
+msgid "Feature media"
+msgstr "フィーチャーメディア"
+
+#: scripts/apps/users/views/user-preferences.html:13
+#: scripts/apps/users/views/user-preferences.html:27
+msgid "Feature preview"
+msgstr "機能プレビュー"
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeatureLabel.tsx:9
+#: ../superdesk-planning/client/components/fields/editor/Featured.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:83
+msgid "Featured"
+msgstr "特集"
+
+#: scripts/apps/authoring/views/confirm-media-associated.html:8
+msgid "Featured Media"
+msgstr "特集メディア"
+
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:75
+msgid "Featured Stories"
+msgstr "特集記事"
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:66
+msgid "Featured Stories Locked"
+msgstr "特集記事がロックされています"
+
+#: ../superdesk-planning/client/actions/planning/notifications.ts:383
+msgid "Featured Stories Unlocked"
+msgstr "特集記事のロックが解除されました"
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:133
+msgid "Featured Stories based on timezone: {{tz}}"
+msgstr "タイムゾーン{{tz}}に基づく特集記事"
+
+#: ../superdesk-planning/client/actions/planning/notifications.ts:384
+msgid "Featured stories you were managing was unlocked by"
+msgstr "管理していた特集記事のロックが解除されました"
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:20
+msgid "Featuremedia History"
+msgstr "フィーチャーメディア履歴"
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/index.js:50
+msgid "Featuremedia Updates"
+msgstr "フィーチャーメディア更新"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:99
+msgid "Feed Parser"
+msgstr "フィードパーサー"
+
+#: scripts/core/menu/views/menu.html:105
+msgid "Feedback"
+msgstr "フィードバック"
+
+#: scripts/core/menu/views/menu.html:107
+msgid "Feedback/Suggestions"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:92
+msgid "Feeding Service"
+msgstr "フィーディングサービス"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:64
+msgid "Fern Green"
+msgstr "ファーングリーン"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:434
+#: ../superdesk-analytics/client/utils.js:151 scripts/apps/ingest/index.ts:129
+#: scripts/apps/ingest/index.ts:166
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:4
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:25
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:39
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:70
+#: scripts/core/interactive-article-actions-panel/actions/fetch-to-action.tsx:116
+msgid "Fetch"
+msgstr "取得"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:87
+msgid "Fetch As"
+msgstr "名前を付けて取得"
+
+#: scripts/core/lang/missing-translations-strings.ts:17
+msgid "Fetch Content To a Desk"
+msgstr "デスクにコンテンツを取得"
+
+#: scripts/apps/ingest/index.ts:115 scripts/apps/ingest/index.ts:146
+msgid "Fetch To"
+msgstr "取得先"
+
+#: scripts/apps/monitoring/index.ts:122
+msgid "Fetch an item"
+msgstr "アイテムを取得"
+
+#: scripts/core/interactive-article-actions-panel/actions/fetch-to-action.tsx:101
+msgid "Fetch and open"
+msgstr "取得して開く"
+
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:48
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:78
+#: scripts/core/interactive-article-actions-panel/action-tabs.tsx:11
+msgid "Fetch to"
+msgstr "取得先"
+
+#: scripts/api/article-fetch.tsx:104
+msgid "Fetch valid({{count}})"
+msgstr "有効な取得（{{count}}）"
+
+#: scripts/apps/search/components/fields/state.tsx:33
+msgid "Fetched"
+msgstr "取得済み"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:269
+#: scripts/apps/authoring/versioning/history/views/history.html:76
+msgid "Fetched by"
+msgstr "取得者"
+
+#: scripts/apps/content-filters/views/filter-search.html:9
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:59
+msgid "Field"
+msgstr "フィールド"
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:66
+msgid ""
+"Field\n"
+"                                    type"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:200
+msgid "Field \"{{field}}\" will be permanently deleted."
+msgstr "フィールド「{{field}}」は完全に削除されます。"
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:88
+msgid "Field ID to prefill from"
+msgstr "事前入力元のフィールドID"
+
+#: ../superdesk-planning/client/validators/planning.ts:108
+#: scripts/apps/authoring-react/authoring-react.tsx:1007
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:168
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:203
+msgid "Field is required"
+msgstr "フィールドは必須です"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:88
+msgid "File"
+msgstr "ファイル"
+
+#: scripts/apps/publish/views/file-config.html:11
+#: scripts/apps/publish/views/file-config.html:9
+#: scripts/apps/publish/views/ftp-config.html:25
+msgid "File Extension"
+msgstr "ファイル拡張子"
+
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:201
+msgid "File Name"
+msgstr "ファイル名"
+
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:211
+msgid "File Size"
+msgstr "ファイルサイズ"
+
+#: scripts/apps/profiling/views/profiling.html:37
+msgid "File name/line"
+msgstr "ファイル名/行"
+
+#: scripts/apps/monitoring/views/monitoring-view.html:161
+msgid "File types"
+msgstr "ファイルタイプ"
+
+#: scripts/extensions/sams/dist/src/containers/FileUploadModal.js:203
+#: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:203
+#: scripts/extensions/sams/src/containers/FileUploadModal.tsx:230
+msgid "File uploaded successfully"
+msgid_plural "{{count}} files uploaded successfully"
+msgstr[0] "{{count}}件のファイルが正常にアップロードされました"
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:224
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:117
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:149
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:143
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:224
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:117
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:149
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:143
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:108
+#: scripts/extensions/sams/dist/src/utils/ui.js:108
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:254
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:136
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:168
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:168
+#: scripts/extensions/sams/src/utils/ui.tsx:101
+msgid "Filename"
+msgstr "ファイル名"
+
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:169
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:169
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:169
+msgid "Filename:"
+msgstr "ファイル名："
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:297
+msgid "Files"
+msgstr "ファイル"
+
+#: ../superdesk-planning/client/components/UI/SubNav/Dropdown.tsx:227
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:815
+#: scripts/core/views/sdselect.html:10
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:221
+#: scripts/extensions/broadcasting/dist/src/page.js:225
+#: scripts/extensions/broadcasting/src/page.tsx:348
+msgid "Filter"
+msgstr "フィルター"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:69
+msgid "Filter \"{{ name }}\" will be permanently deleted."
+msgstr "フィルター「{{ name }}」は完全に削除されます。"
+
+#: scripts/apps/content-filters/views/manage-filters.html:102
+msgid "Filter Condition"
+msgstr "フィルター条件"
+
+#: scripts/apps/content-filters/views/filter-search-result.html:7
+#: scripts/apps/content-filters/views/settings.html:14
+msgid "Filter Conditions"
+msgstr "フィルター条件"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:183
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:36
+msgid "Filter Details"
+msgstr "フィルター詳細"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:89
+msgid "Filter Large"
+msgstr "フィルター（大）"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:225
+msgid "Filter Name"
+msgstr "フィルター名"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:140
+msgid "Filter Schedule"
+msgstr "フィルタースケジュール"
+
+#: scripts/apps/content-filters/views/settings.html:19
+msgid "Filter Search"
+msgstr "フィルター検索"
+
+#: scripts/apps/content-filters/views/manage-filters.html:66
+msgid "Filter Statement"
+msgstr "フィルター条件"
+
+#: scripts/apps/content-filters/views/manage-filters.html:133
+msgid "Filter Test"
+msgstr "フィルターテスト"
+
+#: scripts/apps/content-filters/views/production-test.html:4
+msgid "Filter Test Results"
+msgstr "フィルターテスト結果"
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:111
+msgid "Filter by day:"
+msgstr "日ごとにフィルター："
+
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:99
+msgid "Filter condition saved."
+msgstr "フィルター条件が保存されました。"
+
+#: scripts/apps/contacts/views/search-panel.html:3
+msgid "Filter contacts"
+msgstr "連絡先をフィルター"
+
+#: scripts/apps/monitoring/views/monitoring-view.html:158
+msgid "Filter file types"
+msgstr "ファイルタイプをフィルター"
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:50
+msgid "Filter statement {{id}} does not have a filter condition."
+msgstr "フィルター条件{{id}}にフィルター条件が設定されていません。"
+
+#: scripts/apps/templates/views/templates.html:8
+msgid "Filter:"
+msgstr "フィルター："
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:76
+msgid "Filtered By"
+msgstr "フィルター条件"
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:48
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:48
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-panel.html:48
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-panel.html:48
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-panel.html:48
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-panel.html:48
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-panel.html:48
+#: scripts/apps/archive/views/list.html:14
+#: scripts/apps/contacts/views/list.html:19
+#: scripts/apps/contacts/views/list.html:20
+#: scripts/apps/content-api/views/list.html:4
+#: scripts/apps/content-api/views/list.html:5
+#: scripts/apps/content-api/views/search-panel.html:8
+#: scripts/apps/content-filters/views/settings.html:9
+#: scripts/apps/legal-archive/views/legal_archive.html:3
+#: scripts/apps/legal-archive/views/legal_archive.html:4
+#: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:49
+#: scripts/apps/search/views/search-panel.html:64
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:292
+msgid "Filters"
+msgstr "フィルター"
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:78
+#: scripts/apps/authoring/editor/views/find-replace.html:5
+msgid "Find"
+msgstr "検索"
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:12
+#: scripts/apps/authoring/editor/find-replace.ts:95
+msgid "Find and Replace"
+msgstr "検索と置換"
+
+#: scripts/apps/search/index.ts:108
+msgid "Find live and archived content"
+msgstr "公開中およびアーカイブ済みコンテンツを検索"
+
+#: scripts/apps/users/config.ts:39
+msgid "Find your colleagues"
+msgstr "同僚を検索"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:67
+msgid "Fire Brick"
+msgstr "ファイアブリック"
+
+#: ../superdesk-planning/client/utils/filters.ts:63
+msgid "First"
+msgstr "最初"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:35
+msgid "First Day"
+msgstr "初日"
+
+#: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:224
+msgid "First Event Ends"
+msgstr "最初のイベント終了"
+
+#: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:205
+msgid "First Event Starts"
+msgstr "最初のイベント開始"
+
+#: scripts/apps/contacts/constants.ts:68
+#: scripts/apps/contacts/views/search-panel.html:14
+#: scripts/core/directives/views/phone-home-modal-directive.html:19
+msgid "First Name"
+msgstr "名"
+
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:1058
+msgid "First created"
+msgstr "最初に作成"
+
+#: scripts/apps/search/views/search-filters.html:118
+msgid "Flags"
+msgstr "フラグ"
+
+#: scripts/apps/archive/views/metadata-view.html:166
+msgid "Flash"
+msgstr "フラッシュ"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:90
+msgid "Flip Horizontal"
+msgstr "左右反転"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:91
+msgid "Flip Vertical"
+msgstr "上下反転"
+
+#: scripts/apps/authoring/views/change-image.html:208
+msgid "Flip horizontal"
+msgstr "左右反転"
+
+#: scripts/apps/authoring/views/change-image.html:209
+msgid "Flip vertical"
+msgstr "上下反転"
+
+#: scripts/apps/archive/views/metadata-view.html:164
+msgid "Focal length"
+msgstr "焦点距離"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:92
+msgid "Folder Close"
+msgstr "フォルダーを閉じる"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:93
+msgid "Folder Open"
+msgstr "フォルダーを開く"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:94
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-panel.tsx:94
+#: scripts/apps/authoring/views/theme-select.html:18
+#: scripts/apps/authoring/views/theme-select.html:69
+msgid "Font"
+msgstr "フォント"
+
+#: scripts/apps/workspace/content/constants.ts:28
+msgid "Footer"
+msgstr "フッター"
+
+#: scripts/apps/workspace/content/constants.ts:29
+msgid "Footers"
+msgstr "フッター"
+
+#: scripts/apps/publish/views/subscribers.html:218
+msgid "For Content API only subscriber destinations are not required."
+msgstr "コンテンツAPI専用の配信先には送信先は不要です。"
+
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:21
+msgid "For Publication"
+msgstr "公開用"
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:63
+#: scripts/extensions/sams/dist/src/utils/assets.js:63
+#: scripts/extensions/sams/src/utils/assets.ts:75
+msgid "Force Unlock"
+msgstr "強制ロック解除"
+
+#: scripts/core/auth/login-modal.html:32
+msgid "Forgot password?"
+msgstr "パスワードをお忘れですか？"
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:74
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:54
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:177
+#: scripts/apps/authoring/views/preview-formatted.html:18
+#: scripts/apps/publish/views/destination.html:9
+msgid "Format"
+msgstr "フォーマット"
+
+#: scripts/apps/archive/views/export.html:10
+#: scripts/apps/authoring-react/toolbar/export-modal.tsx:88
+#: scripts/apps/authoring/views/preview-formatted.html:13
+msgid "Formatters"
+msgstr "フォーマッター"
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:34
+msgid "Formatting Marks"
+msgstr "書式マーク"
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:69
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:75
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:177
+msgid "Formatting Options"
+msgstr "書式オプション"
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:17
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:316
+#: scripts/apps/workspace/content/views/FormattingOptionsMultiSelect.tsx:34
+msgid "Formatting options"
+msgstr "書式オプション"
+
+#: ../superdesk-planning/client/components/fields/editor/OverrideAutoAssignToWorkflow.tsx:15
+msgid "Forward Planning"
+msgstr "フォワードプランニング"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:95
+msgid "Forward Thin"
+msgstr "進む（細）"
+
+#: ../superdesk-planning/client/utils/filters.ts:145
+msgid "Fr"
+msgstr "金"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:16
+msgid "Frequency"
+msgstr "頻度"
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:112
+msgid "Fri"
+msgstr "金"
+
+#: ../superdesk-planning/client/utils/events.tsx:1458
+#: scripts/core/datetime/datetime.ts:294
+msgid "Friday"
+msgstr "金曜日"
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:43
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:241
+#: ../superdesk-planning/client/components/fields/editor/CreationDate.tsx:42
+#: ../superdesk-planning/client/components/fields/editor/StartDateTime.tsx:33
+#: ../superdesk-planning/client/components/fields/preview/index.ts:150
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:67
+#: scripts/core/interactive-article-actions-panel/actions/publish-action.tsx:181
+msgid "From"
+msgstr "開始"
+
+#: scripts/apps/search/constants.ts:12
+#: scripts/apps/search/views/search-parameters.html:102
+msgid "From Desk"
+msgstr "送信元デスク"
+
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:73
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:84
+msgid "From template"
+msgstr "テンプレートから"
+
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:30
+msgid "From:"
+msgstr "開始："
+
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:327
+msgid "Fulfil Assignment with this item?"
+msgstr "このアイテムでアサインメントを履行しますか？"
+
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:152
+msgid "Fulfil assignment"
+msgstr "アサインメントを履行"
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:160
+msgid "Full"
+msgstr "全体"
+
+#: scripts/apps/users/views/list.html:33
+msgid "Full name"
+msgstr "氏名"
+
+#: scripts/apps/authoring/authoring/components/toggleFullWithEditor.tsx:20
+msgid "Full width mode"
+msgstr "全幅モード"
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:69
+#: scripts/extensions/sams/dist/src/utils/assets.js:69
+#: scripts/extensions/sams/src/utils/assets.ts:81
+msgid "Full-screen preview"
+msgstr "全画面プレビュー"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:96
+msgid "Fullscreen"
+msgstr "全画面"
+
+#: scripts/apps/profiling/views/profiling.html:38
+msgid "Function"
+msgstr "機能"
+
+#: ../superdesk-planning/client/constants/assignments.ts:215
+msgid "Future Assignments"
+msgstr "今後のアサインメント"
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:247
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:247
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:317
+msgid "GB"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:199
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:191
+#: scripts/apps/legal-archive/views/legal_archive.html:52
+msgid "GUID"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:10
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:70
+#: scripts/apps/publish/views/subscribers.html:75
+#: scripts/apps/users/views/edit-form.html:16
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:12
+#: scripts/core/keyboard/keyboard.ts:400 scripts/core/keyboard/keyboard.ts:409
+msgid "General"
+msgstr "一般"
+
+#: scripts/apps/authoring/views/article-edit.html:580
+msgid "Generate From URL"
+msgstr "URLから生成"
+
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-parameters.html:1
+msgid "Generate a report showing activity on a desk."
+msgstr "デスクのアクティビティを示すレポートを生成します。"
+
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:1
+msgid ""
+"Generate a report showing average and maximum time it took to produce "
+"content per desk."
+msgstr "デスクごとのコンテンツ製作の平均・最大時間を示すレポートを生成します。"
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-parameters.html:1
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-parameters.html:1
+msgid "Generate a report showing statistics for published content."
+msgstr "公開済みコンテンツの統計を示すレポートを生成します。"
+
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-parameters.html:1
+msgid ""
+"Generate a report showing the time between original publish and update "
+"publish."
+msgstr "初回公開と更新公開の間の時間を示すレポートを生成します。"
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-parameters.html:1
+msgid ""
+"Generate a report showing updates to featuremedia items after initial "
+"publish."
+msgstr "初回公開後のフィーチャーメディアアイテムの更新を示すレポートを生成します。"
+
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-parameters.html:1
+msgid "Generate a report showing user activity."
+msgstr "ユーザーアクティビティを示すレポートを生成します。"
+
+#: scripts/apps/authoring-react/fields/embed/editor.tsx:40
+msgid "Generate from URL"
+msgstr "URLから生成"
+
+#: scripts/apps/publish/views/subscribers.html:318
+msgid "Generate token"
+msgstr "トークンを生成"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:188
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:191
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:399
+msgid "Generated name for created rundowns"
+msgstr "作成されたランダウンの自動生成名"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:534
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:127
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:443
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:102
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/ScheduledUpdateForm.tsx:132
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:221
+#: ../superdesk-planning/client/components/fields/editor/Genre.tsx:26
+#: ../superdesk-planning/client/components/fields/preview/index.ts:192
+#: ../superdesk-planning/client/utils/contentProfiles.ts:325
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:336
+#: scripts/apps/authoring-react/field-adapters/genre.ts:26
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:139
+#: scripts/apps/search/directives/SearchFilters.ts:45
+#: scripts/apps/search/services/SearchService.ts:72
+#: scripts/apps/workspace/content/constants.ts:30
+msgid "Genre"
+msgstr "ジャンル"
+
+#: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:102
+#: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:78
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Genre.tsx:18
+msgid "Genre:"
+msgstr "ジャンル："
+
+#: scripts/core/auth/reset-password.html:17
+msgid "Get token"
+msgstr "トークンを取得"
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:15
+msgid "Global"
+msgstr "グローバル"
+
+#: scripts/apps/content-filters/views/manage-filters.html:51
+msgid "Global Block"
+msgstr "グローバルブロック"
+
+#: scripts/apps/desks/views/desk-config-modal.html:249
+#: scripts/apps/desks/views/desk-config-modal.html:350
+msgid "Global Read"
+msgstr "グローバル読み取り"
+
+#: scripts/apps/desks/views/desk-config-modal.html:310
+msgid "Global Read:"
+msgstr "グローバル読み取り："
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-list.html:28
+msgid "Global Saved Reports"
+msgstr "グローバル保存済みレポート"
+
+#: scripts/apps/search/views/saved-searches.html:36
+msgid "Global Saved Searches"
+msgstr "グローバル保存済み検索"
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:66
+msgid "Global saved searches"
+msgstr "グローバル保存済み検索"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:97
+msgid "Globe"
+msgstr "地球"
+
+#: scripts/apps/legal-archive/views/legal_archive.html:94
+#: scripts/apps/search/views/item-globalsearch.html:19
+msgid "Go"
+msgstr "移動"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:268
+msgid "Go Back"
+msgstr "戻る"
+
+#: scripts/apps/master-desk/components/HeaderComponent.tsx:208
+msgid "Go To Desk"
+msgstr "デスクへ移動"
+
+#: scripts/apps/production-api-keys/utils.tsx:36
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:46
+#: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:36
+#: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:44
+msgid "Go back"
+msgstr "戻る"
+
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:41
+msgid "Go to content profiles"
+msgstr "コンテンツプロファイルへ移動"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:45
+msgid "Go to items"
+msgstr "アイテムへ移動"
+
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:133
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:92
+msgid "Go-To"
+msgstr "移動"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:98
+#: ../superdesk-planning/client/utils/index.ts:593
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:253
+msgid "Graphic"
+msgstr "グラフィック"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:50
+msgid "Gray"
+msgstr "グレー"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:52
+msgid "Gray Text"
+msgstr "グレーテキスト"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:59
+msgid "Green"
+msgstr "緑"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:99
+msgid "Grid View"
+msgstr "グリッド表示"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:100
+msgid "Grid View Large"
+msgstr "グリッド表示（大）"
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:298
+msgid "Group \"{{group}}\" and all its fields will be permanently deleted."
+msgstr "グループ「{{group}}」とそのすべてのフィールドが完全に削除されます。"
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:301
+msgid "Group \"{{group}}\" will be permanently deleted."
+msgstr "グループ「{{group}}」は完全に削除されます。"
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:2
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:2
+msgid "Group By"
+msgstr "グループ化"
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-parameters.html:7
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-parameters.html:7
+msgid "Group By:"
+msgstr "グループ化："
+
+#: scripts/apps/authoring-react/macros/macros.tsx:359
+#: scripts/apps/authoring/macros/views/macros-widget.html:3
+msgid "Group Macros"
+msgstr "グループマクロ"
+
+#: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:155
+msgid "Group by day"
+msgstr "日ごとにグループ化"
+
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:326
+msgid "Groups"
+msgstr "グループ"
+
+#: scripts/core/lang/missing-translations-strings.ts:22
+msgid "Groups Management"
+msgstr "グループ管理"
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:402
+msgid "Guid"
+msgstr "GUID"
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:20
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:79
+msgid "H1"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:21
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:80
+msgid "H2"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:22
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:81
+msgid "H3"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:23
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:82
+msgid "H4"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:24
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:83
+msgid "H5"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:25
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:84
+msgid "H6"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:47
+msgid "HEADLINE is too long"
+msgstr "HEADLINEが長すぎます"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/TimeInputs.tsx:45
+msgid "HOUR"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:161
+msgid "Half"
+msgstr "半分"
+
+#: scripts/core/auth/reset-password.html:69
+msgid "Have password? Sign in."
+msgstr "パスワードをお持ちですか？サインインしてください。"
+
+#: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:101
+msgid "Header fields"
+msgstr "ヘッダーフィールド"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:101
+msgid "Heading 1"
+msgstr "見出し1"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:102
+msgid "Heading 2"
+msgstr "見出し2"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:103
+msgid "Heading 3"
+msgstr "見出し3"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:104
+msgid "Heading 4"
+msgstr "見出し4"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:105
+msgid "Heading 5"
+msgstr "見出し5"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:106
+msgid "Heading 6"
+msgstr "見出し6"
+
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:67
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:57
+#: ../superdesk-planning/client/components/fields/preview/index.ts:259
+#: ../superdesk-planning/client/components/fields/resources/planning.ts:22
+#: ../superdesk-planning/client/utils/contentProfiles.ts:319
+#: scripts/apps/authoring-react/data-layer.ts:204
+#: scripts/apps/authoring-react/field-adapters/headline.ts:20
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-panel.tsx:134
+#: scripts/apps/authoring/views/theme-select.html:36
+#: scripts/apps/authoring/views/theme-select.html:87
+#: scripts/apps/content-filters/views/production-test-view.html:20
+#: scripts/apps/legal-archive/views/legal_archive.html:64
+#: scripts/apps/master-desk/components/FilterPanelComponent.tsx:141
+#: scripts/apps/packaging/views/sd-package-edit.html:4
+#: scripts/apps/publish/views/publish-queue.html:106
+#: scripts/apps/search/views/search-parameters.html:13
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:379
+#: scripts/apps/workspace/content/constants.ts:31
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:311
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:311
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:501
+msgid "Headline"
+msgstr "見出し"
+
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-tooltip.html:3
+msgid "Headline:"
+msgstr "見出し："
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines-widget.js:49
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/main-panel.js:14
+#: scripts/extensions/ai-widget/dist/src/headlines/headlines-widget.js:49
+#: scripts/extensions/ai-widget/dist/src/main-panel.js:14
+#: scripts/extensions/ai-widget/src/headlines/headlines-widget.tsx:74
+#: scripts/extensions/ai-widget/src/main-panel.tsx:25
+msgid "Headlines"
+msgstr "見出し"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:107
+msgid "Heart"
+msgstr "ハート"
+
+#: scripts/extensions/helloWorld/dist/src/extension.js:5
+#: scripts/extensions/helloWorld/dist/src/extensions/helloWorld/src/extension.js:5
+#: scripts/extensions/helloWorld/src/extension.ts:6
+msgid "Hello world"
+msgstr "Hello world"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:108
+msgid "Help Large"
+msgstr "ヘルプ（大）"
+
+#: scripts/apps/users/views/edit-form.html:238
+msgid "Help us translate Superdesk"
+msgstr "Superdeskの翻訳にご協力ください"
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:115
+msgid ""
+"Helper\n"
+"                                    text"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:395
+msgid "Helplines/Contact Information"
+msgstr ""
+
+#: scripts/apps/publish/views/email-config.html:11
+msgid "Hidden recipients (blind carbon copy)"
+msgstr "非表示の受信者（BCC）"
+
+#: ../superdesk-planning/client/components/fields/related_events.tsx:40
+msgid "Hide 1 event"
+msgid_plural "Hide {{n}} events"
+msgstr[0] "{{n}}件のイベントを非表示"
+
+#: ../superdesk-planning/client/components/fields/related_plannings.tsx:30
+msgid "Hide 1 planning item"
+msgid_plural "Hide {{n}} planning items"
+msgstr[0] "{{n}}件のプランニングアイテムを非表示"
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:250
+msgid "Hide Date"
+msgstr "日付を非表示"
+
+#: scripts/apps/authoring/views/article-edit.html:586
+msgid "Hide Preview"
+msgstr "プレビューを非表示"
+
+#: scripts/apps/authoring/preview/fullPreviewMultiple.tsx:46
+msgid "Hide media"
+msgstr "メディアを非表示"
+
+#: scripts/apps/authoring-react/fields/embed/editor.tsx:55
+msgid "Hide preview"
+msgstr "プレビューを非表示"
+
+#: scripts/apps/search/components/fields/nested-link.tsx:27
+msgid "Hide previous items"
+msgstr "前のアイテムを非表示"
+
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:6
+msgid "Hide sent/queued items"
+msgstr "送信済み/キュー中のアイテムを非表示"
+
+#: scripts/apps/publish/views/subscribers.html:209
+msgid "High priority"
+msgstr "高優先度"
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:35
+msgid "Highcharts {{licenseType}} License"
+msgstr "Highcharts {{licenseType}}ライセンス"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:109
+msgid "Highlight Package"
+msgstr "ハイライトパッケージ"
+
+#: scripts/apps/packaging/views/sd-package-items-edit.html:21
+msgid "Highlight Preview"
+msgstr "ハイライトプレビュー"
+
+#: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:159
+msgid "Highlight characters"
+msgstr "文字をハイライト"
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:15
+msgid "Highlight with name"
+msgstr "名前でハイライト"
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:219
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/manage-highlights.tsx:21
+#: scripts/apps/authoring-react/toolbar/highlights-modal.tsx:74
+#: scripts/apps/authoring/views/authoring-topbar.html:331
+#: scripts/apps/highlights/index.ts:61 scripts/apps/highlights/index.ts:83
+#: scripts/apps/highlights/views/package_highlights_dropdown_directive.html:2
+#: scripts/apps/templates/services/TemplatesService.ts:71
+msgid "Highlights"
+msgstr "ハイライト"
+
+#: scripts/apps/highlights/index.ts:70
+msgid "Highlights View"
+msgstr "ハイライト表示"
+
+#: scripts/apps/highlights/views/settings.html:4
+msgid "Highlights configurations"
+msgstr "ハイライト設定"
+
+#: scripts/core/lang/missing-translations-strings.ts:17
+msgid "Highlights/Summary List Management"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/Editor.tsx:63
+#: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:92
+#: scripts/apps/authoring/versioning/versioning.ts:8
+msgid "History"
+msgstr "履歴"
+
+#: scripts/core/lang/missing-translations-strings.ts:18
+msgid "Hold"
+msgstr "保留"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:110
+msgid "Home"
+msgstr "ホーム"
+
+#: scripts/apps/publish/views/ftp-config.html:2
+msgid "Host"
+msgstr "ホスト"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleHour.tsx:41
+msgid "Hour"
+msgstr "時間"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:127
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:213
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-parameters.html:24
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-preview.html:10
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:31
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:62
+#: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:20
+msgid "Hourly"
+msgstr "毎時"
+
+#: ../superdesk-planning/client/utils/filters.ts:42
+msgid "Hourly to {{ desk }}"
+msgstr "毎時{{ desk }}へ"
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:148
+#: scripts/core/ui/views/sd-timepicker-popup.html:9
+msgid "Hours"
+msgstr "時間"
+
+#: scripts/apps/users/directives/UserRolesDirective.ts:46
+msgid "I'm sorry but a role with that name already exists."
+msgstr "同じ名前のロールが既に存在します。"
+
+#: scripts/apps/users/directives/UserRolesDirective.ts:50
+msgid "I'm sorry but there was an error when saving the role."
+msgstr "ロールの保存中にエラーが発生しました。"
+
+#: scripts/apps/ingest/directives/IngestRoutingContent.ts:188
+msgid "I'm sorry but there was an error when saving the routing scheme."
+msgstr "ルーティングスキームの保存中にエラーが発生しました。"
+
+#: scripts/apps/ingest/directives/IngestRulesContent.ts:37
+msgid "I'm sorry but there was an error when saving the rule set."
+msgstr "ルールセットの保存中にエラーが発生しました。"
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:110
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:29
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:39
+msgid "ID"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:45
+msgid ""
+"ID\n"
+"                                must contain only letters, digits and "
+"characters -, _."
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:43
+msgid ""
+"ID conflicts\n"
+"                                with system field."
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:41
+msgid "ID must be unique."
+msgstr "IDは一意でなければなりません。"
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:93
+msgid "Icon"
+msgstr "アイコン"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:85
+msgid "Id: {{id}}"
+msgstr "ID：{{id}}"
+
+#: scripts/apps/publish/views/email-config.html:26
+msgid "Identifier for the media in the email template"
+msgstr "メールテンプレート内のメディア識別子"
+
+#: scripts/apps/publish/views/email-config.html:21
+msgid "Identifier for the media within the email html template"
+msgstr "メールHTMLテンプレート内のメディア識別子"
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:53
+msgid "Identifiers have to be specified for all items."
+msgstr "すべてのアイテムに識別子を指定する必要があります。"
+
+#: scripts/apps/workspace/content/views/profile-settings.html:173
+msgid ""
+"If enabled, it will be possible to embed articles using this content profile "
+"into other articles that accept embeds (configurable in content profile "
+"field settings)"
+msgstr "有効にすると、このコンテンツプロファイルを使用した記事を、埋め込みを受け入れる他の記事に埋め込むことができます（コンテンツプロファイルのフィールド設定で設定可能）"
+
+#: scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx:134
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx:194
+#: scripts/core/ui/views/sd-timezone.html:17
+msgid "If not set, the UTC+0 time zone is assumed."
+msgstr "未設定の場合、UTC+0タイムゾーンが使用されます。"
+
+#: scripts/apps/desks/views/desk-config-modal.html:84
+msgid "If selected, content published from this desk will be not be expired"
+msgstr "選択すると、このデスクから公開されたコンテンツは期限切れになりません"
+
+#: scripts/core/editor3/components/embeds/EmbedInput.tsx:153
+msgid "If you paste an embed code, it will be used \"as is\"."
+msgstr "埋め込みコードを貼り付けると、そのまま使用されます。"
+
+#: scripts/apps/users/views/settings-roles.html:55
+msgid ""
+"If you select a default role for content creation or editing,\n"
+"                        Superdesk will prefill the Authors field with user's "
+"name and the role.\n"
+"                        The roles are managed in <b>Author roles</b> "
+"controlled vocabulary in the Metadata section."
+msgstr ""
+
+#: ../superdesk-planning/client/components/ConfirmationModal.tsx:137
+#: ../superdesk-planning/client/components/FulFilAssignmentModal/index.tsx:104
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:176
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:48
+#: scripts/apps/desks/controllers/DeskConfigController.ts:96
+#: scripts/core/ui/components/IgnoreCancelSaveDialog.tsx:57
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:38
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:74
+msgid "Ignore"
+msgstr "無視"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:111
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:155
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:168
+msgid "Ignore changes?"
+msgstr "変更を無視しますか？"
+
+#: scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx:74
+msgid "Ignore word"
+msgstr "単語を無視"
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:233
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:235
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:107
+#: scripts/extensions/sams/dist/src/utils/assets.js:107
+#: scripts/extensions/sams/src/utils/assets.ts:142
+msgid "Image"
+msgstr "画像"
+
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:103
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:103
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:114
+msgid "Image Preview"
+msgstr "画像プレビュー"
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:82
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:185
+msgid "Image Width"
+msgstr "画像幅"
+
+#: scripts/core/upload/crop-directive.ts:41
+msgid ""
+"Image is bigger than {{maxFileSize}}MB, upload file size may be limited!"
+msgstr "画像が{{maxFileSize}}MBを超えています。アップロードファイルサイズが制限される場合があります。"
+
+#: scripts/apps/authoring/views/change-image.html:217
+msgid "Image size"
+msgstr "画像サイズ"
+
+#: scripts/api/article-fetch.tsx:111
+msgid "Image size validation failed"
+msgstr "画像サイズの検証に失敗しました"
+
+#: scripts/extensions/auto-tagging-widget/dist/src/ImageTaggingComponent/ImageTaggingComponent.js:199
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:199
+#: scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.tsx:297
+msgid ""
+"Image suggestions are based on generated tags and can be added to article "
+"content by dragging."
+msgstr "画像の候補は生成されたタグに基づいており、ドラッグして記事コンテンツに追加できます。"
+
+#: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:73
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:73
+#: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:56
+msgid "Images only"
+msgstr "画像のみ"
+
+#: scripts/apps/users/import/views/import-user.html:44
+msgid "Import"
+msgstr "インポート"
+
+#: scripts/apps/users/import/import.ts:50
+msgid "Import user"
+msgstr "ユーザーをインポート"
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/field-components/time-header-common.tsx:35
+msgid "In 1 hr"
+msgstr "1時間後"
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:104
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DateInputPopup.tsx:217
+#: scripts/core/ui/components/Form/DateInput/DateInputPopup.tsx:199
+msgid "In 2 days"
+msgstr "2日後"
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/field-components/time-header-common.tsx:46
+msgid "In 2 hr"
+msgstr "2時間後"
+
+#: scripts/apps/vocabularies/services/VocabularyService.ts:136
+msgid "In 3 days"
+msgstr "3日後"
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/field-components/time-header-common.tsx:24
+msgid "In 30 min"
+msgstr "30分後"
+
+#: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:32
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/State.tsx:36
+#: ../superdesk-planning/client/constants/assignments.ts:203
+#: ../superdesk-planning/client/utils/index.ts:390
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:10
+#: scripts/apps/master-desk/components/AssignmentsComponent.tsx:46
+#: scripts/apps/search/components/fields/state.tsx:35
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:298
+msgid "In Progress"
+msgstr "進行中"
+
+#: scripts/apps/authoring-react/data-layer.ts:428
+#: scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.ts:72
+msgid ""
+"In the story {{slugline}} sent at: {{date}}.{{lineBreak}}This is a corrected "
+"repeat."
+msgstr "記事{{slugline}}は{{date}}に送信されました。{{lineBreak}}これは修正された再送です。"
+
+#: ../superdesk-planning/client/utils/index.ts:335
+#: scripts/apps/contacts/components/ContactInfo.tsx:64
+#: scripts/apps/contacts/services/ContactsService.ts:62
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:92
+#: scripts/apps/publish/directives/SubscribersDirective.ts:67
+#: scripts/apps/users/controllers/UserListController.ts:158
+#: scripts/apps/workspace/content/views/profile-settings.html:62
+msgid "Inactive"
+msgstr "無効"
+
+#: scripts/apps/publish/views/email-config.html:17
+msgid "Include Feature Media"
+msgstr "フィーチャーメディアを含む"
+
+#: ../superdesk-planning/client/components/fields/editor/IncludeKilled.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:91
+msgid "Include Killed"
+msgstr "キル済みを含む"
+
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:303
+msgid "Include Rewrites"
+msgstr "書き直しを含む"
+
+#: ../superdesk-planning/client/components/fields/editor/IncludeScheduledUpdates.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:95
+msgid "Include Scheduled Updates"
+msgstr "スケジュール済み更新を含む"
+
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:175
+msgid "Include Spike"
+msgstr "スパイクを含む"
+
+#: ../superdesk-planning/client/components/fields/editor/SpikeState.tsx:31
+msgid "Include Spiked"
+msgstr "スパイク済みを含む"
+
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:358
+msgid "Include all locked items"
+msgstr "すべてのロック済みアイテムを含む"
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:64
+msgid "Include rewrites"
+msgstr "書き直しを含む"
+
+#: scripts/apps/search/views/search-parameters.html:152
+msgid "Include spiked content"
+msgstr "スパイク済みコンテンツを含む"
+
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:15
+msgid "Included Statistics"
+msgstr "含まれる統計"
+
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-preview.html:13
+msgid "Included Stats"
+msgstr "含まれる統計"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:372
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:425
+msgid "Incoming"
+msgstr "受信"
+
+#: scripts/apps/desks/views/desk-config-modal.html:386
+msgid "Incoming Rule"
+msgstr "受信ルール"
+
+#: scripts/apps/desks/views/desk-config-modal.html:334
+msgid "Incoming Rule:"
+msgstr "受信ルール："
+
+#: scripts/apps/desks/views/desk-config-modal.html:307
+#: scripts/apps/desks/views/desk-config-modal.html:362
+#: scripts/apps/workspace/content/constants.ts:57
+msgid "Incoming Stage"
+msgstr "受信ステージ"
+
+#: scripts/core/editor3/components/media/MediaBlock.tsx:17
+msgid "Indefinite Usage"
+msgstr "無期限使用"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:111
+msgid "Indent Left"
+msgstr "左インデント"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:112
+msgid "Indent Right"
+msgstr "右インデント"
+
+#: scripts/apps/authoring/metadata/metadata.ts:1420
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:21
+msgid "Info"
+msgstr "情報"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:113
+msgid "Info Large"
+msgstr "情報（大）"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:114
+msgid "Info Sign"
+msgstr "情報マーク"
+
+#: scripts/extensions/auto-tagging-widget/dist/src/ImageTaggingComponent/ImageTaggingComponent.js:199
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:199
+#: scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.tsx:293
+msgid "Information"
+msgstr "情報"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:115
+#: scripts/apps/ingest/index.ts:182 scripts/apps/ingest/index.ts:83
+#: scripts/apps/ingest/views/settings/settings.html:4
+#: scripts/apps/search/views/item-repo.html:3
+msgid "Ingest"
+msgstr "取り込み"
+
+#: scripts/core/lang/missing-translations-strings.ts:18
+msgid "Ingest Channels"
+msgstr "取り込みチャンネル"
+
+#: scripts/apps/ingest/index.ts:92
+#: scripts/apps/ingest/views/dashboard/dashboard.html:2
+msgid "Ingest Dashboard"
+msgstr "取り込みダッシュボード"
+
+#: scripts/apps/ingest/controllers/IngestDashboardController.ts:36
+msgid "Ingest Dashboard preferences could not be saved."
+msgstr "取り込みダッシュボードの設定を保存できませんでした。"
+
+#: scripts/apps/archive/views/metadata-view.html:26
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:263
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:84
+#: scripts/apps/publish/views/publish-queue.html:110
+#: scripts/apps/workspace/content/constants.ts:32
+msgid "Ingest Provider"
+msgstr "取り込みプロバイダー"
+
+#: scripts/apps/publish/views/publish-queue.html:30
+msgid "Ingest Provider:"
+msgstr "取り込みプロバイダー："
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:596
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:151
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:493
+msgid "Ingest Providers"
+msgstr "取り込みプロバイダー"
+
+#: scripts/apps/ingest/views/settings/settings.html:15
+msgid "Ingest Routing"
+msgstr "取り込みルーティング"
+
+#: scripts/apps/ingest/views/settings/settings.html:12
+msgid "Ingest Rule sets"
+msgstr "取り込みルールセット"
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:99
+msgid "Ingest Source"
+msgstr "取り込みソース"
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:353
+msgid "Ingest Source deleted."
+msgstr "取り込みソースが削除されました。"
+
+#: scripts/apps/ingest/views/settings/settings.html:9
+msgid "Ingest Sources"
+msgstr "取り込みソース"
+
+#: scripts/apps/ingest/ingest-stats-widget/stats.ts:9
+#: scripts/core/lang/missing-translations-strings.ts:44
+msgid "Ingest Stats"
+msgstr "取り込み統計"
+
+#: scripts/apps/archive/views/metadata-view.html:128
+msgid "Ingest provider sequence"
+msgstr "取り込みプロバイダーシーケンス"
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:270
+msgid "Ingest sequence"
+msgstr "取り込みシーケンス"
+
+#: ../superdesk-planning/client/components/AuditInformation/index.tsx:49
+msgid "Ingest: {{ name }}"
+msgstr "取り込み：{{ name }}"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:19
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:28
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:22
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:198
+#: ../superdesk-planning/client/utils/index.ts:351
+#: scripts/apps/search/components/fields/state.tsx:31
+msgid "Ingested"
+msgstr "取り込み済み"
+
+#: scripts/extensions/datetimeField/dist/src/config.js:24
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:24
+#: scripts/extensions/datetimeField/src/config.tsx:32
+msgid "Initial time offset"
+msgstr "初期時間オフセット"
+
+#: scripts/apps/authoring-react/article-widgets/inline-comments.tsx:9
+#: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:19
+#: scripts/apps/authoring/track-changes/inline-comments.ts:137
+msgid "Inline comments"
+msgstr "インラインコメント"
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:119
+msgid "Input Type"
+msgstr "入力タイプ"
+
+#: scripts/apps/authoring-react/fields/tag-input/editor.tsx:23
+msgid "Input tags here"
+msgstr "ここにタグを入力"
+
+#: scripts/core/editor3/components/links/LinkInput.tsx:221
+#: scripts/core/editor3/components/links/LinkInput.tsx:253
+msgid "Insert"
+msgstr "挿入"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:116
+#: scripts/apps/users/views/edit-form.html:312
+msgid "Instagram"
+msgstr "Instagram"
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:87
+msgid "Installed Version:"
+msgstr "インストール済みバージョン："
+
+#: scripts/apps/authoring/authoring/index.ts:474
+msgid "Instant Spellchecking, when automatic spellchecking turned off"
+msgstr "自動スペルチェックがオフの場合のインスタントスペルチェック"
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:181
+msgid "Insufficient privileges to view the assignment"
+msgstr "アサインメントを表示する権限がありません"
+
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:166
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:188
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:243
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:188
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:243
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:93
+#: scripts/extensions/sams/dist/src/utils/ui.js:93
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:230
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:309
+#: scripts/extensions/sams/src/utils/ui.tsx:68
+msgid "Internal"
+msgstr "内部"
+
+#: scripts/apps/internal-destinations/index.ts:13
+#: scripts/apps/internal-destinations/views/settings.html:5
+msgid "Internal Destinations"
+msgstr "内部送信先"
+
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/ScheduledUpdateForm.tsx:145
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:225
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:40
+#: ../superdesk-planning/client/components/fields/preview/index.ts:246
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:27
+#: ../superdesk-planning/client/utils/contentProfiles.ts:293
+msgid "Internal Note"
+msgstr "内部メモ"
+
+#: ../superdesk-planning/client/components/InternalNoteLabel/index.tsx:83
+msgid "Internal Note:"
+msgstr "内部メモ："
+
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-parameters.html:22
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-preview.html:9
+msgid "Interval"
+msgstr "間隔"
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/index.tsx:191
+msgid "Invalid Date"
+msgstr "無効な日付"
+
+#: scripts/apps/archive/controllers/file-upload-error-modal.tsx:73
+msgid "Invalid File : {{name}}"
+msgstr "無効なファイル：{{name}}"
+
+#: scripts/apps/users/views/edit-form.html:258
+msgid "Invalid format. Only Alphanumerics are allowed."
+msgstr "無効な形式です。英数字のみ使用できます。"
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:315
+msgid "Invalid time"
+msgstr "無効な時間"
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:146
+msgid "Invalid value for latitude"
+msgstr "緯度の値が無効です"
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:148
+msgid "Invalid value for longitude"
+msgstr "経度の値が無効です"
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:69
+#: ../superdesk-planning/client/components/fields/preview/index.ts:278
+#: ../superdesk-planning/client/components/fields/resources/events.ts:86
+#: ../superdesk-planning/client/utils/contentProfiles.ts:343
+msgid "Invitation Details"
+msgstr "招待の詳細"
+
+#: scripts/apps/search-providers/views/search-provider-config.html:41
+msgid "Is Default"
+msgstr "デフォルト"
+
+#: scripts/apps/archive/views/metadata-view.html:165
+msgid "Iso"
+msgstr "ISO"
+
+#: scripts/validate-instance-configuration.tsx:85
+msgid "Issue with extension \"{{id}}\":"
+msgid_plural "Issues with extension \"{{id}}\":"
+msgstr[0] "拡張機能「{{id}}」の問題："
+
+#: ../superdesk-planning/client/utils/confirmAddingRelatedItems.tsx:29
+msgid "Issues detected:"
+msgstr "問題が検出されました："
+
+#: scripts/apps/templates/views/create-template.html:26
+msgid "It will create a new template."
+msgstr "新しいテンプレートが作成されます。"
+
+#: scripts/apps/templates/views/create-template.html:25
+msgid "It will update existing template."
+msgstr "既存のテンプレートが更新されます。"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:117
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:31
+msgid "Italic"
+msgstr "斜体"
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:76
+msgid "Italic (Ctrl+I)"
+msgstr "斜体（Ctrl+I）"
+
+#: ../superdesk-planning/client/utils/index.ts:599
+msgid "Item"
+msgstr "アイテム"
+
+#: ../superdesk-planning/client/utils/planning.tsx:523
+msgid "Item \"{{name}}\" is already added as related"
+msgstr "アイテム「{{name}}」は既に関連として追加されています"
+
+#: ../superdesk-planning/client/utils/planning.tsx:511
+msgid "Item \"{{name}}\" is locked and can not be added as related"
+msgstr "アイテム「{{name}}」はロックされているため関連として追加できません"
+
+#: scripts/apps/archive/controllers/DuplicateController.ts:20
+#: scripts/apps/search/controllers/get-multi-actions.tsx:256
+msgid "Item Duplicated"
+msgstr "アイテムが複製されました"
+
+#: scripts/apps/ingest/controllers/ExternalSourceController.ts:25
+msgid "Item Fetched."
+msgstr "アイテムが取得されました。"
+
+#: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:56
+msgid "Item History"
+msgstr "アイテム履歴"
+
+#: scripts/apps/authoring-react/toolbar/translate-modal.tsx:80
+#: scripts/extensions/ai-widget/dist/src/extension.js:32
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/extension.js:32
+#: scripts/extensions/ai-widget/src/extension.ts:35
+msgid "Item Translated"
+msgstr "アイテムが翻訳されました"
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:73
+#: ../superdesk-planning/client/components/fields/editor/ItemType.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:104
+msgid "Item Type"
+msgstr "アイテムタイプ"
+
+#: ../superdesk-planning/client/actions/main.ts:1466
+#: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:206
+#: ../superdesk-planning/client/controllers/FulfilAssignmentController.tsx:172
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:106
+msgid "Item Unlocked"
+msgstr "アイテムのロックが解除されました"
+
+#: scripts/apps/search/components/Item.tsx:44
+#: scripts/core/ui/components/article-item-concise.tsx:78
+msgid "Item actions"
+msgstr "アイテムアクション"
+
+#: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:242
+#: ../superdesk-planning/client/controllers/FulfilAssignmentController.tsx:186
+msgid "Item already linked to a Planning item"
+msgstr "アイテムは既にプランニングアイテムにリンクされています"
+
+#: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:258
+#: ../superdesk-planning/client/controllers/FulfilAssignmentController.tsx:192
+#: ../superdesk-planning/client/controllers/UnlinkAssignmentController.tsx:38
+msgid "Item already locked."
+msgstr "アイテムは既にロックされています。"
+
+#: scripts/core/editor3/components/article-embed/can-add-article-embed.ts:30
+msgid "Item content profile is not configured to allow embedding."
+msgstr "アイテムのコンテンツプロファイルは埋め込みを許可する設定になっていません。"
+
+#: scripts/api/article-duplicate.tsx:42
+msgid "Item duplicated"
+msgid_plural "Items duplicated"
+msgstr[0] "アイテムが複製されました"
+
+#: scripts/apps/archive/directives/ArchivedItemKill.ts:47
+msgid "Item has been killed."
+msgstr "アイテムがキルされました。"
+
+#: scripts/apps/archive/directives/ResendItem.ts:39
+msgid "Item has been resent."
+msgstr "アイテムが再送されました。"
+
+#: ../superdesk-planning/client/actions/main.ts:1663 scripts/api/article.ts:294
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:445
+msgid ""
+"Item has changed since it was opened. Please close and reopen the item to "
+"continue. Regrettably, your changes cannot be saved."
+msgstr "アイテムが開かれた後に変更されました。続行するにはアイテムを閉じて再度開いてください。申し訳ございませんが、変更は保存できません。"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:60
+msgid "Item has not been transmitted to any subscriber"
+msgstr "アイテムはどの配信先にも送信されていません"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/index.tsx:41
+#: scripts/apps/authoring/versioning/views/versioning.html:6
+#: scripts/apps/legal-archive/views/legal_archive.html:127
+#: scripts/apps/search/views/item-preview.html:18
+msgid "Item history"
+msgstr "アイテム履歴"
+
+#: scripts/apps/packaging/directives/PackageItemsEdit.ts:21
+msgid "Item is already in this package."
+msgstr "アイテムは既にこのパッケージに含まれています。"
+
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:55
+#: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:55
+#: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:151
+msgid "Item is locked and marked user can not be changed."
+msgstr "アイテムがロックされているため、マークしたユーザーを変更できません。"
+
+#: scripts/apps/authoring/authoring/controllers/AssociationController.ts:299
+msgid "Item is locked. Cannot associate media item."
+msgstr "アイテムがロックされています。メディアアイテムを関連付けできません。"
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:120
+msgid "Item locked"
+msgstr "アイテムがロックされました"
+
+#: scripts/apps/highlights/services/HighlightsService.ts:125
+msgid "Item marked"
+msgstr "アイテムがマークされました"
+
+#: scripts/apps/authoring-react/fields/media/editor.tsx:134
+msgid "Item not added. Maximum limit of {{n}} items exceeded."
+msgstr "アイテムが追加されませんでした。最大{{n}}件の制限を超えています。"
+
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:65
+msgid "Item not found!"
+msgstr "アイテムが見つかりません。"
+
+#: scripts/apps/search/directives/ItemGlobalSearch.ts:49
+msgid "Item not found..."
+msgstr "アイテムが見つかりません..."
+
+#: ../superdesk-planning/client/controllers/UnlinkAssignmentController.tsx:27
+msgid "Item not linked to a Planning item."
+msgstr "アイテムはプランニングアイテムにリンクされていません。"
+
+#: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:205
+#: scripts/apps/search/views/item-preview.html:2
+msgid "Item preview"
+msgstr "アイテムプレビュー"
+
+#: scripts/api/article.ts:380
+msgid "Item published."
+msgstr "アイテムが公開されました。"
+
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:190
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:257
+msgid "Item saved."
+msgstr "アイテムが保存されました。"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:114
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:29
+msgid "Item sent to Subscriber"
+msgstr "アイテムが配信先に送信されました"
+
+#: scripts/apps/ingest/ingest-stats-widget/configuration.html:11
+msgid "Item type stats"
+msgstr "アイテムタイプ統計"
+
+#: scripts/apps/highlights/services/HighlightsService.ts:125
+msgid "Item unmarked"
+msgstr "アイテムのマークが解除されました"
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:299
+#: scripts/apps/authoring/multiedit/multiedit.ts:375
+msgid "Item updated."
+msgstr "アイテムが更新されました。"
+
+#: scripts/apps/authoring/authoring/controllers/AssociationController.ts:200
+msgid "Item was not added. Only 1 item is allowed for this field."
+msgid_plural ""
+"Item was not added. Only {{number}} items are allowed in this field."
+msgstr[0] "アイテムが追加されませんでした。このフィールドには最大{{number}}件のアイテムのみ許可されています。"
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:490
+msgid "Item was unpublished successfully."
+msgstr "アイテムの公開取り消しが成功しました。"
+
+#: scripts/apps/search/MultiImageEdit.ts:198
+msgid "Item {{headline}} unlocked by another user."
+msgstr "アイテム{{headline}}が別のユーザーによってロック解除されました。"
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:96
+msgid "Item {{headline}} was unlocked by {{username}}."
+msgstr "アイテム{{headline}}が{{username}}によってロック解除されました。"
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:15
+#: scripts/core/views/sdSearchList.html:36
+msgid "Items"
+msgstr "アイテム"
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:128
+msgid "Items Count"
+msgstr "アイテム数"
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:241
+msgid "Items Created"
+msgstr "作成済みアイテム"
+
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions-bulk.js:21
+#: scripts/extensions/markForUser/dist/src/get-article-actions-bulk.js:21
+#: scripts/extensions/markForUser/src/get-article-actions-bulk.tsx:26
+msgid "Items are marked for different users"
+msgstr "アイテムは異なるユーザーにマークされています"
+
+#: scripts/apps/dashboard/user-activity/user-activity.ts:22
+msgid "Items created by the user"
+msgstr "ユーザーが作成したアイテム"
+
+#: scripts/apps/dashboard/user-activity/user-activity.ts:25
+msgid "Items locked by the user"
+msgstr "ユーザーがロックしたアイテム"
+
+#: scripts/apps/dashboard/user-activity/user-activity.ts:28
+msgid "Items marked for the user"
+msgstr "ユーザーにマークされたアイテム"
+
+#: scripts/apps/dashboard/user-activity/user-activity.ts:31
+msgid "Items moved to a working stage by the user"
+msgstr "ユーザーがワーキングステージに移動したアイテム"
+
+#: scripts/api/article-fetch.tsx:131
+msgid "Items that can not be fetched"
+msgstr "取得できないアイテム"
+
+#: ../superdesk-analytics/client/email_report/directives/EmailReportModal.js:91
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsList.js:101
+msgid "JPEG Image"
+msgstr "JPEG画像"
+
+#: scripts/apps/users/views/edit-form.html:186
+msgid "Jabber Identifier (JID)"
+msgstr "Jabber ID（JID）"
+
+#: scripts/apps/contacts/constants.ts:73
+#: scripts/apps/contacts/views/search-panel.html:39
+#: scripts/apps/users/views/edit-form.html:277
+msgid "Job Title"
+msgstr "役職"
+
+#: ../superdesk-planning/client/components/Main/JumpToDropdown.tsx:61
+#: ../superdesk-planning/client/components/Main/JumpToDropdown.tsx:67
+msgid "Jump to specific date"
+msgstr "指定日に移動"
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/kill-action.tsx:9
+#: scripts/apps/authoring/views/authoring-topbar.html:158
+msgid "K"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:245
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:245
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:315
+msgid "KB"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:118
+msgid "Kanban View"
+msgstr "カンバン表示"
+
+#: scripts/core/keyboard/views/keyboard-modal.html:3
+msgid "Keyboard Shortcuts"
+msgstr "キーボードショートカット"
+
+#: ../superdesk-planning/client/components/fields/editor/Keywords.tsx:25
+#: ../superdesk-planning/client/components/fields/preview/index.ts:184
+#: ../superdesk-planning/client/utils/contentProfiles.ts:335
+#: scripts/apps/archive/views/preview.html:54
+#: scripts/apps/authoring-react/field-adapters/keywords.ts:25
+#: scripts/apps/authoring-react/field-adapters/keywords.ts:47
+#: scripts/apps/content-filters/views/production-test-view.html:21
+#: scripts/apps/search/views/search-parameters.html:229
+#: scripts/apps/workspace/content/constants.ts:33
+msgid "Keywords"
+msgstr "キーワード"
+
+#: ../superdesk-analytics/client/utils.js:162
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:119
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/kill-action.tsx:10
+#: scripts/apps/authoring/views/authoring-topbar.html:155
+#: scripts/apps/authoring/views/authoring-topbar.html:156
+#: scripts/apps/authoring/views/authoring-topbar.html:157
+#: scripts/apps/templates/services/TemplatesService.ts:69
+msgid "Kill"
+msgstr "キル"
+
+#: scripts/apps/authoring/authoring/index.ts:309
+msgid "Kill item"
+msgstr "アイテムをキル"
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:32
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:84
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:28
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:202
+#: ../superdesk-planning/client/utils/index.ts:363
+#: scripts/apps/search/components/fields/state.tsx:42
+msgid "Killed"
+msgstr "キル済み"
+
+#: scripts/apps/authoring/versioning/history/HistoryController.ts:184
+msgid "Killed by"
+msgstr "キル者"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:574
+msgid "Kills"
+msgstr "キル"
+
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:58
+#: scripts/apps/authoring-react/fields/date/config.tsx:37
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:143
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:87
+#: scripts/apps/workspace/content/views/profile-settings.html:115
+#: scripts/apps/workspace/content/views/profile-settings.html:150
+msgid "Label"
+msgstr "ラベル"
+
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:126
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/language.ts:36
+#: ../superdesk-planning/client/components/fields/editor/Language.tsx:75
+#: ../superdesk-planning/client/components/fields/preview/index.ts:108
+#: ../superdesk-planning/client/utils/contentProfiles.ts:267
+#: scripts/apps/archive/views/metadata-view.html:118
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:161
+#: scripts/apps/authoring-react/field-adapters/language.ts:14
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:44
+#: scripts/apps/desks/views/settings.html:90
+#: scripts/apps/templates/views/template-editor-modal.html:119
+#: scripts/apps/users/views/edit-form.html:19
+#: scripts/apps/users/views/edit-form.html:229
+#: scripts/apps/users/views/edit-form.html:234
+#: scripts/apps/workspace/content/constants.ts:34
+#: scripts/extensions/annotationsLibrary/dist/src/GetFields.js:14
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/GetFields.js:14
+#: scripts/extensions/annotationsLibrary/src/GetFields.ts:15
+msgid "Language"
+msgstr "言語"
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:31
+msgid "Language code"
+msgstr "言語コード"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Language.tsx:17
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx:209
+msgid "Language:"
+msgstr "言語："
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:158
+#: scripts/apps/search/views/search-filters.html:18
+msgid "Languages"
+msgstr "言語"
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-footer.js:32
+#: scripts/extensions/ai-widget/dist/src/translations/translations-footer.js:32
+#: scripts/extensions/ai-widget/src/translations/translations-footer.tsx:50
+msgid "Languages are not available."
+msgstr "言語が利用できません。"
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:76
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:11
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:17
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:23
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:5
+#: ../superdesk-planning/client/utils/filters.ts:119
+#: scripts/apps/highlights/views/highlights_config_modal.html:45
+msgid "Last"
+msgstr "最後"
+
+#: scripts/apps/search/directives/DateFilters.ts:47
+msgid "Last 24 Hours"
+msgstr "過去24時間"
+
+#: scripts/apps/search/directives/DateFilters.ts:31
+msgid "Last 30 Days"
+msgstr "過去30日間"
+
+#: scripts/apps/search/directives/DateFilters.ts:39
+msgid "Last 7 Days"
+msgstr "過去7日間"
+
+#: scripts/apps/search/directives/DateFilters.ts:55
+msgid "Last 8 Hours"
+msgstr "過去8時間"
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:63
+#: scripts/core/lang/missing-translations-strings.ts:20
+msgid "Last Day"
+msgstr "最終日"
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:34
+msgid "Last Item Arrived"
+msgstr "最後のアイテム到着"
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:27
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:20
+#: scripts/core/lang/missing-translations-strings.ts:21
+msgid "Last Month"
+msgstr "先月"
+
+#: scripts/apps/contacts/constants.ts:69
+#: scripts/apps/contacts/views/search-panel.html:22
+#: scripts/core/directives/views/phone-home-modal-directive.html:24
+msgid "Last Name"
+msgstr "姓"
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:30
+msgid "Last Time Updated"
+msgstr "最終更新日時"
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:14
+msgid "Last Updated"
+msgstr "最終更新"
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:22
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:14
+#: scripts/core/lang/missing-translations-strings.ts:26
+msgid "Last Week"
+msgstr "先週"
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:31
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:26
+msgid "Last Year"
+msgstr "昨年"
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/PreviewArticle.tsx:83
+#: scripts/apps/authoring/preview/fullPreview.tsx:77
+msgid "Last modified"
+msgstr "最終更新"
+
+#: scripts/apps/profiling/views/profiling.html:24
+#: scripts/apps/publish/views/publish-queue.html:78
+msgid "Last refreshed at"
+msgstr "最終更新日時"
+
+#: scripts/apps/search/views/saved-search-subscribe.html:21
+msgid "Last report sent on:"
+msgstr "最終レポート送信日："
+
+#: scripts/apps/archive/views/metadata-view.html:93
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:381
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:171
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:38
+#: scripts/apps/production-api-keys/ProductionApiItem.tsx:33
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:1054
+msgid "Last updated"
+msgstr "最終更新"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:735
+msgid "Last {{days}} days"
+msgstr "過去{{days}}日間"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:728
+msgid "Last {{hours}} hours"
+msgstr "過去{{hours}}時間"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:780
+msgid "Last {{months}} months"
+msgstr "過去{{months}}か月間"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:751
+msgid "Last {{weeks}} weeks"
+msgstr "過去{{weeks}}週間"
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:301
+msgid "Latitude"
+msgstr "緯度"
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:50
+msgid ""
+"Learn more about Superdesk at <a href=\"https://www.superdesk.org/\" "
+"title=\"Superdesk\" target=\"_blank\">www.superdesk.org</a>. For help and "
+"support, join the discussion on <a href=\"https://forum.sourcefabric.org/"
+"categories/superdesk-dev\" title=\"Superdesk forum\" "
+"target=\"_blank\">Superdesk forums</a>."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/toggleFullWithEditor.tsx:20
+msgid "Leave full width mode"
+msgstr "全幅モードを終了"
+
+#: scripts/apps/archive/views/item-preview.html:10
+#: scripts/apps/archive/views/metadata-view.html:193
+#: scripts/apps/archive/views/preview.html:41
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:128
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:237
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:26
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:31
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:79
+#: scripts/apps/authoring/views/authoring-header.html:62
+#: scripts/apps/search/components/MediaInfo.tsx:61
+#: scripts/apps/search/components/fields/flags.tsx:23
+#: scripts/apps/search/components/fields/flags.tsx:25
+#: scripts/apps/search/views/search-filters.html:122
+#: scripts/apps/templates/views/template-editor-modal.html:108
+#: scripts/core/itemList/views/relatedItem-list-widget.html:33
+msgid "Legal"
+msgstr "法務"
+
+#: scripts/apps/legal-archive/index.ts:37
+msgid "Legal Archive"
+msgstr "法的アーカイブ"
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:70
+msgid "License ID:"
+msgstr "ライセンスID："
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:45
+msgid "License Type"
+msgstr "ライセンスタイプ"
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:56
+msgid "Licensee Contact:"
+msgstr "ライセンシー連絡先："
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:50
+msgid "Licensee:"
+msgstr "ライセンシー："
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:53
+msgid "Light Gray"
+msgstr "ライトグレー"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:54
+msgid "Lighter Gray"
+msgstr "より薄いグレー"
+
+#: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:163
+msgid "Limit further typing"
+msgstr "入力を制限"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:99
+msgid "Line"
+msgstr "行"
+
+#: ../superdesk-analytics/client/utils.js:160
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:120
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:29
+#: scripts/core/editor3/components/toolbar/TableControls.tsx:118
+msgid "Link"
+msgstr "リンク"
+
+#: scripts/core/editor3/components/toolbar/index.tsx:287
+msgid "Link (Ctrl+K)"
+msgstr "リンク（Ctrl+K）"
+
+#: scripts/core/editor3/components/links/LinkToolbar.tsx:52
+msgid "Link controls:"
+msgstr "リンク操作："
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:276
+msgid "Link has been removed"
+msgstr "リンクが削除されました"
+
+#: scripts/core/auth/auth.ts:103
+msgid "Link sent. Please check your email inbox."
+msgstr "リンクを送信しました。メールの受信箱を確認してください。"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/index.tsx:186
+#: ../superdesk-planning/client/planning-extension/src/extension.ts:204
+#: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:172
+msgid "Link to Assignment"
+msgstr "アサインメントにリンク"
+
+#: scripts/apps/authoring/versioning/history/views/history.html:131
+msgid "Linked by"
+msgstr "リンク者"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:398
+msgid "Linked by {{user}}"
+msgstr "{{user}}がリンク"
+
+#: scripts/apps/authoring-react/fields/linked-items/index.tsx:28
+msgid "Linked items (authoring-react)"
+msgstr "リンクされたアイテム（authoring-react）"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:121
+msgid "LinkedIn"
+msgstr "LinkedIn"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:122
+msgid "LinkedIn Circle"
+msgstr "LinkedIn（丸）"
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/link-field.ts:14
+#: ../superdesk-planning/client/components/fields/editor/EventLinks.tsx:62
+#: ../superdesk-planning/client/components/fields/resources/events.ts:53
+#: ../superdesk-planning/client/utils/contentProfiles.ts:299
+msgid "Links"
+msgstr "リンク"
+
+#: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:78
+msgid "List"
+msgstr "リスト"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:123
+msgid "List Alternate"
+msgstr "リスト（代替）"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:124
+msgid "List Menu"
+msgstr "リストメニュー"
+
+#: scripts/apps/vocabularies/services/SchemaFactory.ts:9
+msgid "List Name"
+msgstr "リスト名"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:125
+msgid "List Plus"
+msgstr "リ���ト追加"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:126
+#: scripts/apps/desks/directives/DeskConfigModal.ts:34
+#: scripts/apps/search-providers/directive.ts:16
+#: scripts/apps/search/views/search.html:17
+#: scripts/apps/search/views/search.html:18
+#: scripts/apps/users/directives/UserPreferencesDirective.ts:28
+#: scripts/apps/users/directives/UserPreferencesDirective.ts:30
+msgid "List View"
+msgstr "リスト表示"
+
+#: scripts/apps/monitoring/directives/utils.ts:88
+msgid "List view"
+msgstr "リスト表示"
+
+#: scripts/apps/authoring/suggest/SuggestView.html:4
+msgid "Live Suggestions"
+msgstr "ライブ候補"
+
+#: scripts/apps/authoring/views/authoring-topbar.html:278
+msgid "Live suggestions"
+msgstr "ライブ候補"
+
+#: scripts/apps/stream/views/activity-stream.html:30
+msgid "Load more"
+msgstr "さらに読み込む"
+
+#: ../superdesk-planning/client/components/Main/ListPanel.tsx:338
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModalSubnav.tsx:52
+#: scripts/core/menu/notifications/views/notifications.html:17
+msgid "Loading"
+msgstr "読み込み中"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentGroupList.tsx:350
+msgid "Loading more..."
+msgstr "さらに読み込み中..."
+
+#: scripts/apps/publish-preview/previewModal.tsx:45
+msgid "Loading preview"
+msgstr "プレビューを読み込み中"
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditor.js:78
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditor.js:78
+#: scripts/extensions/videoEditor/src/VideoEditor.tsx:132
+msgid "Loading video..."
+msgstr "動画を読み込み中..."
+
+#: scripts/apps/dashboard/views/workspace.html:63
+#: scripts/apps/search/components/ItemList.tsx:511
+#: scripts/apps/users/views/user-list-item.html:36
+#: scripts/core/list/views/list-view.html:2
+#: scripts/core/ui/components/select2.tsx:192
+msgid "Loading..."
+msgstr "読み込み中..."
+
+#: scripts/apps/desks/views/desk-config-modal.html:354
+msgid "Local Read Only"
+msgstr "ローカル読み取り専用"
+
+#: scripts/apps/desks/views/desk-config-modal.html:315
+msgid "Local Read Only:"
+msgstr "ローカル読み取り専用："
+
+#: scripts/apps/desks/views/desk-config-modal.html:252
+msgid "Local Readonly"
+msgstr "ローカル読み取り専用"
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:260
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:56
+msgid "Locality"
+msgstr "地域"
+
+#: scripts/core/lang/missing-translations-strings.ts:14
+#: scripts/core/lang/missing-translations-strings.ts:31
+msgid "Located"
+msgstr "所在地"
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/locations-field.ts:19
+#: ../superdesk-planning/client/components/fields/editor/Location.tsx:49
+#: ../superdesk-planning/client/components/fields/preview/Location.tsx:19
+#: ../superdesk-planning/client/components/fields/preview/index.ts:113
+#: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/location/index.tsx:25
+#: ../superdesk-planning/client/utils/contentProfiles.ts:283
+msgid "Location"
+msgstr "ロケーション"
+
+#: ../superdesk-planning/client/components/fields/editor/Location.tsx:62
+msgid "Location Details"
+msgstr "ロケーション詳細"
+
+#: ../superdesk-planning/client/api/locations.ts:86
+msgid "Location deleted"
+msgstr "ロケーションが削除されました"
+
+#: ../superdesk-planning/client/controllers/LocationsController.tsx:27
+msgid "Locations"
+msgstr "ロケーション"
+
+#: ../superdesk-planning/client/apps/LocationsApp.tsx:13
+msgid "Locations Content"
+msgstr "ロケーションコンテンツ"
+
+#: ../superdesk-analytics/client/utils.js:170
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:127
+msgid "Lock"
+msgstr "ロック"
+
+#: ../superdesk-planning/client/components/fields/editor/LockState.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:117
+msgid "Lock State"
+msgstr "ロック状態"
+
+#: ../superdesk-planning/client/components/fields/editor/LockState.tsx:18
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:147
+#: scripts/apps/authoring/views/article-edit.html:460
+msgid "Locked"
+msgstr "ロック済み"
+
+#: scripts/apps/archive/views/item-lock.html:7
+#: scripts/apps/authoring-react/subcomponents/lock-info-generic.tsx:47
+#: scripts/apps/authoring-react/subcomponents/lock-info.tsx:48
+#: scripts/apps/authoring/views/authoring-topbar.html:20
+msgid "Locked by"
+msgstr "ロック者"
+
+#: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:91
+msgid "Locked by this user"
+msgstr "このユーザーがロック中"
+
+#: scripts/apps/archive/views/item-lock.html:19
+msgid "Locked by you in another browser"
+msgstr "別のブラウザでロック中"
+
+#: scripts/core/auth/login-modal.html:21
+msgid "Log In"
+msgstr "ログイン"
+
+#: scripts/core/auth/login-modal.html:57
+msgid "Log In with Google"
+msgstr "Googleでログイン"
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:41
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:87
+msgid "Log Messages"
+msgstr "ログメッセージ"
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:239
+#: ../superdesk-planning/client/components/fields/resources/events.ts:20
+msgid "Long Description"
+msgstr "長い説明"
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:310
+msgid "Longitude"
+msgstr "経度"
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:19
+msgid "Lowercase"
+msgstr "小文字"
+
+#: ../superdesk-planning/client/components/Main/CalendarNavigation.tsx:66
+msgid "M"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:72
+msgid "MASTER"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:246
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:246
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:316
+msgid "MB"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:75
+msgid "MO"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:411
+msgid "MORE"
+msgstr ""
+
+#: scripts/apps/desks/views/actionpicker.html:26
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:59
+msgid "Macro"
+msgstr "マクロ"
+
+#: scripts/apps/authoring/macros/macros.ts:399
+#: scripts/apps/desks/views/desk-config-modal.html:465
+msgid "Macros"
+msgstr "マクロ"
+
+#: scripts/apps/authoring-react/macros/macros.tsx:37
+msgid "Macros widget"
+msgstr "マクロウィジェット"
+
+#: scripts/core/menu/views/menu.html:85
+msgid "Main menu"
+msgstr "メインメニュー"
+
+#: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:26
+msgid "Make Global"
+msgstr "グローバルにする"
+
+#: scripts/apps/templates/views/template-editor-modal.html:59
+msgid "Make Public"
+msgstr "公開にする"
+
+#: scripts/apps/search/views/save-search-dialog.html:14
+msgid "Make global"
+msgstr "グローバルにする"
+
+#: scripts/apps/users/views/change-avatar.html:53
+msgid "Make sure you're looking the best"
+msgstr "最高の見た目を心がけましょう"
+
+#: scripts/apps/production-api-keys/utils.tsx:45
+msgid ""
+"Make sure you've saved your Client Secret.You won't be able to access it "
+"again after closing"
+msgstr "クライアントシークレットを保存してください。閉じた後は再度アクセスできなくなります"
+
+#: scripts/apps/search/views/search-panel.html:45
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/availability-settings.js:190
+#: scripts/extensions/availability-manager/dist/src/settings/availability-settings.js:190
+#: scripts/extensions/availability-manager/src/settings/availability-settings.tsx:330
+msgid "Manage"
+msgstr "管理"
+
+#: ../superdesk-planning/client/components/Agendas/ManageAgendasModal.tsx:67
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:22
+msgid "Manage Agendas"
+msgstr "アジェンダを管理"
+
+#: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:211
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:34
+msgid "Manage Coverage Profiles"
+msgstr "取材プロファイルを管理"
+
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:96
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:66
+msgid "Manage Custom Layouts"
+msgstr "カスタムレイアウトを管理"
+
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:59
+msgid "Manage Event & Planning Filters"
+msgstr "イベントとプランニングフィルターを管理"
+
+#: ../superdesk-planning/client/api/contentProfiles.ts:210
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:43
+msgid "Manage Event Profile"
+msgstr "イベントプロファイルを管理"
+
+#: ../superdesk-planning/client/components/Events/ManageEventTemplatesModal.tsx:96
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:50
+msgid "Manage Event Templates"
+msgstr "イベントテンプレートを管理"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:202
+msgid "Manage Events & Planning Filters"
+msgstr "イベントとプランニングフィルターを管理"
+
+#: scripts/core/lang/missing-translations-strings.ts:18
+msgid "Manage Global Saved Searches"
+msgstr "グローバル保存済み検索を管理"
+
+#: ../superdesk-planning/index.ts:28 ../superdesk-planning/index.ts:29
+msgid "Manage Locations"
+msgstr "ロケーションを管理"
+
+#: ../superdesk-planning/client/api/contentProfiles.ts:183
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:29
+msgid "Manage Planning Profile"
+msgstr "プランニングプロファイルを管理"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:144
+#: scripts/extensions/broadcasting/dist/src/page.js:148
+#: scripts/extensions/broadcasting/src/page.tsx:209
+msgid "Manage Rundown Templates"
+msgstr "ランダウンテンプレートを管理"
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:243
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:243
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:349
+msgid "Manage SAMS"
+msgstr "SAMSを管理"
+
+#: scripts/core/lang/missing-translations-strings.ts:18
+msgid "Manage Search Providers"
+msgstr "検索プロバイダーを管理"
+
+#: scripts/extensions/sams/dist/src/components/sets/manageSetsModal.js:99
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:118
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/manageSetsModal.js:99
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:118
+#: scripts/extensions/sams/src/components/sets/manageSetsModal.tsx:94
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:140
+msgid "Manage Sets"
+msgstr "セットを管理"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:151
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:153
+#: scripts/extensions/broadcasting/dist/src/page.js:155
+#: scripts/extensions/broadcasting/dist/src/page.js:157
+#: scripts/extensions/broadcasting/src/page.tsx:223
+#: scripts/extensions/broadcasting/src/page.tsx:228
+msgid "Manage Shows"
+msgstr "ショーを管理"
+
+#: scripts/core/menu/views/menu.html:72
+msgid "Manage profile"
+msgstr "プロファイルを管理"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:146
+#: scripts/extensions/broadcasting/dist/src/page.js:150
+#: scripts/extensions/broadcasting/src/page.tsx:214
+msgid "Manage rundown templates"
+msgstr "ランダウンテンプレートを管理"
+
+#: scripts/apps/search/views/saved-search-subscribe.html:5
+#: scripts/apps/search/views/saved-searches.html:27
+#: scripts/apps/search/views/saved-searches.html:56
+msgid "Manage subscription"
+msgstr "サブスクリプションを管理"
+
+#: scripts/apps/users/config.ts:145
+msgid "Manage user roles"
+msgstr "ユーザーロールを管理"
+
+#: scripts/apps/users/config.ts:135
+msgid "Manage users"
+msgstr "ユーザーを管理"
+
+#: scripts/apps/search/views/saved-search-manage-subscribers.html:5
+msgid "Manage:"
+msgstr "管理："
+
+#: scripts/apps/authoring-react/fields/dropdown/config-main.tsx:86
+msgid "Manual entry"
+msgstr "手動入力"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:128
+msgid "Map Marker"
+msgstr "マップマーカー"
+
+#: ../superdesk-analytics/client/utils.js:172
+msgid "Mark"
+msgstr "マーク"
+
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:38
+#: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:38
+#: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:111
+msgid "Mark and send"
+msgstr "マークして送信"
+
+#: ../superdesk-planning/client/constants/events.ts:162
+msgid "Mark as Postponed"
+msgstr "延期としてマーク"
+
+#: ../superdesk-planning/client/constants/events.ts:170
+#: ../superdesk-planning/client/utils/assignments.ts:263
+msgid "Mark as completed"
+msgstr "完了としてマーク"
+
+#: scripts/extensions/markForUser/dist/src/extension.js:44
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/extension.js:44
+#: scripts/extensions/markForUser/src/extension.tsx:51
+msgid "Mark for User"
+msgstr "ユーザーにマーク"
+
+#: scripts/apps/desks/index.ts:60 scripts/apps/monitoring/index.ts:130
+msgid "Mark for desk"
+msgstr "デスクにマーク"
+
+#: scripts/apps/highlights/index.ts:46 scripts/apps/monitoring/index.ts:129
+msgid "Mark for highlight"
+msgstr "ハイライトにマーク"
+
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions.js:29
+#: scripts/extensions/markForUser/dist/src/get-article-actions.js:29
+#: scripts/extensions/markForUser/src/get-article-actions.tsx:32
+msgid "Mark for other user"
+msgstr "他のユーザーにマーク"
+
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions-bulk.js:24
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions.js:13
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:19
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:27
+#: scripts/extensions/markForUser/dist/src/get-article-actions-bulk.js:24
+#: scripts/extensions/markForUser/dist/src/get-article-actions.js:13
+#: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:19
+#: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:27
+#: scripts/extensions/markForUser/src/get-article-actions-bulk.tsx:30
+#: scripts/extensions/markForUser/src/get-article-actions.tsx:14
+#: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:61
+#: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:91
+msgid "Mark for user"
+msgstr "ユーザーにマーク"
+
+#: scripts/core/lang/missing-translations-strings.ts:19
+msgid "Mark items for Highlights/Summary Lists"
+msgstr "��イライト/サマリーリスト用にアイテムをマーク"
+
+#: scripts/apps/search/constants.ts:17
+#: scripts/apps/search/views/search-parameters.html:71
+msgid "Marked Desks"
+msgstr "マーク済みデスク"
+
+#: scripts/apps/archive/views/marked_item_title.html:13
+#: scripts/apps/search/components/HighlightsList.tsx:74
+#: scripts/apps/search/components/MarkedDesksList.tsx:86
+msgid "Marked For"
+msgstr "マーク先"
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:311
+msgid "Marked For Not Publication"
+msgstr "非公開としてマーク"
+
+#: scripts/apps/authoring/versioning/history/views/history.html:88
+msgid "Marked by"
+msgstr "マーク者"
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/marked-desks.tsx:11
+#: scripts/apps/authoring-react/toolbar/highlights-management.tsx:74
+msgid "Marked for"
+msgstr "マーク先"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:319
+msgid "Marked for desk {{x}} by {{user}}"
+msgstr "{{user}}がデスク{{x}}にマーク"
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:256
+#: scripts/apps/authoring-react/toolbar/mark-for-desks/mark-for-desks-modal.tsx:37
+#: scripts/apps/authoring/views/authoring-topbar.html:337
+msgid "Marked for desks"
+msgstr "デスクにマーク済み"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:285
+msgid "Marked for highlight {{x}} by {{user}}"
+msgstr "{{user}}がハイライト{{x}}にマーク"
+
+#: scripts/extensions/markForUser/dist/src/extension.js:19
+#: scripts/extensions/markForUser/dist/src/extension.js:64
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/extension.js:19
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/extension.js:64
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-marked-for-me-component.js:101
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-marked-for-me-component.js:99
+#: scripts/extensions/markForUser/dist/src/get-marked-for-me-component.js:101
+#: scripts/extensions/markForUser/dist/src/get-marked-for-me-component.js:99
+#: scripts/extensions/markForUser/src/extension.tsx:26
+#: scripts/extensions/markForUser/src/extension.tsx:71
+#: scripts/extensions/markForUser/src/get-marked-for-me-component.tsx:140
+#: scripts/extensions/markForUser/src/get-marked-for-me-component.tsx:148
+msgid "Marked for me"
+msgstr "自分用にマーク済み"
+
+#: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:99
+msgid "Marked for this user"
+msgstr "このユーザー用にマーク済み"
+
+#: scripts/apps/master-desk/index.ts:12 scripts/apps/master-desk/index.ts:23
+msgid "Master Desk"
+msgstr "マスターデスク"
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:7
+msgid "Match Any"
+msgstr "いずれかに一致"
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:8
+msgid "Match Prefix"
+msgstr "プレフィックスに一致"
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:97
+msgid "Max"
+msgstr "最大"
+
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:147
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:147
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:149
+msgid "Max Asset Size"
+msgstr "最大アセットサイズ"
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:272
+msgid "Max. number of items"
+msgstr "最大アイテム数"
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:280
+#: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:31
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:28
+#: scripts/apps/publish/views/subscribers.html:193
+msgid "Maximum"
+msgstr "最大"
+
+#: scripts/apps/content-filters/views/manage-filters.html:44
+msgid "Maximum 80 characters."
+msgstr "最大80文字。"
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:241
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:241
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:301
+msgid "Maximum Asset Size"
+msgstr "最大アセットサイズ"
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:25
+msgid "Maximum items allowed"
+msgstr "許可される最大アイテム数"
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:44
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:216
+msgid "Maximum length"
+msgstr "最大文字数"
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:226
+msgid "Maximum soft length"
+msgstr "ソフト最大文字数"
+
+#: scripts/apps/authoring-react/field-adapters/_media_self.ts:29
+#: scripts/apps/publish/views/subscribers.html:147
+#: scripts/apps/workspace/content/constants.ts:35
+#: scripts/core/editor3/components/toolbar/index.tsx:302
+msgid "Media"
+msgstr "メディア"
+
+#: scripts/apps/authoring-react/fields/media/index.tsx:21
+msgid "Media (authoring-react)"
+msgstr "メディア（authoring-react）"
+
+#: scripts/apps/contacts/index.ts:22
+msgid "Media Contacts"
+msgstr "メディア連絡先"
+
+#: scripts/apps/publish/views/subscribers.html:143
+msgid "Media Type"
+msgstr "メディアタイプ"
+
+#: scripts/apps/vocabularies/constants.ts:18
+msgid "Media gallery"
+msgstr "メディアギャラリー"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:57
+msgid "Medium Blue"
+msgstr "ミディアムブルー"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:49
+msgid "Medium Gray"
+msgstr "ミディアムグレー"
+
+#: scripts/apps/users/views/edit-form.html:61
+msgid "Member since"
+msgstr "登録日"
+
+#: scripts/core/editor3/highlightsConfig.ts:92
+msgid "Merge paragraphs"
+msgstr "段落を結合"
+
+#: scripts/apps/publish/views/publish-queue.html:116
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:69
+msgid "Message"
+msgstr "メッセージ"
+
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:82
+msgid "Message Group ID"
+msgstr "メッセージグループID"
+
+#: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:66
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:19
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:3
+#: scripts/apps/authoring/views/change-image.html:153
+#: scripts/apps/content-filters/views/production-test-view.html:55
+#: scripts/apps/legal-archive/views/legal_archive.html:123
+#: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:77
+#: scripts/apps/packaging/views/search-widget-preview.html:8
+#: scripts/apps/search/views/item-preview.html:12
+#: scripts/apps/search/views/multi-image-edit.html:88
+#: scripts/apps/templates/views/template-editor-modal.html:102
+#: scripts/apps/vocabularies/index.ts:43
+msgid "Metadata"
+msgstr "メタデータ"
+
+#: scripts/apps/vocabularies/views/settings.html:4
+msgid "Metadata management"
+msgstr "メタデータ管理"
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:86
+msgid "Min"
+msgstr "最小"
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:485
+#: ../superdesk-planning/client/constants/tooltips.ts:33
+msgid "Minimise"
+msgstr "最小化"
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/minimize-button.tsx:12
+#: scripts/apps/authoring/views/authoring-topbar.html:248
+#: scripts/apps/authoring/views/authoring-topbar.html:249
+msgid "Minimize"
+msgstr "最小化"
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:277
+#: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:28
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:20
+#: scripts/apps/publish/views/subscribers.html:184
+msgid "Minimum"
+msgstr "最小"
+
+#: scripts/api/article-fetch.tsx:122
+#: scripts/apps/archive/controllers/file-upload-error-modal.tsx:44
+msgid "Minimum allowed image size is {{minWidth}}x{{minHeight}}"
+msgstr "許可される最小画像サイズは{{minWidth}}x{{minHeight}}です"
+
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:213
+msgid "Minimum height and width should be greater than or equal to 200"
+msgstr "高さと幅の最小値は200以上でなければなりません"
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:32
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:206
+msgid "Minimum length"
+msgstr "最小文字数"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:129
+msgid "Minus Sign"
+msgstr "マイナス記号"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:130
+msgid "Minus Small"
+msgstr "マイナス（小）"
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:162
+#: scripts/core/ui/views/sd-timepicker-popup.html:15
+msgid "Minutes"
+msgstr "分"
+
+#: scripts/apps/authoring-react/macros/macros.tsx:71
+msgid "Miscellaneous"
+msgstr "その他"
+
+#: scripts/apps/authoring/views/authoring-header.html:61
+msgid "Missing Link"
+msgstr "リンク切れ"
+
+#: ../superdesk-planning/client/utils/filters.ts:133
+msgid "Mo"
+msgstr "月"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:131
+msgid "Mobile"
+msgstr "携帯"
+
+#: scripts/apps/archive/views/preview.html:9
+#: scripts/apps/authoring-react/fields/attachments/difference-row.tsx:30
+#: scripts/apps/authoring/authoring/modified-info.tsx:20
+msgid "Modified"
+msgstr "更新済み"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:96
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:96
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:182
+msgid "Modified at {{time}} by {{user}}"
+msgstr "{{user}}が{{time}}に更新"
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:139
+#: scripts/extensions/availability-manager/dist/src/utils.js:139
+#: scripts/extensions/availability-manager/src/utils.ts:159
+msgid "Modified by {{user}} at {{date}}"
+msgstr "{{user}}が{{date}}に更新"
+
+#: scripts/apps/search/directives/DateFilters.ts:85
+msgid "Modified from"
+msgstr "更新日（開始）"
+
+#: scripts/apps/search/directives/DateFilters.ts:86
+msgid "Modified to"
+msgstr "更新日（終了）"
+
+#: ../superdesk-planning/client/components/UI/List/CreatedUpdatedColumn.tsx:29
+msgid "Modified: {{ datetime }}"
+msgstr "更新日時：{{ datetime }}"
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:108
+msgid "Mon"
+msgstr "月"
+
+#: ../superdesk-planning/client/utils/events.tsx:1454
+#: scripts/core/datetime/datetime.ts:290
+msgid "Monday"
+msgstr "月曜日"
+
+#: scripts/apps/monitoring/aggregate-widget/aggregate.ts:6
+msgid "Monitor"
+msgstr "モニター"
+
+#: scripts/apps/monitoring/config.ts:19 scripts/apps/monitoring/config.ts:7
+#: scripts/apps/monitoring/views/monitoring-view.html:21
+#: scripts/apps/monitoring/views/monitoring-view.html:3
+#: scripts/core/lang/missing-translations-strings.ts:44
+msgid "Monitoring"
+msgstr "モニタリング"
+
+#: scripts/apps/desks/views/settings.html:43
+#: scripts/apps/desks/views/settings.html:47
+#: scripts/apps/monitoring/views/aggregate-settings.html:2
+#: scripts/apps/monitoring/views/monitoring-view.html:107
+msgid "Monitoring settings"
+msgstr "モニタリング設定"
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:163
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:83
+msgid "Month"
+msgstr "月"
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:32
+msgid "Month(s)"
+msgstr "月"
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:40
+#: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:26
+msgid "Monthly"
+msgstr "毎月"
+
+#: ../superdesk-planning/client/utils/filters.ts:51
+msgid "Monthly on the {{ day }} day @ {{ time }} to {{ desk }}"
+msgstr "毎月{{ day }}日の{{ time }}に{{ desk }}へ"
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:78
+msgid "Monthly on the {{day}} day at {{hour}}"
+msgstr "毎月{{day}}日の{{hour}}に"
+
+#: ../superdesk-planning/client/components/ItemActionsMenu/index.tsx:71
+#: scripts/apps/authoring/views/authoring-topbar.html:260
+#: scripts/apps/authoring/views/authoring-topbar.html:261
+#: scripts/apps/monitoring/views/item-actions-menu.html:10
+#: scripts/apps/monitoring/views/monitoring-view.html:159
+#: scripts/apps/monitoring/views/monitoring-view.html:201
+msgid "More actions"
+msgstr "その他のアクション"
+
+#: scripts/core/ui/components/content-create-dropdown/more-templates.tsx:49
+msgid "More templates"
+msgstr "その他のテンプレート"
+
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:82
+#: scripts/core/ui/components/content-create-dropdown/initial-view.tsx:181
+msgid "More templates..."
+msgstr "その他のテンプレート..."
+
+#: ../superdesk-analytics/client/utils.js:166
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:132
+msgid "Move"
+msgstr "移動"
+
+#: scripts/core/lang/missing-translations-strings.ts:19
+msgid "Move Content to another desk"
+msgstr "別のデスクにコンテンツを移動"
+
+#: ../superdesk-analytics/client/utils.js:167
+msgid "Move From"
+msgstr "移動元"
+
+#: ../superdesk-analytics/client/utils.js:168
+msgid "Move To"
+msgstr "移動先"
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:209
+msgid "Move down"
+msgstr "下に移動"
+
+#: scripts/apps/monitoring/index.ts:113
+msgid "Move focus to next stage or group"
+msgstr "次のステージまたはグループにフォーカスを移動"
+
+#: scripts/apps/monitoring/index.ts:115
+msgid "Move focus to previous stage or group"
+msgstr "前のステージまたはグループにフォーカスを移動"
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:197
+msgid "Move up"
+msgstr "上に移動"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:253
+#: scripts/apps/authoring/versioning/history/views/history.html:75
+msgid "Moved by"
+msgstr "移動者"
+
+#: scripts/apps/desks/views/desk-config-modal.html:397
+msgid "Moved onto stage Rule"
+msgstr "ステージ移動ルール"
+
+#: scripts/apps/desks/views/desk-config-modal.html:338
+msgid "Moved onto stage Rule:"
+msgstr "ステージ移動ルール："
+
+#: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:154
+msgid "Moved to a working stage by this user"
+msgstr "このユーザーがワーキングステージに移動"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:134
+#: scripts/apps/authoring-react/multi-edit-modal.tsx:240
+msgid "Multi Edit"
+msgstr "複数編集"
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:123
+msgid "Multi Line"
+msgstr "複数行"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:133
+msgid "Multi Start"
+msgstr "複数開始"
+
+#: scripts/apps/vocabularies/constants.ts:52
+msgid "Multi selection"
+msgstr "複数選択"
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:167
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:124
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:157
+msgid "Multi-edit"
+msgstr "複数編集"
+
+#: scripts/core/editor3/components/toolbar/index.tsx:320
+msgid "Multi-line quote"
+msgstr "複数行引用"
+
+#: scripts/apps/workspace/index.ts:39
+msgid "Multi-select (or deselect) an item"
+msgstr "���イテムを複数選択（または選択解除）"
+
+#: scripts/apps/authoring/multiedit/views/multiedit.html:2
+#: scripts/apps/authoring/views/authoring-topbar.html:296
+#: scripts/apps/authoring/views/opened-articles.html:22
+msgid "Multiedit"
+msgstr "複数編集"
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:178
+msgid "Multilingual"
+msgstr "多言語"
+
+#: ../superdesk-planning/client/components/fields/resources/planning.ts:33
+#: ../superdesk-planning/client/utils/contentProfiles.ts:353
+msgid "Multiple Content"
+msgstr "複数コンテンツ"
+
+#: ../superdesk-planning/client/validators/events.ts:129
+msgid "Must be greater than 1"
+msgstr "1より大���くなければなりません"
+
+#: ../superdesk-planning/client/validators/events.ts:102
+msgid "Must be greater than starting date"
+msgstr "開始日より後でなければなりません"
+
+#: ../superdesk-planning/client/validators/events.ts:126
+msgid "Must be less than {{ maximum }}"
+msgstr "{{ maximum }}未満でなければなりません"
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:46
+msgid ""
+"Must be {{MIN_LENGTH}} characters long and contain {{MIN_STRENGTH}} out of 4 "
+"of the following:"
+msgstr "{{MIN_LENGTH}}文字以上で、以下の4種類のうち{{MIN_STRENGTH}}種類を含む必要があります："
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:165
+msgid "Must select at least one day"
+msgstr "少なくとも1日を選���してください"
+
+#: ../superdesk-planning/client/validators/events.ts:283
+msgid "Must start with \"http://\", \"https://\" or \"www.\""
+msgstr "「http://」、「https://」または「www.」で始まる必要があります"
+
+#: ../superdesk-planning/client/components/Assignments/DesksSubNavDropDown.tsx:20
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:75
+msgid "My Assignments"
+msgstr "自分のアサインメント"
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:115
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:254
+msgid "My Events"
+msgstr "自分のイベント"
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:242
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:98
+msgid "My Events & Planning"
+msgstr "自分のイベントとプランニング"
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:174
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:271
+msgid "My Planning"
+msgstr "自分のプランニング"
+
+#: scripts/apps/users/index.ts:89
+msgid "My Profile"
+msgstr "マイプロファイル"
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-list.html:12
+msgid "My Saved Reports"
+msgstr "���分の��存済みレポート"
+
+#: scripts/apps/search/views/saved-searches.html:7
+msgid "My Saved Searches"
+msgstr "自分の保存済み検索"
+
+#: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:92
+msgid "My Templates"
+msgstr "自分のテンプレート"
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:17
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-dropdown.html:10
+msgid "NO SUGGESTIONS."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:33
+msgid "NTB Currency Macro"
+msgstr "NTB通貨マクロ"
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:31
+#: ../superdesk-planning/client/components/Agendas/ManageAgendasModal.tsx:15
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:98
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:20
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/assignCalendarForm.tsx:77
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:122
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/convertToRecurringEventForm.tsx:137
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:97
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:96
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:199
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:85
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikePlanningForm.tsx:42
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikeEventForm.tsx:80
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikePlanningForm.tsx:41
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateEventRepetitionsForm.tsx:104
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:216
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:218
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:44
+#: ../superdesk-planning/client/components/fields/preview/index.ts:214
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:38
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:16
+#: ../superdesk-planning/client/utils/contentProfiles.ts:271
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:51
+#: scripts/apps/content-filters/views/manage-filters.html:42
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:6
+#: scripts/apps/production-api-keys/ProductionApiKeys.tsx:12
+#: scripts/apps/production-api-keys/config.ts:12
+#: scripts/apps/publish/views/destination.html:4
+#: scripts/apps/publish/views/subscribers.html:112
+#: scripts/apps/search-providers/views/search-provider-config.html:82
+#: scripts/apps/search/views/save-search-dialog.html:7
+#: scripts/apps/templates/views/create-template.html:12
+#: scripts/apps/vocabularies/services/SchemaFactory.ts:6
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:52
+#: scripts/extensions/annotationsLibrary/dist/src/GetFields.js:8
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/GetFields.js:8
+#: scripts/extensions/annotationsLibrary/src/GetFields.ts:9
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:55
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:55
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:89
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:180
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:221
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:111
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:143
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:235
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:141
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:140
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:180
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:221
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:111
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:143
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:235
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:141
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:140
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:106
+#: scripts/extensions/sams/dist/src/utils/ui.js:106
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:191
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:244
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:126
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:158
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:279
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:139
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:165
+#: scripts/extensions/sams/src/utils/ui.tsx:99
+msgid "Name"
+msgstr "名前"
+
+#: scripts/apps/vocabularies/ManageVocabularyItemTranslations.tsx:28
+msgid "Name ({{language}})"
+msgstr "名前（{{language}}）"
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:131
+msgid "Name Translations"
+msgstr "名前の翻訳"
+
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:218
+msgid ""
+"Name field should only have alphanumeric characters, dashes and underscores"
+msgstr "名前フィールドには英数字、ハイフン、アンダースコアのみ使用できます"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:79
+msgid "Name is not unique."
+msgstr "名前が一意ではありません。"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:153
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:77
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:77
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:187
+msgid "Name is required."
+msgstr "名前は必須です。"
+
+#: scripts/apps/publish/views/email-config.html:30
+msgid "Name of the rendition to attach to the email"
+msgstr "メールに添付するレンディション名"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:71
+msgid "Navy"
+msgstr "ネイビー"
+
+#: scripts/apps/search/views/search-filters.html:11
+#: scripts/apps/search/views/search-filters.html:111
+#: scripts/apps/search/views/search-filters.html:124
+#: scripts/apps/search/views/search-filters.html:132
+#: scripts/apps/search/views/search-filters.html:24
+#: scripts/apps/search/views/search-filters.html:37
+#: scripts/apps/search/views/search-filters.html:50
+#: scripts/apps/search/views/search-filters.html:72
+#: scripts/apps/search/views/search-filters.html:85
+#: scripts/apps/search/views/search-filters.html:98
+msgid "Negate"
+msgstr "否定"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:51
+msgid "Neutral Gray"
+msgstr "ニュートラルグレー"
+
+#: scripts/apps/publish/views/subscribers.html:278
+msgid "Never"
+msgstr "しない"
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:28
+msgid "Never expire"
+msgstr "期限なし"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:573
+msgid "New"
+msgstr "新規"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:135
+msgid "New Document"
+msgstr "新規ドキュメント"
+
+#: scripts/apps/users/views/settings-roles.html:30
+msgid "New Role"
+msgstr "新しいロール"
+
+#: scripts/core/editor3/components/annotations/AnnotationInput.tsx:310
+msgid "New annotation"
+msgstr "新しい注釈"
+
+#: scripts/apps/desks/views/desk-config-modal.html:237
+msgid "New stage"
+msgstr "新しいステージ"
+
+#: scripts/apps/search/views/saved-search-subscribe.html:6
+msgid "New subscription"
+msgstr "新しいサブスクリプション"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:133
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:133
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:256
+msgid "New template"
+msgstr "新しいテンプレート"
+
+#: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:185
+#: scripts/apps/monitoring/views/aggregate-settings.html:158
+#: scripts/extensions/availability-manager/dist/src/correspondent-availability/filters.js:81
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/correspondent-availability/filters.js:81
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/availability-settings.js:183
+#: scripts/extensions/availability-manager/dist/src/settings/availability-settings.js:183
+#: scripts/extensions/availability-manager/src/correspondent-availability/filters.tsx:115
+#: scripts/extensions/availability-manager/src/settings/availability-settings.tsx:313
+msgid "Next"
+msgstr "次へ"
+
+#: scripts/apps/search/directives/DateFilters.ts:23
+msgid "Next 3 Months"
+msgstr "今後3か月"
+
+#: scripts/apps/search/directives/DateFilters.ts:15
+msgid "Next Month"
+msgstr "来月"
+
+#: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:29
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:162
+msgid "Next Week"
+msgstr "来週"
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:115
+#: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:114
+msgid "Next match"
+msgstr "次の一致"
+
+#: scripts/apps/users/config.ts:158
+msgid "Next user"
+msgstr "次のユーザー"
+
+#: scripts/core/ui/components/generic-form/input-types/checkbox.tsx:10
+#: scripts/core/ui/components/generic-form/input-types/yes-no.tsx:7
+msgid "No"
+msgstr "いいえ"
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:182
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:267
+#: ../superdesk-planning/client/components/fields/editor/NoAgendaAssigned.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:121
+msgid "No Agenda Assigned"
+msgstr "アジェンダ未割り当て"
+
+#: ../superdesk-planning/client/components/Agendas/AgendaNameList.tsx:14
+msgid "No Agenda Assigned."
+msgstr "アジェンダ未割り当て。"
+
+#: scripts/extensions/sams/dist/src/components/assets/assetListPanel.js:62
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetListPanel.js:62
+#: scripts/extensions/sams/src/components/assets/assetListPanel.tsx:35
+msgid "No Assets found"
+msgstr "アセットが見つかりません"
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:123
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:248
+#: ../superdesk-planning/client/components/fields/editor/NoCalendarAssigned.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:125
+msgid "No Calendar Assigned"
+msgstr "カレンダー未割り当て"
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:337
+msgid "No Content Linking"
+msgstr "コンテンツリンクなし"
+
+#: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:23
+msgid "No Coverage Assigned"
+msgstr "取材未割り当て"
+
+#: ../superdesk-planning/client/components/UI/Form/InputArray/index.tsx:190
+msgid "No Coverages Yet"
+msgstr "取材は���だありません"
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:129
+msgid "No Coverge"
+msgstr "取材なし"
+
+#: scripts/apps/templates/constants.ts:11
+msgid "No Desk"
+msgstr "デスクなし"
+
+#: ../superdesk-planning/client/components/Main/ListPanel.tsx:343
+msgid "No Event or Planning items found"
+msgstr "イベントまたはプランニングアイテムが見つかりません"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:7
+msgid "No Fetch actions defined"
+msgstr "取得アクションが定義されていません"
+
+#: scripts/apps/highlights/views/search_highlights_dropdown_directive.html:6
+msgid "No Filter"
+msgstr "フィルターなし"
+
+#: scripts/apps/products/views/products.html:39
+msgid "No Products Found"
+msgstr "プロダクトが見つかりません"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:39
+msgid "No Publish actions defined"
+msgstr "公開アクションが定義されていません"
+
+#: scripts/apps/publish/views/subscribers.html:57
+msgid "No Subscribers Found"
+msgstr "配信先が見つかりません"
+
+#: ../superdesk-planning/client/components/fields/editor/ContentTemplate.tsx:70
+#: ../superdesk-planning/client/components/fields/editor/ExportTemplate.tsx:38
+msgid "No Templates Available"
+msgstr "利用可能なテンプレートがありません"
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:39
+#: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:39
+#: scripts/extensions/ai-widget/src/translations/translations-body.tsx:84
+msgid "No Translations yet"
+msgstr "翻訳はまだありません"
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:51
+msgid "No agendas assigned."
+msgstr "アジェンダが割り当てられていません。"
+
+#: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:233
+#: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:227
+#: ../superdesk-planning/client/components/UI/FileReadOnlyList.tsx:65
+msgid "No attached files added."
+msgstr "添付ファイルが追加されていません。"
+
+#: scripts/apps/desks/directives/MarkDesksDropdown.ts:25
+#: scripts/apps/desks/views/mark_desks_dropdown_directive.html:8
+#: scripts/apps/search/components/actions-menu/Item.tsx:168
+msgid "No available desks"
+msgstr "利用可能なデスクがありません"
+
+#: scripts/apps/desks/directives/MarkDesksDropdown.ts:24
+#: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:113
+#: scripts/apps/highlights/views/mark_highlights_dropdown_directive.html:8
+#: scripts/apps/highlights/views/package_highlights_dropdown_directive.html:26
+#: scripts/apps/search/components/actions-menu/Item.tsx:167
+msgid "No available highlights"
+msgstr "利用可能なハイライトがありません"
+
+#: scripts/apps/archive/views/package_item_labels_dropdown_directive.html:13
+msgid "No available labels"
+msgstr "利用可能なラベルがありません"
+
+#: scripts/apps/translations/views/TranslationDropdown.html:8
+msgid "No available languages"
+msgstr "利用可能な言語がありません"
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:123
+msgid "No available selections"
+msgstr "利用可能な選択肢がありません"
+
+#: scripts/apps/desks/directives/MarkDesksDropdown.ts:26
+#: scripts/apps/search/components/actions-menu/Item.tsx:169
+msgid "No available translations"
+msgstr "利用可能な翻訳がありません"
+
+#: ../superdesk-planning/client/components/PlanningTemplatesModal/TemplatesListView.tsx:38
+msgid "No calendar"
+msgstr "カレンダーなし"
+
+#: ../superdesk-planning/client/components/fields/calendars.tsx:80
+msgid "No calendars assigned"
+msgstr "カレンダーが割り当てられていません"
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:59
+msgid "No calendars assigned."
+msgstr "カレンダーが割り当てられていません。"
+
+#: scripts/apps/dashboard/world-clock/configuration.html:20
+msgid "No clock here!"
+msgstr "ここにクロックはありません。"
+
+#: scripts/apps/authoring-react/generic-widgets/comments/CommentsWidget.tsx:170
+#: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:216
+#: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:48
+msgid "No comments have been posted"
+msgstr "コメントはまだ投稿されていません"
+
+#: scripts/apps/authoring/comments/views/comments-widget.html:23
+msgid "No comments so far."
+msgstr "まだコメントはありません。"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-filter.html:5
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:11
+msgid "No content filter defined"
+msgstr "コンテンツフィルターが定義されていません"
+
+#: scripts/extensions/availability-manager/dist/src/correspondent-availability/with-availability-records.js:54
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/correspondent-availability/with-availability-records.js:54
+#: scripts/extensions/availability-manager/src/correspondent-availability/with-availability-records.tsx:98
+msgid "No data available"
+msgstr "データがありません"
+
+#: ../superdesk-analytics/client/charts/views/table.html:22
+msgid "No data found"
+msgstr "データが見つかりません"
+
+#: scripts/apps/users/views/edit-form.html:222
+msgid "No desk selected"
+msgstr "デスクが選択されていません"
+
+#: scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx:174
+#: scripts/core/interactive-article-actions-panel/actions/send-to-tab.tsx:40
+msgid "No destinations are available."
+msgstr "利用可能な送信先がありません。"
+
+#: scripts/core/spellcheck/spellcheck.ts:527
+msgid "No dictionary available for spell checking."
+msgstr "スペルチェック用の辞書がありません。"
+
+#: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:77
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:77
+#: scripts/extensions/sams/src/components/sets/setListPanel.tsx:84
+msgid "No disabled sets configured"
+msgstr "無効なセットは設定されていません"
+
+#: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:75
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:75
+#: scripts/extensions/sams/src/components/sets/setListPanel.tsx:62
+msgid "No draft sets configured"
+msgstr "下書きセットは設定されていません"
+
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:99
+msgid "No events yet, drop some here, or click the plus button"
+msgstr "イベントはまだありません。ここにドロップするか、プラスボタンをクリックしてください"
+
+#: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:251
+#: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:129
+msgid "No external links added."
+msgstr "外部リンクが追加されていません。"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:20
+msgid "No fetch or publish actions defined"
+msgstr "取得または公開アクションが定義されていません"
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:1080
+msgid ""
+"No formatters found for {{formats}} while publishing item having unique name."
+msgstr "ユニーク名を持つアイテムの公開中に{{formats}}のフォーマッターが見つかりませんでした。"
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:206
+msgid "No highlights have been created yet."
+msgstr "ハイライトはまだ作成されていません。"
+
+#: scripts/apps/users/views/change-avatar.html:15
+msgid "No image"
+msgstr "画像なし"
+
+#: scripts/core/ui/components/generic-form/input-types/select_single_value.tsx:88
+#: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/editor.js:34
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/editor.js:34
+#: scripts/extensions/broadcasting/src/authoring-fields/subitems/editor.tsx:70
+msgid "No items available"
+msgstr "利用可能なアイテムがありません"
+
+#: ../superdesk-planning/client/components/UI/Form/SelectMetaTermsInput/SelectFieldPopup.tsx:379
+#: ../superdesk-planning/client/components/UI/Form/SelectMetaTermsInput/SelectFieldPopup.tsx:471
+msgid "No items found"
+msgstr "アイテムが見つかりません"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:176
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:176
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:339
+msgid "No items found matching search criteria"
+msgstr "検索条件に一致するアイテムが見つかりません"
+
+#: scripts/core/ui/components/select2.tsx:194
+msgid "No items found."
+msgstr "アイテムが見つかりません。"
+
+#: scripts/apps/search/components/WidgetItemList.tsx:38
+msgid "No items in this stage"
+msgstr "このステージにアイテムはありません"
+
+#: ../superdesk-planning/client/actions/multiSelect.ts:208
+msgid "No items selected."
+msgstr "アイテムが選択されていません。"
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:11
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-inner-dropdown.html:10
+msgid "No items to add!"
+msgstr "追加するアイテムがありません。"
+
+#: scripts/apps/desks/views/task-status-items.html:3
+msgid "No items with this status"
+msgstr "この状態のアイテムはありません"
+
+#: scripts/core/ui/components/virtual-lists/select.tsx:149
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:146
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:146
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:294
+msgid "No items yet"
+msgstr "アイテムはまだありません"
+
+#: scripts/apps/archive/views/package_item_labels_dropdown_directive.html:4
+msgid "No label"
+msgstr "ラベルなし"
+
+#: scripts/apps/authoring-react/macros/macros.tsx:317
+msgid "No macros configured."
+msgstr "マクロが設定されていません。"
+
+#: scripts/extensions/annotationsLibrary/dist/src/AnnotationsSelect.js:24
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/AnnotationsSelect.js:24
+#: scripts/extensions/annotationsLibrary/src/AnnotationsSelect.tsx:50
+msgid "No matches found in the library."
+msgstr "ライブラリに一致するものが見つかりません。"
+
+#: scripts/apps/authoring/macros/views/macros-replace.html:2
+msgid "No matches found."
+msgstr "一致するものが見つかりません。"
+
+#: scripts/apps/profiling/views/profiling.html:32
+msgid "No of calls"
+msgstr "呼び出し回数"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:179
+msgid "No options available for this field"
+msgstr "このフィールドに利用可能なオプションがありません"
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:101
+msgid "No planning items have been added"
+msgstr "プランニングアイテムが追加されていません"
+
+#: scripts/apps/users/directives/UserPreferencesDirective.ts:442
+msgid ""
+"No preferred categories selected. Should you choose to proceed with your "
+"choice. A default set of categories will be selected for you."
+msgstr "優先カテゴリーが選択されていません。このまま続行すると、デフォルトのカテゴリーセットが選択されます。"
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EditorFieldEventRelatedItems.tsx:85
+msgid "No related articles yet"
+msgstr "関連記事はまだありません"
+
+#: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:149
+msgid "No related planning items."
+msgstr "関連プランニングアイテムはありません。"
+
+#: ../superdesk-planning/client/components/Locations/LocationsList.tsx:79
+msgid "No result"
+msgstr "結果なし"
+
+#: scripts/apps/dashboard/user-activity/components/Group.tsx:55
+msgid "No results for this user"
+msgstr "このユーザーの結果はありません"
+
+#: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:205
+#: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:230
+msgid "No results found"
+msgstr "結果が見つかりません"
+
+#: scripts/core/ui/components/SelectUser.tsx:102
+msgid "No results found."
+msgstr "結果が見つかりません。"
+
+#: scripts/apps/master-desk/components/UserListComponent.tsx:38
+msgid "No role"
+msgstr "ロールなし"
+
+#: scripts/apps/users/views/settings-roles.html:22
+msgid "No roles created yet."
+msgstr "ロールはまだ作成されていません。"
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:63
+msgid "No rules defined in a set."
+msgstr "セットにルールが定義されていません。"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:58
+msgid "No rules defined yet"
+msgstr "ルールはまだ定義されていません"
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:180
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningSelectedList.tsx:25
+msgid "No selected featured stories"
+msgstr "選択された特集記事はありません"
+
+#: scripts/core/auth/login-modal.html:43
+#: scripts/core/auth/reset-password.html:33
+#: scripts/core/auth/reset-password.html:80
+#: scripts/core/auth/secure-login.html:34
+msgid "No server response so far.<br>Let me try again."
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:123
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:123
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:239
+msgid "No show selected"
+msgstr "ショーが選択されていません"
+
+#: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/subitems-view-edit.js:58
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.js:58
+#: scripts/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.tsx:142
+msgid "No subitems"
+msgstr "サブアイテムなし"
+
+#: scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx:91
+msgid "No suggestions available"
+msgstr "利用可能な候補はありません"
+
+#: scripts/apps/authoring/track-changes/views/suggestions-widget.html:46
+msgid "No suggestions have been resolved"
+msgstr "解決された提案はありません"
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:363
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:363
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:642
+msgid "No tags yet"
+msgstr "タグはまだありません"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:149
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:149
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:316
+msgid "No template selected"
+msgstr "テンプレートが選択されていません"
+
+#: ../superdesk-planning/client/components/PlanningTemplatesModal/TemplatesListView.tsx:73
+msgid "No templates available in this calendar group."
+msgstr "このカレンダーグループに利用可能なテンプレートはありません。"
+
+#: ../superdesk-planning/client/components/PlanningTemplatesModal/TemplatesListView.tsx:83
+msgid "No templates found."
+msgstr "テンプレートが見つかりません。"
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:251
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:251
+#: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:371
+msgid "No thumbnail"
+msgstr "サムネイルなし"
+
+#: scripts/extensions/sams/dist/src/api/assets.js:382
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:382
+#: scripts/extensions/sams/src/api/assets.ts:483
+msgid "No usable Sets found. Enable one first"
+msgstr "利用可能なセットが見つかりません。先にセットを有効にしてください"
+
+#: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:76
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:76
+#: scripts/extensions/sams/src/components/sets/setListPanel.tsx:73
+msgid "No usable sets configured"
+msgstr "利用可能なセットが設定されていません"
+
+#: scripts/apps/users/views/list.html:28
+msgid "No user roles defined!"
+msgstr "ユーザーロールが定義されていません。"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/assignCalendarForm.tsx:87
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:136
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:107
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:95
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikeEventForm.tsx:90
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:338
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:231
+msgid "No. of Events"
+msgstr "イベント数"
+
+#: scripts/apps/publish/views/subscribers.html:148
+msgid "Non-media"
+msgstr "非メディア"
+
+#: ../superdesk-planning/client/components/UI/Form/ColouredValueInput/ColouredValuePopup.tsx:129
+#: ../superdesk-planning/client/components/UI/Form/ColouredValueInput/index.tsx:146
+#: ../superdesk-planning/client/components/UI/Form/ColouredValueInput/index.tsx:165
+#: ../superdesk-planning/client/components/fields/editor/base/numberSelect.tsx:78
+#: scripts/apps/archive/views/marked_item_title.html:22
+#: scripts/apps/archive/views/metadata-view.html:54
+#: scripts/apps/authoring/metadata/views/metadata-dropdown.html:34
+#: scripts/apps/desks/directives/DeskConfigModal.ts:33
+#: scripts/apps/publish/views/publish-queue.html:23
+#: scripts/apps/publish/views/publish-queue.html:39
+#: scripts/apps/publish/views/publish-queue.html:54
+#: scripts/apps/publish/views/publish-queue.html:68
+#: scripts/apps/search-providers/directive.ts:15
+#: scripts/apps/templates/views/template-editor-modal.html:178
+#: scripts/apps/templates/views/template-editor-modal.html:84
+#: scripts/apps/users/views/settings-roles.html:69
+#: scripts/apps/users/views/settings-roles.html:79
+#: scripts/core/ui/components/Form/ColouredValueInput/ColouredValuePopup.tsx:123
+#: scripts/core/ui/components/Form/ColouredValueInput/index.tsx:101
+#: scripts/core/ui/components/Form/ColouredValueInput/index.tsx:87
+#: scripts/core/views/sdSearchList.html:32
+msgid "None"
+msgstr "なし"
+
+#: scripts/apps/authoring/metadata/views/metadata-target-publishing.html:3
+#: scripts/apps/ingest/directives/IngestRoutingAction.ts:67
+#: scripts/core/interactive-article-actions-panel/subcomponents/controlled-vocabulary-select.tsx:46
+msgid "Not"
+msgstr "否定"
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:432
+msgid "Not Active"
+msgstr "無効"
+
+#: scripts/apps/search/constants.ts:35
+msgid "Not Category"
+msgstr "カテゴリー以外"
+
+#: scripts/apps/search/constants.ts:32
+msgid "Not Desk"
+msgstr "デスク以外"
+
+#: scripts/apps/desks/views/settings.html:87
+msgid "Not Expired"
+msgstr "期限内"
+
+#: ../superdesk-planning/client/components/fields/editor/NotForPublication.tsx:15
+#: ../superdesk-planning/client/constants/tooltips.ts:31
+#: scripts/apps/archive/views/item-preview.html:9
+#: scripts/apps/archive/views/metadata-view.html:192
+#: scripts/apps/archive/views/preview.html:40
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:107
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:230
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:15
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:20
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:78
+#: scripts/apps/authoring/views/authoring-header.html:64
+#: scripts/apps/search/components/fields/flags.tsx:15
+#: scripts/apps/search/components/fields/flags.tsx:17
+#: scripts/apps/templates/views/template-editor-modal.html:104
+msgid "Not For Publication"
+msgstr "非公開"
+
+#: scripts/apps/search/constants.ts:34
+msgid "Not Genre"
+msgstr "ジャンル以外"
+
+#: scripts/apps/search/constants.ts:41
+msgid "Not Language"
+msgstr "言語以外"
+
+#: scripts/apps/search/constants.ts:39
+msgid "Not Legal"
+msgstr "法務対象外"
+
+#: ../superdesk-planning/client/components/fields/editor/LockState.tsx:21
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:148
+msgid "Not Locked"
+msgstr "ロックされていない"
+
+#: scripts/apps/search/constants.ts:38
+msgid "Not Priority"
+msgstr "優先度以外"
+
+#: scripts/apps/search/constants.ts:40
+msgid "Not Sms"
+msgstr "SMS以外"
+
+#: scripts/apps/search/constants.ts:37
+msgid "Not Source"
+msgstr "ソース以外"
+
+#: scripts/apps/search/constants.ts:33
+msgid "Not Type"
+msgstr "タイプ以外"
+
+#: scripts/apps/search/constants.ts:36
+msgid "Not Urgency"
+msgstr "緊急度以外"
+
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:10
+msgid "Not been transmitted to any subscriber"
+msgstr "どの配信先にも送信されていません"
+
+#: ../superdesk-planning/client/validators/profile.ts:100
+msgid "Not enough"
+msgstr "不足"
+
+#: ../superdesk-planning/client/validators/profile.ts:101
+msgid "Not enough {{ name }}"
+msgstr "{{ name }}が不足しています"
+
+#: ../superdesk-planning/client/components/fields/preview/Flags.tsx:23
+msgid "Not for Publication"
+msgstr "非公開"
+
+#: scripts/core/ui/components/List/PubStatus.tsx:22
+msgid "Not for publication"
+msgstr "非公開"
+
+#: ../superdesk-planning/client/components/UI/List/PubStatus.tsx:38
+msgid "Not posted"
+msgstr "未投稿"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:134
+msgid "Not scheduled"
+msgstr "未スケジュール"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:152
+#: ../superdesk-planning/client/components/fields/preview/index.ts:200
+#: ../superdesk-planning/client/utils/planning.tsx:1816
+msgid "Not scheduled yet"
+msgstr "未スケジュール"
+
+#: scripts/extensions/availability-manager/dist/src/components/status-select.js:20
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/components/status-select.js:20
+#: scripts/extensions/availability-manager/src/components/status-select.tsx:41
+msgid "Not set"
+msgstr "未設定"
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:319
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:96
+msgid "Notes"
+msgstr "メモ"
+
+#: ../superdesk-planning/client/components/NotificationModal.tsx:44
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:227
+msgid "Notification"
+msgstr "通知"
+
+#: scripts/apps/monitoring/views/desk-notifications.html:15
+msgid "Notification list"
+msgstr "通知リスト"
+
+#: scripts/apps/monitoring/views/desk-notifications.html:4
+#: scripts/apps/users/views/user-preferences.html:15
+#: scripts/apps/users/views/user-preferences.html:70
+#: scripts/core/menu/notifications/views/notifications.html:3
+msgid "Notifications"
+msgstr "通知"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:150
+msgid "Notify when idle for more than"
+msgstr "アイドル時間が超過したら通知"
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:84
+#: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:67
+msgid "Number"
+msgstr "数値"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentGroupList.tsx:306
+msgid "Number of Assignments:"
+msgstr "アサインメント数："
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:83
+msgid "Number of assignments in TO DO"
+msgstr "TODO内のアサインメント数"
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:71
+#: scripts/apps/users/activity-widget/configuration.html:7
+msgid "Number of items"
+msgstr "アイテム数"
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:27
+msgid "OEM"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:312
+#: scripts/apps/desks/views/desk-config-modal.html:317
+msgid "OFF"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/EditCoverageAssignmentModal.tsx:106
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:106
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:120
+#: scripts/apps/authoring/macros/views/macros-replace.html:3
+#: scripts/core/auth/auth.ts:242
+#: scripts/core/directives/PasswordStrengthDirective.ts:40
+#: scripts/core/services/modalService.tsx:151
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:391
+msgid "OK"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:311
+#: scripts/apps/desks/views/desk-config-modal.html:316
+msgid "ON"
+msgstr ""
+
+#: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:87
+msgid "OR"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:25
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:25
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:35
+msgid "Object"
+msgstr "オブジェクト"
+
+#: scripts/apps/search/views/search-parameters.html:196
+msgid "Object Name (Slugline)"
+msgstr "オブジェクト名（スラッグライン）"
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:26
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:26
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:36
+msgid "Objects"
+msgstr "オブジェクト"
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:281
+msgid "Occur Status"
+msgstr "発生状態"
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/occurrence-status.ts:34
+#: ../superdesk-planning/client/components/fields/editor/EventOccurenceStatus.tsx:30
+#: ../superdesk-planning/client/components/fields/preview/index.ts:175
+msgid "Occurrence Status"
+msgstr "発生状態"
+
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.js:74
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx:82
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:41
+msgid "Off"
+msgstr "オフ"
+
+#: scripts/apps/users/components/UserAvatar.tsx:100
+msgid "Offline"
+msgstr "オフライン"
+
+#: ../superdesk-planning/client/components/ConfirmationModal.tsx:127
+#: scripts/apps/archive/controllers/file-upload-error-modal.tsx:38
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:593
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:21
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-dropdown.html:14
+#: scripts/apps/search/views/save-search.html:31
+#: scripts/apps/users/views/settings-roles.html:88
+#: scripts/core/prompt-modal.tsx:40 scripts/core/services/modalService.tsx:115
+msgid "Ok"
+msgstr "OK"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:136
+msgid "Okay"
+msgstr "OK"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:65
+msgid "Old Gold"
+msgstr "オールドゴールド"
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:37
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.js:73
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx:81
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:40
+#: scripts/apps/templates/views/template-editor-modal.html:151
+msgid "On"
+msgstr "オン"
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:175
+msgid "On Days"
+msgstr "曜日指定"
+
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:341
+msgid ""
+"One of the items that was selected is locked. By default locked items are "
+"not included in the export."
+msgid_plural ""
+"{{ count }} items that were selected are locked. By default locked items are "
+"not included in the export."
+msgstr[0] "選択された{{ count }}件のアイテムがロックされています。デフォルトでロック済みアイテムはエクスポートに含まれません。"
+
+#: scripts/apps/users/components/UserAvatar.tsx:99
+#: scripts/apps/users/controllers/UserListController.ts:156
+msgid "Online"
+msgstr "オンライン"
+
+#: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:86
+msgid "Only 1 image is allowed in this field"
+msgid_plural "Only {{number}} images are allowed in this field"
+msgstr[0] "このフィールドには最大{{number}}枚の画像のみ許可されています"
+
+#: ../superdesk-planning/client/utils/planning.tsx:541
+msgid "Only 1 item can be linked. Adding this would exceed the limit"
+msgstr "リンクできるアイテムは1件のみです。追加すると制限を超えます"
+
+#: ../superdesk-planning/client/components/fields/editor/OnlyPosted.tsx:15
+msgid "Only Posted"
+msgstr "投稿済みのみ"
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:293
+msgid ""
+"Only allow content with the\n"
+"                                following status:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageForm.tsx:247
+msgid "Only one XMP files are accepted"
+msgstr "XMPファイルは1つのみ受け付けます"
+
+#: scripts/apps/archive/controllers/UploadController.ts:229
+msgid "Only one file can be uploaded"
+msgstr "アップロードできるファイルは1つのみです"
+
+#: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:269
+msgid "Only the following content item types are allowed:"
+msgstr "次のコンテンツアイテムタイプのみ許可されています："
+
+#: scripts/apps/archive/controllers/UploadController.ts:333
+msgid "Only the following files are allowed: {{fileTypes}}"
+msgstr "次のファイルのみ許可されています：{{fileTypes}}"
+
+#: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:89
+msgid "Only the following media item types are allowed:"
+msgstr "次のメディアアイテムタイプのみ許可されています："
+
+#: scripts/apps/authoring-react/fields/media/editor.tsx:159
+msgid "Only the following media types are allowed: {{types}}"
+msgstr "次のメディアタイプのみ許可されています：{{types}}"
+
+#: scripts/core/auth/secure-login.html:28
+msgid "Oops! Authentication has been denied."
+msgstr "認証が拒否されました。"
+
+#: scripts/core/auth/login-modal.html:36
+msgid "Oops! Invalid Username or Password.<br>Please try again."
+msgstr ""
+
+#: scripts/core/auth/reset-password.html:27
+msgid "Oops! Invalid user Email.<br>Please try again."
+msgstr ""
+
+#: scripts/apps/users/views/user-list-item.html:37
+#: scripts/core/list/views/list-view.html:3
+msgid "Oops! There are no items."
+msgstr "アイテムがありません。"
+
+#: ../superdesk-planning/client/actions/multiSelect.ts:238
+#: scripts/apps/authoring/authoring/index.ts:380
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:239
+#: scripts/apps/search-providers/directive.ts:117
+#: scripts/core/editor3/components/links/LinkToolbar.tsx:55
+msgid "Open"
+msgstr "開く"
+
+#: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:43
+#: ../superdesk-planning/client/constants/assignments.ts:196
+msgid "Open Coverage"
+msgstr "取材を開く"
+
+#: scripts/apps/search-providers/views/search-provider-config.html:47
+msgid "Open advanced search panel by default"
+msgstr "デフォルトで詳細検索パネルを開く"
+
+#: scripts/apps/workspace/index.ts:34
+msgid "Open highlights"
+msgstr "ハイライトを開く"
+
+#: scripts/apps/authoring/authoring/index.ts:401
+msgid "Open in new Window"
+msgstr "新しいウィンドウで開く"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/notifications.js:10
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/notifications.js:14
+#: scripts/extensions/broadcasting/dist/src/notifications.js:10
+#: scripts/extensions/broadcasting/dist/src/notifications.js:14
+#: scripts/extensions/broadcasting/src/notifications.ts:22
+#: scripts/extensions/broadcasting/src/notifications.ts:26
+msgid "Open item"
+msgstr "アイテムを開く"
+
+#: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:215
+#: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:218
+msgid "Open link"
+msgstr "リンクを開く"
+
+#: scripts/apps/authoring/views/change-image.html:26
+msgid "Open metadata"
+msgstr "メタデータを開く"
+
+#: scripts/apps/workspace/index.ts:33
+msgid "Open monitoring"
+msgstr "モニタリングを開く"
+
+#: scripts/apps/authoring-react/toolbar/multi-edit-toolbar-action.tsx:58
+msgid "Open multi edit"
+msgstr "複数編集を開く"
+
+#: scripts/apps/authoring-react/packages.tsx:106
+msgid "Open package"
+msgstr "パッケージを開く"
+
+#: scripts/apps/workspace/index.ts:37
+msgid "Open personal"
+msgstr "個人スペースを開く"
+
+#: scripts/apps/workspace/index.ts:38
+msgid "Open search"
+msgstr "検索を開く"
+
+#: scripts/apps/workspace/index.ts:36
+msgid "Open spike"
+msgstr "スパイクを開く"
+
+#: scripts/apps/workspace/index.ts:35
+msgid "Open tasks"
+msgstr "タスクを開く"
+
+#: scripts/apps/workspace/index.ts:32
+msgid "Open workspace / dashboard"
+msgstr "ワークスペース/ダッシュボードを開く"
+
+#: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:40
+msgid "OpenStreetMap Details"
+msgstr "OpenStreetMap詳細"
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:18
+msgid "Opened"
+msgstr "開かれた"
+
+#: scripts/apps/monitoring/views/desk-notifications.html:35
+msgid "Opened by"
+msgstr "オープン者"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:637
+msgid "Operation"
+msgstr "操作"
+
+#: ../superdesk-analytics/client/user_activity_report/views/item-timeline-tooltip.html:4
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-tooltip.html:5
+msgid "Operations:"
+msgstr "操作："
+
+#: scripts/apps/content-filters/views/filter-search.html:18
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:68
+msgid "Operator"
+msgstr "演算子"
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:105
+msgid "Options:"
+msgstr "オプション："
+
+#: scripts/extensions/sams/dist/src/apps/samsAttachmentsWidget.js:199
+#: scripts/extensions/sams/dist/src/apps/samsAttachmentsWidget.js:209
+#: scripts/extensions/sams/dist/src/extensions/sams/src/apps/samsAttachmentsWidget.js:199
+#: scripts/extensions/sams/dist/src/extensions/sams/src/apps/samsAttachmentsWidget.js:209
+#: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:199
+#: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:224
+msgid "Or select an existing asset"
+msgstr "��たは既存のアセットを選択"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:62
+msgid "Orange"
+msgstr "オレンジ"
+
+#: ../superdesk-planning/client/components/OrderBar/OrderFieldInput.tsx:21
+msgid "Order By: {{ name }}"
+msgstr "並び替え：{{ name }}"
+
+#: ../superdesk-analytics/client/charts/views/chart-form-options.html:44
+msgid "Order Data In:"
+msgstr "データの並び順："
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:137
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:26
+msgid "Ordered List"
+msgstr "番号付きリスト"
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:87
+msgid "Ordered list"
+msgstr "番号付きリスト"
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:337
+#: scripts/apps/contacts/directives/ContactsSearchPanelDirective.tsx:87
+#: scripts/apps/contacts/services/ContactsService.ts:39
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:9
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:9
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:15
+msgid "Organisation"
+msgstr "組織"
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:249
+#: scripts/apps/contacts/components/ListTypeIcon.tsx:7
+msgid "Organisation Contact"
+msgstr "組織連絡先"
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:10
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:10
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:16
+msgid "Organisations"
+msgstr "組織"
+
+#: ../superdesk-planning/client/components/Archive/ArchivePreview/index.tsx:63
+#: scripts/apps/archive/views/item-preview.html:24
+#: scripts/apps/archive/views/preview.html:122
+#: scripts/apps/authoring-react/article-widgets/translations/translations.tsx:58
+#: scripts/apps/authoring/translations/translationsWidget.tsx:48
+#: scripts/apps/authoring/views/authoring-header.html:84
+#: scripts/apps/authoring/views/change-image.html:125
+#: scripts/apps/authoring/views/change-image.html:232
+#: scripts/apps/authoring/views/change-image.html:92
+msgid "Original"
+msgstr "オリジナル"
+
+#: scripts/apps/authoring/views/article-edit.html:306
+msgid ""
+"Original ({{item.renditions.original.width}} x "
+"{{item.renditions.original.height}} px)"
+msgstr "オリジナル（{{item.renditions.original.width}} x {{item.renditions.original.height}} px）"
+
+#: ../superdesk-analytics/client/views/renditions-preview.html:33
+msgid ""
+"Original ({{preview.item.update.update.renditions.original.width}} x "
+"{{preview.item.update.update.renditions.original.height}} px)"
+msgstr "オリジナル（{{preview.item.update.update.renditions.original.width}} x {{preview.item.update.update.renditions.original.height}} px）"
+
+#: scripts/apps/search/components/fields/translations.tsx:26
+msgid "Original Article"
+msgstr "元の記事"
+
+#: scripts/apps/archive/views/metadata-view.html:102
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:176
+msgid "Original ID"
+msgstr "オリジナルID"
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:386
+msgid "Original Id"
+msgstr "オリジナルID"
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:19
+msgid "Original Image"
+msgstr "オリジナル画像"
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:27
+#: scripts/apps/archive/views/metadata-view.html:31
+msgid "Original Source"
+msgstr "元のソース"
+
+#: scripts/apps/archive/views/metadata-view.html:106
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:390
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:182
+msgid "Original creator"
+msgstr "元の作成者"
+
+#: scripts/apps/authoring-react/fields/media/media-metadata.tsx:43
+msgid "Original size"
+msgstr "オリジナルサイズ"
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:432
+#: scripts/apps/authoring/tests/changeImage.spec.ts:56
+msgid "Original size cannot be less than the required crop sizes."
+msgstr "オリジナルサイズは必要なトリミングサイズより小さくできません。"
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:188
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:60
+msgid "Original source"
+msgstr "元のソース"
+
+#: ../superdesk-planning/client/components/UI/Form/SelectInputWithFreeText.tsx:70
+#: ../superdesk-planning/client/components/fields/editor/base/selectWithFreeText.tsx:171
+#: ../superdesk-planning/client/components/fields/editor/base/selectWithFreeText.tsx:174
+#: scripts/apps/vocabularies/controllers/VocabularyConfigController.ts:12
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:125
+#: scripts/extensions/sams/dist/src/utils/assets.js:125
+#: scripts/extensions/sams/src/utils/assets.ts:154
+msgid "Other"
+msgstr "その他"
+
+#: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:264
+msgid "Other Coverages"
+msgstr "その他の取材"
+
+#: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:100
+msgid "Other Names"
+msgstr "その他の名前"
+
+#: scripts/apps/vocabularies/views/settings.html:37
+msgid "Other fields"
+msgstr "その他のフィールド"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:373
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:426
+msgid "Outgoing"
+msgstr "送信"
+
+#: scripts/apps/desks/views/desk-config-modal.html:408
+msgid "Outgoing Rule"
+msgstr "送信ルール"
+
+#: scripts/apps/desks/views/desk-config-modal.html:342
+msgid "Outgoing Rule:"
+msgstr "送信ルール："
+
+#: scripts/apps/publish/views/file-config.html:2
+#: scripts/apps/publish/views/file-config.html:4
+msgid "Output file path"
+msgstr "出力ファイルパス"
+
+#: scripts/apps/monitoring/directives/AggregateSettings.ts:55
+msgid "Output/Published"
+msgstr ""
+
+#: scripts/apps/monitoring/directives/AggregateSettings.ts:49
+msgid "Output/Scheduled"
+msgstr ""
+
+#: scripts/apps/monitoring/directives/AggregateSettings.ts:61
+msgid "Output/Sent"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:313
+msgid "Override Auto Assign to Workflow"
+msgstr "自動ワークフロー割り当てを上書き"
+
+#: scripts/apps/master-desk/MasterDesk.tsx:36
+#: scripts/apps/users/controllers/UserEditController.ts:14
+msgid "Overview"
+msgstr "概要"
+
+#: scripts/apps/templates/views/templates.html:48
+msgid "Owner"
+msgstr "オーナー"
+
+#: scripts/apps/authoring/views/authoring-topbar.html:79
+msgid "P"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/publish-and-continue.tsx:29
+#: scripts/apps/authoring/views/authoring-topbar.html:100
+msgid "P & C"
+msgstr "P & C"
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:116
+#: scripts/extensions/sams/dist/src/utils/assets.js:116
+#: scripts/extensions/sams/src/utils/assets.ts:148
+msgid "PDF"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/directives/EmailReportModal.js:95
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsList.js:105
+msgid "PDF File"
+msgstr "PDFファイル"
+
+#: ../superdesk-planning/client/validators/planning.ts:29
+msgid "PLANNING DATE cannot be in the past"
+msgstr "プランニング日は過去の日付にできません"
+
+#: ../superdesk-analytics/client/email_report/directives/EmailReportModal.js:92
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsList.js:102
+msgid "PNG Image"
+msgstr "PNG画像"
+
+#: scripts/apps/authoring-react/subcomponents/content-profile-dropdown.tsx:32
+#: scripts/apps/authoring/views/authoring-header.html:24
+#: scripts/apps/authoring/views/authoring-header.html:28
+msgid "PROFILE"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/publish-correction.tsx:13
+msgid "PUBLISH"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:98
+msgid "Pacific/Auckland"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:99
+msgid "Pacific/Honolulu"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:100
+msgid "Pacific/Noumea"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:101
+msgid "Pacific/Port Moresby"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:256
+msgid "Package"
+msgstr "パッケージ"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:138
+msgid "Package Create"
+msgstr "パッケージ作成"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:139
+msgid "Package Plus"
+msgstr "パッケージ追加"
+
+#: scripts/apps/publish/views/http-push-config.html:2
+msgid "Package individual items"
+msgstr "個別アイテムをパッケージ化"
+
+#: scripts/apps/authoring-react/data-layer.ts:212
+#: scripts/apps/authoring-react/field-adapters/package_items.ts:9
+msgid "Package items"
+msgstr "パッケージアイテム"
+
+#: scripts/apps/authoring-react/fields/package-items/index.tsx:36
+msgid "Package items (authoring-react)"
+msgstr "パッケージアイテム（authoring-react）"
+
+#: scripts/apps/archive/views/item-preview.html:5
+msgid "Package preview"
+msgstr "パッケージプレビュー"
+
+#: scripts/apps/workspace/content/constants.ts:7
+msgid "Package story labels"
+msgstr "パッケージ記事ラベル"
+
+#: scripts/apps/authoring-react/packages.tsx:22
+#: scripts/apps/authoring/packages/packages.ts:47
+msgid "Packages"
+msgstr "パッケージ"
+
+#: scripts/apps/authoring-react/data-layer.ts:223
+msgid "Packages profile"
+msgstr "パッケージプロファイル"
+
+#: scripts/core/list/views/sdPaginationAlt.html:2
+msgid "Page"
+msgstr "ページ"
+
+#: ../superdesk-analytics/client/charts/views/chart-form-options.html:57
+msgid "Page Size"
+msgstr "ページサイズ"
+
+#: scripts/core/list/views/sdPagination.html:2
+msgid "Page Size:"
+msgstr "ページサイズ："
+
+#: scripts/apps/legal-archive/views/legal_archive.html:24
+msgid "Pagination"
+msgstr "ページネーション"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:140
+msgid "Paragraph"
+msgstr "段落"
+
+#: scripts/apps/publish/views/subscribers.html:203
+msgid "Parallel publishing"
+msgstr "並列公開"
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:41
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:41
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-panel.html:41
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-panel.html:41
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-panel.html:41
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-panel.html:41
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-panel.html:41
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-panel.html:41
+#: scripts/apps/content-api/views/search-panel.html:5
+#: scripts/apps/search/views/search-panel.html:63
+msgid "Parameters"
+msgstr "パラメーター"
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:642
+msgid "Parent coverage not linked to a news item yet."
+msgstr "���取材はまだニュースアイテムにリンクされていません。"
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:58
+#: scripts/extensions/availability-manager/dist/src/utils.js:58
+#: scripts/extensions/availability-manager/src/utils.ts:61
+msgid "Partially available"
+msgstr "一部���用可能"
+
+#: scripts/apps/publish/views/ftp-config.html:15
+msgid "Passive mode"
+msgstr "パッシブモード"
+
+#: scripts/apps/ingest/views/settings/searchConfig.html:6
+#: scripts/apps/publish/views/ftp-config.html:11
+#: scripts/apps/search-providers/views/search-provider-config.html:117
+#: scripts/apps/users/views/edit-form.html:17
+#: scripts/apps/users/views/edit-form.html:205
+msgid "Password"
+msgstr "パスワード"
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:75
+msgid "Password is too weak."
+msgstr "パスワードが弱すぎます。"
+
+#: scripts/core/auth/auth.ts:114
+msgid "Password was changed. You can login using your new password."
+msgstr "パスワードが変更されました。新しいパスワードでログインできます。"
+
+#: ../superdesk-planning/client/utils/events.tsx:871
+#: ../superdesk-planning/client/utils/events.tsx:885
+msgid "Past Events"
+msgstr "過去のイベント"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:141
+msgid "Paste"
+msgstr "貼り付け"
+
+#: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:191
+msgid "Paste link"
+msgstr "リンクを貼り付け"
+
+#: scripts/apps/authoring/media/views/media-copy-metadata-directive.html:3
+msgid "Paste metadata"
+msgstr "メタデータを貼り付け"
+
+#: scripts/apps/publish/views/ftp-config.html:21
+msgid "Path"
+msgstr "パス"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:142
+msgid "Pause"
+msgstr "一時停止"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:143
+msgid "Paywall"
+msgstr "ペイウォール"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:144
+msgid "Pencil"
+msgstr "鉛筆"
+
+#: scripts/apps/users/controllers/UserListController.ts:157
+msgid "Pending"
+msgstr "保留中"
+
+#: scripts/apps/desks/views/desk-config-modal.html:426
+#: scripts/apps/desks/views/settings.html:71
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:14
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:14
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:21
+msgid "People"
+msgstr "人物"
+
+#: scripts/apps/products/views/products-config-modal.html:70
+msgid "Permitting"
+msgstr "許可中"
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:13
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:13
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:20
+msgid "Person"
+msgstr "個人"
+
+#: scripts/apps/contacts/services/ContactsService.ts:38
+msgid "Person (Last Name)"
+msgstr "個人（姓）"
+
+#: scripts/apps/contacts/components/ListTypeIcon.tsx:7
+msgid "Person Contact"
+msgstr "個人連絡先"
+
+#: scripts/apps/dictionaries/views/settings.html:48
+#: scripts/apps/monitoring/controllers/AggregateCtrl.ts:568
+#: scripts/apps/monitoring/views/aggregate-settings.html:122
+#: scripts/apps/monitoring/views/aggregate-settings.html:143
+#: scripts/apps/monitoring/views/aggregate-settings.html:55
+#: scripts/apps/templates/constants.ts:10
+msgid "Personal"
+msgstr "個人"
+
+#: scripts/apps/dictionaries/views/settings.html:28
+msgid "Personal Dictionary"
+msgstr "個人辞書"
+
+#: scripts/apps/monitoring/controllers/AggregateCtrl.ts:40
+msgid "Personal Items"
+msgstr "個人アイテム"
+
+#: scripts/apps/monitoring/config.ts:54
+msgid "Personal Space"
+msgstr "個人スペース"
+
+#: ../superdesk-planning/client/constants/index.ts:170
+msgid "Personal Workspace"
+msgstr "個人ワークスペース"
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:33
+msgid ""
+"Personal dictionary for language \"{{dictionary.language_id}}\" already "
+"exists."
+msgstr "言語「{{dictionary.language_id}}」の個人辞書は既に存在します。"
+
+#: scripts/apps/users/controllers/UserEditController.ts:23
+msgid "Personal preferences"
+msgstr "個人設定"
+
+#: scripts/apps/monitoring/config.ts:64
+#: scripts/core/interactive-article-actions-panel/subcomponents/destination-select.tsx:28
+msgid "Personal space"
+msgstr "個人スペース"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:145
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:394
+msgid "Phone"
+msgstr "電話"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:146
+msgid "Photo"
+msgstr "写真"
+
+#: scripts/apps/desks/directives/DeskConfigModal.ts:40
+#: scripts/apps/monitoring/directives/utils.ts:110
+#: scripts/apps/search-providers/directive.ts:17
+#: scripts/apps/search/views/search.html:27
+#: scripts/apps/search/views/search.html:28
+#: scripts/apps/users/directives/UserPreferencesDirective.ts:29
+msgid "Photo Grid View"
+msgstr "フォトグリッド表示"
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:110
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:92
+msgid "Phrase"
+msgstr "フレーズ"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:147
+msgid "Pick"
+msgstr "選択"
+
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:385
+msgid "Pick task"
+msgstr "タスクを選択"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:148
+#: ../superdesk-planning/client/utils/index.ts:589
+#: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:58
+msgid "Picture"
+msgstr "画像"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:102
+msgid "Pie"
+msgstr "円グラフ"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:149
+#: scripts/apps/authoring-react/widget-header-component.tsx:24
+msgid "Pin"
+msgstr "ピン"
+
+#: scripts/apps/authoring/widgets/WidgetHeaderComponent.tsx:24
+msgid "Pin/Unpin"
+msgstr ""
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/place-field.ts:37
+#: ../superdesk-planning/client/components/fields/editor/Place.tsx:25
+#: ../superdesk-planning/client/utils/contentProfiles.ts:279
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:343
+#: scripts/apps/authoring-react/field-adapters/place.ts:52
+#: scripts/apps/authoring-react/field-adapters/place.ts:82
+#: scripts/apps/workspace/content/constants.ts:36
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:21
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:21
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:30
+msgid "Place"
+msgstr "場所"
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:137
+#: scripts/core/lang/missing-translations-strings.ts:12
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:22
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:22
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:31
+msgid "Places"
+msgstr "場所"
+
+#: ../superdesk-planning/client/components/fields/list/Places.tsx:20
+msgid "Places:"
+msgstr "場所："
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/rundown-items.js:40
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/rundown-items.js:40
+#: scripts/extensions/broadcasting/src/rundowns/components/rundown-items.tsx:128
+msgid "Planned"
+msgstr "計画済み"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:103
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/airing-info-block.js:16
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/planned-duration-label.js:12
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show.js:72
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:34
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:103
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/airing-info-block.js:16
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/planned-duration-label.js:12
+#: scripts/extensions/broadcasting/dist/src/shows/create-show.js:72
+#: scripts/extensions/broadcasting/dist/src/shows/manage-shows.js:34
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:133
+#: scripts/extensions/broadcasting/src/rundowns/components/airing-info-block.tsx:29
+#: scripts/extensions/broadcasting/src/rundowns/components/planned-duration-label.tsx:22
+#: scripts/extensions/broadcasting/src/shows/create-show.tsx:119
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:46
+msgid "Planned duration"
+msgstr "予定��間"
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:76
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/index.tsx:245
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:41
+#: ../superdesk-planning/client/components/ItemIcon.tsx:30
+#: ../superdesk-planning/client/components/ItemIcon.tsx:37
+#: ../superdesk-planning/client/components/Main/ItemEditorModal/EditorModalPanel.tsx:169
+#: ../superdesk-planning/client/components/fields/editor/ItemType.tsx:24
+#: ../superdesk-planning/client/components/fields/index.tsx:238
+#: ../superdesk-planning/client/controllers/PlanningController.tsx:45
+#: ../superdesk-planning/client/index.ts:68
+#: ../superdesk-planning/client/index.ts:69
+#: ../superdesk-planning/client/utils/eventsplanning.ts:21
+#: ../superdesk-planning/client/utils/history.tsx:75
+#: ../superdesk-planning/index.ts:13 ../superdesk-planning/index.ts:14
+#: scripts/apps/authoring/authoring/constants.ts:17
+#: scripts/apps/authoring/views/authoring-topbar.html:315
+#: scripts/apps/production-api-keys/config.ts:27
+#: scripts/apps/users/views/user-preferences.html:19
+#: scripts/apps/users/views/user-preferences.html:203
+msgid "Planning"
+msgstr "プランニング"
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:61
+msgid "Planning Cancelled"
+msgstr "プランニングキャンセル済み"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikePlanningForm.tsx:49
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikePlanningForm.tsx:48
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/planning-date.tsx:25
+#: ../superdesk-planning/client/components/fields/editor/PlanningDateTime.tsx:64
+#: ../superdesk-planning/client/components/fields/preview/index.ts:180
+#: ../superdesk-planning/client/utils/contentProfiles.ts:303
+msgid "Planning Date"
+msgstr "プランニング日"
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/Editor.tsx:188
+#: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:127
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/planning-details-widget.js:25
+#: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:11
+msgid "Planning Details"
+msgstr "プランニング詳細"
+
+#: ../superdesk-planning/client/api/contentProfiles.ts:185
+msgid "Planning Fields"
+msgstr "プランニングフィールド"
+
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:43
+#: ../superdesk-planning/client/utils/index.ts:583
+msgid "Planning Item"
+msgstr "プランニングアイテム"
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:283
+msgid "Planning Item has been cancelled"
+msgstr "プランニングアイテムがキャンセルされました"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:143
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:111
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:214
+msgid "Planning Items"
+msgstr "プランニングアイテム"
+
+#: scripts/core/lang/missing-translations-strings.ts:19
+msgid "Planning Management"
+msgstr "プランニング管理"
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:150
+msgid "Planning Module (Items created per user)"
+msgstr "プランニングモジュール（ユーザーごとの作成アイテム）"
+
+#: ../superdesk-analytics/client/planning_usage_report/directives/PlanningUsageReportPreview.js:21
+#: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:21
+msgid "Planning Module Usage"
+msgstr "プランニングモジュール使用状況"
+
+#: ../superdesk-analytics/client/planning_usage_report/index.js:45
+msgid "Planning Usage"
+msgstr "プランニング使用状況"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:56
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:69
+msgid "Planning cancelled"
+msgstr "プランニングがキャンセルされました"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelPlanningCoveragesForm.tsx:142
+msgid "Planning cancelled:"
+msgstr "プランニングキャンセル："
+
+#: ../superdesk-planning/client/validators/planning.ts:26
+msgid "Planning date is in the past"
+msgstr "プランニング日が過去です"
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:256
+msgid "Planning duplicated"
+msgstr "プランニングが複製されました"
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:321
+#: ../superdesk-planning/client/actions/planning/ui.ts:365
+msgid "Planning item added as featured story"
+msgstr "プランニングアイテムが特集記事として追加されました"
+
+#: ../superdesk-planning/client/utils/events.tsx:501
+msgid "Planning item already has one related event. Can not add more."
+msgstr "プランニングアイテムには既に関連イベントが1つあります。これ以上追加できません。"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:72
+msgid "Planning item created"
+msgstr "プランニングアイテムが作成されました"
+
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:97
+msgid "Planning item has to be created before adding related events"
+msgstr "関連イベントを追加するには先にプランニングアイテムを作成する必要があります"
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:320
+#: ../superdesk-planning/client/actions/planning/ui.ts:364
+msgid "Planning item removed as featured story"
+msgstr "プランニングアイテムが特集記事から削除されました"
+
+#: ../superdesk-planning/client/components/Main/FiltersBox.tsx:51
+msgid "Planning only"
+msgstr "プランニングのみ"
+
+#: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:66
+msgid "Planning templates"
+msgstr "プランニングテンプレート"
+
+#: ../superdesk-planning/client/components/Editor/bookmarks/AssociatedPlanningsBookmark.tsx:55
+msgid "Planning: {{ name }}"
+msgstr "プランニング：{{ name }}"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:150
+msgid "Play"
+msgstr "再生"
+
+#: scripts/apps/vocabularies/components/UploadConfigModal.tsx:58
+msgid ""
+"Please be aware that uploading external config files\n"
+"                will overwrite your existing configuration."
+msgstr ""
+
+#: scripts/apps/templates/directives/TemplatesDirective.ts:359
+msgid "Please change the default templates first."
+msgstr "先にデフォルトテンプレートを変更してください。"
+
+#: scripts/core/auth/secure-login.html:14
+msgid "Please check that the following id is the same as on your device:"
+msgstr "次のIDがデバイスのものと同じであることを確認してください："
+
+#: scripts/apps/users/config.ts:95
+msgid "Please confirm that you want to delete all the sessions for this user."
+msgstr "このユーザーのすべてのセッションを削除してもよろしいですか。"
+
+#: scripts/apps/users/config.ts:78
+msgid "Please confirm that you want to disable a user."
+msgstr "ユーザーを無効にしてもよろしいですか。"
+
+#: scripts/apps/desks/controllers/DeskConfigController.ts:57
+msgid "Please confirm you want to delete desk."
+msgstr "デスクを削除してもよろしいですか。"
+
+#: scripts/apps/dictionaries/controllers/DictionaryConfigController.ts:89
+msgid "Please confirm you want to delete dictionary."
+msgstr "辞書を削除してもよろしいですか。"
+
+#: scripts/apps/search/views/saved-search-subscribe.html:12
+msgid "Please define the frequency and time of your email notifications below."
+msgstr "メール通知の頻度と時間を以下で設定してください。"
+
+#: scripts/core/auth/login-modal.html:4
+msgid "Please log in again."
+msgstr "もう一度ログインしてください。"
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:86
+msgid "Please provide a valid email address"
+msgstr "有効なメールアドレスを入力してください"
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:94
+#: scripts/apps/users/views/edit-form.html:340
+msgid "Please provide a valid twitter account"
+msgstr "有効なTwitterアカウントを入力してください"
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:129
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:130
+msgid "Please provide an article GUID"
+msgstr "記事のGUIDを入力してください"
+
+#: scripts/apps/products/controllers/ProductsConfigController.ts:234
+msgid "Please provide an article id"
+msgstr "記事IDを入力してください"
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:208
+msgid ""
+"Please specify 'first name, last name' or  'organisation' or both, and at "
+"least one of [{{list}}] fields."
+msgstr "「名、姓」または「組織」あるいは両方、および[{{list}}]フィールドの少なくとも1つを指定してください。"
+
+#: scripts/apps/templates/views/create-template.html:27
+#: scripts/apps/templates/views/template-editor-modal.html:22
+#: scripts/apps/workspace/content/views/profile-settings.html:117
+#: scripts/apps/workspace/content/views/profile-settings.html:152
+msgid "Please use less than 40 characters"
+msgstr "40文字以内にしてください"
+
+#: scripts/apps/content-filters/views/manage-filters.html:45
+msgid "Please use less than 80 characters"
+msgstr "80文字以内にしてください"
+
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:53
+msgid "Please use less than 80 characters."
+msgstr "80文字以内にしてください。"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:151
+msgid "Plus Large"
+msgstr "プラス（大）"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:152
+msgid "Plus Sign"
+msgstr "プラス記号"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:153
+msgid "Plus Small"
+msgstr "プラス（小）"
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:194
+msgid "Point of contact"
+msgstr "連絡窓口"
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:171
+msgid "Point of interest is not defined."
+msgstr "ポイントオブインタレストが定義されていません。"
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:188
+msgid "Point of interest outside the crop {{cropName}} limits"
+msgstr "ポイントオブインタレストがトリミング{{cropName}}の範囲外です"
+
+#: scripts/core/lang/missing-translations-strings.ts:33
+msgid "Populate Abstract"
+msgstr "要約を自動入力"
+
+#: scripts/core/editor3/components/toolbar/FloatingCharacterCount.tsx:45
+msgid "Position"
+msgstr "位置"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:119
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:122
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:372
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:217
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:154
+#: ../superdesk-planning/client/constants/events.ts:165
+#: scripts/apps/authoring/comments/views/comments-widget.html:46
+msgid "Post"
+msgstr "投稿"
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:280
+#: ../superdesk-planning/client/components/Locations/LocationsList.tsx:130
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:76
+#: scripts/apps/contacts/constants.ts:74
+#: scripts/apps/contacts/views/search-panel.html:54
+msgid "Post Code"
+msgstr "郵便番号"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:66
+msgid "Post Event"
+msgstr "イベントを投稿"
+
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.js:75
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.js:70
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.tsx:86
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx:77
+msgid "Post Items"
+msgstr "アイテムを投稿"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:77
+msgid "Post all recurring events or just this one?"
+msgstr "すべての繰り返しイベントを投稿しますか？それともこのイベントのみですか？"
+
+#: scripts/apps/authoring/comments/views/comments-widget.html:45
+msgid "Post on 'Enter'"
+msgstr "Enterキーで投稿"
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:64
+msgid "Post planning items with Event"
+msgstr "イベントとともにプランニングアイテムを投稿"
+
+#: ../superdesk-planning/client/components/AuditInformation/index.tsx:132
+#: ../superdesk-planning/client/components/fields/preview/index.ts:133
+#: ../superdesk-planning/client/constants/tooltips.ts:28
+#: ../superdesk-planning/client/utils/index.ts:415
+#: scripts/core/ui/components/List/PubStatus.tsx:19
+msgid "Posted"
+msgstr "投稿済み"
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:346
+msgid "Posted Featured Stories record"
+msgstr "特集記事レコードが投稿されました"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:104
+msgid "Postpone"
+msgstr "延期"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:102
+msgid "Postpone {{event}}"
+msgstr "{{event}}を延期"
+
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:37
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:208
+#: ../superdesk-planning/client/utils/index.ts:379
+msgid "Postponed"
+msgstr "延期済み"
+
+#: scripts/core/menu/views/menu.html:113
+msgid "Powered by Superdesk technology"
+msgstr "Superdeskテクノロジーを使用"
+
+#: scripts/extensions/predefinedTextField/dist/src/extension.js:10
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/extension.js:10
+#: scripts/extensions/predefinedTextField/src/extension.tsx:12
+msgid "Predefined text field"
+msgstr "定義済みテキストフィールド"
+
+#: scripts/core/lang/missing-translations-strings.ts:15
+msgid "Preferred Categories"
+msgstr "優先カテゴリー"
+
+#: scripts/apps/desks/views/desk-config-modal.html:200
+msgid "Preferred values for vocabularies"
+msgstr "ボキャブラリーの優先値"
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:374
+msgid "Prefill the field with text from:"
+msgstr "次のテキストでフィールドを事前入力："
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:155
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:37
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:250
+msgid "Preformatted"
+msgstr "整形済みテキスト"
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:91
+msgid "Preformatted text"
+msgstr "整形済みテキスト"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:92
+msgid "Preserve Desk"
+msgstr "デスクを保持"
+
+#: scripts/apps/desks/views/desk-config-modal.html:86
+msgid "Preserve Published Content"
+msgstr "公開済みコンテンツを保持"
+
+#: ../superdesk-planning/client/constants/events.ts:171
+#: ../superdesk-planning/client/constants/planning.ts:148
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:254
+#: scripts/apps/authoring-react/fields/embed/editor.tsx:65
+#: scripts/apps/authoring/views/article-edit.html:583
+#: scripts/apps/authoring/views/authoring-topbar.html:197
+#: scripts/apps/authoring/views/authoring.html:23
+#: scripts/apps/search/components/WidgetItem.tsx:94
+#: scripts/core/interactive-article-actions-panel/actions/publish-action.tsx:278
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:52
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:153
+#: scripts/extensions/broadcasting/dist/src/rundowns/manage-rundown-items.js:52
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:153
+#: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:107
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:289
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:39
+#: scripts/extensions/sams/dist/src/utils/assets.js:39
+#: scripts/extensions/sams/src/utils/assets.ts:51
+msgid "Preview"
+msgstr "プレビュー"
+
+#: scripts/apps/authoring/views/preview-formatted.html:6
+msgid "Preview Formatted Story"
+msgstr "フォーマット済み記事をプレビュー"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:156
+msgid "Preview Mode"
+msgstr "プレビューモード"
+
+#: scripts/apps/publish/views/destination.html:17
+msgid "Preview endpoint URL"
+msgstr "プレビューエンドポイントURL"
+
+#: scripts/apps/authoring/authoring/index.ts:472
+msgid "Preview formatted article, when previewFormats feature configured"
+msgstr "previewFormats機能設定時にフォーマット済み記事をプレビュー"
+
+#: scripts/apps/authoring/views/authoring-header.html:74
+msgid "Preview master story"
+msgstr "マスター記事をプレビュー"
+
+#: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:171
+#: scripts/apps/monitoring/views/aggregate-settings.html:155
+#: scripts/extensions/availability-manager/dist/src/correspondent-availability/filters.js:78
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/correspondent-availability/filters.js:78
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/availability-settings.js:178
+#: scripts/extensions/availability-manager/dist/src/settings/availability-settings.js:178
+#: scripts/extensions/availability-manager/src/correspondent-availability/filters.tsx:104
+#: scripts/extensions/availability-manager/src/settings/availability-settings.tsx:301
+msgid "Previous"
+msgstr "前へ"
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:107
+#: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:122
+msgid "Previous match"
+msgstr "前の一致"
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:661
+msgid "Previous scheduled update is not linked to a news item yet."
+msgstr "前のスケジュール済み更新はまだニュースアイテムにリンクされていません。"
+
+#: scripts/apps/users/config.ts:157
+msgid "Previous user"
+msgstr "前のユーザー"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:157
+#: scripts/apps/authoring-react/preview-article-modal.tsx:24
+#: scripts/apps/authoring/preview/fullPreviewMultiple.tsx:57
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:296
+msgid "Print"
+msgstr "印刷"
+
+#: scripts/apps/authoring-react/toolbar-components/integration-wrapper/print-preview-button.tsx:13
+msgid "Print preview"
+msgstr "印刷プレビュー"
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:131
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:129
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateAssignmentForm.tsx:138
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/priority-field.ts:50
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:71
+#: ../superdesk-planning/client/utils/contentProfiles.ts:349
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:286
+#: scripts/apps/authoring-react/field-adapters/priority.ts:38
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:104
+#: scripts/apps/content-api/services/ContentAPISearchService.ts:31
+#: scripts/apps/legal-archive/services/LegalArchiveService.ts:29
+#: scripts/apps/legal-archive/tests/legal.spec.ts:71
+#: scripts/apps/search/components/ItemPriority.tsx:25
+#: scripts/apps/search/components/ItemPriority.tsx:36
+#: scripts/apps/search/directives/SearchFilters.ts:46
+#: scripts/apps/search/services/SearchService.ts:71
+#: scripts/apps/workspace/content/constants.ts:37
+msgid "Priority"
+msgstr "優先度"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:63
+msgid "Priority modified to"
+msgstr "優先度の変更先"
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:288
+#: ../superdesk-planning/client/components/fields/priority.tsx:30
+msgid "Priority:"
+msgstr "優先度："
+
+#: ../superdesk-planning/client/components/PriorityLabel/index.tsx:51
+msgid "Priority: {{ name }}"
+msgstr "優先度：{{ name }}"
+
+#: scripts/apps/contacts/views/list.html:27
+msgid "Privacy Level:"
+msgstr "プライバシーレベル："
+
+#: scripts/apps/contacts/services/ContactsService.ts:57
+#: scripts/apps/templates/constants.ts:9
+#: scripts/apps/users/views/edit-form.html:171
+#: scripts/core/ui/components/content-create-dropdown/dropdown-option.tsx:34
+msgid "Private"
+msgstr "プライベート"
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:89
+msgid "Private saved searches"
+msgstr "プライベート保存済み検索"
+
+#: scripts/apps/users/controllers/UserEditController.ts:32
+msgid "Privileges"
+msgstr "権限"
+
+#: scripts/apps/users/directives/UserPrivilegesDirective.ts:43
+msgid "Privileges not found."
+msgstr "権限が見つかりません。"
+
+#: scripts/apps/users/directives/RolesPrivilegesDirective.ts:34
+#: scripts/apps/users/directives/UserPrivilegesDirective.ts:77
+msgid "Privileges updated."
+msgstr "権限が更新されました。"
+
+#: scripts/apps/packaging/views/sd-package-item-preview.html:37
+#: scripts/apps/packaging/views/sd-package-item-preview.html:8
+msgid "Problems occurred while fetching data."
+msgstr "データ取得中に問題が発生しました。"
+
+#: scripts/apps/products/views/products-config-modal.html:12
+msgid "Product Details"
+msgstr "プロダクト詳細"
+
+#: scripts/apps/products/views/products-config-modal.html:26
+msgid "Product ID"
+msgstr "プロダクトID"
+
+#: scripts/apps/products/views/settings.html:12
+msgid "Product Test"
+msgstr "プロダクトテスト"
+
+#: scripts/apps/products/views/products-config-modal.html:44
+msgid "Product Type"
+msgstr "プロダクトタイプ"
+
+#: scripts/apps/products/controllers/ProductsConfigController.ts:185
+msgid "Product Type is required"
+msgstr "プロダクトタイプは必須です"
+
+#: scripts/apps/products/views/products.html:5
+msgid "Product Type:"
+msgstr "プロダクトタイプ："
+
+#: scripts/apps/products/views/products-config-modal.html:53
+msgid "Product codes"
+msgstr "プロダクトコード"
+
+#: scripts/apps/products/controllers/ProductsConfigController.ts:203
+msgid "Product deleted."
+msgstr "プロダクトが削除されました。"
+
+#: scripts/apps/products/views/products-config-modal.html:40
+msgid "Product description"
+msgstr "プロダクトの説明"
+
+#: scripts/apps/products/controllers/ProductsConfigController.ts:175
+msgid "Product is saved."
+msgstr "プロダクトが保存されました。"
+
+#: scripts/apps/products/views/products-config-modal.html:36
+msgid "Product name"
+msgstr "プロダクト名"
+
+#: scripts/apps/search/views/item-repo.html:4
+msgid "Production"
+msgstr "プロダクション"
+
+#: scripts/apps/production-api-keys/index.ts:13
+#: scripts/apps/production-api-keys/views/settings.html:5
+msgid "Production API"
+msgstr "プロダクションAPI"
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:276
+msgid "Production Stats"
+msgstr "プロダクション統計"
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:293
+#: ../superdesk-analytics/client/production_time_report/index.js:45
+msgid "Production Time"
+msgstr "製作時間"
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:173
+msgid "Production Times"
+msgstr "製作時間"
+
+#: scripts/apps/products/index.ts:20
+#: scripts/apps/products/views/settings.html:9
+#: scripts/apps/publish/views/subscribers.html:168
+#: scripts/apps/publish/views/subscribers.html:257
+msgid "Products"
+msgstr "プロダクト"
+
+#: scripts/apps/products/views/settings.html:4
+msgid "Products management"
+msgstr "プロダクト管理"
+
+#: scripts/apps/profiling/views/profiling.html:6
+msgid "Profile:"
+msgstr "プロファイル："
+
+#: scripts/apps/profiling/index.ts:26
+msgid "Profiling Data"
+msgstr "プロファイリングデータ"
+
+#: scripts/apps/authoring/views/theme-select.html:66
+msgid "Proofread Theme"
+msgstr "校正テーマ"
+
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:104
+msgid "Proofreading Theme"
+msgstr "校正テーマ"
+
+#: scripts/core/auth/reset-password.html:11
+msgid ""
+"Provide your email in order to get 'Reset Token'. Once you get it, use it to "
+"reset your password."
+msgstr "「リセットトークン」を取得するためにメールアドレスを入力してください。取得後、パスワードのリセットに使用してください。"
+
+#: scripts/apps/users/views/change-avatar.html:47
+msgid "Provided image URL is not valid."
+msgstr "指定された画像URLは無効です。"
+
+#: scripts/apps/search/constants.ts:18
+#: scripts/apps/search/views/search-parameters.html:161
+msgid "Provider"
+msgstr "プロバイダー"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:77
+msgid "Provider Name"
+msgstr "プロバイダー名"
+
+#: scripts/apps/search-providers/views/search-provider-config.html:72
+msgid "Provider Type"
+msgstr "プロバイダータイプ"
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:563
+msgid "Provider saved!"
+msgstr "プロバイダーが保存されました。"
+
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:88
+msgid "Provider sequence"
+msgstr "プロバイダーシーケンス"
+
+#: scripts/core/lang/missing-translations-strings.ts:39
+msgid ""
+"Provider {{name}} has gone strangely quiet. Last activity was on {{last}}"
+msgstr "プロバイダー{{name}}が異常に静かです。最後のアクティビティは{{last}}でした"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:279
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:110
+msgid "Provider:"
+msgstr "プロバイダー："
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/index.tsx:218
+msgid "Provider: {{ name }}"
+msgstr "プロバイダー：{{ name }}"
+
+#: scripts/apps/archive/views/metadata-view.html:123
+msgid "PubStatus"
+msgstr "公開状態"
+
+#: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:95
+#: scripts/apps/contacts/services/ContactsService.ts:56
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:189
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:244
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:189
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:244
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:97
+#: scripts/extensions/sams/dist/src/utils/ui.js:97
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:235
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:312
+#: scripts/extensions/sams/src/utils/ui.tsx:84
+msgid "Public"
+msgstr "公開"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:441
+#: ../superdesk-analytics/client/utils.js:154
+#: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:35
+#: scripts/apps/authoring/views/authoring-topbar.html:76
+#: scripts/apps/authoring/views/authoring-topbar.html:77
+#: scripts/apps/authoring/views/authoring-topbar.html:78
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:37
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:32
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:212
+#: scripts/core/interactive-article-actions-panel/action-tabs.tsx:17
+#: scripts/core/interactive-article-actions-panel/action-tabs.tsx:24
+#: scripts/core/interactive-article-actions-panel/actions/publish-action.tsx:304
+msgid "Publish"
+msgstr "公開"
+
+#: scripts/apps/authoring/views/authoring-topbar.html:99
+msgid "Publish & Continue"
+msgstr "公開して続行"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:445
+#: ../superdesk-analytics/client/utils.js:157
+msgid "Publish Embargo"
+msgstr "公開エンバーゴ"
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:577
+msgid "Publish Pars"
+msgstr "公開段落"
+
+#: scripts/apps/publish/index.ts:51
+msgid "Publish Queue"
+msgstr "公開キュー"
+
+#: scripts/apps/archive/views/metadata-view.html:137
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:416
+msgid "Publish Schedule"
+msgstr "公開スケジュール"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:444
+#: ../superdesk-analytics/client/utils.js:155
+msgid "Publish Scheduled"
+msgstr "スケジュール公開"
+
+#: scripts/apps/authoring/views/confirm-media-associated.html:18
+msgid "Publish Without Media"
+msgstr "メディアなしで公開"
+
+#: scripts/apps/authoring/views/authoring-topbar.html:97
+#: scripts/apps/authoring/views/authoring-topbar.html:98
+msgid "Publish and Continue"
+msgstr "公開して続行"
+
+#: scripts/core/interactive-article-actions-panel/actions/publish-action.tsx:290
+msgid "Publish from"
+msgstr "公開元"
+
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx:153
+msgid "Publish schedule"
+msgstr "公開スケジュール"
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:26
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:81
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:65
+#: scripts/apps/dashboard/workspace-tasks/views/desk-stages.html:22
+#: scripts/apps/search/components/fields/state.tsx:37
+#: scripts/apps/search/views/item-repo.html:5
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:301
+msgid "Published"
+msgstr "公開済み"
+
+#: scripts/apps/desks/views/settings.html:86
+msgid "Published Content"
+msgstr "公開済みコンテンツ"
+
+#: ../superdesk-analytics/client/publishing_performance_report/controllers/PublishingPerformanceReportController.ts:383
+msgid "Published Content for {{group}}: {{data}}"
+msgstr "{{group}}の公開済みコンテンツ：{{data}}"
+
+#: ../superdesk-analytics/client/publishing_performance_report/controllers/PublishingPerformanceReportController.ts:389
+msgid "Published Content per {{group}}"
+msgstr "{{group}}ごとの公開済みコンテンツ"
+
+#: scripts/apps/legal-archive/views/legal_archive.html:84
+msgid "Published From"
+msgstr "公開日（開始）"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:234
+msgid "Published Stories"
+msgstr "公開済み記事"
+
+#: ../superdesk-analytics/client/content_publishing_report/controllers/ContentPublishingReportController.js:377
+msgid "Published Stories per {{group}}"
+msgstr "{{group}}ごとの公開済み記事"
+
+#: ../superdesk-analytics/client/content_publishing_report/controllers/ContentPublishingReportController.js:371
+msgid "Published Stories per {{group}} with {{subgroup}} breakdown"
+msgstr "{{group}}ごとの公開済み記事（{{subgroup}}内訳付き）"
+
+#: scripts/apps/legal-archive/views/legal_archive.html:88
+msgid "Published Until"
+msgstr "公開日（終了）"
+
+#: scripts/apps/authoring/versioning/history/HistoryController.ts:180
+msgid "Published by"
+msgstr "公開者"
+
+#: scripts/apps/search/constants.ts:22
+#: scripts/apps/search/directives/DateFilters.ts:93
+msgid "Published from"
+msgstr "公開日（開始）"
+
+#: scripts/apps/search/constants.ts:23
+#: scripts/apps/search/directives/DateFilters.ts:94
+msgid "Published to"
+msgstr "公開日（終了）"
+
+#: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:25
+msgid "Publishing"
+msgstr "公開中"
+
+#: scripts/apps/publish/views/publish-queue.html:108
+msgid "Publishing Action"
+msgstr "公開アクション"
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/index.js:47
+msgid "Publishing Actions"
+msgstr "公開アクション"
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/index.js:48
+msgid "Publishing Actions Widget"
+msgstr "公開アクションウィジェット"
+
+#: ../superdesk-analytics/client/publishing_performance_report/index.js:48
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/controller.js:81
+msgid "Publishing Performance"
+msgstr "公開パフォーマンス"
+
+#: scripts/apps/authoring/authoring/constants.ts:16
+msgid "Publishing actions"
+msgstr "公開アクション"
+
+#: scripts/core/interactive-article-actions-panel/index-ui.tsx:104
+msgid "Publishing multiple items from authoring pane is not supported"
+msgstr "オーサリングペインからの複数アイテムの同時公開はサポートされていません"
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:181
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:56
+msgid "Pubstatus"
+msgstr "公開状態"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:63
+msgid "Purple"
+msgstr "紫"
+
+#: scripts/apps/publish/views/ftp-config.html:30
+msgid "Push associated/feature media items"
+msgstr "関連/フィーチャーメディアアイテムをプッシュ"
+
+#: scripts/apps/publish/views/ftp-config.html:34
+msgid "Push the original rendition"
+msgstr "オリジナルレンディションをプッシュ"
+
+#: scripts/apps/vocabularies/services/SchemaFactory.ts:7
+msgid "QCode"
+msgstr "QCode"
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorTools.js:30
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorTools.js:30
+#: scripts/extensions/videoEditor/src/VideoEditorTools.tsx:68
+msgid "Quality:"
+msgstr "品質："
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:163
+msgid "Quarter"
+msgstr "四半期"
+
+#: scripts/apps/search/views/save-search-dialog.html:4
+msgid "Query"
+msgstr "クエリ"
+
+#: scripts/apps/search/views/raw-search.html:4
+msgid "Query Text"
+msgstr "クエリテキスト"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:158
+msgid "Question Sign"
+msgstr "疑問符"
+
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:67
+msgid "Queue Name"
+msgstr "キュー名"
+
+#: scripts/apps/publish/views/publish-queue.html:112
+msgid "Queued at"
+msgstr "キュー追加日時"
+
+#: scripts/apps/authoring-react/macros/macros.tsx:57
+msgid "Quick List"
+msgstr "クイックリスト"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:159
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:28
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:85
+msgid "Quote"
+msgstr "引用"
+
+#: ../superdesk-planning/client/validators/events.ts:103
+msgid "RECURRING ENDS ON must be greater than START DATE"
+msgstr "繰り返し終了日は開始日より後でなければなりません"
+
+#: ../superdesk-planning/client/validators/events.ts:119
+msgid "RECURRING REPEAT COUNT is a required field"
+msgstr "繰り返し回数は必須フィールドです"
+
+#: ../superdesk-planning/client/validators/events.ts:130
+msgid "RECURRING REPEAT COUNT must be greater than 1"
+msgstr "繰り返し回数は1より大きくなければなりません"
+
+#: ../superdesk-planning/client/validators/events.ts:127
+msgid "RECURRING REPEAT COUNT must be less than {{ maximum }}"
+msgstr "繰り返し回数は{{ maximum }}未満でなければなりません"
+
+#: ../superdesk-planning/client/validators/events.ts:108
+msgid "RECURRING REPEAT ON is a required field"
+msgstr "繰り返し曜日は必須フィールドです"
+
+#: ../superdesk-planning/client/validators/events.ts:113
+msgid "RECURRING REPEAT UNTIL is a required field"
+msgstr "繰り返し終了日は必須フィールドです"
+
+#: scripts/apps/authoring/views/authoring-header.html:53
+msgid "RELATED"
+msgstr ""
+
+#: scripts/apps/search/components/HighlightsList.tsx:98
+#: scripts/apps/search/components/MarkedDesksList.tsx:110
+msgid "REMOVE"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:160
+msgid "Random"
+msgstr "ランダム"
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:9
+msgid "Range"
+msgstr "範囲"
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:168
+msgid "Range cannot be greater than {{max}} days"
+msgstr "範囲は{{max}}日を超えることはできません"
+
+#: scripts/apps/search/views/search-panel.html:15
+msgid "Raw"
+msgstr "RAW"
+
+#: scripts/apps/search/views/raw-search.html:1
+msgid "Raw search"
+msgstr "RAW検索"
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:42
+msgid "Read Only"
+msgstr "読み取り専用"
+
+#: scripts/apps/users/config.ts:150
+msgid "Read user roles"
+msgstr "ユーザーロールを表示"
+
+#: scripts/apps/users/config.ts:140
+msgid "Read users"
+msgstr "ユーザーを表示"
+
+#: scripts/apps/authoring-react/fields/common-field-configuration.tsx:29
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/read-only-label.tsx:7
+#: scripts/apps/authoring/views/authoring-topbar.html:41
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:179
+msgid "Read-only"
+msgstr "読み取り専用"
+
+#: scripts/apps/monitoring/views/monitoring-view.html:206
+msgid "Rearrange Groups"
+msgstr "グループを並び替え"
+
+#: scripts/apps/dashboard/views/workspace.html:5
+msgid "Rearrange widgets"
+msgstr "ウィジェットを並び替え"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:161
+msgid "Reason for Event cancellation:"
+msgstr "イベントキャンセルの理由："
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:82
+msgid "Reason for Event postponement:"
+msgstr "イベント延期の理由："
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelPlanningCoveragesForm.tsx:97
+msgid "Reason for cancelling all coverage:"
+msgstr "すべての取材キャンセルの理由："
+
+#: ../superdesk-planning/client/api/coverages.ts:33
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelCoverageForm.tsx:81
+msgid "Reason for cancelling the coverage"
+msgstr "取材キャンセルの理由"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelPlanningCoveragesForm.tsx:98
+msgid "Reason for cancelling the planning item:"
+msgstr "プランニングアイテムキャンセルの理由："
+
+#: ../superdesk-planning/client/api/coverages.ts:54
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelCoverageForm.tsx:80
+msgid "Reason for cancelling the scheduled update"
+msgstr "スケジュール済み更新キャンセルの理由"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:179
+msgid "Reason for rescheduling this event:"
+msgstr "このイベント再スケジュールの理由："
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:155
+#: ../superdesk-planning/client/constants/assignments.ts:192
+msgid "Reassign"
+msgstr "再割り当て"
+
+#: scripts/apps/search/components/fields/state.tsx:43
+msgid "Recalled"
+msgstr "リコール済み"
+
+#: scripts/apps/authoring/versioning/history/HistoryController.ts:186
+msgid "Recalled by"
+msgstr "リコール者"
+
+#: scripts/core/ui/components/content-create-dropdown/initial-view.tsx:151
+msgid "Recent templates"
+msgstr "最近のテンプレート"
+
+#: scripts/apps/users/views/list.html:42
+msgid "Recently added"
+msgstr "最近追加"
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:62
+#: scripts/apps/publish/views/email-config.html:2
+msgid "Recipients"
+msgstr "受信者"
+
+#: scripts/apps/publish/views/email-config.html:10
+msgid "Recipients (Bcc, hidden)"
+msgstr "受信者（BCC、非表示）"
+
+#: scripts/apps/publish/views/email-config.html:4
+msgid "Recipients (visible to everybody)"
+msgstr "受信者（全員に表示）"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:161
+msgid "Recurring"
+msgstr "繰り返し"
+
+#: ../superdesk-planning/client/components/ItemIcon.tsx:26
+msgid "Recurring Event"
+msgstr "繰り返しイベント"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:120
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:73
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:79
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:85
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:91
+msgid "Recurring Event(s)"
+msgstr "繰り返しイベント"
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:263
+msgid "Recurring Rules"
+msgstr "繰り返しルール"
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:60
+msgid "Red"
+msgstr "赤"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:162
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:44
+#: scripts/core/editor3/components/toolbar/index.tsx:473
+msgid "Redo"
+msgstr "やり直し"
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:220
+#: ../superdesk-planning/client/components/fields/resources/events.ts:42
+#: ../superdesk-planning/client/utils/contentProfiles.ts:275
+msgid "Reference"
+msgstr "参照"
+
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:770
+msgid "Refine search"
+msgstr "検索を絞り込む"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:163
+#: scripts/apps/monitoring/views/monitoring-group-header.html:24
+#: scripts/apps/monitoring/views/monitoring-group-header.html:87
+#: scripts/apps/monitoring/views/monitoring-view.html:99
+#: scripts/apps/profiling/views/profiling.html:23
+#: scripts/apps/publish/views/publish-queue.html:79
+#: scripts/apps/search/views/search-tags.html:24
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:415
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:415
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:794
+msgid "Refresh"
+msgstr "更新"
+
+#: scripts/apps/monitoring/views/monitoring-view.html:99
+msgid "Refresh content"
+msgstr "コンテンツを更新"
+
+#: scripts/apps/authoring/metadata/views/metadata-tags.html:9
+msgid "Refresh suggestions"
+msgstr "候補を更新"
+
+#: scripts/apps/authoring/metadata/views/metadata-tags.html:10
+msgid "Refreshing..."
+msgstr "更新中..."
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines-widget.js:54
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines.js:22
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary-widget.js:55
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary.js:21
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:31
+#: scripts/extensions/ai-widget/dist/src/headlines/headlines-widget.js:54
+#: scripts/extensions/ai-widget/dist/src/headlines/headlines.js:22
+#: scripts/extensions/ai-widget/dist/src/summary/summary-widget.js:55
+#: scripts/extensions/ai-widget/dist/src/summary/summary.js:21
+#: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:31
+#: scripts/extensions/ai-widget/src/headlines/headlines-widget.tsx:100
+#: scripts/extensions/ai-widget/src/headlines/headlines.tsx:46
+#: scripts/extensions/ai-widget/src/summary/summary-widget.tsx:101
+#: scripts/extensions/ai-widget/src/summary/summary.tsx:42
+#: scripts/extensions/ai-widget/src/translations/translations-body.tsx:67
+msgid "Regenerate"
+msgstr "再生成"
+
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:18
+msgid "Region"
+msgstr "地域"
+
+#: ../superdesk-planning/client/components/fields/resources/events.ts:75
+msgid "Registration"
+msgstr "登録"
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:77
+#: ../superdesk-planning/client/components/fields/preview/index.ts:271
+#: ../superdesk-planning/client/components/fields/resources/events.ts:64
+#: ../superdesk-planning/client/utils/contentProfiles.ts:341
+msgid "Registration Details"
+msgstr "登録の詳細"
+
+#: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:163
+msgid "Reject"
+msgstr "却下"
+
+#: scripts/apps/authoring-react/article-widgets/suggestions.tsx:74
+#: scripts/apps/authoring/track-changes/views/suggestions-widget.html:9
+msgid "Rejected"
+msgstr "却下済み"
+
+#: scripts/apps/authoring/track-changes/views/suggestions-widget.html:38
+msgid "Rejected by"
+msgstr "却下者"
+
+#: scripts/apps/authoring-react/article-widgets/suggestions.tsx:127
+msgid "Rejected by {{user}}"
+msgstr "{{user}}が却下"
+
+#: scripts/apps/archive/related-item-widget/relatedItem.ts:114
+msgid "Relate an item"
+msgstr "アイテムを関連付け"
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EditorFieldEventRelatedItems.tsx:54
+#: ../superdesk-planning/client/components/fields/preview/RelatedArticles.tsx:34
+#: ../superdesk-planning/client/components/fields/resources/events.ts:120
+#: ../superdesk-planning/client/utils/contentProfiles.ts:351
+msgid "Related Articles"
+msgstr "関連記事"
+
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:109
+msgid "Related Events"
+msgstr "関連イベント"
+
+#: scripts/apps/archive/related-item-widget/relatedItem.ts:109
+#: scripts/apps/archive/related-item-widget/relatedItem.ts:13
+#: scripts/apps/workspace/content/constants.ts:39
+msgid "Related Items"
+msgstr "関連アイテム"
+
+#: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:134
+msgid "Related Planning Items"
+msgstr "関連プランニングアイテム"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:220
+msgid "Related Planning(s)"
+msgstr "関連プランニング"
+
+#: ../superdesk-planning/client/components/Editor/bookmarks/AssociatedPlanningsBookmark.tsx:95
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:111
+#: ../superdesk-planning/client/utils/contentProfiles.ts:301
+msgid "Related Plannings"
+msgstr "関連プランニング"
+
+#: scripts/apps/vocabularies/views/settings.html:31
+msgid "Related content"
+msgstr "関連コンテンツ"
+
+#: scripts/apps/relations/directives/RelatedItemsDirective.ts:237
+msgid "Related item is not available."
+msgstr "関連アイテムは利用できません。"
+
+#: scripts/apps/relations/directives/RelatedItemsDirective.ts:160
+msgid ""
+"Related item was not added, because the field reached the limit of related "
+"items allowed."
+msgstr "関連アイテムの上限に達したため、関連アイテムは追加されませんでした。"
+
+#: scripts/apps/vocabularies/constants.ts:22
+msgid "Related items"
+msgstr "関連アイテム"
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:16
+msgid "Relative Days"
+msgstr "相対日数"
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:13
+msgid "Relative Hours"
+msgstr "相対時間数"
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:26
+msgid "Relative Months"
+msgstr "相対月数"
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:21
+msgid "Relative Weeks"
+msgstr "相対週数"
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:181
+msgid "Relative value is required"
+msgstr "相対値は必須です"
+
+#: ../superdesk-planning/client/components/Agendas/AgendaListItem.tsx:68
+#: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:58
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:166
+#: ../superdesk-planning/client/components/EventsPlanningFilters/TimeInputs.tsx:84
+#: ../superdesk-planning/client/components/ExportTemplates/ExportTemplateItem.tsx:44
+#: ../superdesk-planning/client/components/UI/Form/FileInput.tsx:117
+#: ../superdesk-planning/client/components/UI/Form/FileInput.tsx:154
+#: ../superdesk-planning/client/components/UI/TermsList.tsx:48
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/RelatedArticlesListComponent.tsx:197
+#: scripts/apps/archive/views/marked_item_title.html:20
+#: scripts/apps/authoring-react/fields/date/config.tsx:93
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:184
+#: scripts/apps/authoring-react/fields/linked-items/editor.tsx:68
+#: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:149
+#: scripts/apps/authoring-react/fields/package-items/editor.tsx:65
+#: scripts/apps/authoring-react/fields/urls/editor.tsx:70
+#: scripts/apps/authoring-react/toolbar/highlights-management.tsx:90
+#: scripts/apps/authoring-react/toolbar/mark-for-desks/mark-for-desks-popover.tsx:48
+#: scripts/apps/authoring/attachments/AttachmentsListItem.tsx:72
+#: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:106
+#: scripts/apps/desks/views/settings.html:57 scripts/apps/ingest/index.ts:102
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:115
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:59
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:126
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:127
+#: scripts/apps/templates/views/templates.html:37
+#: scripts/apps/workspace/content/views/profile-settings.html:48
+#: scripts/core/editor3/highlightsConfig.ts:34
+#: scripts/core/ui/components/select2.tsx:301
+#: scripts/core/ui/components/select2.tsx:302
+#: scripts/extensions/annotationsLibrary/dist/src/annotations-library-page.js:40
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/annotations-library-page.js:40
+#: scripts/extensions/annotationsLibrary/src/annotations-library-page.tsx:80
+#: scripts/extensions/annotationsLibrary/src/annotations-library-page.tsx:81
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:77
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/working-day-view.js:21
+#: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:77
+#: scripts/extensions/availability-manager/dist/src/settings/working-day-view.js:21
+#: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:165
+#: scripts/extensions/availability-manager/src/settings/working-day-view.tsx:44
+#: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/subitems-view-edit.js:39
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.js:39
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:67
+#: scripts/extensions/broadcasting/dist/src/shows/manage-shows.js:67
+#: scripts/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.tsx:81
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:100
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:99
+#: scripts/extensions/datetimeField/dist/src/config.js:36
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:36
+#: scripts/extensions/datetimeField/src/config.tsx:67
+#: scripts/extensions/predefinedTextField/dist/src/config.js:42
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:42
+#: scripts/extensions/predefinedTextField/src/config.tsx:66
+#: scripts/extensions/predefinedTextField/src/config.tsx:67
+msgid "Remove"
+msgstr "削除"
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:36
+msgid "Remove All Format"
+msgstr "すべての書式を削除"
+
+#: ../superdesk-planning/client/constants/assignments.ts:195
+msgid "Remove Assignment"
+msgstr "アサインメントを削除"
+
+#: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:83
+#: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:85
+msgid "Remove Contact"
+msgstr "連絡先を削除"
+
+#: scripts/apps/content-filters/views/manage-filters.html:21
+msgid "Remove Content Filter"
+msgstr "コンテンツフィルターを削除"
+
+#: ../superdesk-planning/client/components/UI/Form/InputArray/index.tsx:84
+msgid "Remove Coverage"
+msgstr "取材を削除"
+
+#: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:127
+msgid "Remove Event"
+msgstr "イベントを削除"
+
+#: ../superdesk-analytics/client/utils.js:179
+msgid "Remove Featuremedia"
+msgstr "フィーチャーメディアを削除"
+
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:30
+msgid "Remove Filter Condition"
+msgstr "フィルター条件を削除"
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:35
+msgid "Remove Format"
+msgstr "書式を削除"
+
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-article.html:4
+msgid "Remove Item"
+msgstr "アイテムを削除"
+
+#: ../superdesk-planning/client/components/GeoLookupInput/LocationItem.tsx:49
+msgid "Remove Location"
+msgstr "ロケーションを削除"
+
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:154
+msgid "Remove Scheduled Update"
+msgstr "スケジュール済み更新を削除"
+
+#: scripts/apps/search-providers/views/search-provider-config.html:17
+msgid "Remove Search Provider"
+msgstr "検索プロバイダーを削除"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:164
+msgid "Remove Sign"
+msgstr "マイナス記号"
+
+#: scripts/apps/templates/views/templates.html:37
+msgid "Remove Template"
+msgstr "テンプレートを削除"
+
+#: scripts/core/editor3/components/toolbar/index.tsx:386
+msgid "Remove all formatting"
+msgstr "すべての書式を削除"
+
+#: scripts/apps/authoring-react/multi-edit-modal.tsx:131
+msgid "Remove article"
+msgstr "記事を削除"
+
+#: scripts/apps/highlights/views/settings.html:20
+msgid "Remove configuration"
+msgstr "設定を削除"
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/index.tsx:277
+msgid "Remove coverage"
+msgstr "取材を削除"
+
+#: scripts/apps/desks/views/settings.html:53
+msgid "Remove desk"
+msgstr "デスクを削除"
+
+#: scripts/apps/dictionaries/views/settings.html:55
+msgid "Remove dictionary"
+msgstr "辞書を削除"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:14
+msgid "Remove fetch action"
+msgstr "取得アクションを削除"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:98
+msgid "Remove field"
+msgstr "フィールドを削除"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-filter.html:16
+msgid "Remove filter"
+msgstr "フィルターを削除"
+
+#: scripts/core/editor3/components/toolbar/index.tsx:377
+msgid "Remove formatting"
+msgstr "書式を削除"
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningItem.tsx:83
+msgid "Remove from Feature Stories"
+msgstr "特集記事から削除"
+
+#: ../superdesk-planning/client/constants/planning.ts:146
+msgid "Remove from featured stories"
+msgstr "特集記事から削除"
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupElementTemplate.tsx:71
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupList.tsx:83
+msgid "Remove group"
+msgstr "グループを削除"
+
+#: scripts/apps/authoring/metadata/views/meta-place-directive.html:33
+#: scripts/apps/authoring/metadata/views/metadata-target-publishing.html:20
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:125
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:128
+#: scripts/apps/search/views/multi-image-edit.html:56
+#: scripts/apps/templates/views/template-editor-modal.html:164
+#: scripts/core/ui/views/sd-multi-select.html:28
+msgid "Remove item"
+msgstr "アイテムを削除"
+
+#: scripts/core/editor3/highlightsConfig.ts:119
+msgid "Remove link"
+msgstr "リンクを削除"
+
+#: scripts/apps/authoring/multiedit/views/multiedit.html:17
+msgid "Remove panel"
+msgstr "パネルを削除"
+
+#: scripts/apps/products/views/products.html:32
+msgid "Remove product"
+msgstr "プロダクトを削除"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:46
+msgid "Remove publish action"
+msgstr "公開アクションを削除"
+
+#: scripts/apps/users/views/settings-roles.html:18
+msgid "Remove role"
+msgstr "ロールを削除"
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:20
+msgid "Remove rule set"
+msgstr "ルールセットを削除"
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:20
+msgid "Remove scheme"
+msgstr "スキームを削除"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:47
+msgid "Remove source"
+msgstr "ソースを削除"
+
+#: scripts/apps/authoring-react/fields/attachments/difference-row.tsx:35
+msgid "Removed"
+msgstr "削除済み"
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:86
+msgid "Removed from featured stories"
+msgstr "特集記事から削除されました"
+
+#: scripts/apps/workspace/views/edit-workspace-modal.html:4
+msgid "Rename Workspace"
+msgstr "ワークスペースの名前を変更"
+
+#: scripts/apps/dashboard/views/workspace.html:29
+#: scripts/apps/monitoring/views/monitoring-view.html:213
+msgid "Rename workspace"
+msgstr "ワークスペースの名前を変更"
+
+#: scripts/apps/publish/views/email-config.html:29
+msgid "Rendition"
+msgstr "レンディション"
+
+#: ../superdesk-analytics/client/views/renditions-preview.html:11
+msgid "Renditions"
+msgstr "レンディション"
+
+#: scripts/apps/authoring/versioning/history/views/history.html:133
+msgid "Reopened by"
+msgstr "再オープン者"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:443
+msgid "Reopened by {{user}}"
+msgstr "{{user}}が再オープン"
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:105
+msgid "Reorder Sections"
+msgstr "セクションを並び替え"
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:108
+msgid "Reorder stages and saved searches for monitoring view"
+msgstr "モニタリング表示のステージと保存済み検索を並び替え"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:165
+msgid "Repeat"
+msgstr "繰り返し"
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/DaysOfWeekInput.tsx:98
+msgid "Repeat On"
+msgstr "繰り返し曜日"
+
+#: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:99
+#: ../superdesk-planning/client/components/Events/RepeatEventSummary/index.tsx:15
+msgid "Repeat Summary"
+msgstr "繰り返しサマリー"
+
+#: ../superdesk-planning/client/validators/profile.ts:44
+#: ../superdesk-planning/client/validators/profile.ts:45
+msgid "Repeat must be set"
+msgstr "繰り返しを設定してください"
+
+#: ../superdesk-planning/client/components/Events/EventScheduleInput/index.tsx:100
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:160
+#: ../superdesk-planning/client/components/fields/editor/EventRecurringRules.tsx:60
+#: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/recurring-rules/index.tsx:23
+msgid "Repeats"
+msgstr "繰り返し"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:88
+msgid "Repetitions updated"
+msgstr "繰り返しが更新されました"
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:125
+#: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:161
+#: scripts/apps/authoring/editor/views/find-replace.html:28
+#: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:91
+msgid "Replace"
+msgstr "置換"
+
+#: scripts/apps/authoring/editor/views/find-replace.html:29
+msgid "Replace All"
+msgstr "すべて置換"
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:141
+msgid "Replace all"
+msgstr "すべて置換"
+
+#: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:106
+msgid "Replace link"
+msgstr "リンクを置換"
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:88
+#: scripts/apps/authoring/editor/views/find-replace.html:13
+msgid "Replace with"
+msgstr "置換後"
+
+#: scripts/apps/authoring-react/article-widgets/suggestions.tsx:87
+msgid "Replace {{x}} with {{y}}"
+msgstr "{{x}}を{{y}}に置換"
+
+#: scripts/apps/authoring/track-changes/views/suggestions-widget.html:25
+msgid "Replace:"
+msgstr "置換："
+
+#: scripts/core/editor3/components/comments/CommentPopup.tsx:218
+msgid "Reply"
+msgstr "返信"
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsModal.js:94
+msgid "Report Schedule created!"
+msgstr "レポートスケジュールが作成されました。"
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsModal.js:95
+msgid "Report Schedule saved!"
+msgstr "レポートスケジュールが保存されました。"
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:67
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:63
+msgid "Report Type"
+msgstr "レポートタイプ"
+
+#: ../superdesk-analytics/client/email_report/services/EmailReportService.js:66
+msgid "Report chart emailed!"
+msgstr "レポートグラフがメール送信されました。"
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:185
+msgid "Report deleted!"
+msgstr "レポートが削除されました。"
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:151
+msgid "Report saved!"
+msgstr "レポートが保存されました。"
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:27
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:46
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:63
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:138
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:156
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:38
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:99
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:196
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:88
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:19
+#: ../superdesk-planning/client/validators/events.ts:107
+#: ../superdesk-planning/client/validators/events.ts:112
+#: ../superdesk-planning/client/validators/events.ts:118
+#: ../superdesk-planning/client/validators/events.ts:241
+#: ../superdesk-planning/client/validators/planning.ts:231
+#: ../superdesk-planning/client/validators/planning.ts:288
+#: ../superdesk-planning/client/validators/planning.ts:292
+#: scripts/apps/authoring-react/authoring-section/get-field-container.tsx:25
+#: scripts/apps/authoring-react/fields/common-field-configuration.tsx:19
+#: scripts/apps/authoring/authoring/article-url-fields.tsx:68
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:172
+#: scripts/core/editor3/directive.tsx:427 scripts/core/ui/ui.ts:1129
+msgid "Required"
+msgstr "必須"
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:24
+msgid "Required field {{key}} is missing. ..."
+msgstr "必須フィールド{{key}}がありません。..."
+
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:116
+msgid "Required {{field}} in item {{item}}"
+msgstr "アイテム{{item}}で{{field}}は必須です"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:98
+#: ../superdesk-planning/client/constants/events.ts:161
+msgid "Reschedule"
+msgstr "再スケジュール"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:96
+msgid "Reschedule {{event}}"
+msgstr "{{event}}を再スケジュール"
+
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:34
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:206
+#: ../superdesk-planning/client/utils/index.ts:369
+msgid "Rescheduled"
+msgstr "再スケジュール済み"
+
+#: ../superdesk-planning/client/components/fields/state.tsx:30
+msgid "Rescheduled Event"
+msgstr "再スケジュール済みイベント"
+
+#: scripts/apps/archive/views/resend-configuration.html:25
+#: scripts/apps/publish/views/publish-queue.html:147
+#: scripts/apps/publish/views/publish-queue.html:90
+msgid "Resend"
+msgstr "再送"
+
+#: scripts/apps/archive/views/resend-configuration.html:4
+msgid "Resend To"
+msgstr "再送先"
+
+#: scripts/apps/archive/index.tsx:280
+msgid "Resend item"
+msgstr "アイテムを再送"
+
+#: scripts/apps/authoring/versioning/history/HistoryController.ts:188
+msgid "Resent by"
+msgstr "再送者"
+
+#: scripts/apps/profiling/views/profiling.html:22
+msgid "Reset"
+msgstr "リセット"
+
+#: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:13
+msgid "Reset Filters"
+msgstr "フィルターをリセット"
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:247
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:247
+#: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:359
+msgid "Reset change"
+msgstr "変更をリセット"
+
+#: scripts/core/auth/reset-password.html:59
+msgid "Reset password"
+msgstr "パスワードをリセット"
+
+#: scripts/core/editor3/components/comments/CommentPopup.tsx:173
+msgid "Resolve"
+msgstr "解決"
+
+#: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:176
+#: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:4
+msgid "Resolved"
+msgstr "解決済み"
+
+#: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:39
+msgid "Resolved by"
+msgstr "解決者"
+
+#: scripts/apps/authoring-react/article-widgets/suggestions.tsx:18
+msgid "Resolved suggestions"
+msgstr "解決済みの提案"
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:592
+msgid "Resolving comments"
+msgstr "コメントを解決中"
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:576
+msgid "Resolving suggestions"
+msgstr "提案を解決中"
+
+#: scripts/apps/publish/views/http-push-config.html:5
+#: scripts/apps/publish/views/http-push-config.html:6
+msgid "Resource URL"
+msgstr "リソースURL"
+
+#: scripts/core/lang/missing-translations-strings.ts:20
+msgid "Restore"
+msgstr "復元"
+
+#: scripts/apps/products/views/product-test.html:15
+msgid "Result Type"
+msgstr "結果タイプ"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:166
+msgid "Retweet"
+msgstr "リツイート"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:167
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:272
+msgid "Revert"
+msgstr "元に戻す"
+
+#: ../superdesk-planning/client/constants/assignments.ts:198
+msgid "Revert Availability"
+msgstr "可用性を元に戻す"
+
+#: scripts/apps/publish/views/subscribers.html:283
+msgid "Revoke"
+msgstr "取り消し"
+
+#: ../superdesk-analytics/client/utils.js:158
+msgid "Rewrite"
+msgstr "書き直し"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:467
+#: scripts/apps/authoring/versioning/history/views/history.html:154
+msgid "Rewrite link is removed"
+msgstr "書き直しリンクが削除されました"
+
+#: ../superdesk-analytics/client/search/views/preview-source-filter.html:13
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:299
+msgid "Rewrites"
+msgstr "書き直し"
+
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:305
+msgid "Rewrites Only"
+msgstr "書き直しのみ"
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:70
+msgid "Rewrites only"
+msgstr "書き直しのみ"
+
+#: scripts/apps/authoring/versioning/history/views/history.html:176
+msgid "Rewritten by"
+msgstr "書き直し者"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:504
+msgid "Rewritten by {{user}}"
+msgstr "{{user}}が書き直し"
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:469
+#: scripts/apps/authoring/versioning/history/views/history.html:157
+msgid "Rewritten link is removed"
+msgstr "書き直しリンクが削除されました"
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:194
+#: scripts/apps/users/views/edit-form.html:155
+#: scripts/apps/users/views/list.html:35
+#: scripts/apps/users/views/user-privileges.html:19
+msgid "Role"
+msgstr "ロール"
+
+#: scripts/apps/users/views/settings-roles.html:45
+msgid "Role Description"
+msgstr "ロールの説明"
+
+#: scripts/apps/users/views/settings-roles.html:38
+msgid "Role Name"
+msgstr "ロール名"
+
+#: scripts/apps/users/views/settings.html:9
+msgid "Roles"
+msgstr "ロール"
+
+#: scripts/core/lang/missing-translations-strings.ts:20
+msgid "Roles Management"
+msgstr "ロール管理"
+
+#: scripts/apps/users/views/settings.html:12
+msgid "Roles privileges"
+msgstr "ロール権限"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:168
+msgid "Rotate Left"
+msgstr "左に回転"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:169
+msgid "Rotate Right"
+msgstr "右に回転"
+
+#: scripts/apps/authoring/views/change-image.html:206
+msgid "Rotate left"
+msgstr "左に回転"
+
+#: scripts/apps/authoring/views/change-image.html:207
+msgid "Rotate right"
+msgstr "右に回転"
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:253
+msgid "Round corners for dropdown items"
+msgstr "ドロップダウンアイテムの角を丸く"
+
+#: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:22
+msgid "Route incoming content to"
+msgstr "受信コンテンツのルーティング先"
+
+#: scripts/apps/search/components/fields/state.tsx:32
+msgid "Routed"
+msgstr "ルーティング済み"
+
+#: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:3
+msgid "Routed from"
+msgstr "ルーティング元"
+
+#: scripts/apps/dashboard/closed-desk/views/top-menu-info.html:8
+msgid "Routed from other desks"
+msgstr "他のデスクからルーティング"
+
+#: scripts/apps/dashboard/closed-desk/views/top-menu-info.html:9
+msgid "Routed from:"
+msgstr "ルーティング元："
+
+#: scripts/core/lang/missing-translations-strings.ts:20
+msgid "Routing Rules Management"
+msgstr "ルーティングルール管理"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:219
+msgid "Routing Scheme"
+msgstr "ルーティングスキーム"
+
+#: scripts/apps/ingest/directives/IngestRoutingContent.ts:182
+msgid "Routing scheme saved."
+msgstr "ルーティングスキームが保存されました。"
+
+#: scripts/apps/dashboard/closed-desk/views/top-menu-info.html:12
+msgid "Routing to:"
+msgstr "ルーティング先："
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:53
+msgid "Rule name"
+msgstr "ルール名"
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:38
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:39
+msgid "Rule set name"
+msgstr "ルールセット名"
+
+#: scripts/apps/ingest/directives/IngestRulesContent.ts:34
+msgid "Rule set saved."
+msgstr "ルールセットが保存されました。"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:210
+msgid "Ruleset"
+msgstr "ルールセット"
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:410
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:410
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:782
+msgid "Run"
+msgstr "実行"
+
+#: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:18
+msgid "Run Report"
+msgstr "レポートを実行"
+
+#: scripts/apps/authoring/views/authoring-topbar.html:370
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:297
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:297
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:497
+msgid "Run automatically"
+msgstr "自動実行"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:170
+#: scripts/extensions/broadcasting/dist/src/page.js:174
+#: scripts/extensions/broadcasting/src/page.tsx:256
+msgid "Rundown"
+msgstr "ランダウン"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:53
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:53
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:89
+msgid "Rundown created"
+msgstr "ランダウンが作成されました"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:86
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:86
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:174
+msgid "Rundown name"
+msgstr "ランダウン名"
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/send-and-duplicate.tsx:17
+#: scripts/apps/authoring/views/authoring-topbar.html:90
+msgid "S & D"
+msgstr "S & D"
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:115
+msgid "SA"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extension.js:13
+#: scripts/extensions/sams/dist/src/extensions/sams/src/extension.js:13
+#: scripts/extensions/sams/src/extension.ts:17
+msgid "SAMS"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoveragePreview/index.tsx:178
+msgid "SCHEDULED UPDATES"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:45
+msgid "SIGNAL"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:47
+msgid "SLUGLINE is too long"
+msgstr "SLUGLINEが長すぎます"
+
+#: scripts/apps/workspace/content/constants.ts:42
+msgid "SMS"
+msgstr ""
+
+#: scripts/apps/authoring-react/field-adapters/sms_message.ts:21
+#: scripts/apps/workspace/content/constants.ts:43
+msgid "SMS Message"
+msgstr "SMSメッセージ"
+
+#: scripts/apps/authoring/views/authoring-header.html:49
+msgid "SOURCE"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:79
+msgid "START DATE cannot be in the past"
+msgstr "開始日は過去の日付にできません"
+
+#: ../superdesk-planning/client/validators/events.ts:15
+msgid "START DATE is a required field"
+msgstr "開始日は必須フィールドです"
+
+#: ../superdesk-planning/client/validators/events.ts:36
+msgid "START TIME is a required field"
+msgstr "開始時間は必須フィールドです"
+
+#: ../superdesk-planning/client/validators/events.ts:30
+msgid "START TIME is required when END TIME is set"
+msgstr "終了時間が設定されている場合、開始時間は必須です"
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:123
+msgid "SU"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:148
+msgid "Sa"
+msgstr "土"
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:188
+msgid "Sample content"
+msgstr "サンプルコンテンツ"
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:113
+msgid "Sat"
+msgstr "土"
+
+#: scripts/apps/authoring/views/change-image.html:256
+msgid "Saturation"
+msgstr "彩度"
+
+#: ../superdesk-planning/client/utils/events.tsx:1459
+#: scripts/core/datetime/datetime.ts:295
+msgid "Saturday"
+msgstr "土曜日"
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:61
+#: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:40
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:211
+#: ../superdesk-analytics/client/utils.js:153
+#: ../superdesk-planning/client/components/Contacts/ActionBar.tsx:25
+#: ../superdesk-planning/client/components/Contacts/ContactEditor.tsx:99
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:407
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:202
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:159
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:278
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:140
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:145
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:53
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:204
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:391
+#: ../superdesk-planning/client/components/ModalWithForm/index.tsx:135
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:231
+#: ../superdesk-planning/client/components/editor-standalone/base-editor-standalone.tsx:127
+#: scripts/apps/authoring-react/multi-edit-modal.tsx:85
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/save-button.tsx:12
+#: scripts/apps/authoring-react/toolbar/highlights-modal.tsx:101
+#: scripts/apps/authoring-react/toolbar/mark-for-desks/mark-for-desks-modal.tsx:62
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:64
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:162
+#: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:134
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:47
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-article.html:8
+#: scripts/apps/authoring/views/authoring-topbar.html:194
+#: scripts/apps/authoring/views/change-image.html:81
+#: scripts/apps/authoring/views/theme-select.html:119
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:265
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:105
+#: scripts/apps/content-filters/views/manage-filters.html:156
+#: scripts/apps/dashboard/views/configuration.html:9
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:11
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:88
+#: scripts/apps/desks/controllers/DeskConfigController.ts:95
+#: scripts/apps/desks/views/desk-config-modal.html:275
+#: scripts/apps/desks/views/desk-config-modal.html:283
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:133
+#: scripts/apps/highlights/views/highlights_config_modal.html:55
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:127
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:71
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:261
+#: scripts/apps/products/views/products-config-modal.html:94
+#: scripts/apps/publish/views/subscribers.html:331
+#: scripts/apps/search-providers/views/search-provider-config.html:126
+#: scripts/apps/search/views/multi-image-edit.html:6
+#: scripts/apps/templates/views/create-template.html:53
+#: scripts/apps/templates/views/template-editor-modal.html:223
+#: scripts/apps/users/views/settings-privileges.html:4
+#: scripts/apps/users/views/user-preferences.html:6
+#: scripts/apps/users/views/user-privileges.html:10
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:332
+#: scripts/apps/workspace/content/views/profile-settings.html:189
+#: scripts/apps/workspace/views/edit-workspace-modal.html:39
+#: scripts/core/ui/components/IgnoreCancelSaveDialog.tsx:71
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:578
+#: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:57
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:56
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:259
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:259
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:409
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-workday-modal.js:108
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/manage-schedule.js:130
+#: scripts/extensions/availability-manager/dist/src/settings/edit-workday-modal.js:108
+#: scripts/extensions/availability-manager/dist/src/settings/manage-schedule.js:130
+#: scripts/extensions/availability-manager/src/settings/edit-workday-modal.tsx:172
+#: scripts/extensions/availability-manager/src/settings/manage-schedule.tsx:211
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-modal.js:53
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-modal.js:53
+#: scripts/extensions/broadcasting/src/shows/create-show-modal.tsx:106
+#: scripts/extensions/sams/dist/src/components/assets/assetEditorPanel.js:146
+#: scripts/extensions/sams/dist/src/components/attachments/editAttachmentModal.js:132
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:222
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditorPanel.js:146
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/editAttachmentModal.js:132
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:222
+#: scripts/extensions/sams/src/components/assets/assetEditorPanel.tsx:131
+#: scripts/extensions/sams/src/components/attachments/editAttachmentModal.tsx:130
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:244
+#: scripts/extensions/videoEditor/dist/src/VideoEditorHeader.js:11
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorHeader.js:11
+#: scripts/extensions/videoEditor/src/VideoEditorHeader.tsx:25
+msgid "Save"
+msgstr "保存"
+
+#: scripts/apps/search/views/multi-image-edit.html:7
+msgid "Save & Close"
+msgstr "保存して閉じる"
+
+#: scripts/apps/desks/views/desk-config-modal.html:214
+#: scripts/apps/desks/views/desk-config-modal.html:451
+msgid "Save & Continue"
+msgstr "保存して続行"
+
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:137
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:372
+msgid "Save & Post"
+msgstr "保存して投稿"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:64
+msgid "Save & Post Event"
+msgstr "保存してイベントを投稿"
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:382
+msgid "Save & Unpost"
+msgstr "保存して投稿取り消し"
+
+#: scripts/apps/workspace/content/views/profile-settings.html:131
+msgid "Save &amp; Continue"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:388
+#: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:225
+msgid "Save All"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:35
+#: scripts/apps/search/views/save-search.html:15
+msgid "Save As"
+msgstr ""
+
+#: scripts/apps/search/views/save-search.html:16
+#: scripts/apps/search/views/save-search.html:17
+msgid "Save Changes"
+msgstr ""
+
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:179
+msgid "Save Changes?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:67
+msgid "Save Event"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:33
+#: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:3
+msgid "Save Report"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:276
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:276
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:426
+msgid "Save Rundown"
+msgstr ""
+
+#: scripts/apps/search/views/save-search.html:10
+msgid "Save Search"
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:713
+msgid "Save all other changes before performing this action."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:60
+msgid "Save and publish"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:72
+msgid "Save and send"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:230
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:65
+#: scripts/apps/authoring/views/authoring-topbar.html:270
+#: scripts/apps/templates/views/create-template.html:5
+msgid "Save as template"
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:245
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:245
+#: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:352
+msgid "Save change"
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-manage-subscribers.html:129
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:220
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:220
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:416
+msgid "Save changes"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:340
+msgid "Save changes before adding to top stories ?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:289
+msgid "Save changes before adding to top stories?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:225
+msgid "Save changes before cancelling the Event?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:956
+msgid "Save changes before creating a planning item ?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorItemActions.tsx:106
+msgid "Save changes before creating a template?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:988
+msgid "Save changes before marking event as complete ?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:249
+msgid "Save changes before postponing the Event?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:272
+msgid "Save changes before rescheduling the Event?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1578
+msgid "Save changes before spiking ?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:307
+msgid "Save changes before updating Event Repetitions?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:202
+msgid "Save changes before updating the Event's time?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:402
+msgid "Save changes without re-posting?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:112
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:169
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:264
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:46
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:59
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:71
+#: scripts/apps/desks/controllers/DeskConfigController.ts:94
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:34
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:70
+msgid "Save changes?"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:470
+msgid "Save current item"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/events.ts:169
+msgid "Save event as a template"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:364
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:364
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:630
+msgid "Save item"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:401
+msgid "Save password"
+msgstr ""
+
+#: scripts/apps/search/views/save-search.html:23
+msgid "Save search"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:22
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:22
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-panel.html:22
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-panel.html:22
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-panel.html:22
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-panel.html:22
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-panel.html:22
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-panel.html:22
+#: scripts/apps/search/views/search-panel.html:9
+#: scripts/apps/users/directives/UserEditDirective.ts:240
+msgid "Saved"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:348
+msgid "Saved Featured Stories record"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:71
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:83
+msgid "Saved Report"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:166
+msgid ""
+"Saved Report has changed since it was opened. Please re-select the Saved "
+"Report to continue. Regrettably, your changes cannot be saved."
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:62
+msgid "Saved Searches"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:238
+msgid "Saved report not found!"
+msgstr ""
+
+#: scripts/apps/search/directives/SavedSearches.ts:116
+msgid "Saved search removed"
+msgstr ""
+
+#: scripts/apps/search/views/saved-searches.html:1
+msgid "Saved searches"
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:117
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:117
+#: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:181
+msgid "Saving capture thumbnail..."
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:131
+#: scripts/apps/desks/directives/DeskeditBasic.ts:31
+#: scripts/apps/desks/directives/DeskeditPeople.ts:50
+#: scripts/apps/desks/directives/DeskeditStages.ts:163
+#: scripts/core/notify/notify.tsx:59
+msgid "Saving..."
+msgstr ""
+
+#: scripts/apps/search/views/search-parameters.html:249
+msgid "Scanpix ID(s)"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:105
+msgid "Scatter"
+msgstr ""
+
+#: scripts/apps/templates/views/templates.html:56
+msgid "Sched. Desk / Stage"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:27
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:49
+#: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:2
+#: scripts/apps/search/views/edit-time-interval.html:1
+msgid "Schedule"
+msgstr ""
+
+#: scripts/apps/templates/views/template-editor-modal.html:175
+msgid "Schedule Desk"
+msgstr ""
+
+#: scripts/apps/templates/views/template-editor-modal.html:197
+msgid "Schedule Macro"
+msgstr ""
+
+#: scripts/apps/templates/views/template-editor-modal.html:187
+msgid "Schedule Stage"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduledUpdates.tsx:98
+msgid "Schedule an update"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:84
+msgid "Schedule will be permanently deleted."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:132
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:25
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:200
+#: ../superdesk-planning/client/constants/tooltips.ts:30
+#: ../superdesk-planning/client/utils/contentProfiles.ts:329
+#: ../superdesk-planning/client/utils/index.ts:356
+#: ../superdesk-planning/client/utils/index.ts:357
+#: scripts/apps/search/components/fields/state.tsx:38
+msgid "Scheduled"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:174
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:88
+msgid "Scheduled Date"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.ts:70
+msgid "Scheduled Desk Output"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:151
+msgid "Scheduled Export"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.ts:38
+msgid "Scheduled Time"
+msgstr ""
+
+#: scripts/apps/templates/views/templates.html:68
+msgid "Scheduled Time(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduledUpdates.tsx:64
+#: ../superdesk-planning/client/utils/contentProfiles.ts:331
+msgid "Scheduled Updates"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:113
+#: scripts/apps/templates/views/template-editor-modal.html:156
+msgid "Scheduled at"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/HistoryController.ts:180
+msgid "Scheduled by"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/common/PreviewFilterSchedule.tsx:46
+msgid "Scheduled export: {{ description }}"
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:426
+msgid "Scheduled from {{start}} to {{end}}"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/planning.ts:320
+msgid "Scheduled updates have to be after the previous updates."
+msgstr ""
+
+#: ../superdesk-planning/client/validators/planning.ts:324
+msgid "Scheduled updates should have a date/time."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:73
+msgid "Scheduled:"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:51
+msgid "Scheduling"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:103
+msgid "Scheme details"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:41
+msgid "Scheme name"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:49
+msgid "Scheme rules"
+msgstr ""
+
+#: scripts/apps/production-api-keys/config.ts:18
+msgid "Scopes"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentFilterPanel.tsx:131
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:38
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:39
+#: ../superdesk-planning/client/components/Main/SearchPanel.tsx:140
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:170
+#: ../superdesk-planning/client/components/UI/SearchBar/index.tsx:84
+#: ../superdesk-planning/client/components/UI/SearchBox.tsx:126
+#: ../superdesk-planning/client/components/UI/SearchField/index.tsx:87
+#: scripts/apps/contacts/views/search-panel.html:87
+#: scripts/apps/content-api/views/search-panel.html:23
+#: scripts/apps/content-filters/views/filter-search.html:44
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:55
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:6
+#: scripts/apps/legal-archive/views/legal_archive.html:42
+#: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:11
+#: scripts/apps/monitoring/views/monitoring-view.html:84
+#: scripts/apps/packaging/views/search.html:4
+#: scripts/apps/publish/views/publish-queue.html:8
+#: scripts/apps/search/directives/SearchContainer.ts:21
+#: scripts/apps/search/index.ts:110 scripts/apps/search/index.ts:120
+#: scripts/apps/search/index.ts:129
+#: scripts/apps/search/views/item-searchbar.html:9
+#: scripts/apps/search/views/menu-providers.html:3
+#: scripts/apps/search/views/menu-providers.html:4
+#: scripts/apps/search/views/menu.html:3 scripts/apps/search/views/menu.html:4
+#: scripts/apps/search/views/save-search.html:13
+#: scripts/apps/search/views/save-search.html:5
+#: scripts/apps/search/views/saved-search-manage-subscribers.html:34
+#: scripts/apps/search/views/search-parameters.html:241
+#: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:351
+#: scripts/core/itemList/views/relatedItem-list-widget.html:5
+#: scripts/core/itemList/views/relatedItem-list-widget.html:7
+#: scripts/core/lang/missing-translations-strings.ts:26
+#: scripts/core/list/views/searchbar.html:4
+#: scripts/core/ui/components/SearchBar/index.tsx:139
+#: scripts/core/ui/components/select2.tsx:224
+#: scripts/core/views/sdSearchList.html:43
+#: scripts/core/views/sdTypeahead.html:4
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:127
+#: scripts/extensions/broadcasting/dist/src/page.js:131
+#: scripts/extensions/broadcasting/src/page.tsx:186
+msgid "Search"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:238
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:238
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:336
+msgid "Search Assets"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/SubNavBar.tsx:72
+msgid "Search Assignments"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:432
+msgid "Search Categories"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:480
+msgid "Search Content State"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:396
+msgid "Search Content Type"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:384
+msgid "Search Desks"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:536
+msgid "Search Enter Desk Actions"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:557
+msgid "Search Exit Desk Actions"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:86
+msgid "Search Filters"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:444
+msgid "Search Genre"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:494
+msgid "Search Ingest Providers"
+msgstr ""
+
+#: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:160
+msgid "Search OpenStreetMap"
+msgstr ""
+
+#: scripts/apps/search-providers/directive.ts:92
+msgid "Search Provider deleted."
+msgstr ""
+
+#: scripts/apps/search-providers/directive.ts:53
+msgid "Search Provider saved."
+msgstr ""
+
+#: scripts/apps/search-providers/index.ts:37
+#: scripts/apps/search-providers/views/settings.html:4
+msgid "Search Providers"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:118
+msgid "Search Related Articles"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:456
+msgid "Search Source"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:509
+msgid "Search Stages"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/FullText.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:87
+msgid "Search Text"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:468
+msgid "Search Urgency"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:414
+#: ../superdesk-analytics/client/search/views/user-select.html:17
+msgid "Search Users"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-recipients-input.html:9
+msgid "Search emails"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Contacts/SelectSearchContactsField/SelectListPopup.tsx:226
+msgid "Search for a contact"
+msgstr ""
+
+#: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupInput.tsx:289
+msgid "Search for a location"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/configuration.html:34
+msgid "Search for clock"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:91
+msgid "Search icons...."
+msgstr ""
+
+#: scripts/apps/content-api/index.ts:22
+msgid "Search items is content API"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:116
+#: ../superdesk-planning/client/components/Main/SubNavBar.tsx:29
+msgid "Search planning"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:217
+msgid "Search provider contacts"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-list.html:6
+msgid "Search saved reports"
+msgstr ""
+
+#: scripts/apps/search/views/saved-searches.html:3
+msgid "Search saved searches"
+msgstr ""
+
+#: scripts/apps/search/views/save-search-dialog.html:18
+msgid "Search shortcut"
+msgstr ""
+
+#: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:81
+msgid "Search templates"
+msgstr ""
+
+#: scripts/apps/search/directives/SaveSearch.ts:72
+msgid "Search was saved successfully"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:157
+#: scripts/core/ui/components/SearchBar/manual.tsx:37
+#: scripts/core/ui/components/SelectUser.tsx:101
+msgid "Search..."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:31
+msgid "Search/Browse Locations"
+msgstr ""
+
+#: scripts/core/ui/views/sd-timepicker-popup.html:21
+msgid "Seconds"
+msgstr ""
+
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:50
+msgid "Secret Access Key"
+msgstr ""
+
+#: scripts/apps/publish/views/http-push-config.html:13
+msgid "Secret Token"
+msgstr ""
+
+#: scripts/core/auth/secure-login.html:18
+msgid "Secure Log In"
+msgstr ""
+
+#: scripts/apps/products/views/products.html:10
+#: scripts/apps/publish/views/subscribers.html:10
+#: scripts/core/views/sdSearchList.html:3
+msgid "Select"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:277
+msgid "Select Agenda"
+msgstr ""
+
+#: scripts/apps/search/views/multi-image-edit.html:25
+msgid "Select All"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/selectAssetModal.js:150
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/selectAssetModal.js:150
+#: scripts/extensions/sams/src/components/assets/selectAssetModal.tsx:162
+msgid "Select Asset(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/DesksSubNavDropDown.tsx:49
+msgid "Select Assignments From:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:260
+msgid "Select Calendar"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/drop-zone.tsx:76
+msgid "Select Files"
+msgstr ""
+
+#: scripts/apps/archive/views/resend-configuration.html:10
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:55
+msgid "Select Subscribers"
+msgstr ""
+
+#: scripts/apps/workspace/views/workspace-dropdown.html:5
+msgid "Select Workspace"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:179
+msgid ""
+"Select a default content profile which is used for articles fetched from "
+"ingest. If you don't see any, create one\n"
+"                                   <a href=\"#/settings/content-"
+"profiles\">here</a>"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:156
+msgid ""
+"Select a default template for new articles. If you don't see any, first make "
+"sure that there is at least one content profile. Each time a profile is "
+"created, Superdesk creates a template with the same name."
+msgstr ""
+
+#: scripts/core/ui/components/generic-form/input-types/desk_single_value.tsx:40
+msgid "Select a desk"
+msgstr ""
+
+#: scripts/core/ui/components/generic-form/input-types/macro_single_value.tsx:27
+#: scripts/core/ui/components/generic-form/input-types/stage_single_value.tsx:42
+msgid "Select a desk first"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:123
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:123
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:240
+msgid "Select a show from the dropdown above."
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:149
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:149
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:317
+msgid "Select a template from the sidebar."
+msgstr ""
+
+#: scripts/core/ui/components/SelectUser.tsx:100
+#: scripts/core/ui/components/SelectUser.tsx:51
+msgid "Select a user"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-vocabulary/config.tsx:27
+msgid "Select a vocabulary"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:110
+msgid "Select a vocabulary for predefined snippets"
+msgstr ""
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:332
+msgid "Select all"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:149
+msgid "Select all categories"
+msgstr ""
+
+#: ../superdesk-planning/client/components/FulFilAssignmentModal/index.tsx:76
+msgid "Select an Assignment"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/multi-edit-toolbar-action.tsx:35
+msgid "Select articles"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:70
+msgid "Select at most 1 file to upload."
+msgstr ""
+
+#: scripts/apps/archive/controllers/UploadController.ts:233
+#: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:207
+msgid "Select at most {{maxUploads}} files to upload."
+msgstr ""
+
+#: scripts/apps/ingest/ingest-stats-widget/configuration.html:20
+msgid "Select color"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/compare-versions.html:12
+msgid "Select current version."
+msgstr ""
+
+#: scripts/apps/search/views/edit-time-interval.html:5
+msgid "Select days"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:161
+msgid "Select default categories only"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/mark-for-desks/mark-for-desks-modal.tsx:43
+#: scripts/apps/master-desk/components/HeaderComponent.tsx:224
+msgid "Select desks"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:18
+msgid "Select desks for view"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:41
+msgid "Select either Search or Browse the locations"
+msgstr ""
+
+#: scripts/extensions/predefinedTextField/dist/src/editor.js:34
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/editor.js:34
+#: scripts/extensions/predefinedTextField/src/editor.tsx:53
+msgid "Select from a predefined value"
+msgstr ""
+
+#: scripts/apps/search/views/edit-time-interval.html:19
+msgid "Select hours"
+msgstr ""
+
+#: ../superdesk-planning/client/components/SelectItemModal.tsx:29
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-inner-dropdown.html:2
+msgid "Select item"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:117
+msgid "Select next item on focused stage or group"
+msgstr ""
+
+#: scripts/apps/publish-preview/previewModal.tsx:87
+msgid "Select preview target"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:119
+msgid "Select previous item on focused stage or group"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:65
+msgid "Select saved searches for view"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/select-show.js:21
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/select-show.js:21
+#: scripts/extensions/broadcasting/src/rundowns/components/select-show.tsx:53
+msgid "Select show"
+msgstr ""
+
+#: scripts/apps/ingest/ingest-stats-widget/configuration.html:7
+msgid "Select source"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:62
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:85
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:85
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:157
+msgid "Select template"
+msgstr ""
+
+#: scripts/apps/archive/views/upload.html:39
+msgid "Select them from folder"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/video-thumbnail-editor.tsx:122
+msgid "Select thumbnail"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:63
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:63
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:141
+msgid "Select type"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/version-header.tsx:29
+msgid "Select version"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventMetadata/RelatedEventListItem.tsx:93
+#: ../superdesk-planning/client/components/RelatedPlannings/PlanningMetaData/RelatedPlanningListItem.tsx:101
+#: scripts/core/editor3/components/toolbar/FloatingCharacterCount.tsx:46
+msgid "Selected"
+msgstr ""
+
+#: scripts/core/views/sdSearchList.html:21
+msgid "Selected item"
+msgstr ""
+
+#: scripts/core/views/sdSearchList.html:14
+msgid "Selected items"
+msgstr ""
+
+#: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:77
+#: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:33
+msgid "Selected text:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:200
+msgid "Selections automatically removed"
+msgstr ""
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:39
+#: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:170
+msgid "Send"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:89
+msgid "Send & duplicate"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/send-correction.tsx:13
+#: scripts/apps/authoring/views/authoring-topbar.html:214
+msgid "Send Correction"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:117
+msgid "Send Email"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:221
+msgid "Send Kill"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:7
+msgid "Send Report via Email"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:228
+msgid "Send Takedown"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/send-and-duplicate.tsx:15
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/send-and-duplicate.tsx:16
+#: scripts/apps/authoring/views/authoring-topbar.html:86
+#: scripts/apps/authoring/views/authoring-topbar.html:87
+msgid "Send and duplicate"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:157
+msgid "Send and open"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx:144
+msgid "Send correction"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/send-kill-action.tsx:13
+msgid "Send kill"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:14
+msgid "Send notifications via email"
+msgstr ""
+
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:70
+msgid "Send only after publish schedule"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:183
+msgid "Send package and items"
+msgid_plural "Send packages and items"
+msgstr[0] ""
+
+#: scripts/apps/packaging/index.ts:110
+msgid "Send package to"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:277
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:201
+#: scripts/core/interactive-article-actions-panel/action-tabs.tsx:9
+msgid "Send to"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/send-to-publish/interactive-article-actions-widget.tsx:12
+#: scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx:20
+#: scripts/apps/authoring/views/authoring-topbar.html:400
+#: scripts/apps/authoring/views/authoring-topbar.html:401
+msgid "Send to / Publish"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:292
+msgid "Send to Personal Space"
+msgstr ""
+
+#: scripts/apps/users/components/EmailNotificationPreferences.tsx:24
+msgid "Send {{name}} notifications"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:22
+msgid "Sending"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.ts:68
+msgid "Sent Desk Output"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:443
+msgid "Sent From"
+msgstr ""
+
+#: scripts/apps/monitoring/controllers/AggregateCtrl.ts:41
+msgid "Sent Items"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:436
+msgid "Sent To"
+msgstr ""
+
+#: scripts/api/article-send.tsx:257
+msgid "Sent successfully"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:16
+msgid "Sent/Queued as"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:89
+msgid "Sent/Queued as {{name}} to {{destination}} at {{date}}"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:104
+msgid "Sequence No"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:181
+msgid "Sequence Number Settings"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateEventRepetitionsForm.tsx:111
+msgid "Series Start Date"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:128
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:143
+msgid "Service"
+msgstr ""
+
+#: scripts/apps/users/controllers/SessionsDeleteCommand.ts:13
+msgid "Sessions cleared"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:192
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:136
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:165
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:192
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:136
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:165
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:246
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:166
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:191
+msgid "Set"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:132
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:132
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:127
+msgid "Set Details"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/attachments/samsAttachmentsList.js:116
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/samsAttachmentsList.js:116
+#: scripts/extensions/sams/src/components/attachments/samsAttachmentsList.tsx:129
+msgid "Set Disabled"
+msgstr ""
+
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:42
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:59
+#: scripts/apps/publish/views/ftp-config.html:12
+#: scripts/apps/publish/views/http-push-config.html:14
+msgid "Set and hidden thereafter"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:50
+msgid "Set as default"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/sets.js:34
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:34
+#: scripts/extensions/sams/src/api/sets.ts:46
+msgid "Set created successfully"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/sets.js:77
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:77
+#: scripts/extensions/sams/src/api/sets.ts:98
+msgid "Set deleted successfully"
+msgstr ""
+
+#: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:90
+msgid "Set highlights"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:219
+msgid "Set label in current package"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:131
+msgid "Set maximum items per stages and saved searches for view"
+msgstr ""
+
+#: scripts/apps/monitoring/aggregate-widget/aggregate.ts:17
+msgid ""
+"Set up different monitors to follow any topics from ingest or production, "
+"desk outputs or any part of the workflow. All you need is to give it a "
+"sensible name, select a saved search or desk or its workflow stages. Monitor "
+"anything, anywhere, anytime. You can have as many Monitor widgets as you "
+"wish."
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/sets.js:57
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:57
+#: scripts/extensions/sams/src/api/sets.ts:76
+msgid "Set updated successfully"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/notifications/sets.js:45
+#: scripts/extensions/sams/dist/src/notifications/sets.js:45
+#: scripts/extensions/sams/src/notifications/sets.ts:50
+msgid "Set was deleted by another user."
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/notifications/sets.js:25
+#: scripts/extensions/sams/dist/src/notifications/sets.js:25
+#: scripts/extensions/sams/src/notifications/sets.ts:28
+msgid "Set was updated by another user."
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:176
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:176
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:206
+msgid "Sets"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:171
+#: scripts/apps/settings/index.ts:19 scripts/apps/settings/settings.tsx:32
+#: scripts/core/menu/views/menu.html:30
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:139
+#: scripts/extensions/broadcasting/dist/src/page.js:143
+#: scripts/extensions/broadcasting/src/page.tsx:204
+msgid "Settings"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:172
+msgid "Share Alternate"
+msgstr ""
+
+#: scripts/apps/search/views/item-preview.html:3
+msgid "Shift preview"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:37
+msgid "Short"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:138
+msgid "Shortcuts"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/planning.ts:305
+#: ../superdesk-planning/client/validators/planning.ts:307
+msgid "Should be after the previous scheduled update/coverage"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:56
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:16
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/select-show.js:10
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/applied-filters.js:16
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/select-show.js:10
+#: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:31
+#: scripts/extensions/broadcasting/src/rundowns/components/select-show.tsx:35
+msgid "Show"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/related_events.tsx:46
+msgid "Show 1 event"
+msgid_plural "Show {{n}} events"
+msgstr[0] ""
+
+#: ../superdesk-planning/client/components/fields/related_plannings.tsx:35
+msgid "Show 1 planning item"
+msgid_plural "Show {{n}} planning items"
+msgstr[0] ""
+
+#: scripts/apps/archive/views/provider-menu.html:9
+msgid "Show All"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:121
+msgid "Show Bookmark"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:332
+msgid "Show Crops"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:186
+msgid "Show Floating Character Count"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:352
+msgid "Show Image Title"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Preview/ExpandableText.tsx:47
+#: scripts/apps/master-desk/components/HeaderComponent.tsx:226
+#: scripts/apps/master-desk/components/HeaderComponent.tsx:229
+msgid "Show all"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/Language.tsx:96
+msgid "Show all language fields"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:93
+msgid "Show all messages"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:19
+#: scripts/extensions/broadcasting/dist/src/shows/manage-shows.js:19
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:31
+msgid "Show code"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:48
+msgid "Show crops for pictures"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:101
+msgid "Show error messages"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:302
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:302
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:509
+msgid "Show image suggestions"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:30
+msgid "Show in embedded form"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:263
+msgid "Show in preview"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:120
+msgid "Show input for editing description"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:110
+msgid "Show input for editing title"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Archive/ArchivePreview/index.tsx:42
+#: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:93
+#: ../superdesk-planning/client/components/UI/Preview/ExpandableText.tsx:46
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEventItem.tsx:94
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx:109
+msgid "Show less"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Archive/ArchivePreview/index.tsx:42
+#: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:93
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEventItem.tsx:94
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx:109
+msgid "Show more"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show.js:66
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:13
+#: scripts/extensions/broadcasting/dist/src/shows/create-show.js:66
+#: scripts/extensions/broadcasting/dist/src/shows/manage-shows.js:13
+#: scripts/extensions/broadcasting/src/shows/create-show.tsx:95
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:25
+msgid "Show name"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Location/index.tsx:54
+#: ../superdesk-planning/client/components/Locations/LocationsList.tsx:93
+msgid "Show on map"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/WidgetsConfig.tsx:57
+msgid "Show or hide the widgets in the right toolbar in the editor workspace."
+msgstr ""
+
+#: scripts/apps/search/components/fields/nested-link.tsx:28
+msgid "Show previous items"
+msgstr ""
+
+#: scripts/apps/search/index.ts:138
+msgid "Show search modal"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:3
+msgid "Show sent/queued items"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:128
+msgid ""
+"Show to users\n"
+"                                as"
+msgstr ""
+
+#: scripts/apps/archive/views/item-crops.html:1
+#: scripts/apps/authoring-react/fields/media/media-carousel/image-crops.tsx:22
+msgid "Show/hide crops"
+msgstr ""
+
+#: scripts/apps/users/views/change-avatar.html:17
+msgid "Shows your initials instead"
+msgstr ""
+
+#: scripts/apps/authoring-react/field-adapters/sign_off.tsx:118
+#: scripts/apps/workspace/content/constants.ts:40
+#: scripts/core/lang/missing-translations-strings.ts:18
+msgid "Sign Off"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:31
+msgid "Sign in as a different user."
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:73
+msgid "Sign out"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:159
+#: scripts/apps/users/views/edit-form.html:254
+msgid "Sign-Off"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:364
+#: scripts/apps/search/views/search-parameters.html:22
+msgid "Sign-off"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:173
+#: scripts/apps/archive/views/metadata-view.html:45
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:303
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:124
+msgid "Signal"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:10
+msgid "Single Day"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:122
+msgid "Single Line"
+msgstr ""
+
+#: scripts/core/editor3/components/media/MediaBlock.tsx:13
+msgid "Single Usage"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:57
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:214
+msgid "Single line"
+msgstr ""
+
+#: scripts/apps/vocabularies/constants.ts:48
+msgid "Single selection"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:120
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:152
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:152
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:120
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:152
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:152
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:110
+#: scripts/extensions/sams/dist/src/utils/ui.js:110
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:141
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:173
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:177
+#: scripts/extensions/sams/src/utils/ui.tsx:103
+msgid "Size"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:247
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:247
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:320
+msgid "Size From:"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:251
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:251
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:334
+msgid "Size To:"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:176
+#: scripts/extensions/sams/dist/src/components/assets/assetGridItem.js:125
+#: scripts/extensions/sams/dist/src/components/assets/assetListItem.js:120
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:176
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetGridItem.js:125
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetListItem.js:120
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:179
+#: scripts/extensions/sams/src/components/assets/assetGridItem.tsx:155
+#: scripts/extensions/sams/src/components/assets/assetListItem.tsx:137
+msgid "Size:"
+msgstr ""
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:41
+msgid "Skip"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:174
+msgid "Skip Next"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:175
+msgid "Skip Previous"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:203
+msgid "Skip config test"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:59
+msgid "Slack Channel Name"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:176
+msgid "Slideshow"
+msgstr ""
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:18
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:66
+#: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:429
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:78
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/assignCalendarForm.tsx:70
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:115
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/convertToRecurringEventForm.tsx:130
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:90
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:89
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:192
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:78
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikePlanningForm.tsx:34
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikeEventForm.tsx:73
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikePlanningForm.tsx:33
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateEventRepetitionsForm.tsx:97
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:209
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:48
+#: ../superdesk-planning/client/components/fields/preview/index.ts:225
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:49
+#: ../superdesk-planning/client/utils/contentProfiles.ts:269
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:282
+#: scripts/apps/authoring-react/field-adapters/slugline.ts:21
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:96
+#: scripts/apps/content-api/services/ContentAPISearchService.ts:32
+#: scripts/apps/legal-archive/services/LegalArchiveService.ts:28
+#: scripts/apps/legal-archive/tests/legal.spec.ts:70
+#: scripts/apps/legal-archive/views/legal_archive.html:71
+#: scripts/apps/master-desk/components/FilterPanelComponent.tsx:126
+#: scripts/apps/search/services/SearchService.ts:70
+#: scripts/apps/search/views/search-parameters.html:6
+#: scripts/apps/workspace/content/constants.ts:41
+msgid "Slugline"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:4
+msgid "Slugline Match"
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-tooltip.html:2
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:85
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateAssignmentForm.tsx:118
+msgid "Slugline:"
+msgstr ""
+
+#: scripts/apps/archive/views/item-preview.html:11
+#: scripts/apps/archive/views/metadata-view.html:194
+#: scripts/apps/archive/views/preview.html:42
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:244
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:80
+#: scripts/apps/authoring/views/authoring-header.html:63
+#: scripts/apps/search/components/fields/flags.tsx:32
+#: scripts/apps/search/views/search-filters.html:130
+#: scripts/core/itemList/views/relatedItem-list-widget.html:34
+msgid "Sms"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:24
+msgid "Some Coverages Assigned"
+msgstr ""
+
+#: scripts/apps/authoring/multiedit/multiedit.ts:85
+msgid "Some articles failed to unlock"
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:42
+#: ../superdesk-planning/client/planning-extension/src/extension.ts:57
+msgid "Some items are linked to in-progress planning coverage."
+msgstr ""
+
+#: scripts/api/article-send.tsx:135
+msgid ""
+"Some packages contain the following published items that can not be sent:"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:477
+msgid "Some related planning item post validation failed"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:458
+msgid ""
+"Some selected items have not yet been posted. All selections must be visible "
+"to subscribers."
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:53
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:53
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:124
+msgid "Some tags can not be displayed"
+msgstr ""
+
+#: scripts/core/upload/crop-directive.ts:57
+msgid "Sorry, but avatar must be at least 200x200 pixels big."
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:39
+#: scripts/core/auth/reset-password.html:29
+#: scripts/core/auth/reset-password.html:76
+#: scripts/core/auth/secure-login.html:30
+msgid "Sorry, but can't reach the server now.<br>Please try again later."
+msgstr ""
+
+#: scripts/core/upload/image-crop-directive.ts:251
+msgid "Sorry, but image must be at least {{width}}x{{height}}."
+msgstr ""
+
+#: scripts/apps/authoring/attachments/AttachmentsWidget.tsx:38
+msgid ""
+"Sorry, but some files \"{{filenames}}\" are bigger than limit ({{limit}})"
+msgstr ""
+
+#: scripts/apps/templates/views/create-template.html:23
+msgid "Sorry, but template name must be unique."
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:37
+#: scripts/core/auth/reset-password.html:28
+#: scripts/core/auth/reset-password.html:75
+#: scripts/core/auth/secure-login.html:29
+msgid "Sorry, but your account has been suspended."
+msgstr ""
+
+#: scripts/apps/workspace/views/edit-workspace-modal.html:23
+msgid "Sorry, given workspace name is in use"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:40
+msgid "Sorry, this role name already exists."
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:38
+msgid "Sorry, user not found."
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:138
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:138
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:163
+msgid "Sort By"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:28
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-preview.html:15
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-preview.html:17
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-preview.html:24
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:28
+msgid "Sort Order"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-group-header.html:37
+#: scripts/apps/search/views/item-sortbar.html:12
+#: scripts/apps/search/views/item-sortbar.html:6
+msgid "Sort by"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:239
+msgid "Sort by:"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:262
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:262
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:410
+msgid "Sort by: {{ field }}"
+msgstr ""
+
+#: scripts/apps/search/views/item-sortbar.html:19
+msgid "Sort order"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:266
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:266
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:424
+msgid "Sort order: Ascending"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:267
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:267
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:425
+msgid "Sort order: Descending"
+msgstr ""
+
+#: scripts/apps/legal-archive/views/legal_archive.html:29
+msgid "Sorting"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-group-header.html:28
+msgid "Sorting:"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:586
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:455
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:105
+#: ../superdesk-planning/client/components/fields/editor/IngestSource.tsx:25
+#: scripts/apps/archive/views/metadata-associateditem-view.html:23
+#: scripts/apps/archive/views/metadata-view.html:36
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:297
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:116
+#: scripts/apps/content-filters/views/production-test-view.html:22
+#: scripts/apps/search-providers/views/search-provider-config.html:89
+#: scripts/apps/workspace/content/constants.ts:44
+msgid "Source"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:85
+msgid "Source Name"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:3
+msgid "Source Type:"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:44
+msgid "Source for User Created Articles"
+msgstr ""
+
+#: scripts/apps/ingest/ingest-stats-widget/configuration.html:9
+msgid "Source stats"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/tag-popover.js:20
+#: scripts/extensions/auto-tagging-widget/dist/src/tag-popover.js:20
+#: scripts/extensions/auto-tagging-widget/src/tag-popover.tsx:29
+msgid "Source:"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:133
+#: scripts/apps/search/views/search-filters.html:44
+msgid "Sources"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:361
+msgid "Spell Checker"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:442
+#: ../superdesk-analytics/client/utils.js:164
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:139
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:74
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:153
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:250
+#: ../superdesk-planning/client/constants/events.ts:154
+#: scripts/apps/archive/show-spike-dialog.tsx:61
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:189
+msgid "Spike"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:120
+msgid "Spike Item"
+msgstr ""
+
+#: scripts/apps/monitoring/config.ts:29
+msgid "Spike Monitoring"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:138
+msgid "Spike Planning Item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:146
+msgid "Spike State"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:104
+msgid "Spike all recurring events or just this one?"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:127
+msgid "Spike item(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/planning.ts:135
+msgid "Spike planning"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:72
+msgid "Spike {{event}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:45
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:40
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:210
+#: ../superdesk-planning/client/utils/index.ts:346
+#: scripts/apps/dashboard/workspace-tasks/views/desk-stages.html:17
+#: scripts/apps/search/components/fields/state.tsx:36
+#: scripts/apps/search/constants.ts:14
+msgid "Spiked"
+msgstr ""
+
+#: scripts/apps/search/views/search-parameters.html:145
+msgid "Spiked Content"
+msgstr ""
+
+#: scripts/apps/monitoring/config.ts:40
+#: scripts/apps/monitoring/views/monitoring-view.html:257
+msgid "Spiked Items"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:177
+msgid "Spiked Only"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:221
+#: scripts/apps/authoring/versioning/history/views/history.html:63
+msgid "Spiked by"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:4
+msgid "Spiked items"
+msgstr ""
+
+#: scripts/apps/search/views/search-parameters.html:153
+msgid "Spiked only content"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:108
+msgid "Spline"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:83
+msgid "Split paragraph"
+msgstr ""
+
+#: scripts/apps/desks/views/actionpicker.html:15
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:48
+#: scripts/apps/workspace/content/constants.ts:45
+#: scripts/core/interactive-article-actions-panel/subcomponents/destination-select.tsx:87
+msgid "Stage"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:299
+msgid "Stage Details"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:369
+msgid "Stage description"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:320
+msgid "Stage description:"
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskeditStages.ts:190
+msgid "Stage has been modified elsewhere. Please reload the desks"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:289
+msgid "Stage with name"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:624
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:157
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:508
+#: scripts/apps/desks/views/desk-config-modal.html:228
+#: scripts/apps/desks/views/settings.html:67
+#: scripts/apps/monitoring/views/monitoring-view.html:23
+#: scripts/apps/monitoring/views/monitoring-view.html:66
+msgid "Stages"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:177
+msgid "Star"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:178
+msgid "Star Empty"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:87
+msgid "Start Date"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:18
+msgid "Start Time (inclusive)"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:191
+msgid "Start Working"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:174
+msgid "Start date cannot be greater than today"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:76
+msgid "Start date is in the past"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:160
+msgid "Start date is required"
+msgstr ""
+
+#: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:31
+msgid "Start routing"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:87
+#: scripts/apps/search/views/item-searchbar.html:19
+msgid "Start search"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:571
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:123
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:53
+#: scripts/apps/archive/views/metadata-view.html:188
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:217
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:76
+#: scripts/apps/contacts/constants.ts:76
+#: scripts/apps/contacts/views/search-panel.html:68
+#: scripts/apps/content-filters/views/production-test-view.html:18
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:186
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:240
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:130
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:162
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:186
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:240
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:130
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:162
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:217
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:300
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:154
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:186
+msgid "State"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:598
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:611
+msgid "State/Province or Region"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:268
+#: ../superdesk-planning/client/components/Locations/LocationsList.tsx:124
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:64
+msgid "State/Province/Region"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:145
+msgid "States"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:64
+#: scripts/apps/publish/views/publish-queue.html:115
+#: scripts/apps/publish/views/subscribers.html:79
+#: scripts/apps/search-providers/views/search-provider-config.html:35
+#: scripts/apps/workspace/content/views/profile-settings.html:60
+#: scripts/extensions/availability-manager/dist/src/correspondent-availability/filters.js:114
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/correspondent-availability/filters.js:114
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/manage-schedule.js:168
+#: scripts/extensions/availability-manager/dist/src/settings/manage-schedule.js:168
+#: scripts/extensions/availability-manager/src/correspondent-availability/filters.tsx:199
+#: scripts/extensions/availability-manager/src/settings/manage-schedule.tsx:286
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:124
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:124
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:158
+msgid "Status"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx:233
+#: scripts/apps/contacts/views/list.html:38
+#: scripts/apps/publish/views/publish-queue.html:46
+#: scripts/apps/publish/views/subscribers.html:15
+msgid "Status:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:112
+msgid "Status: Unassigned"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:143
+msgid "Status: {{ state }}"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:11
+msgid "Status: {{filter}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:179
+msgid "Stop"
+msgstr ""
+
+#: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:37
+msgid "Stop routing"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:254
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:150
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:254
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:150
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:342
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:154
+msgid "Storage Destination"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:256
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:153
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:256
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:153
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:348
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:159
+msgid "Storage Provider"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:243
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:243
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:311
+msgid "Storage Unit"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setListItem.js:97
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListItem.js:97
+#: scripts/extensions/sams/src/components/sets/setListItem.tsx:85
+msgid "Storage:"
+msgstr ""
+
+#: scripts/apps/publish/views/odbc-config.html:11
+#: scripts/apps/publish/views/odbc-config.html:9
+msgid "Stored Procedure"
+msgstr ""
+
+#: scripts/apps/products/views/product-test.html:9
+msgid "Story GUID"
+msgstr ""
+
+#: scripts/apps/legal-archive/views/legal_archive.html:78
+#: scripts/apps/search/views/search-parameters.html:31
+msgid "Story Text"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem.ts:183
+msgid "Story is associated as update."
+msgstr ""
+
+#: ../superdesk-planning/client/reducers/featuredPlanning.ts:177
+msgid "Story with slugline \"{{ slugline }}\" is added to the list"
+msgstr ""
+
+#: ../superdesk-planning/client/reducers/featuredPlanning.ts:195
+#: ../superdesk-planning/client/reducers/featuredPlanning.ts:215
+msgid "Story with slugline \"{{ slugline }}\" is removed from the list"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:180
+msgid "Stream"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:534
+msgid "Street Address"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:533
+msgid "Street Address, PO Box, Company Name"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:65
+msgid "Strength"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:181
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:40
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:78
+msgid "Strikethrough"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:41
+msgid "Strong"
+msgstr ""
+
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:49
+msgid "Style"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:130
+msgid "Su"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:6
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:6
+msgid "Subgroup By"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-parameters.html:23
+msgid "Subgroup By:"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:112
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:112
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:144
+msgid "Subitem attachments"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/index.js:13
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/index.js:13
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:130
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:130
+#: scripts/extensions/broadcasting/src/authoring-fields/subitems/index.tsx:30
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:165
+msgid "Subitems"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:547
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:117
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/subject.ts:45
+#: ../superdesk-planning/client/components/fields/editor/Subjects.tsx:26
+#: ../superdesk-planning/client/utils/contentProfiles.ts:289
+#: scripts/apps/authoring-react/field-adapters/subject.tsx:26
+#: scripts/apps/search/constants.ts:15
+#: scripts/apps/workspace/content/constants.ts:46
+msgid "Subject"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/planning.ts:109
+msgid "Subject is a required field"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:39
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:150
+msgid "Subject:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:162
+#: scripts/core/lang/missing-translations-strings.ts:12
+msgid "Subjects"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/list/Subject.tsx:20
+msgid "Subjects:"
+msgstr ""
+
+#: scripts/core/editor3/components/annotations/AnnotationInput.tsx:287
+#: scripts/core/editor3/components/comments/CommentInput.tsx:97
+#: scripts/core/ui/components/Modal/ModalPrompt.tsx:55
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:261
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:261
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:379
+msgid "Submit"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/index.ts:396
+#: scripts/apps/search/components/fields/state.tsx:34
+msgid "Submitted"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:109
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:202
+msgid "Submitting...."
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-subscribe.html:34
+#: scripts/apps/search/views/saved-searches.html:21
+#: scripts/apps/search/views/saved-searches.html:50
+msgid "Subscribe"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:109
+#: scripts/apps/search/constants.ts:20
+#: scripts/apps/search/views/search-parameters.html:181
+msgid "Subscriber"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:84
+msgid "Subscriber Schedule Settings"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:156
+msgid "Subscriber codes"
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:284
+msgid "Subscriber could not be initialized!"
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:213
+msgid "Subscriber saved."
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:14
+msgid "Subscriber:"
+msgstr ""
+
+#: scripts/apps/content-filters/views/filter-search-result.html:42
+#: scripts/apps/products/views/products-config-modal.html:16
+#: scripts/apps/publish/index.ts:41 scripts/apps/publish/views/settings.html:4
+msgid "Subscribers"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:182
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:39
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:92
+msgid "Subscript"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/views/chart-form-options.html:15
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:15
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-preview.html:6
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-preview.html:6
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-preview.html:6
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:15
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-preview.html:6
+msgid "Subtitle"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:244
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:40
+msgid "Suburb"
+msgstr ""
+
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:27
+msgid "Success"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:183
+msgid "Suggestion"
+msgstr ""
+
+#: scripts/apps/authoring/track-changes/suggestions.ts:91
+#: scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx:84
+msgid "Suggestions"
+msgstr ""
+
+#: scripts/apps/authoring/suggest/SuggestView.html:8
+msgid "Suggestions will appear here once the article's body starts changing..."
+msgstr ""
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:278
+#: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:29
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:32
+msgid "Sum"
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/main-panel.js:18
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary-widget.js:48
+#: scripts/extensions/ai-widget/dist/src/main-panel.js:18
+#: scripts/extensions/ai-widget/dist/src/summary/summary-widget.js:48
+#: scripts/extensions/ai-widget/src/main-panel.tsx:35
+#: scripts/extensions/ai-widget/src/summary/summary-widget.tsx:70
+msgid "Summary"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:106
+msgid "Sun"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1460
+#: scripts/core/datetime/datetime.ts:296
+msgid "Sunday"
+msgstr ""
+
+#: scripts/apps/contacts/controllers/ContactsController.ts:33
+msgid "Superdesk Contacts Management"
+msgstr ""
+
+#: scripts/core/menu/views/superdesk-view.html:50
+msgid "Superdesk is experiencing network connection issues:/"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:114
+msgid "Superdesk logo"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:184
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:38
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:93
+msgid "Superscript"
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskConfigModal.ts:37
+#: scripts/apps/monitoring/directives/utils.ts:103
+#: scripts/apps/users/directives/UserPreferencesDirective.ts:31
+msgid "Swimlane View"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/Language.tsx:111
+msgid "Switch Metadata Language"
+msgstr ""
+
+#: scripts/apps/authoring-react/multi-edit-modal.tsx:115
+msgid "Switch article"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-swtich.tsx:16
+msgid "Switch authoring"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-swtich.tsx:18
+msgid "Switch authoring?"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:111
+msgid "Switch between grouped/single desk view"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:109
+msgid "Switch between grouped/single stage view"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:38
+msgid "Switch to feature preview"
+msgstr ""
+
+#: scripts/apps/archive/views/list.html:20
+#: scripts/apps/contacts/views/list.html:6
+#: scripts/apps/content-api/views/list.html:12
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:270
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:270
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:439
+msgid "Switch to grid view"
+msgstr ""
+
+#: scripts/apps/archive/views/list.html:21
+#: scripts/apps/contacts/views/list.html:7
+#: scripts/apps/content-api/views/list.html:13
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:271
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:271
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:440
+msgid "Switch to list view"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:185
+msgid "Switches"
+msgstr ""
+
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:148
+#: scripts/apps/system-messages/index.ts:34
+msgid "System Message"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:140
+msgid "T"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/to-desk.tsx:14
+#: scripts/apps/authoring/views/authoring-topbar.html:58
+msgid "T D"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:119
+#: ../superdesk-planning/client/components/UI/DateTime.tsx:49
+#: ../superdesk-planning/client/constants/index.ts:166
+#: ../superdesk-planning/client/utils/index.ts:962
+#: ../superdesk-planning/client/utils/planning.tsx:1380
+#: ../superdesk-planning/client/utils/planning.tsx:1795
+msgid "TBC"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:99
+msgid "TH"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:25
+msgid "TIMEZONE is a required field"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:83
+msgid "TU"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:41
+msgid "Tab"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:42
+msgid "Tab As Spaces"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:93
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:186
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:33
+#: scripts/core/editor3/components/toolbar/index.tsx:310
+msgid "Table"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:191
+msgid "Table Header"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:192
+msgid "Table Header Large"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:193
+msgid "Table Header List"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/tag-input/index.tsx:26
+msgid "Tag-input (authoring-react)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:83
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:40
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:195
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:230
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:139
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:168
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:195
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:230
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:139
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:168
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:266
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:274
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:171
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:196
+msgid "Tags"
+msgstr ""
+
+#: scripts/apps/authoring-react/field-adapters/anpa_take_key.ts:20
+#: scripts/apps/workspace/content/constants.ts:10
+msgid "Take Key"
+msgstr ""
+
+#: scripts/apps/users/controllers/ChangeAvatarController.ts:7
+msgid "Take a picture"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:132
+msgid "Take created by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:418
+msgid "Take created by {{user}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:299
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:120
+msgid "Take key"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:471
+#: scripts/apps/authoring/versioning/history/views/history.html:160
+msgid "Take link is removed"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:163
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/takedown-action.tsx:10
+#: scripts/apps/authoring/views/authoring-topbar.html:137
+#: scripts/apps/authoring/views/authoring-topbar.html:138
+#: scripts/apps/authoring/views/authoring-topbar.html:139
+msgid "Takedown"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:333
+msgid "Takedown item"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:577
+msgid "Takedowns"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:50
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:90
+msgid "Taken Down"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:427
+msgid "Taken as a rewrite of"
+msgstr ""
+
+#: scripts/core/itemList/views/relatedItem-list-widget.html:31
+msgid "Takes"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:187
+msgid "Takes Package"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:540
+msgid "Tansa is not responding. You can continue editing or publish the story."
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:105
+msgid "Target"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:151
+#: scripts/apps/products/views/products-config-modal.html:76
+msgid "Target Regions"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:156
+msgid "Target Subscriber Types"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:146
+#: scripts/apps/templates/views/template-editor-modal.html:135
+msgid "Target Subscribers"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:130
+msgid "Target Type"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:5
+msgid "Target Type:"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:67
+msgid "Target Types"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:131
+msgid "Target regions"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:106
+msgid "Target subscribers"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:148
+msgid "Target types"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:163
+msgid "Targetable by users"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:188
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:405
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:2
+msgid "Tasks"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:20
+msgid "Tasks Management"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:58
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:58
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:74
+msgid "Tech. title"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/subitems-view-edit.js:46
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.js:46
+#: scripts/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.tsx:101
+msgid "Technical information"
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:19
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:72
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:111
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:72
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:111
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:136
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:210
+msgid "Template"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:49
+msgid "Template Content"
+msgstr ""
+
+#: scripts/apps/templates/views/template-editor-modal.html:46
+msgid "Template Type"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/api.ts:842
+msgid "Template already exists. Do you want to overwrite it?"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:93
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:93
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:206
+msgid "Template based settings"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/api.ts:796
+#: ../superdesk-planning/client/components/Events/ManageEventTemplatesModal.tsx:72
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:70
+#: scripts/apps/templates/views/template-editor-modal.html:21
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:184
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:187
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:384
+msgid "Template name"
+msgstr ""
+
+#: scripts/apps/templates/directives/TemplatesDirective.ts:248
+msgid "Template saved."
+msgstr ""
+
+#: scripts/apps/templates/views/templates.html:45
+msgid "Template type"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:117
+msgid "Template will be updated"
+msgstr ""
+
+#: scripts/apps/templates/index.ts:46
+#: scripts/apps/templates/views/templates.html:3
+msgid "Templates"
+msgstr ""
+
+#: scripts/apps/authoring-react/field-adapters/usageterms.ts:20
+msgid "Terms of use"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:138
+msgid "Test"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:19
+msgid "Test Filter Against Content"
+msgstr ""
+
+#: scripts/apps/products/views/product-test.html:24
+msgid "Test Products"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:189
+#: ../superdesk-planning/client/utils/index.ts:587
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:83
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:247
+#: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:56
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:119
+#: scripts/extensions/sams/dist/src/utils/assets.js:119
+#: scripts/extensions/sams/src/utils/assets.ts:150
+msgid "Text"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:190
+msgid "Text Format"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:142
+msgid "Th"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/agenda.ts:407
+msgid "The Agenda you were viewing was deleted!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/notifications.ts:22
+msgid "The Assignment you were viewing was removed."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/notifications.ts:39
+msgid "The Event and Planning filter you were viewing is deleted!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/notifications.ts:16
+msgid "The Event and Planning filter you were viewing is modified!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/notifications.ts:123
+msgid "The Event was spiked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/notifications.ts:152
+msgid "The Event was unspiked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1410
+msgid "The Event you were editing was unlocked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1405
+msgid "The Event you were editing was unlocked by \"{{ userName }}\""
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1399
+msgid "The Event you were editing was updated via ingest"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:214
+msgid "The Events and Planning view filter is deleted."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:187
+msgid "The Events and Planning view filter is {{action}}."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:196
+msgid "The Events and Planning view filter with this name already exists"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:37
+msgid "The Planning Item(s) has been spiked."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:59
+msgid "The Planning Item(s) has been unspiked."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/notifications.ts:218
+msgid "The Planning item was spiked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/notifications.ts:251
+msgid "The Planning item was unspiked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1411
+msgid "The Planning item you were editing was unlocked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1406
+msgid "The Planning item you were editing was unlocked by \"{{ userName }}\""
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1400
+msgid "The Planning item you were editing was updated via ingest"
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:31
+msgid ""
+"The Product ID can be copied and used as Superdesk Newshub product query."
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:278
+msgid "The Saved Report you are using was deleted!"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:270
+msgid ""
+"The Saved Report you are using was updated! Please re-select the Saved Report"
+msgstr ""
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:52
+msgid ""
+"The Superdesk project is developed and maintained on <a href=\"https://"
+"github.com/superdesk\" title=\"Superdesk GitHub\" target=\"_blank\">GitHub</"
+"a> by <a href=\"https://www.sourcefabric.org/\" title=\"Sourcefabric\" "
+"target=\"_blank\">Sourcefabric</a>."
+msgstr ""
+
+#: scripts/core/auth/reset-password.html:74
+msgid "The activation token is not valid."
+msgstr ""
+
+#: scripts/core/editor3/components/annotations/AnnotationInput.tsx:220
+#: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:85
+msgid "The annotation will be deleted. Are you sure?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:107
+msgid "The assignment has been accepted"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:105
+msgid "The assignment has been accepted by"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:541
+msgid "The assignment has been reverted."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:463
+msgid "The assignment was reassigned."
+msgstr ""
+
+#: scripts/core/editor3/components/comments/CommentPopup.tsx:151
+msgid "The comment will be deleted. Are you sure?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/InputArray/index.tsx:94
+msgid "The coverage has been removed"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/tooltips.ts:29
+msgid "The event has been killed"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:64
+msgid "The event(s) have been spiked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:81
+msgid "The event(s) have been unspiked"
+msgstr ""
+
+#: scripts/apps/archive/controllers/file-upload-error-modal.tsx:31
+msgid "The file was not uploaded"
+msgid_plural "Some files were not uploaded"
+msgstr[0] ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:112
+msgid "The following Events are in use and will not be spiked:"
+msgstr ""
+
+#: scripts/extensions/predefinedTextField/dist/src/config.js:66
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:66
+#: scripts/extensions/predefinedTextField/src/config.tsx:106
+msgid "The following placeholders are available to be used in definitions:"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:246
+#: scripts/apps/relations/directives/RelatedItemsDirective.ts:141
+msgid "The following status is not allowed in this field: {{status}}"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:121
+msgid "The helper text must not exceed 120 characters."
+msgstr ""
+
+#: scripts/core/helpers/crud-manager-http.tsx:52
+msgid "The item has been created."
+msgstr ""
+
+#: scripts/core/helpers/crud-manager-http.tsx:97
+msgid "The item has been deleted."
+msgstr ""
+
+#: scripts/core/helpers/crud-manager-http.tsx:86
+msgid "The item has been updated."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:30
+msgid "The item is read-only."
+msgstr ""
+
+#: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:207
+#: ../superdesk-planning/client/controllers/FulfilAssignmentController.tsx:173
+msgid "The item was unlocked by \"{{ username }}\""
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:396
+msgid "The item with unsaved changes must be closed before you can filter."
+msgstr ""
+
+#: ../superdesk-planning/client/api/locations.ts:24
+msgid "The location has been created"
+msgstr ""
+
+#: ../superdesk-planning/client/api/locations.ts:62
+msgid "The location has been updated"
+msgstr ""
+
+#: scripts/apps/users/views/change-avatar.html:33
+msgid "The minimum image resolution is 200x200 pixels."
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:61
+msgid ""
+"The name of a Slack channel associated with this desk, the # is not required"
+msgstr ""
+
+#: scripts/api/article-send.tsx:113
+msgid ""
+"The package \"{{name}}\" contains the following published items that can not "
+"be sent:"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-swtich.tsx:19
+msgid "The page needs to be reloaded in order to do that."
+msgstr ""
+
+#: scripts/apps/users/directives/ChangePasswordDirective.ts:21
+#: scripts/core/auth/login-modal-directive.ts:75
+msgid "The password has been changed."
+msgstr ""
+
+#: scripts/apps/users/directives/ResetPasswordDirective.ts:18
+msgid "The password has been reset."
+msgstr ""
+
+#: scripts/apps/publish/views/email-config.html:35
+msgid "The rendition to attach to the email"
+msgstr ""
+
+#: scripts/core/editor3/components/comments/CommentPopup.tsx:155
+msgid "The reply will be deleted. Are you sure?"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:23
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:23
+#: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:64
+msgid "The show {{name}} has been successfully created"
+msgstr ""
+
+#: scripts/apps/archive/controllers/file-upload-error-modal.tsx:61
+msgid "The size of {{filename}} is {{width}}x{{height}}"
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:401
+msgid ""
+"The subscriber is currently inactive, but the schedule from {{start}} to "
+"{{end}} is valid. The subscriber will be activated on save."
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:383
+msgid ""
+"The subscriber is set to start on {{date}}, but the Active switch will "
+"override this and activate the subscriber on save."
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:391
+msgid ""
+"The subscriber schedule ended on {{date}}, but the Active switch will keep "
+"the subscriber active on save."
+msgstr ""
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:39
+msgid ""
+"The use of Highcharts is provided under a license with the following details:"
+msgstr ""
+
+#: scripts/apps/dashboard/user-activity/user-activity.ts:14
+msgid ""
+"The user activity widget provides information about user activity. Using the "
+"widget, editors can search and select a user. Upon selection a list of "
+"content items is shown categorized as follows:"
+msgstr ""
+
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:226
+msgid "The values should be unique for {{uniqueField}}"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:55
+msgid ""
+"The vocabulary {{name}} can't be deleted because it is currently used in the "
+"following Content Profile:"
+msgid_plural ""
+"The vocabulary {{name}} can't be deleted because it is currently used in the "
+"following Content Profiles:"
+msgstr[0] ""
+
+#: ../superdesk-planning/client/actions/main.ts:468
+msgid "The {{ itemType }} has been posted"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:318
+msgid "The {{ itemType }} has been saved"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:396
+msgid "The {{ itemType }} has been unposted"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:257
+msgid "Themes"
+msgstr ""
+
+#: scripts/apps/contacts/components/ItemList.tsx:180
+#: scripts/apps/master-desk/components/ListItemsComponent.tsx:45
+#: scripts/apps/search/components/ItemList.tsx:523
+#: scripts/core/itemList/LazyLoader.tsx:216
+msgid "There are currently no items"
+msgstr ""
+
+#: scripts/validate-instance-configuration.tsx:108
+msgid "There are issues with instance configuration"
+msgstr ""
+
+#: scripts/api/highlights.ts:37
+msgid "There are items locked or not published. Do you want to continue?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionsMenu/ActionsMenuPopup.tsx:91
+msgid "There are no actions available."
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:207
+msgid "There are no assignments completed"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:213
+msgid "There are no assignments for today"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:204
+msgid "There are no assignments in progress"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:201
+msgid "There are no assignments to do"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/difference.tsx:29
+msgid "There are no changes"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:210
+msgid "There are no current assignments"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/FiltersList.tsx:52
+msgid "There are no events and planing view filters."
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:216
+msgid "There are no future assignments"
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:586
+msgid "There are no items matching the search."
+msgstr ""
+
+#: scripts/core/ui/components/virtual-lists/virtual-list.tsx:206
+msgid "There are no items yet"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:566
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:594
+msgid "There are no items yet."
+msgstr ""
+
+#: scripts/apps/search-providers/directive.ts:24
+msgid "There are no providers available."
+msgstr ""
+
+#: scripts/core/editor3/components/links/AttachmentList.tsx:83
+msgid ""
+"There are no public attachments yet. Upload some first using Attachments "
+"widget."
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/suggestions.tsx:208
+msgid "There are no resolved suggestions"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:173
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:173
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:333
+msgid "There are no rundowns yet"
+msgstr ""
+
+#: scripts/apps/master-desk/components/UsersComponent.tsx:150
+msgid "There are no users assigned to this desk"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/prefered-cv-items-config.html:15
+msgid "There are no vocabularies configured."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:58
+msgid "There are some unsaved changes, do you want to save and publish it now?"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:70
+msgid "There are some unsaved changes, do you want to save and send it now?"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:45
+msgid "There are some unsaved changes, do you want to save it now?"
+msgstr ""
+
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:71
+msgid "There are some unsaved changes, go to the article to save changes?"
+msgstr ""
+
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:35
+msgid "There are some unsaved changes, save it now?"
+msgstr ""
+
+#: scripts/core/auth/auth.ts:241
+msgid "There are some unsaved changes. Please save them before signing out."
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:163
+msgid "There are unsaved changes, but the form is invalid"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:113
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:170
+msgid "There are unsaved changes."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:28
+msgid ""
+"There are unsaved changes. If you navigate away, your changes will be lost."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/notifications.ts:350
+msgid "There is a {{ type }} assignment '{{ slugline }}' {{ state }}"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem.ts:194
+msgid "There is an error. Failed to associate update."
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:40
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/utils/handle-unsaved-rundown-changes.js:18
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:40
+#: scripts/extensions/broadcasting/dist/src/utils/handle-unsaved-rundown-changes.js:18
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:90
+#: scripts/extensions/broadcasting/src/utils/handle-unsaved-rundown-changes.ts:23
+msgid "There is an item open in editing mode. Discard changes?"
+msgstr ""
+
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:269
+msgid "There is an update assignment for this story due at ''."
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:296
+msgid "There is no token for subscriber."
+msgstr ""
+
+#: scripts/apps/highlights/controllers/HighlightsConfig.ts:60
+msgid "There was a problem while saving highlights configuration"
+msgstr ""
+
+#: scripts/apps/users/controllers/ChangeAvatarController.ts:51
+#: scripts/apps/users/controllers/ChangeAvatarController.ts:63
+msgid "There was a problem with your upload"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:42
+msgid "There was a problem, Planning item not spiked!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:63
+msgid "There was a problem, Planning item not unspiked!"
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskeditBasic.ts:61
+msgid "There was a problem, desk not created/updated."
+msgstr ""
+
+#: scripts/apps/desks/controllers/DeskConfigController.ts:106
+msgid "There was a problem, desk not saved. Refresh Desks."
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:50
+msgid "There was a problem, dictionary not created/updated."
+msgstr ""
+
+#: scripts/apps/search/directives/ItemGlobalSearch.ts:59
+#: scripts/apps/search/directives/ItemGlobalSearch.ts:91
+msgid "There was a problem, item can not open."
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskeditPeople.ts:66
+msgid "There was a problem, members not saved. Refresh Desks."
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:291
+msgid "There was a problem, stage not created/updated."
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskeditStages.ts:241
+msgid "There was a problem, stage was not deleted."
+msgstr ""
+
+#: scripts/apps/search/components/ErrorBox.tsx:7
+msgid "There was an error archiving this item"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/multiSelect.ts:255
+msgid "There was an error when exporting."
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:195
+msgid "There was an error when saving the contact."
+msgstr ""
+
+#: scripts/apps/users/directives/UserEditDirective.ts:268
+msgid "There was an error when saving the user account."
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary.js:22
+#: scripts/extensions/ai-widget/dist/src/summary/summary.js:22
+#: scripts/extensions/ai-widget/src/summary/summary.tsx:45
+msgid "There was an error when trying to generate a summary."
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:32
+#: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:32
+#: scripts/extensions/ai-widget/src/translations/translations-body.tsx:70
+msgid "There was an error when trying to generate a translation."
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines.js:23
+#: scripts/extensions/ai-widget/dist/src/headlines/headlines.js:23
+#: scripts/extensions/ai-widget/src/headlines/headlines.tsx:49
+msgid "There was an error when trying to generate headlines."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:219
+msgid "There was an error, could not delete Events and Planning view filter."
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:92
+msgid "There was an error. Content filter cannot be deleted."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:262
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:477
+msgid "There was an error. Failed to generate update."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:281
+msgid "There was an error. Failed to remove link."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:463
+msgid "There was an error. Failed to save the area of interest."
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:128
+msgid "There was an error. Filter condition cannot be deleted."
+msgstr ""
+
+#: scripts/apps/users/directives/UserRolesDirective.ts:68
+msgid "There was an error. Role cannot be deleted."
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestRoutingContent.ts:55
+msgid "There was an error. Routing scheme cannot be deleted."
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestRulesContent.ts:54
+msgid "There was an error. Rule set cannot be deleted."
+msgstr ""
+
+#: scripts/apps/templates/directives/TemplatesDirective.ts:371
+msgid "There was an error. Template cannot be deleted."
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:162
+msgid "Third"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:259
+msgid "This Coverage"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:261
+msgid ""
+"This Event is scheduled to occur after the end date of its recurring cycle!"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:28
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:21
+msgid "This Month"
+msgstr ""
+
+#: scripts/core/editor3/components/embeds/EmbedInput.tsx:92
+msgid "This URL could not be embedded."
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:23
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:15
+#: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:26
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:160
+msgid "This Week"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:32
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:27
+msgid "This Year"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:277
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:365
+#: ../superdesk-planning/client/constants/events.ts:174
+msgid "This and all future events"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:276
+msgid "This and all future planning"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:587
+msgid ""
+"This article contains unresolved comments.Click on Cancel to go back to "
+"editing toresolve those comments or OK to ignore and proceed with publishing"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:25
+msgid "This event is a recurring event!"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:84
+msgid "This event is a recurring event. Post all recurring events"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:271
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:362
+#: ../superdesk-planning/client/constants/events.ts:173
+msgid "This event only"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts:58
+msgid "This field is read-only"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:181
+#: ../superdesk-planning/client/validators/assignments.tsx:8
+#: ../superdesk-planning/client/validators/events.ts:14
+#: ../superdesk-planning/client/validators/events.ts:19
+#: ../superdesk-planning/client/validators/events.ts:24
+#: ../superdesk-planning/client/validators/events.ts:29
+#: ../superdesk-planning/client/validators/events.ts:35
+#: ../superdesk-planning/client/validators/events.ts:40
+#: ../superdesk-planning/client/validators/index.ts:108
+#: ../superdesk-planning/client/validators/planning.ts:169
+#: ../superdesk-planning/client/validators/planning.ts:207
+#: ../superdesk-planning/client/validators/profile.ts:107
+#: ../superdesk-planning/client/validators/profile.ts:65
+#: ../superdesk-planning/client/validators/profile.ts:77
+#: ../superdesk-planning/client/validators/profile.ts:85
+#: scripts/core/ui/ui.ts:1108
+msgid "This field is required"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:190
+msgid "This field is required by the system"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:72
+#: scripts/apps/contacts/components/Form/MultiTextInput.tsx:34
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:196
+#: scripts/apps/users/views/edit-form.html:118
+#: scripts/apps/users/views/edit-form.html:139
+#: scripts/apps/users/views/edit-form.html:85
+#: scripts/apps/users/views/edit-form.html:97
+msgid "This field is required."
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:92
+msgid ""
+"This field will initialize with the value of specified field when toggled "
+"from \"off\" to \"on\". Only plain-text gets copied. Formatting options or "
+"links are not preserved."
+msgstr ""
+
+#: scripts/apps/templates/directives/TemplatesDirective.ts:358
+msgid "This is a default template of the following desk(s): {{deskNames}}."
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:351
+msgid "This is a recurring event."
+msgstr ""
+
+#: scripts/apps/authoring/views/theme-select.html:38
+#: scripts/apps/authoring/views/theme-select.html:89
+msgid "This is the headline"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/editor.tsx:175
+msgid "This item is already added"
+msgstr ""
+
+#: scripts/apps/relations/directives/RelatedItemsDirective.ts:154
+msgid "This item is already added as related."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/controllers/AssociationController.ts:211
+msgid "This item is already added."
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:26
+#: ../superdesk-planning/client/planning-extension/src/extension.ts:40
+msgid "This item is linked to in-progress planning coverage."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:118
+msgid "This item was locked by {{username}}."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:101
+msgid "This item was unlocked by {{username}}."
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:249
+msgid "This item will be permanently deleted."
+msgstr ""
+
+#: scripts/core/editor3/components/BaseUnstyledComponent.tsx:130
+msgid "This link is not embeddable."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModalSubnav.tsx:66
+msgid "This list contains unposted changes!"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:270
+msgid "This planning only"
+msgstr ""
+
+#: scripts/apps/archive/views/preview.html:100
+msgid "This story has been rewritten by:"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:112
+msgid ""
+"This vocabulary is not currently used in any Content Profile and can be "
+"safely removed."
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:42
+msgid "This week"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:46
+msgid ""
+"This widget allows you to create literally any content view you may need in "
+"Superdesk, be it production or ingest. All you need is to select a desk, its "
+"stages or a saved search. Name your view once you are done. Enjoy!"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:83
+msgid "This will also post the related event's entire recurring series"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:118
+msgid "This will also postpone the following planning items"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:105
+msgid "This will also remove linked assignments if any"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:762
+msgid ""
+"This will also remove other linked assignments (if any, for story updates). "
+"Are you sure?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:51
+msgid "This will also {{action}} the following events"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:39
+msgid "This will also {{action}} the following planning items"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:119
+msgid ""
+"This will appear below the field in the\n"
+"                                    Editor."
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/convertToRecurringEventForm.tsx:152
+msgid "This will create new events in the remote ({{timeZone}}) timezone"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:269
+msgid "This will create the new event in the remote ({{timeZone}}) timezone"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:222
+msgid "This will mark as rescheduled the following planning items"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:553
+msgid ""
+"This will unlink the text item associated with the assignment. Are you sure ?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:111
+msgid "Thu"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/video-thumbnail-editor.tsx:117
+msgid "Thumbnail"
+msgstr ""
+
+#: scripts/apps/archive/views/related-items-preview.html:12
+#: scripts/apps/relations/views/related-items.html:30
+msgid "Thumbnail for related item"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1457
+#: scripts/core/datetime/datetime.ts:293
+msgid "Thursday"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/DateTime.tsx:49
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:355
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:194
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:79
+#: scripts/apps/search/views/edit-time-interval.html:15
+msgid "Time"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/time/index.tsx:20
+msgid "Time (authoring-react)"
+msgstr ""
+
+#: scripts/core/editor3/components/media/MediaBlock.tsx:15
+msgid "Time Restricted"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventDateTime.tsx:59
+msgid "Time TBC"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:141
+#: scripts/core/ui/views/sd-timezone.html:1
+msgid "Time Zone"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:52
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:64
+#: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:52
+#: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:64
+#: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:131
+#: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:98
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:26
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:36
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:47
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:64
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:59
+#: scripts/extensions/datetimeField/src/editor.tsx:101
+msgid "Time cannot be empty"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:50
+#: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:50
+#: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:92
+msgid "Time from"
+msgstr ""
+
+#: scripts/extensions/datetimeField/dist/src/config.js:33
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:33
+#: scripts/extensions/datetimeField/src/config.tsx:57
+msgid "Time increment steps"
+msgstr ""
+
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/template-editor.js:20
+#: scripts/extensions/datetimeField/dist/src/template-editor.js:20
+#: scripts/extensions/datetimeField/src/template-editor.tsx:26
+msgid ""
+"Time offset is configured to be {{x}} minutes for this field. When an "
+"article is created\n"
+"            based on this template, it's value will initialize to creation "
+"time + {{x}} minutes"
+msgstr ""
+
+#: scripts/apps/profiling/views/profiling.html:34
+msgid "Time per call"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:344
+msgid "Time picker"
+msgstr ""
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:315
+msgid "Time spent producing content"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:62
+#: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:62
+#: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:125
+msgid "Time to"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx:113
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx:180
+msgid "Time zone"
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:559
+msgid "Timeline"
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-tooltip.html:4
+msgid "Times:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:249
+#: scripts/core/lang/missing-translations-strings.ts:34
+msgid "Timezone"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/views/chart-form-options.html:3
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:11
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-preview.html:2
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-preview.html:2
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-preview.html:2
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:11
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-preview.html:2
+#: scripts/apps/archive/views/metadata-associateditem-view.html:3
+#: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:197
+#: scripts/apps/authoring/attachments/AttachmentsEditorModal.tsx:61
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:177
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:63
+#: scripts/core/editor3/components/media/MediaBlock.tsx:148
+#: scripts/core/editor3/components/media/MediaBlock.tsx:237
+#: scripts/core/editor3/components/media/MediaBlock.tsx:276
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:52
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:52
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:64
+#: scripts/extensions/predefinedTextField/dist/src/config.js:15
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:15
+#: scripts/extensions/predefinedTextField/src/config.tsx:23
+msgid "Title"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:125
+#: scripts/apps/authoring/views/item-association.html:70
+#: scripts/apps/authoring/views/item-carousel.html:93
+#: scripts/core/editor3/components/media/MediaBlock.tsx:163
+msgid "Title:"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:50
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:262
+#: ../superdesk-planning/client/components/fields/editor/CreationDate.tsx:49
+#: ../superdesk-planning/client/components/fields/editor/EndDateTime.tsx:33
+#: ../superdesk-planning/client/components/fields/preview/index.ts:75
+msgid "To"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:357
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:379
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:65
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:87
+msgid "To Be Confirmed"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/to-desk.tsx:13
+#: scripts/apps/authoring/views/authoring-topbar.html:55
+#: scripts/apps/authoring/views/authoring-topbar.html:56
+#: scripts/apps/authoring/views/authoring-topbar.html:57
+#: scripts/apps/search/constants.ts:13
+#: scripts/apps/search/views/search-parameters.html:115
+msgid "To Desk"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:200
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:9
+#: scripts/apps/master-desk/components/AssignmentsComponent.tsx:40
+msgid "To Do"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:195
+msgid "To Lowercase"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:196
+msgid "To Uppercase"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:70
+msgid ""
+"To delete this vocabulary, you must first remove it from all Content "
+"Profiles listed above."
+msgstr ""
+
+#: scripts/core/editor3/components/embeds/EmbedInput.tsx:152
+msgid "To get a responsive embed code, paste a URL."
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/difference.tsx:72
+msgid ""
+"To see detailed differences, compare primary and secondary items visually"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:18
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:129
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:31
+msgid "To:"
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-footer.js:40
+#: scripts/extensions/ai-widget/dist/src/translations/translations-footer.js:40
+#: scripts/extensions/ai-widget/src/translations/translations-footer.tsx:65
+msgid "To: {{ language }}"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:18
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:9
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:276
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:102
+#: ../superdesk-planning/client/components/Main/CalendarNavigation.tsx:25
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DateInputPopup.tsx:209
+#: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:20
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:156
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:18
+#: scripts/apps/highlights/views/highlights_config_modal.html:41
+#: scripts/apps/vocabularies/services/VocabularyService.ts:126
+#: scripts/core/datetime/absdate-directive.ts:20
+#: scripts/core/ui/components/Form/DateInput/DateInputPopup.tsx:191
+#: scripts/extensions/availability-manager/dist/src/correspondent-availability/filters.js:59
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/correspondent-availability/filters.js:59
+#: scripts/extensions/availability-manager/src/correspondent-availability/filters.tsx:71
+msgid "Today"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:212
+msgid "Todays Assignments"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:78
+msgid "Toggle"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:88
+msgid "Toggle Header"
+msgstr ""
+
+#: scripts/apps/authoring/widgets/widgets.ts:519
+msgid "Toggle Nth widget, where 'N' is order of widget it appears"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:456
+#: scripts/apps/authoring/views/article-edit.html:457
+msgid "Toggle Sign-Off lock"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:89
+msgid "Toggle Suggestions Mode"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:142
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:54
+msgid "Toggle advanced Filters"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:43
+msgid "Toggle bold"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-section/get-field-container.tsx:70
+msgid "Toggle field"
+msgstr ""
+
+#: scripts/apps/search/views/search.html:3
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:249
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:249
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:376
+msgid "Toggle filters"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:90
+msgid "Toggle formatting marks"
+msgstr ""
+
+#: scripts/apps/archive/views/preview.html:79
+msgid "Toggle header info"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:49
+msgid "Toggle italic"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:15
+msgid "Toggle main menu"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:343
+msgid "Toggle search"
+msgstr ""
+
+#: scripts/apps/search/index.ts:139
+msgid "Toggle search view"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:73
+msgid "Toggle strikethrough"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:61
+msgid "Toggle subscript"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:67
+msgid "Toggle superscript"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/integration-wrapper/toggle-theme-button.tsx:13
+#: scripts/apps/authoring/views/authoring.html:33
+msgid "Toggle theme"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:55
+msgid "Toggle underline"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:311
+msgid "Token expiry"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:103
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DateInputPopup.tsx:213
+#: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:23
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:158
+#: scripts/apps/vocabularies/services/VocabularyService.ts:131
+#: scripts/core/ui/components/Form/DateInput/DateInputPopup.tsx:195
+msgid "Tomorrow"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/profile.ts:61
+msgid "Too long"
+msgstr ""
+
+#: scripts/apps/authoring/attachments/AttachmentsWidget.tsx:24
+msgid "Too many files selected. Only 1 file is allowed"
+msgid_plural "Too many files selected. Only {{count}} files are allowed"
+msgstr[0] ""
+
+#: ../superdesk-planning/client/validators/profile.ts:58
+#: ../superdesk-planning/client/validators/profile.ts:59
+msgid "Too many {{ name }}"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/profile.ts:103
+msgid "Too short"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:432
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:440
+msgid "Total"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:257
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:257
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:394
+msgid "Total Assets: {{ total }}"
+msgstr ""
+
+#: scripts/apps/profiling/views/profiling.html:33
+msgid "Total time"
+msgstr ""
+
+#: scripts/apps/search/views/item-sortbar.html:2
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:732
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:259
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:259
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:402
+msgid "Total:"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:21
+msgid "Transformation Rules Management"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:244
+#: scripts/apps/authoring-react/toolbar/translate-modal.tsx:100
+#: scripts/apps/authoring-react/toolbar/translate-modal.tsx:124
+#: scripts/apps/translations/index.ts:40
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-footer.js:43
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-widget.js:44
+#: scripts/extensions/ai-widget/dist/src/translations/translations-footer.js:43
+#: scripts/extensions/ai-widget/dist/src/translations/translations-widget.js:44
+#: scripts/extensions/ai-widget/src/translations/translations-footer.tsx:81
+#: scripts/extensions/ai-widget/src/translations/translations-widget.tsx:83
+msgid "Translate"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:352
+msgid "Translate item to"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:196
+#: scripts/apps/authoring/versioning/history/views/history.html:41
+msgid "Translated by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/translations/translations.tsx:63
+#: scripts/apps/authoring/translations/translationsWidget.tsx:53
+#: scripts/apps/authoring/views/authoring-header.html:81
+msgid "Translated from"
+msgstr ""
+
+#: scripts/apps/search/components/fields/translations.tsx:58
+#: scripts/apps/search/components/fields/translations.tsx:72
+msgid "Translation"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/translations/translations.tsx:14
+#: scripts/apps/authoring/translations/index.ts:12
+#: scripts/apps/authoring/views/authoring-topbar.html:348
+#: scripts/apps/search/components/fields/translations.tsx:40
+#: scripts/apps/search/components/fields/translations.tsx:72
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/main-panel.js:22
+#: scripts/extensions/ai-widget/dist/src/main-panel.js:22
+#: scripts/extensions/ai-widget/src/main-panel.tsx:45
+msgid "Translations"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:114
+msgid "Transmitted at"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:197
+msgid "Trash"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:33
+#: ../superdesk-planning/client/components/fields/preview/base/utils.ts:16
+msgid "True"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:48
+#: scripts/core/auth/reset-password.html:38
+#: scripts/core/auth/reset-password.html:85
+#: scripts/core/auth/secure-login.html:39
+msgid "Trying to reconnect...<br>Please wait."
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:136
+msgid "Tu"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:109
+msgid "Tue"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1455
+#: scripts/core/datetime/datetime.ts:291
+msgid "Tuesday"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:39
+msgid "Turn off feature preview"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:198
+#: scripts/apps/users/views/edit-form.html:329
+msgid "Twitter"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:199
+msgid "Twitter Circle"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:36
+#: scripts/apps/archive/views/metadata-view.html:207
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:419
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:423
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:201
+#: scripts/apps/workspace/content/constants.ts:47
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:123
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:155
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:123
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:155
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:146
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:178
+msgid "Type"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:80
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:80
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:191
+msgid "Type is required."
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:89
+msgid "Type to search or create a new label"
+msgstr ""
+
+#: scripts/apps/authoring-react/generic-widgets/comments/CommentsWidget.tsx:184
+#: scripts/core/editor3/components/comments/CommentTextArea.tsx:122
+msgid "Type your comment..."
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/list/ItemType.tsx:18
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:173
+#: scripts/extensions/sams/dist/src/components/assets/assetGridItem.js:122
+#: scripts/extensions/sams/dist/src/components/assets/assetListItem.js:118
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:173
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetGridItem.js:122
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetListItem.js:118
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:175
+#: scripts/extensions/sams/src/components/assets/assetGridItem.tsx:147
+#: scripts/extensions/sams/src/components/assets/assetListItem.tsx:131
+msgid "Type:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:139
+msgid "Type: {{ type }}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:152
+msgid "Type: {{type}}"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:121
+msgid "U"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/unspike.tsx:9
+msgid "UNSPIKE"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:149
+msgid "UP"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:18
+msgid "UPCOMING"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/update-action.tsx:10
+#: scripts/apps/authoring/views/authoring-header.html:57
+msgid "UPDATE"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:97
+#: scripts/core/editor3/components/links/LinkInput.tsx:67
+msgid "URL"
+msgstr ""
+
+#: scripts/core/editor3/components/embeds/EmbedInput.tsx:95
+msgid "URL not found."
+msgstr ""
+
+#: scripts/apps/vocabularies/views/settings.html:34
+msgid "URLs"
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:211
+msgid "Uknown validation error"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:21
+msgid "Un Spike"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/uploadAssetModal.js:148
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/uploadAssetModal.js:148
+#: scripts/extensions/sams/src/components/assets/uploadAssetModal.tsx:122
+msgid "Unable to find Asset associated with the file!"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/index.tsx:227
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:208
+#: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:211
+#: scripts/apps/dashboard/workspace-tasks/views/assignee-view.html:8
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:50
+msgid "Unassigned"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:56
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:72
+#: scripts/extensions/availability-manager/dist/src/utils.js:56
+#: scripts/extensions/availability-manager/dist/src/utils.js:72
+#: scripts/extensions/availability-manager/src/utils.ts:59
+#: scripts/extensions/availability-manager/src/utils.ts:75
+msgid "Unavailable"
+msgstr ""
+
+#: scripts/core/views/sdselect.html:14
+msgid "Uncheck all"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:200
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:30
+msgid "Underline"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:77
+msgid "Underline (Ctrl+U)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:201
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:43
+#: scripts/core/editor3/components/toolbar/index.tsx:462
+msgid "Undo"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:203
+#: scripts/apps/content-filters/views/production-test-view.html:19
+#: scripts/apps/legal-archive/views/legal_archive.html:58
+#: scripts/apps/publish/views/publish-queue.html:105
+#: scripts/apps/search/constants.ts:10
+#: scripts/apps/search/views/search-parameters.html:42
+msgid "Unique Name"
+msgstr ""
+
+#: scripts/apps/search/views/item-globalsearch.html:11
+msgid "Unique Name/ID/GUID"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:405
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:197
+msgid "Unique name"
+msgstr ""
+
+#: scripts/core/ui/constants.ts:5
+msgid "Unknow error occured. Try repeating the action or reloading the page."
+msgstr ""
+
+#: scripts/apps/search/services/TagService.ts:198
+msgid "Unknown"
+msgstr ""
+
+#: scripts/apps/archive/directives/ArchivedItemKill.ts:39
+msgid "Unknown Error: Cannot kill the item"
+msgstr ""
+
+#: scripts/apps/archive/directives/ResendItem.ts:45
+msgid "Unknown Error: Cannot resend the item"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:436
+msgid "Unknown Error: Item not published."
+msgstr ""
+
+#: scripts/apps/desks/controllers/DeskConfigController.ts:69
+msgid "Unknown Error: There was a problem, desk was not deleted."
+msgstr ""
+
+#: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:73
+msgid "Unknown Type ({{qcode}})"
+msgstr ""
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:365
+msgid "Unknown error occured, Try descheduling again."
+msgstr ""
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:302
+msgid ""
+"Unknown error occured. Try publishing the item from the article edit view."
+msgstr ""
+
+#: scripts/api/article-send.tsx:248
+msgid "Unknown error occurred"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:161
+msgid "Unlink"
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:140
+#: ../superdesk-planning/client/planning-extension/src/extension.ts:188
+#: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:155
+msgid "Unlink as Coverage"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEventItem.tsx:75
+msgid "Unlink related event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx:90
+msgid "Unlink related planning"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:310
+msgid "Unlink update"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:148
+msgid "Unlinked by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:456
+msgid "Unlinked by {{user}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:171
+#: ../superdesk-planning/client/components/LockContainer/LockContainerPopup.tsx:42
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:59
+#: scripts/apps/archive/views/item-lock.html:10
+#: scripts/apps/archive/views/item-lock.html:22
+#: scripts/apps/authoring-react/subcomponents/lock-info-generic.tsx:62
+#: scripts/apps/authoring-react/subcomponents/lock-info.tsx:58
+#: scripts/apps/authoring/views/authoring-topbar.html:22
+msgid "Unlock"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:21
+msgid "Unlock content"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:468
+msgid "Unlock current item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:202
+#: scripts/apps/authoring/views/article-edit.html:461
+msgid "Unlocked"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:173
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:22
+#: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:22
+#: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:77
+msgid "Unmark"
+msgstr ""
+
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions.js:21
+#: scripts/extensions/markForUser/dist/src/get-article-actions.js:21
+#: scripts/extensions/markForUser/src/get-article-actions.tsx:23
+msgid "Unmark user"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:102
+msgid "Unmarked by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:336
+msgid "Unmarked from desk({{x}}) by {{user}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:302
+msgid "Unmarked from highlight({{x}}) by {{user}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:203
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:27
+msgid "Unordered List"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:86
+msgid "Unordered list"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:119
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:122
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:382
+msgid "Unpost"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:78
+msgid "Unpost all recurring events or just this one?"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:14
+#: scripts/apps/authoring/authoring/index.ts:426
+#: scripts/apps/authoring/views/authoring-topbar.html:146
+#: scripts/apps/authoring/views/authoring-topbar.html:147
+#: scripts/apps/authoring/views/authoring-topbar.html:148
+msgid "Unpublish"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:69
+msgid "Unpublish related items:"
+msgstr ""
+
+#: scripts/apps/search/components/fields/state.tsx:44
+msgid "Unpublished"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/HistoryController.ts:190
+msgid "Unpublished by"
+msgstr ""
+
+#: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:168
+#: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:3
+msgid "Unresolved"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:499
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:123
+#: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:83
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:712
+#: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:18
+msgid "Unsaved changes"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:438
+#: ../superdesk-analytics/client/utils.js:165
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:144
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:80
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:164
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:261
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:204
+#: ../superdesk-planning/client/constants/events.ts:155
+#: scripts/apps/authoring/views/authoring-topbar.html:166
+#: scripts/apps/authoring/views/authoring-topbar.html:167
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:89
+#: scripts/core/interactive-article-actions-panel/action-tabs.tsx:15
+#: scripts/core/interactive-article-actions-panel/actions/unspike-action.tsx:76
+msgid "Unspike"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:134
+msgid "Unspike Item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:143
+msgid "Unspike Planning Item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikeEventForm.tsx:99
+msgid "Unspike all recurring events or just this one?"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/planning.ts:136
+msgid "Unspike planning"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:78
+msgid "Unspike {{event}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:49
+msgid "Unspiked"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:237
+#: scripts/apps/authoring/versioning/history/views/history.html:74
+msgid "Unspiked by"
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-subscribe.html:29
+msgid "Unsubscribe"
+msgstr ""
+
+#: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:227
+msgid "Unsubscribe desk"
+msgstr ""
+
+#: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:215
+msgid "Unsubscribe user"
+msgstr ""
+
+#: scripts/validate-instance-configuration.tsx:32
+msgid ""
+"Unsupported extension point is being used: "
+"`contributions.authoringHeaderComponents`"
+msgstr ""
+
+#: ../superdesk-planning/client/components/WorkqueueContainer/WorkqueueItem.tsx:41
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:6
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:4
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-dropdown.html:6
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-inner-dropdown.html:7
+#: scripts/apps/authoring/views/dashboard-articles.html:21
+#: scripts/apps/authoring/views/opened-articles.html:13
+#: scripts/apps/workspace/views/workspace-dropdown.html:25
+#: scripts/apps/workspace/views/workspace-dropdown.html:6
+#: scripts/core/utils.tsx:452
+msgid "Untitled"
+msgstr ""
+
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:138
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:401
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:224
+#: scripts/apps/archive/index.tsx:294
+#: scripts/apps/authoring/attachments/AttachmentsEditorModal.tsx:51
+#: scripts/apps/authoring/views/authoring-topbar.html:118
+#: scripts/apps/authoring/views/authoring-topbar.html:119
+#: scripts/apps/authoring/views/authoring-topbar.html:120
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:231
+msgid "Update"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:256
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:470
+msgid "Update Created."
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:4
+msgid "Update Cycle:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:200
+msgid "Update Due:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:114
+#: ../superdesk-planning/client/constants/events.ts:164
+msgid "Update Repetitions"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:113
+msgid "Update Repetitions of the Series"
+msgstr ""
+
+#: ../superdesk-analytics/client/update_time_report/controllers/UpdateTimeReportController.js:162
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeReportPreview.js:21
+#: ../superdesk-analytics/client/update_time_report/index.js:50
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:93
+msgid "Update Time"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/assignCalendarForm.tsx:96
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:352
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:355
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:298
+msgid "Update all recurring events or just this one?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:258
+msgid "Update all recurring planning or just this one?"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:121
+msgid "Update every"
+msgstr ""
+
+#: scripts/validate-instance-configuration.tsx:42
+msgid "Update or disable incompatible extensions."
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-subscribe.html:33
+msgid "Update subscription"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/events.ts:160
+msgid "Update time"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:90
+msgid "Update time of {{event}}"
+msgstr ""
+
+#: scripts/apps/search/components/fields/update.tsx:17
+msgid "Update {{sequence}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:44
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:130
+#: ../superdesk-planning/client/components/AuditInformation/index.tsx:121
+#: scripts/apps/archive/views/item-preview.html:12
+#: scripts/apps/archive/views/metadata-view.html:195
+#: scripts/apps/archive/views/preview.html:43
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:251
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:81
+#: scripts/apps/authoring/views/authoring-header.html:65
+#: scripts/apps/contacts/services/ContactsService.ts:41
+#: scripts/apps/content-api/services/ContentAPISearchService.ts:28
+#: scripts/apps/legal-archive/services/LegalArchiveService.ts:24
+#: scripts/apps/legal-archive/tests/legal.spec.ts:66
+#: scripts/apps/search/components/fields/updated.tsx:18
+#: scripts/apps/search/services/SearchService.ts:66
+#: scripts/apps/search/tests/search.spec.ts:248
+#: scripts/apps/workspace/content/views/profile-settings.html:65
+#: scripts/core/itemList/views/relatedItem-list-widget.html:35
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:149
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:149
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:114
+#: scripts/extensions/sams/dist/src/utils/ui.js:114
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:174
+#: scripts/extensions/sams/src/utils/ui.tsx:107
+msgid "Updated"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:129
+msgid "Updated Fields:"
+msgstr ""
+
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:68
+msgid "Updated In"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:104
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:104
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:178
+msgid "Updated at {{date}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:129
+#: scripts/apps/authoring/versioning/history/views/history.html:18
+msgid "Updated by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:119
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:135
+msgid "Updated fields:"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetListItem.js:114
+#: scripts/extensions/sams/dist/src/components/common/versionUserDateLines.js:98
+#: scripts/extensions/sams/dist/src/components/sets/setListItem.js:95
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetListItem.js:114
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/versionUserDateLines.js:69
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListItem.js:95
+#: scripts/extensions/sams/src/components/assets/assetListItem.tsx:124
+#: scripts/extensions/sams/src/components/common/versionUserDateLines.tsx:52
+#: scripts/extensions/sams/src/components/sets/setListItem.tsx:80
+msgid "Updated {{ datetime }}"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/common/versionUserDateLines.js:99
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/versionUserDateLines.js:70
+#: scripts/extensions/sams/src/components/common/versionUserDateLines.tsx:57
+msgid "Updated {{ datetime }} by"
+msgstr ""
+
+#: scripts/apps/contacts/components/ContactFooter.tsx:18
+msgid "Updated:"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:576
+msgid "Updates"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:34
+msgid ""
+"Updates can only be created for text items. The type of this item is {{type}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:205
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:136
+#: scripts/apps/search/views/multi-image-edit.html:17
+#: scripts/extensions/sams/dist/src/containers/FileUploadModal.js:233
+#: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:233
+#: scripts/extensions/sams/src/containers/FileUploadModal.tsx:295
+msgid "Upload"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/settings.html:9
+msgid "Upload Config"
+msgstr ""
+
+#: scripts/apps/archive/controllers/UploadController.ts:165
+msgid "Upload Error:"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/uploadAssetModal.js:190
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:245
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/uploadAssetModal.js:190
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:245
+#: scripts/extensions/sams/src/components/assets/uploadAssetModal.tsx:200
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:358
+msgid "Upload New Asset(s)"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/UploadConfigModal.tsx:69
+msgid "Upload config"
+msgstr ""
+
+#: scripts/apps/users/controllers/ChangeAvatarController.ts:6
+msgid "Upload from computer"
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:243
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:243
+#: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:342
+msgid "Upload image"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:106
+#: scripts/apps/search/views/multi-image-edit.html:12
+#: scripts/core/ui/components/content-create-dropdown/initial-view.tsx:210
+msgid "Upload media"
+msgstr ""
+
+#: scripts/apps/authoring/views/item-carousel.html:166
+msgid "Upload new"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetListPanel.js:62
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetListPanel.js:62
+#: scripts/extensions/sams/src/components/assets/assetListPanel.tsx:36
+msgid "Upload new Assets or change your search filters"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:256
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:256
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:351
+msgid "Uploaded From:"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:258
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:258
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:361
+msgid "Uploaded To:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:119
+msgid "Uploading {{current}} of {{total}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:118
+msgid "Uploading..."
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:18
+msgid "Uppercase"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:560
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:139
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:467
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:108
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/urgency-field.ts:45
+#: ../superdesk-planning/client/components/fields/editor/Urgency.tsx:25
+#: ../superdesk-planning/client/components/fields/preview/Urgency.tsx:33
+#: ../superdesk-planning/client/components/fields/preview/index.ts:167
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:115
+#: ../superdesk-planning/client/services/PlanningStoreService.ts:251
+#: ../superdesk-planning/client/utils/contentProfiles.ts:309
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:284
+#: scripts/apps/authoring-react/field-adapters/urgency.ts:37
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:100
+#: scripts/apps/authoring/views/authoring-header.html:319
+#: scripts/apps/content-api/services/ContentAPISearchService.ts:30
+#: scripts/apps/legal-archive/services/LegalArchiveService.ts:26
+#: scripts/apps/legal-archive/tests/legal.spec.ts:68
+#: scripts/apps/search/components/ItemUrgency.tsx:23
+#: scripts/apps/search/components/ItemUrgency.tsx:35
+#: scripts/apps/search/directives/SearchFilters.ts:47
+#: scripts/apps/search/services/SearchService.ts:68
+#: scripts/apps/search/tests/search.spec.ts:249
+#: scripts/apps/workspace/content/constants.ts:48
+msgid "Urgency"
+msgstr ""
+
+#: scripts/apps/ingest/ingest-stats-widget/configuration.html:10
+msgid "Urgency stats"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/urgency.tsx:21
+msgid "Urgency:"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/urls/index.tsx:20
+msgid "Urls (authoring-react)"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:76
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:76
+#: scripts/extensions/sams/src/components/sets/setListPanel.tsx:72
+msgid "Usable Sets"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:85
+msgid "Usage"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.ts:49
+msgid "Usage Terms"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:40
+#: scripts/apps/archive/views/metadata-view.html:181
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:145
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:35
+#: scripts/apps/templates/views/template-editor-modal.html:113
+msgid "Usage terms"
+msgstr ""
+
+#: scripts/apps/authoring/views/confirm-media-associated.html:17
+msgid "Use Media"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:111
+msgid "Use Togglebox"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:18
+msgid "Use Transport Layer Security (FTPS)"
+msgstr ""
+
+#: scripts/apps/users/controllers/ChangeAvatarController.ts:8
+msgid "Use a Web URL"
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:238
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:238
+#: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:329
+msgid "Use current frame"
+msgstr ""
+
+#: scripts/extensions/predefinedTextField/dist/src/editor.js:59
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/editor.js:59
+#: scripts/extensions/predefinedTextField/src/editor.tsx:98
+msgid "Use custom value"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:210
+msgid "Use priority queue for transmission."
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:135
+msgid "Use the article GUID for testing."
+msgstr ""
+
+#: scripts/extensions/annotationsLibrary/dist/src/AnnotationSelectSingleItem.js:14
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.js:14
+#: scripts/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.tsx:36
+msgid "Use this"
+msgstr ""
+
+#: scripts/apps/search/components/fields/used.tsx:16
+#: scripts/apps/search/views/item-preview.html:21
+msgid "Used"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:508
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:114
+#: ../superdesk-analytics/client/search/views/user-select.html:5
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:206
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:159
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:52
+#: scripts/apps/users/views/user-privileges.html:18
+msgid "User"
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/index.js:46
+#: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:340
+#: scripts/apps/dashboard/user-activity/user-activity.ts:37
+msgid "User Activity"
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:185
+msgid "User Activity - {{username}}"
+msgstr ""
+
+#: scripts/apps/users/config.ts:38
+#: scripts/core/lang/missing-translations-strings.ts:21
+msgid "User Management"
+msgstr ""
+
+#: scripts/apps/users/import/views/import-user.html:28
+msgid "User Profile to Import"
+msgstr ""
+
+#: scripts/apps/users/config.ts:66 scripts/apps/users/views/settings.html:4
+msgid "User Roles"
+msgstr ""
+
+#: scripts/apps/users/directives/UserPrivilegesDirective.ts:32
+msgid "User not found."
+msgstr ""
+
+#: scripts/apps/users/directives/UserPreferencesDirective.ts:163
+msgid "User preferences could not be saved..."
+msgstr ""
+
+#: scripts/apps/users/directives/UserPreferencesDirective.ts:159
+msgid "User preferences saved"
+msgstr ""
+
+#: scripts/apps/users/directives/UserRolesDirective.ts:35
+msgid "User role created."
+msgstr ""
+
+#: scripts/apps/users/directives/UserPrivilegesDirective.ts:55
+msgid "User role not found."
+msgstr ""
+
+#: scripts/apps/users/directives/UserRolesDirective.ts:37
+msgid "User role updated."
+msgstr ""
+
+#: scripts/apps/users/controllers/UserResolver.ts:12
+msgid "User was not found, sorry."
+msgstr ""
+
+#: scripts/apps/users/directives/UserEditDirective.ts:266
+msgid "User was not found. The account might have been deleted."
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/views/item-timeline-tooltip.html:2
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:102
+msgid "User:"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/searchConfig.html:2
+#: scripts/apps/publish/views/ftp-config.html:7
+#: scripts/apps/publish/views/ftp-config.html:8
+#: scripts/apps/search-providers/views/search-provider-config.html:109
+#: scripts/apps/users/views/list.html:34
+msgid "Username"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:115
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:413
+#: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:564
+#: scripts/apps/master-desk/MasterDesk.tsx:38
+#: scripts/apps/production-api-keys/config.ts:25
+#: scripts/apps/users/views/list.html:2
+msgid "Users"
+msgstr ""
+
+#: scripts/apps/users/config.ts:56
+msgid "Users Profile"
+msgstr ""
+
+#: scripts/apps/users/views/edit.html:9
+msgid "Users Profile:"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:13
+msgid "Users archive view format"
+msgstr ""
+
+#: scripts/apps/archive/views/export.html:17
+#: scripts/apps/archive/views/export.html:18
+#: scripts/apps/authoring-react/toolbar/export-modal.tsx:104
+msgid "Validate"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:299
+msgid "Validate Characters"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/date/config.tsx:53
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:147
+msgid "Value"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:282
+msgid "Value must be greater than or equal to 2."
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:284
+msgid "Value must be less than or equal to 99."
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:207
+msgid "Value must be unique"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:79
+msgid "Value type"
+msgstr ""
+
+#: scripts/apps/content-filters/views/filter-search.html:26
+#: scripts/apps/content-filters/views/filter-search.html:30
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:77
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:83
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:88
+msgid "Values"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:85
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:366
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:163
+msgid "Version"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:110
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:397
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:186
+msgid "Version creator"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:76
+msgid "Version: {{n}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/index.tsx:40
+#: scripts/apps/authoring/versioning/versioning.ts:8
+#: scripts/apps/authoring/versioning/views/versioning.html:3
+msgid "Versions"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/index.tsx:15
+msgid "Versions and item history"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:207
+#: ../superdesk-planning/client/utils/index.ts:591
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:238
+#: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:62
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:110
+#: scripts/extensions/sams/dist/src/utils/assets.js:110
+#: scripts/extensions/sams/src/utils/assets.ts:144
+msgid "Video"
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditor.js:306
+#: scripts/extensions/videoEditor/dist/src/VideoEditor.js:80
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditor.js:306
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditor.js:80
+#: scripts/extensions/videoEditor/src/VideoEditor.tsx:134
+#: scripts/extensions/videoEditor/src/VideoEditor.tsx:422
+msgid "Video is editing, please wait..."
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:235
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:235
+#: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:322
+msgid "Video thumbnail"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:74
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:74
+#: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:57
+msgid "Videos only"
+msgstr ""
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:28
+msgid "View Latest Item Version"
+msgstr ""
+
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:120
+msgid "View Original"
+msgstr ""
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:33
+msgid "View Original Image"
+msgstr ""
+
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:131
+msgid "View Update"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:120
+msgid "View an item"
+msgstr ""
+
+#: ../superdesk-analytics/client/index.js:95
+msgid "View analytics reports"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:168
+msgid "View associated event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:155
+msgid "View duplicate event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:140
+msgid "View duplicate planning item"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:14
+#: scripts/apps/users/views/user-preferences.html:43
+msgid "View formats"
+msgstr ""
+
+#: scripts/apps/users/views/list.html:67
+msgid "View full profile"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:516
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:106
+msgid "View item"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:403
+msgid "View linked item"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:13
+msgid "View name"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:49
+msgid "View notifications"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:165
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:189
+#: ../superdesk-planning/client/components/fields/state.tsx:32
+msgid "View original event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:152
+msgid "View original planning item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:143
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:204
+msgid "View planning item"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:58
+msgid "View profile details"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:177
+msgid "View rescheduled event"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:58
+msgid "View schedules"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:155
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:180
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:205
+msgid "View source item"
+msgstr ""
+
+#: scripts/apps/contacts/index.ts:23
+msgid "View/Manage media contacts"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectCustomVocabulariesList.tsx:27
+#: ../superdesk-planning/client/components/fields/index.tsx:226
+#: scripts/apps/vocabularies/views/settings.html:16
+msgid "Vocabularies"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:22
+msgid "Vocabularies Management"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/config-main.tsx:82
+msgid "Vocabulary"
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/src/extension.ts:283
+msgid "Vocabulary `locators` is not configured!"
+msgstr ""
+
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:101
+msgid "Vocabulary saved successfully"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:20
+#: scripts/apps/users/views/user-preferences.html:248
+msgid "Vocabulary values"
+msgstr ""
+
+#: scripts/apps/vocabularies/controllers/VocabularyConfigController.ts:243
+msgid "Vocabulary was deleted."
+msgstr ""
+
+#: scripts/validate-instance-configuration.tsx:56
+msgid "Vocabulary with ID \"categories\" is required"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/CalendarNavigation.tsx:56
+msgid "W"
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:44
+msgid "WARNING unknown filter condition value: {{ value }}"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:91
+msgid "WE"
+msgstr ""
+
+#: scripts/apps/archive/views/preview.html:63
+#: scripts/apps/authoring/suggest/SuggestView.html:16
+#: scripts/apps/authoring/suggest/SuggestView.html:64
+#: scripts/apps/authoring/views/authoring-header.html:42
+msgid "WORD"
+msgid_plural "WORDS"
+msgstr[0] ""
+
+#: scripts/api/article-send.tsx:103
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:24
+#: scripts/core/auth/auth.ts:242
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:387
+msgid "Warning"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:208
+msgid "Warning Sign"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:139
+msgid "We"
+msgstr ""
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:48
+msgid ""
+"We will send occasional updates on Superdesk developments to the email "
+"address you have provided. Your data will be kept secure and it won't be "
+"used for any other purpose. You may opt-out of receiving further email "
+"communications at any time."
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:38
+msgid "Weak"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:110
+msgid "Wed"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1456
+#: scripts/core/datetime/datetime.ts:292
+msgid "Wednesday"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:160
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:80
+#: scripts/extensions/availability-manager/dist/src/constants.js:35
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/constants.js:35
+#: scripts/extensions/availability-manager/src/constants.ts:43
+msgid "Week"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/Days.tsx:32
+msgid "Week Days"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:31
+msgid "Week(s)"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:37
+#: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:23
+msgid "Weekly"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:48
+msgid "Weekly @ {{ time }} to {{ desk }}"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:71
+msgid "Weekly on {{days}} at {{hour}}"
+msgstr ""
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:4
+msgid "Welcome to Superdesk"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:2
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:9
+msgid "When"
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:38
+#: scripts/apps/highlights/views/highlights_config_modal.html:47
+msgid "When creating a highlights package"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:204
+msgid "When enabled it can send multiple items at the same time."
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:55
+msgid "White"
+msgstr ""
+
+#: scripts/apps/dashboard/views/widget.html:11
+#: scripts/apps/dashboard/views/widget.html:12
+msgid "Widget settings"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:8
+msgid ""
+"Widget settings <span translate>for \"{{currentDesk.name}}\" Desk</span>"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:95
+msgid "Widgets"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:58
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:156
+msgid "Width"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:102
+msgid ""
+"Width of the\n"
+"                                    popup window (in pixels)"
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:73
+msgid "Wire/Paper"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/NoCoverage.tsx:15
+msgid "Without Coverage"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:17
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:288
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:292
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:108
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:112
+msgid "Word Count"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:232
+msgid "Work stages"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:100
+msgid "Work started"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:101
+msgid "Work started on coverage"
+msgstr ""
+
+#: scripts/core/activity/activity.ts:22
+msgid "Workflow"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:171
+msgid "Workflow State"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/index.tsx:229
+msgid "Workflow States"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:305
+#: scripts/apps/desks/views/desk-config-modal.html:358
+#: scripts/apps/workspace/content/constants.ts:55
+msgid "Working Stage"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/working-hours-grid-labels.js:16
+#: scripts/extensions/availability-manager/dist/src/settings/working-hours-grid-labels.js:16
+#: scripts/extensions/availability-manager/src/settings/working-hours-grid-labels.tsx:25
+msgid "Working hours"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:94 scripts/apps/dashboard/index.ts:53
+#: scripts/apps/dashboard/views/workspace.html:24
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:376
+#: scripts/apps/ingest/index.ts:72 scripts/apps/stream/index.ts:18
+msgid "Workspace"
+msgstr ""
+
+#: scripts/apps/workspace/views/edit-workspace-modal.html:15
+msgid "Workspace name"
+msgstr ""
+
+#: scripts/apps/workspace/views/workspace-dropdown.html:1
+msgid "Workspace:"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/world-clock.ts:209
+#: scripts/core/lang/missing-translations-strings.ts:44
+msgid "World Clock"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/world-clock.ts:42
+msgid "World clock added: {{zone}}"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/world-clock.ts:44
+msgid "World clock removed: {{zone}}"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/world-clock.ts:221
+#: scripts/core/lang/missing-translations-strings.ts:45
+msgid "World clock widget"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:339
+msgid "XMP File"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:33
+msgid "Year(s)"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:61
+msgid "Yellow"
+msgstr ""
+
+#: scripts/core/ui/components/generic-form/input-types/checkbox.tsx:10
+#: scripts/core/ui/components/generic-form/input-types/yes-no.tsx:6
+msgid "Yes"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:16
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:16
+#: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:38
+msgid "Yes, create a template"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:17
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:8
+msgid "Yesterday"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:106
+msgid ""
+"You are about to delete the vocabulary {{name}}. This action can't be undone."
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:109
+msgid ""
+"You are changing you personal preferences. If you would like to set the "
+"default order for the desk, you can do so from the settings page."
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:249
+msgid "You are creating a new planning item."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:73
+msgid "You are currently managing featured story in another session"
+msgstr ""
+
+#: scripts/validate-instance-configuration.tsx:38
+msgid "You are likely running an outdated version of auto tagging extension."
+msgstr ""
+
+#: scripts/apps/workspace/content/services/ContentService.ts:71
+msgid "You are not allowed to create an article there."
+msgstr ""
+
+#: scripts/apps/workspace/content/services/ContentService.ts:69
+msgid "You are not allowed to create article on readonly stage."
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:510
+msgid ""
+"You are trying to add multiple related events when only one is allowed. Only "
+"the first event({{name}}) will be added."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageForm.tsx:233
+msgid "You can associate only one XMP file"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:134
+msgid ""
+"You can choose the default content view of your desk. Use only if you want "
+"to override individual users' monitoring view preferences. Select \"none\" "
+"if you want to let users decide."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:148
+msgid ""
+"You can either completely block further writing after the characterlimit is "
+"reached or highlight exceeding characters in red."
+msgstr ""
+
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:154
+msgid "You can't multi-edit, because these articles can't be edited"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:35
+msgid "You cannot change workflow status"
+msgstr ""
+
+#: scripts/core/menu/notifications/views/notifications.html:13
+msgid "You don't have any notifications"
+msgstr ""
+
+#: scripts/apps/monitoring/views/item-actions-menu.html:44
+msgid "You don't have the privileges to perform any action"
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-subscribe.html:12
+msgid "You have chosen to subscribe to"
+msgstr ""
+
+#: scripts/api/highlights.ts:53 scripts/apps/search/MultiImageEdit.ts:173
+msgid "You have unsaved changes, do you want to continue?"
+msgstr ""
+
+#: scripts/apps/desks/controllers/DeskConfigController.ts:93
+msgid "You have unsaved changes. Do you want to save them now?"
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:76
+msgid "You have unsaved changes. What would you like to do?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:242
+msgid ""
+"You made changes to this planning item that is part of a recurring event."
+msgstr ""
+
+#: scripts/apps/production-api-keys/config.ts:40
+msgid ""
+"Your Client ID and Client Secret will be generated when you save. Make sure "
+"to copy the Client Secret immediately. It will only be shown once and it "
+"cannot be retrieved later."
+msgstr ""
+
+#: scripts/apps/users/import/views/import-user.html:11
+msgid "Your Credentials"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:198
+msgid "Your Slack user name without the leading @"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:500
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:124
+#: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:84
+msgid "Your changes will be lost if you close now. What would you like to do?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:285
+msgid "Your changes will be lost if you switch now. What would you like to do?"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/configuration.html:12
+msgid "Your clock"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:71
+msgid "Your password has expired. Please change your password."
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:4
+msgid "Your session has expired."
+msgstr ""
+
+#: scripts/apps/vocabularies/components/UploadComplete.tsx:8
+msgid "Your upload was successful"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:209
+msgid "Zoom In"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:210
+msgid "Zoom Out"
+msgstr ""
+
+#: scripts/apps/search/views/saved-searches.html:11
+msgid "[Global]"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/constants.ts:8
+#: scripts/apps/authoring/media/MediaMetadataView.tsx:16
+#: scripts/core/editor3/components/media/MediaBlock.tsx:164
+#: scripts/core/editor3/components/media/MediaBlock.tsx:205
+#: scripts/core/editor3/components/media/MediaBlock.tsx:209
+#: scripts/core/editor3/components/media/MediaBlock.tsx:213
+#: scripts/core/editor3/components/media/MediaBlock.tsx:219
+#: scripts/core/editor3/components/media/MediaBlock.tsx:224
+#: scripts/core/editor3/components/media/MediaBlock.tsx:251
+#: scripts/core/editor3/components/media/MediaBlock.tsx:255
+#: scripts/core/editor3/components/media/MediaBlock.tsx:261
+#: scripts/core/editor3/components/media/MediaBlock.tsx:266
+#: scripts/core/editor3/components/media/MediaBlock.tsx:291
+#: scripts/core/editor3/components/media/MediaBlock.tsx:295
+#: scripts/core/editor3/components/media/MediaBlock.tsx:301
+#: scripts/core/editor3/components/media/MediaBlock.tsx:306
+msgid "[No Value]"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:103
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:97
+msgid "a Recurring Event"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:51
+msgid "a lower case letter (a-z)"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:53
+msgid "a number (0-9)"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:54
+msgid "a special character (!@#$%^&...)"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:36
+msgid "active"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:38
+msgid "added new task {{subject}} of type {{type}}"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:35
+msgid "added new {{type}} item about \"{{subject}}\""
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:35
+msgid "added new {{type}} item with empty header/title"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:78
+msgid "added to workflow"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:167
+#: scripts/apps/users/views/user-preferences.html:147
+#: scripts/core/utils.tsx:342
+msgid "all"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:289
+#: scripts/apps/highlights/views/highlights_config_modal.html:15
+msgid "already exists"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:103
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:120
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:73
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:79
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:85
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:91
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:97
+msgid "an Event"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:52
+msgid "an upper case letter (A-Z)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:56
+msgid "and"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:45
+msgid "and '{{ user }}'"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:90
+msgid "annotation"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:13
+msgid "archive"
+msgstr ""
+
+#: scripts/apps/search/components/ItemContainer.tsx:20
+msgid "archived"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:140
+msgid "as rewrite of"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:45
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:17
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:22
+msgid "at"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:401
+#: scripts/apps/archive/controllers/UploadController.ts:330
+#: scripts/apps/authoring-react/fields/media/editor.tsx:151
+#: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:198
+#: scripts/core/lang/missing-translations-strings.ts:9
+#: scripts/core/utils.tsx:281 scripts/core/utils.tsx:349
+msgid "audio"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-article.html:7
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:7
+msgid "author"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:27
+msgid "authoring"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:83
+msgid "bold"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/FileInput.tsx:205
+#: scripts/core/ui/components/Form/FileInput.tsx:137
+#: scripts/extensions/sams/dist/src/apps/samsAttachmentsWidget.js:197
+#: scripts/extensions/sams/dist/src/apps/samsAttachmentsWidget.js:207
+#: scripts/extensions/sams/dist/src/extensions/sams/src/apps/samsAttachmentsWidget.js:197
+#: scripts/extensions/sams/dist/src/extensions/sams/src/apps/samsAttachmentsWidget.js:207
+#: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:195
+#: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:219
+msgid "browse"
+msgstr ""
+
+#: scripts/apps/search/components/SelectBox.tsx:68
+msgid "bulk actions"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:43
+#: ../superdesk-planning/client/components/AuditInformation/index.tsx:110
+#: ../superdesk-planning/client/components/AuditInformation/index.tsx:121
+#: ../superdesk-planning/client/components/AuditInformation/index.tsx:132
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:60
+#: ../superdesk-planning/client/utils/history.tsx:64
+#: scripts/apps/archive/views/preview.html:7
+#: scripts/apps/authoring/authoring/created-info.tsx:53
+#: scripts/apps/authoring/suggest/SuggestView.html:23
+#: scripts/apps/authoring/suggest/SuggestView.html:71
+#: scripts/apps/authoring/versioning/versions/views/versions.html:7
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:2
+msgid "by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:210
+msgid "by {{user}}"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:223
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:223
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:284
+msgid "cancel"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:88
+msgid "cancelled"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:14
+msgid "categories"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:211
+msgid "change password"
+msgstr ""
+
+#: scripts/core/menu/notifications/views/notifications.html:42
+msgid ""
+"changed the following original item. Please make sure to update the "
+"corresponding translated item accordingly"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/CharacterCount.tsx:30
+#: scripts/apps/authoring/authoring/components/CharacterCount.tsx:64
+#: scripts/apps/authoring/authoring/directives/CharacterCount.ts:13
+#: scripts/core/editor3/components/toolbar/FloatingCharacterCount.tsx:48
+msgid "characters"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:583
+msgid "city"
+msgstr ""
+
+#: scripts/core/ui/components/virtual-lists/select.tsx:176
+msgid "clear"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:50
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:50
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:116
+msgid "close"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:41
+msgid "closed"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:112
+msgid "color"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/TableControls.tsx:102
+msgid "column"
+msgstr ""
+
+#: scripts/core/menu/notifications/views/notifications.html:31
+msgid "commented on"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:91
+msgid "comments"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:13
+msgid "compact"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:9
+#: scripts/core/utils.tsx:283
+msgid "composite"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:390
+msgid "confirm"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:69
+msgid "confirmed"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:181
+msgid "contact saved."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:10
+msgid "content"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:12
+msgid "corrected"
+msgstr ""
+
+#: scripts/apps/search/components/fields/update.tsx:15
+msgid "correction sequence"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/meta-place-directive.html:20
+msgid "country"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:34
+msgid "create"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:189
+msgid "created"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/agenda.ts:240
+msgid "created  planning item."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/agenda.ts:229
+msgid "created / planning item(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:42
+#: ../superdesk-planning/client/components/RelatedPlannings/index.tsx:102
+msgid "created by"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:36
+msgid "created new version {{version}} for item {{type}} about \"{{subject}}\""
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:42
+msgid "created user {{user}}"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:379
+msgid "current"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:86
+msgid "custom blocks"
+msgstr ""
+
+#: scripts/apps/workspace/helpers/getTypeForFieldId.ts:17
+msgid "custom vocabulary"
+msgstr ""
+
+#: scripts/apps/workspace/helpers/getTypeForFieldId.ts:8
+msgid "date"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:41
+#: scripts/apps/desks/views/content-expiry.html:3
+msgid "day"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:11
+#: scripts/apps/authoring-react/fields/date/config.tsx:83
+#: scripts/apps/desks/views/content-expiry.html:32
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:153
+msgid "days"
+msgstr ""
+
+#: scripts/apps/users/views/settings-privileges.html:16
+#: scripts/apps/users/views/settings-roles.html:15
+#: scripts/apps/users/views/user-preferences.html:159
+msgid "default"
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:21
+msgid "default template"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:26
+msgid "desk Output"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:9
+#: scripts/apps/authoring/versioning/versions/views/versions.html:13
+#: scripts/apps/search/components/ItemContainer.tsx:13
+#: scripts/core/itemList/views/relatedItem-list-widget.html:38
+msgid "desk:"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:272
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:272
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:455
+msgid "details"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:34
+#: scripts/apps/users/views/user-list-item.html:15
+msgid "disabled"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:36
+msgid "disabled user {{user}}"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-replace.html:9
+msgid "done"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:11
+msgid "draft"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:42
+msgid "due"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:58
+msgid "duplicate id"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:463
+msgid "e.g. @cityofsydney"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:338
+msgid "e.g. @superdeskman"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:559
+msgid "e.g. Rhodes, CBD"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:489
+msgid "e.g. cityofsydney from https://www.facebook.com/cityofsydney"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:513
+msgid "e.g. cityofsydney from https://www.instagram.com/cityofsydney"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:447
+msgid "e.g. http://www.website.com"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:254
+msgid "e.g. professor, commissioner"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:303
+msgid "e.g. superdeskman from https://www.facebook.com/superdeskman"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:320
+msgid "e.g. superdeskman from https://www.instagram.com/superdeskman"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:49
+#: scripts/apps/users/views/edit-form.html:131
+msgid "email"
+msgstr ""
+
+#: scripts/apps/archive/views/item-state.html:6
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:225
+msgid "embargo"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:93
+#: scripts/apps/workspace/helpers/getTypeForFieldId.ts:9
+msgid "embed"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:94
+msgid "embed articles"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:97
+#: scripts/extensions/availability-manager/dist/src/utils.js:97
+#: scripts/extensions/availability-manager/src/utils.ts:100
+msgid "end time"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:10
+msgid "error"
+msgstr ""
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:71
+msgid "event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:71
+msgid "events"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:26
+msgid "example"
+msgstr ""
+
+#: scripts/apps/archive/views/item-preview.html:19
+#: scripts/apps/archive/views/preview.html:116
+#: scripts/apps/search/components/MediaInfo.tsx:37
+#: scripts/apps/search/components/fields/expiry.tsx:15
+msgid "expires"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:276
+msgid "expires:"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:51
+msgid "facebook"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:11
+msgid "failed"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:435
+msgid "fax"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:14
+msgid "feature"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:11
+msgid "fetched"
+msgstr ""
+
+#: scripts/apps/archive/views/fetched-desks.html:2
+#: scripts/apps/search/components/FetchedDesksInfo.tsx:75
+msgid "fetched in"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/form-validation.js:11
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/form-validation.js:20
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/form-validation.js:24
+#: scripts/extensions/broadcasting/dist/src/form-validation.js:11
+#: scripts/extensions/broadcasting/dist/src/form-validation.js:20
+#: scripts/extensions/broadcasting/dist/src/form-validation.js:24
+#: scripts/extensions/broadcasting/src/form-validation.ts:10
+#: scripts/extensions/broadcasting/src/form-validation.ts:18
+#: scripts/extensions/broadcasting/src/form-validation.ts:22
+msgid "field can not be empty"
+msgstr ""
+
+#: scripts/api/article-fetch.tsx:135
+msgid "file name"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:230
+msgid "first"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:275
+#: scripts/apps/users/views/edit-form.html:82
+msgid "first name"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/tests/index_test.ts:208
+msgid "foo"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1428
+msgid "for"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:9
+msgid "for \"{{currentDesk.name}}\" Desk"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:2
+msgid "for \"{{name}}\" Desk"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:42
+msgid "for '{{ desk }}'"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:97
+msgid "for desk"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:94
+msgid "for highlight"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1428
+msgid "for {{ repeatCount }} repeats"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:87
+msgid "formatting marks"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:36
+#: scripts/apps/authoring/versioning/history/views/history.html:47
+#: scripts/apps/authoring/versioning/history/views/history.html:69
+msgid "from"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:28
+msgid "from content"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:95
+msgid "from coverage assignment by"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:122
+msgid "from highlight"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:361
+msgid "from highlight: {{x}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:238
+msgid "from {{from}} to {{to}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:228
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:244
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:260
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:276
+msgid "from:"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:73
+msgid "full name"
+msgstr ""
+
+#: scripts/core/itemList/views/relatedItem-list-widget.html:42
+msgid "genre:"
+msgstr ""
+
+#: scripts/core/ui/components/UserPopup/UserPopup.tsx:27
+msgid "go to profile"
+msgstr ""
+
+#: scripts/core/utils.tsx:285 scripts/core/utils.tsx:345
+msgid "graphic"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:66
+msgid "h1"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:67
+msgid "h2"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:68
+msgid "h3"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:69
+msgid "h4"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:70
+msgid "h5"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:71
+msgid "h6"
+msgstr ""
+
+#: scripts/api/article-fetch.tsx:137
+msgid "height"
+msgstr ""
+
+#: scripts/core/views/sdSlider.html:3
+msgid "high"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:34
+msgid "highlights"
+msgstr ""
+
+#: scripts/core/utils.tsx:347
+msgid "highlights package"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:255
+msgid "honorific"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:5
+#: scripts/apps/highlights/views/highlights_config_modal.html:45
+msgid "hours"
+msgstr ""
+
+#: scripts/apps/desks/views/content-expiry.html:4
+#: scripts/apps/desks/views/content-expiry.html:40
+msgid "hr"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:162
+msgid "hrs"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extension.js:26
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/extension.js:26
+#: scripts/extensions/auto-tagging-widget/src/extension.tsx:28
+msgid "iMatrics"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:270
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:50
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:270
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:50
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:111
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:444
+msgid "iMatrics service error"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:54
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:54
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:128
+msgid ""
+"iMatrics service has returned tags referencing parents that do not exist in "
+"the response."
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extension.js:10
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/extension.js:10
+#: scripts/extensions/auto-tagging-widget/src/extension.tsx:11
+msgid "iMatrics tagging"
+msgstr ""
+
+#: scripts/apps/archive/controllers/UploadController.ts:322
+#: scripts/apps/authoring-react/fields/media/editor.tsx:147
+#: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:196
+msgid "image"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/ImageTaggingComponent/ImageTaggingComponent.js:198
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:198
+#: scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.tsx:279
+msgid "image suggestions ({{n}})"
+msgstr ""
+
+#: scripts/core/ui/views/sd-timepicker-popup.html:4
+msgid "in 1 h"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:126
+#: scripts/core/ui/components/Form/TimeInput/TimeInputPopup.tsx:98
+msgid "in 1 hr"
+msgstr ""
+
+#: scripts/core/ui/views/sd-timepicker-popup.html:5
+msgid "in 2 h"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:130
+#: scripts/core/ui/components/Form/TimeInput/TimeInputPopup.tsx:102
+msgid "in 2 hrs"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:122
+#: scripts/core/ui/components/Form/TimeInput/TimeInputPopup.tsx:94
+#: scripts/core/ui/views/sd-timepicker-popup.html:3
+msgid "in 30 min"
+msgstr ""
+
+#: ../superdesk-planning/client/components/RelatedPlannings/index.tsx:76
+msgid "in agenda"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:72
+msgid "in the last 24 hours."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:10
+msgid "in-progress"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:10
+msgid "in_progress"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:35
+#: scripts/apps/users/views/user-list-item.html:16
+msgid "inactive"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:11
+msgid "ingested"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:52
+msgid "instagram"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/attachments/samsAttachmentsList.js:114
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/samsAttachmentsList.js:114
+#: scripts/extensions/sams/src/components/attachments/samsAttachmentsList.tsx:121
+msgid "internal"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:82
+msgid "italic"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:429
+msgid "item"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem.ts:166
+msgid "item metadata associated."
+msgstr ""
+
+#: scripts/apps/master-desk/components/OverviewComponent.tsx:235
+msgid "items in production"
+msgstr ""
+
+#: scripts/apps/master-desk/components/AssignmentsComponent.tsx:168
+msgid "items in total"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:12
+msgid "killed"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:111
+msgid "label"
+msgstr ""
+
+#: scripts/apps/packaging/views/sd-package-item-preview.html:24
+msgid "label: <b>{{label.name}}</b>"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:232
+msgid "last"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:296
+#: scripts/apps/users/views/edit-form.html:94
+msgid "last name"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:80
+msgid "last update and last item arrived."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/ReadingTime.ts:20
+#: scripts/apps/authoring/authoring/directives/ReadingTime.ts:54
+msgid "less than one minute read"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/line-count.tsx:21
+msgid "line"
+msgid_plural "lines"
+msgstr[0] ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:77
+msgid "link"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:143
+msgid "linked to"
+msgstr ""
+
+#: scripts/apps/contacts/views/search-results.html:4
+#: scripts/apps/content-api/views/search-results.html:4
+#: scripts/apps/legal-archive/views/legal_archive.html:107
+#: scripts/apps/search/views/search-results.html:6
+msgid "loading"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/ImageTaggingComponent/ImageTaggingComponent.js:197
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:197
+#: scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.tsx:278
+msgid "loading image suggestions..."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ListPanel.tsx:435
+msgid "loading more items..."
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskeditPeople.ts:13
+#: scripts/apps/desks/directives/DeskeditStages.ts:92
+#: scripts/core/ui/components/virtual-lists/virtual-list.tsx:255
+msgid "loading..."
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:560
+msgid "locality"
+msgstr ""
+
+#: scripts/apps/search/components/ItemContainer.tsx:16
+msgid "location:"
+msgstr ""
+
+#: scripts/core/views/sdSlider.html:2
+msgid "low"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:100
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:31
+msgid "lowercase"
+msgstr ""
+
+#: scripts/apps/packaging/services/PackagesService.ts:24
+#: scripts/apps/packaging/services/PackagesService.ts:55
+msgid "main"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:390
+msgid "make this mode the default"
+msgstr ""
+
+#: scripts/core/views/sdSearchList.html:17
+msgid "many"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:76
+msgid "media"
+msgstr ""
+
+#: scripts/core/menu/notifications/views/notifications.html:35
+msgid "mentioned you"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:13
+msgid "mgrid"
+msgstr ""
+
+#: scripts/apps/desks/views/content-expiry.html:48
+#: scripts/apps/desks/views/content-expiry.html:5
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:133
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:174
+msgid "min"
+msgstr ""
+
+#: scripts/extensions/datetimeField/dist/src/config.js:31
+#: scripts/extensions/datetimeField/dist/src/config.js:52
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:31
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:52
+#: scripts/extensions/datetimeField/src/config.tsx:100
+#: scripts/extensions/datetimeField/src/config.tsx:51
+msgid "minutes"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-widget.html:31
+msgid "miscellaneous"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:47
+msgid "mobile"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:23
+#: scripts/apps/authoring-react/fields/date/config.tsx:85
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:155
+msgid "months"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:85
+msgid "multi-line quote"
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-subscribe.html:23
+msgid "never"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:385
+msgid "new"
+msgstr ""
+
+#: scripts/core/ui/components/content-create-dropdown/content-create-dropdown.tsx:17
+msgid "new item"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-replace.html:8
+#: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:444
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:832
+msgid "next"
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterSearchController.ts:112
+msgid "no results found"
+msgstr ""
+
+#: scripts/apps/profiling/views/profiling.html:10
+#: scripts/apps/publish/views/publish-queue.html:18
+#: scripts/apps/publish/views/publish-queue.html:34
+#: scripts/apps/publish/views/publish-queue.html:50
+#: scripts/apps/publish/views/publish-queue.html:64
+#: scripts/apps/users/views/user-preferences.html:153
+msgid "none"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/subcomponents/controlled-vocabulary-select.tsx:95
+msgid "not"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:650
+msgid "notes"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:13
+msgid "notifications"
+msgstr ""
+
+#: scripts/core/list/views/sdPagination.html:15
+#: scripts/core/list/views/sdPaginationAlt.html:2
+#: scripts/core/views/sdSearchList.html:15
+msgid "of"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:63
+#: ../superdesk-planning/client/utils/events.tsx:1467
+#: scripts/apps/authoring/versioning/history/views/history.html:12
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:17
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:22
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:11
+msgid "on"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1443
+msgid "on all week (including weekends)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:100
+msgid "on assignment by"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:23
+msgid "on the"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1440
+msgid "on week days"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/text-statistics.tsx:22
+msgid "one word"
+msgid_plural "{{x}} words"
+msgstr[0] ""
+
+#: scripts/core/editor3/components/article-embed/article-embed.tsx:32
+msgid "open in a new window"
+msgstr ""
+
+#: scripts/extensions/markForUser/dist/src/extension.js:48
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/extension.js:48
+#: scripts/extensions/markForUser/src/extension.tsx:55
+msgid "open item"
+msgstr ""
+
+#: scripts/apps/archive/views/upload.html:38
+#: scripts/core/auth/login-modal.html:53
+msgid "or"
+msgstr ""
+
+#: scripts/apps/users/views/change-avatar.html:31
+msgid "or Select from computer"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:73
+#: scripts/core/editor3/helpers/highlights.ts:67
+msgid "ordered list"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:320
+#: scripts/apps/contacts/constants.ts:71
+msgid "organisation"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:624
+msgid "other"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:400
+#: scripts/core/utils.tsx:346
+msgid "package"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:60
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:60
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:139
+msgid "parent ID"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/searchConfig.html:7
+#: scripts/apps/users/import/views/import-user.html:19
+#: scripts/core/auth/login-modal.html:16
+msgid "password"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:81
+#: scripts/core/auth/reset-password.html:54
+msgid "passwords must be same"
+msgstr ""
+
+#: scripts/apps/users/views/user-list-item.html:17
+msgid "pending"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:48
+msgid "phone"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:177
+msgid "phone number"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:399
+#: scripts/core/lang/missing-translations-strings.ts:9
+#: scripts/core/utils.tsx:287 scripts/core/utils.tsx:344
+msgid "picture"
+msgstr ""
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:75
+msgid "planning item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:75
+msgid "planning items"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:141
+msgid "please provide a valid email address"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:121
+msgid ""
+"please use only letters (a-z), numbers (0-9), dashes (&mdash;), underscores "
+"(_), apostrophes (') and periods (.)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:121
+msgid "post"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:570
+msgid "postcode"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/history.tsx:84
+msgid "posted"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:74
+msgid "pre"
+msgstr ""
+
+#: scripts/core/editor3/helpers/highlights.ts:68 scripts/core/utils.tsx:289
+msgid "preformatted"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-replace.html:7
+#: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:443
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:831
+msgid "prev"
+msgstr ""
+
+#: scripts/apps/publish-preview/previewModal.tsx:122
+msgid "preview"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:25
+msgid "production"
+msgstr ""
+
+#: scripts/apps/users/import/views/import-user.html:31
+msgid "profile"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:233
+msgid "public"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:9
+msgid "publish"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:12
+msgid "published"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:59
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:59
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:138
+msgid "qcode"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-widget.html:14
+msgid "quick list"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:75
+#: scripts/core/editor3/helpers/highlights.ts:65
+msgid "quote"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:98
+msgid "redo"
+msgstr ""
+
+#: scripts/apps/workspace/helpers/getTypeForFieldId.ts:10
+#: scripts/apps/workspace/helpers/getTypeForFieldId.ts:7
+msgid "related content"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:89
+msgid "remove all format"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:88
+msgid "remove format"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:111
+msgid "removed desk"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:108
+msgid "removed highlight"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:37
+msgid "removed item {{type}} about {{subject}}"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-replace.html:6
+msgid "replace"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:43
+msgid "replaced item {{type}} about {{subject}}"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:181
+#: scripts/core/editor3/directive.tsx:452
+msgid "required"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:208
+msgid "reset password"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:11
+msgid "retrying"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/versions/views/versions.html:20
+msgid "revert"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:72
+msgid "reverted"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:182
+msgid "rewrite id"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:41
+msgid "role {{role}} is granted new privileges: Please re-login."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:11
+msgid "routed"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/TableControls.tsx:90
+msgid "row"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:12
+msgid "scheduled"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:26
+msgid "scheduled Desk Output"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:25
+msgid "search"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:118
+msgid "search provider password"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:110
+msgid "search provider username"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:144
+msgid "sec"
+msgstr ""
+
+#: scripts/core/views/sdSearchList.html:5
+msgid "selected"
+msgstr ""
+
+#: scripts/apps/search/components/SelectBox.tsx:63
+msgid "selection not allowed"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:9
+msgid "send"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:20
+msgid "since"
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterSearchController.ts:31
+msgid "single value is required"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:32
+msgid "slugline"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:10
+msgid "sluglines"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:146
+msgid "sorry, a user with this email already exists"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:119
+msgid "sorry, this username is already taken."
+msgstr ""
+
+#: scripts/apps/search/components/MediaInfo.tsx:26
+msgid "source"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:90
+msgid "source of the search provider"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:12
+msgid "spiked"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:91
+msgid "spiked and unlinked"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:26
+msgid "stage"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:10
+#: scripts/apps/authoring/versioning/versions/views/versions.html:14
+#: scripts/core/itemList/views/relatedItem-list-widget.html:39
+msgid "stage:"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:94
+#: scripts/extensions/availability-manager/dist/src/utils.js:94
+#: scripts/extensions/availability-manager/src/utils.ts:98
+msgid "start time"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:100
+#: scripts/extensions/availability-manager/dist/src/utils.js:100
+#: scripts/extensions/availability-manager/src/utils.ts:102
+msgid ""
+"start time cannot be greater than end time ({{start_time}} - {{end_time}})"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/meta-place-directive.html:19
+msgid "state, region, ..."
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:109
+#: scripts/extensions/availability-manager/dist/src/utils.js:109
+#: scripts/extensions/availability-manager/src/utils.ts:114
+msgid "status"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:80
+msgid "strikethrough"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:83
+#: scripts/core/lang/missing-translations-strings.ts:11
+msgid "submitted"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:79
+msgid "subscript"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:32
+msgid "subscription"
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-manage-subscribers.html:16
+#: scripts/apps/search/views/search-panel.html:43
+msgid "subscriptions"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:10
+msgid "success"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:92
+msgid "suggestions"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:78
+msgid "superscript"
+msgstr ""
+
+#: scripts/apps/legal-archive/views/legal_archive.html:16
+msgid "switch to grid view"
+msgstr ""
+
+#: scripts/apps/legal-archive/views/legal_archive.html:17
+msgid "switch to list view"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:95
+msgid "tab"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:96
+msgid "tab as space"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:84
+msgid "table"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:58
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:58
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:137
+msgid "tag name"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:398
+#: scripts/apps/workspace/helpers/getTypeForFieldId.ts:6
+#: scripts/core/lang/missing-translations-strings.ts:9
+#: scripts/core/utils.tsx:291 scripts/core/utils.tsx:343
+msgid "text"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:84
+#: scripts/apps/authoring/versioning/history/views/history.html:83
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:72
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:61
+#: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:61
+#: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:121
+msgid "to"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:41
+msgid "to '{{ desk }}'"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:75
+msgid "to coverage assignment by"
+msgstr ""
+
+#: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:150
+msgid "toggle difference"
+msgstr ""
+
+#: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:134
+msgid "toggle primary"
+msgstr ""
+
+#: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:142
+msgid "toggle secondary"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:85
+msgid "translations"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:50
+msgid "twitter"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:81
+msgid "underline"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:97
+msgid "undo"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:72
+#: scripts/core/editor3/helpers/highlights.ts:66
+msgid "unordered list"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:121
+msgid "unpost"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/history.tsx:87
+msgid "unposted"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1413
+msgid "until {{until}}"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:27
+msgid "update"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:189
+#: ../superdesk-planning/client/components/Agendas/AgendaListItem.tsx:47
+#: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:140
+#: scripts/apps/search/components/MediaInfo.tsx:32
+msgid "updated"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:40
+msgid "updated Ingest Channel {{name}}"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:25
+msgid "updated fields"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:38
+msgid "updated task {{subject}} for item {{type}}"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:34
+msgid "uploaded media {{name}}"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:30
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:99
+msgid "uppercase"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:98
+msgid "url of the search provider"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:37
+msgid "user {{user}} has been added to desk {{desk}}: Please re-login."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:41
+msgid "user {{user}} is granted new privileges: Please re-login."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:42
+msgid "user {{user}} is updated to administrator: Please re-login."
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/searchConfig.html:3
+#: scripts/apps/users/import/views/import-user.html:14
+#: scripts/apps/users/views/edit-form.html:106
+#: scripts/core/auth/login-modal.html:15
+msgid "username"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:10
+msgid "users"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/form-validation.js:27
+#: scripts/extensions/broadcasting/dist/src/form-validation.js:27
+#: scripts/extensions/broadcasting/src/form-validation.ts:26
+msgid "value must be greater than zero"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:241
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:241
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:304
+msgid "value of 0 will disable this restriction"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-article.html:5
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:13
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:6
+#: scripts/apps/authoring/versioning/history/views/history.html:105
+#: scripts/apps/authoring/versioning/history/views/history.html:119
+#: scripts/apps/authoring/versioning/history/views/history.html:137
+#: scripts/apps/authoring/versioning/history/views/history.html:151
+#: scripts/apps/authoring/versioning/history/views/history.html:168
+#: scripts/apps/authoring/versioning/history/views/history.html:179
+#: scripts/apps/authoring/versioning/history/views/history.html:191
+#: scripts/apps/authoring/versioning/history/views/history.html:22
+#: scripts/apps/authoring/versioning/history/views/history.html:33
+#: scripts/apps/authoring/versioning/history/views/history.html:44
+#: scripts/apps/authoring/versioning/history/views/history.html:55
+#: scripts/apps/authoring/versioning/history/views/history.html:66
+#: scripts/apps/authoring/versioning/history/views/history.html:80
+#: scripts/apps/authoring/versioning/history/views/history.html:9
+#: scripts/apps/authoring/versioning/history/views/history.html:91
+#: scripts/apps/authoring/versioning/versions/views/versions.html:18
+msgid "version"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:117
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:121
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:260
+msgid "version {{n}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:161
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:176
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:238
+msgid "version: {{n}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:402
+#: scripts/apps/archive/controllers/UploadController.ts:326
+#: scripts/apps/authoring-react/fields/media/editor.tsx:155
+#: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:197
+#: scripts/core/lang/missing-translations-strings.ts:9
+#: scripts/core/utils.tsx:293 scripts/core/utils.tsx:348
+msgid "video"
+msgstr ""
+
+#: scripts/apps/desks/views/settings.html:77
+msgid "view all"
+msgstr ""
+
+#: scripts/core/notification/notification.ts:231
+msgid ""
+"vocabulary has been updated. Please re-login to see updated vocabulary values"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:448
+msgid "website"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:17
+#: scripts/apps/authoring-react/fields/date/config.tsx:84
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:154
+msgid "weeks"
+msgstr ""
+
+#: scripts/api/article-fetch.tsx:136
+msgid "width"
+msgstr ""
+
+#: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:110
+#: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:95
+msgid "with"
+msgstr ""
+
+#: scripts/apps/authoring/track-changes/views/suggestions-widget.html:27
+msgid "with:"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:112
+#: scripts/extensions/availability-manager/dist/src/utils.js:112
+#: scripts/extensions/availability-manager/src/utils.ts:118
+msgid "working hours are not set"
+msgstr ""
+
+#: scripts/apps/search/components/ItemContainer.tsx:17
+msgid "workspace"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/date/config.tsx:86
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:156
+msgid "years"
+msgstr ""
+
+#: scripts/apps/dashboard/views/configuration.html:2
+msgid "{{ 'Configuration' }}"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:729
+msgid "{{ :: 'Attachments' | translate }}"
+msgstr ""
+
+#: scripts/core/itemList/views/relatedItem-list-widget.html:51
+msgid "{{ :: action.title }}"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/versions/views/versions.html:19
+msgid "{{ :: version.state | removeLodash }}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:78
+msgid "{{ count }} {{ type }} selected"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:325
+msgid "{{ itemType }} created"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/index.ts:119
+#: ../superdesk-planning/client/validators/planning.ts:170
+#: ../superdesk-planning/client/validators/planning.ts:210
+msgid "{{ key }} is a required field"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-widget.html:17
+#: scripts/apps/authoring/macros/views/macros-widget.html:26
+#: scripts/apps/authoring/macros/views/macros-widget.html:35
+#: scripts/apps/authoring/macros/views/macros-widget.html:9
+msgid "{{ macro.label }}"
+msgstr ""
+
+#: scripts/apps/search/views/multi-action-bar.html:4
+msgid "{{ multi.count}} Item selected"
+msgid_plural "{{ multi.count}} Items selected"
+msgstr[0] ""
+
+#: ../superdesk-planning/client/components/fields/calendars.tsx:45
+msgid "{{ name }} (disabled)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/base/multilingualText.tsx:150
+msgid "{{ name }} ({{ language }})"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/assignments.tsx:9
+#: ../superdesk-planning/client/validators/profile.ts:108
+#: ../superdesk-planning/client/validators/profile.ts:66
+#: ../superdesk-planning/client/validators/profile.ts:78
+#: ../superdesk-planning/client/validators/profile.ts:86
+msgid "{{ name }} is a required field"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/profile.ts:62
+msgid "{{ name }} is too long"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/profile.ts:104
+msgid "{{ name }} is too short"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:117
+#: scripts/apps/monitoring/views/aggregate-settings.html:138
+msgid "{{ output.listLabel }}"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/notifications.ts:371
+msgid "{{ type }} assignment '{{ slugline }}' is deleted"
+msgstr ""
+
+#: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:4
+msgid "{{ widget.configuration.label || widget.label }}"
+msgstr ""
+
+#: scripts/apps/dashboard/views/configuration.html:2
+msgid "{{ widget.label }}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Archive/ArchivePreview/ArchivePreviewMetadataList.tsx:16
+msgid "{{ wordCount }} words"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:25
+msgid "{{:: monitoring.getGroupLabel(card, aggregate.settings.type)}}"
+msgstr ""
+
+#: scripts/apps/authoring/views/item-actions-by-intent.html:5
+msgid "{{::group._id}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:118
+msgid "{{action}} {{event}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ItemEditorModal/EditorModalPanel.tsx:166
+msgid "{{action}} {{type}}"
+msgstr ""
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:370
+msgid "{{count}} articles have been descheduled"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:224
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:224
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:287
+msgid "{{count}} item selected"
+msgid_plural "{{count}} items selected"
+msgstr[0] ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:123
+#: ../superdesk-analytics/client/utils.js:196
+msgid "{{days}} days"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:144
+msgid "{{error.email}}"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-config-errors.html:2
+msgid "{{errorMessage|translate}}"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:575
+#: scripts/apps/authoring/views/article-edit.html:627
+#: scripts/apps/authoring/views/article-edit.html:711
+msgid "{{field.display_name}}"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/service-config.html:47
+msgid "{{field.label | translate}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:112
+msgid "{{field}} (optional)"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:384
+msgid "{{field}} cannot be earlier than now!"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:109
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:94
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:97
+#: scripts/extensions/availability-manager/dist/src/utils.js:109
+#: scripts/extensions/availability-manager/dist/src/utils.js:94
+#: scripts/extensions/availability-manager/dist/src/utils.js:97
+#: scripts/extensions/availability-manager/src/utils.ts:100
+#: scripts/extensions/availability-manager/src/utils.ts:114
+#: scripts/extensions/availability-manager/src/utils.ts:98
+msgid "{{field}} cannot be empty"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:372
+msgid "{{field}} date is required!"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:380
+msgid "{{field}} is not a valid date!"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:376
+msgid "{{field}} time is required!"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:118
+#: ../superdesk-analytics/client/utils.js:202
+msgid "{{hours}} hours"
+msgstr ""
+
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:99
+msgid "{{hours}} hours, {{minutes}} minutes"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/views/chart-colour-picker.html:2
+msgid "{{label | translate}}"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:62
+msgid "{{labels.saml}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:105
+#: ../superdesk-analytics/client/utils.js:208
+msgid "{{minutes}} minutes"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:133
+msgid "{{months}} months"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:84
+msgid "{{multiSelectCount}} Item selected"
+msgid_plural "{{multiSelectCount}} Items selected"
+msgstr[0] ""
+
+#: scripts/apps/authoring/authoring/directives/WordCount.html:1
+msgid "{{numWords}} words"
+msgstr ""
+
+#: scripts/api/article-fetch.tsx:117
+msgid "{{n}} images can not be fetched because they are too small."
+msgid_plural "One image can not be fetched because it is too small."
+msgstr[0] ""
+
+#: scripts/apps/authoring-react/fields/media/difference.tsx:41
+msgid "{{n}} items added"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/difference.tsx:54
+msgid "{{n}} items modified"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/difference.tsx:62
+msgid "{{n}} items re-ordered"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/difference.tsx:47
+msgid "{{n}} items removed"
+msgstr ""
+
+#: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:105
+msgid "{{n}} of {{total}} matches"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:65
+msgid "{{roles[user.role].name}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:213
+msgid "{{seconds}} seconds"
+msgstr ""
+
+#: scripts/apps/users/views/edit.html:19
+msgid "{{section.label}}"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/confirmAddingRelatedItems.tsx:44
+msgid "{{some}} of {{total}} items can not be added as related"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:40
+msgid "{{status}} Ingest Channel {{name}}"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:1
+msgid "{{title}}"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:132
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:70
+msgid "{{type.label}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:44
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:45
+msgid "{{update.date}} - {{update.operation}} by {{update.user}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:128
+msgid "{{weeks}} weeks"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:124
+#: scripts/extensions/sams/dist/src/utils/ui.js:124
+#: scripts/extensions/sams/src/utils/ui.tsx:119
+msgid "{{width}} * {{height}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-metadata.tsx:44
+msgid "{{width}} x {{height}} px"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:55
+msgid "{{wordsCount}} word"
+msgid_plural "{{ $count}} words"
+msgstr[0] ""
+
+#: scripts/extensions/datetimeField/dist/src/editor.js:76
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:81
+#: scripts/extensions/datetimeField/src/editor.tsx:140
+msgid "{{x}} hour"
+msgid_plural "{{x}} hours"
+msgstr[0] ""
+
+#: scripts/apps/search/components/fields/linesCount.tsx:14
+msgid "{{x}} lines"
+msgstr ""
+
+#: scripts/extensions/datetimeField/dist/src/editor.js:79
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:84
+#: scripts/extensions/datetimeField/src/editor.tsx:149
+msgid "{{x}} min"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/ReadingTime.ts:22
+#: scripts/apps/authoring/authoring/directives/ReadingTime.ts:52
+msgid "{{x}} min read"
+msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -14663,125 +14663,125 @@ msgstr "保存して投稿取り消し"
 
 #: scripts/apps/workspace/content/views/profile-settings.html:131
 msgid "Save &amp; Continue"
-msgstr ""
+msgstr "保存して続行"
 
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:388
 #: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:225
 msgid "Save All"
-msgstr ""
+msgstr "すべて保存"
 
 #: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:35
 #: scripts/apps/search/views/save-search.html:15
 msgid "Save As"
-msgstr ""
+msgstr "名前を付けて保存"
 
 #: scripts/apps/search/views/save-search.html:16
 #: scripts/apps/search/views/save-search.html:17
 msgid "Save Changes"
-msgstr ""
+msgstr "変更を保存"
 
 #: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:179
 msgid "Save Changes?"
-msgstr ""
+msgstr "変更を保存しますか？"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:67
 msgid "Save Event"
-msgstr ""
+msgstr "イベントを保存"
 
 #: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:33
 #: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:3
 msgid "Save Report"
-msgstr ""
+msgstr "レポートを保存"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:276
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:276
 #: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:426
 msgid "Save Rundown"
-msgstr ""
+msgstr "ランダウンを保存"
 
 #: scripts/apps/search/views/save-search.html:10
 msgid "Save Search"
-msgstr ""
+msgstr "検索を保存"
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:713
 msgid "Save all other changes before performing this action."
-msgstr ""
+msgstr "このアクションを実行する前に他のすべての変更を保存してください。"
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:60
 msgid "Save and publish"
-msgstr ""
+msgstr "保存して公開"
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:72
 msgid "Save and send"
-msgstr ""
+msgstr "保存して送信"
 
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:230
 #: scripts/apps/authoring-react/toolbar/template-modal.tsx:65
 #: scripts/apps/authoring/views/authoring-topbar.html:270
 #: scripts/apps/templates/views/create-template.html:5
 msgid "Save as template"
-msgstr ""
+msgstr "テンプレートとして保存"
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:245
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:245
 #: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:352
 msgid "Save change"
-msgstr ""
+msgstr "変更を保存"
 
 #: scripts/apps/search/views/saved-search-manage-subscribers.html:129
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:220
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:220
 #: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:416
 msgid "Save changes"
-msgstr ""
+msgstr "変更を保存"
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:340
 msgid "Save changes before adding to top stories ?"
-msgstr ""
+msgstr "トップ記事に追加する前に変更を保存しますか？"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:289
 msgid "Save changes before adding to top stories?"
-msgstr ""
+msgstr "トップ記事に追加する前に変更を保存しますか？"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:225
 msgid "Save changes before cancelling the Event?"
-msgstr ""
+msgstr "イベントをキャンセルする前に変更を保存しますか？"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:956
 msgid "Save changes before creating a planning item ?"
-msgstr ""
+msgstr "プランニングアイテムを作成する前に変更を保存しますか？"
 
 #: ../superdesk-planning/client/components/Main/ItemEditor/EditorItemActions.tsx:106
 msgid "Save changes before creating a template?"
-msgstr ""
+msgstr "テンプレートを作成する前に変更を保存しますか？"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:988
 msgid "Save changes before marking event as complete ?"
-msgstr ""
+msgstr "イベントを完了にする前に変更を保存しますか？"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:249
 msgid "Save changes before postponing the Event?"
-msgstr ""
+msgstr "イベントを延期する前に変更を保存しますか？"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:272
 msgid "Save changes before rescheduling the Event?"
-msgstr ""
+msgstr "イベントを再スケジュールする前に変更を保存しますか？"
 
 #: ../superdesk-planning/client/actions/main.ts:1578
 msgid "Save changes before spiking ?"
-msgstr ""
+msgstr "スパイクする前に変更を保存しますか？"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:307
 msgid "Save changes before updating Event Repetitions?"
-msgstr ""
+msgstr "イベントの繰り返しを更新する前に変更を保存しますか？"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:202
 msgid "Save changes before updating the Event's time?"
-msgstr ""
+msgstr "イベントの時間を更新する前に変更を保存しますか？"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:402
 msgid "Save changes without re-posting?"
-msgstr ""
+msgstr "再投稿せずに変更を保存しますか？"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:112
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:169
@@ -14793,29 +14793,29 @@ msgstr ""
 #: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:34
 #: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:70
 msgid "Save changes?"
-msgstr ""
+msgstr "変更を保存しますか？"
 
 #: scripts/apps/authoring/authoring/index.ts:470
 msgid "Save current item"
-msgstr ""
+msgstr "現在のアイテムを保存"
 
 #: ../superdesk-planning/client/constants/events.ts:169
 msgid "Save event as a template"
-msgstr ""
+msgstr "イベントをテンプレートとして保存"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:364
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:364
 #: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:630
 msgid "Save item"
-msgstr ""
+msgstr "アイテムを保存"
 
 #: scripts/apps/users/views/edit-form.html:401
 msgid "Save password"
-msgstr ""
+msgstr "パスワードを保存"
 
 #: scripts/apps/search/views/save-search.html:23
 msgid "Save search"
-msgstr ""
+msgstr "検索を保存"
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:22
 #: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:22
@@ -14828,44 +14828,44 @@ msgstr ""
 #: scripts/apps/search/views/search-panel.html:9
 #: scripts/apps/users/directives/UserEditDirective.ts:240
 msgid "Saved"
-msgstr ""
+msgstr "保存済み"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:348
 msgid "Saved Featured Stories record"
-msgstr ""
+msgstr "特集記事レコードが保存されました"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:71
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:83
 msgid "Saved Report"
-msgstr ""
+msgstr "保存済みレポート"
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:166
 msgid ""
 "Saved Report has changed since it was opened. Please re-select the Saved "
 "Report to continue. Regrettably, your changes cannot be saved."
-msgstr ""
+msgstr "保存済みレポートが開かれた後に変更されました。続行するには保存済みレポートを再選択してください。申し訳ございませんが、変更は保存できません。"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:62
 msgid "Saved Searches"
-msgstr ""
+msgstr "保存済み検索"
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:238
 msgid "Saved report not found!"
-msgstr ""
+msgstr "保存済みレポートが見つかりません。"
 
 #: scripts/apps/search/directives/SavedSearches.ts:116
 msgid "Saved search removed"
-msgstr ""
+msgstr "保存済み検索が削除されました"
 
 #: scripts/apps/search/views/saved-searches.html:1
 msgid "Saved searches"
-msgstr ""
+msgstr "保存済み検索"
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:117
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:117
 #: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:181
 msgid "Saving capture thumbnail..."
-msgstr ""
+msgstr "キャプチャサムネイルを保存中..."
 
 #: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:131
 #: scripts/apps/desks/directives/DeskeditBasic.ts:31
@@ -14873,46 +14873,46 @@ msgstr ""
 #: scripts/apps/desks/directives/DeskeditStages.ts:163
 #: scripts/core/notify/notify.tsx:59
 msgid "Saving..."
-msgstr ""
+msgstr "保存中..."
 
 #: scripts/apps/search/views/search-parameters.html:249
 msgid "Scanpix ID(s)"
-msgstr ""
+msgstr "Scanpix ID"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:105
 msgid "Scatter"
-msgstr ""
+msgstr "散布図"
 
 #: scripts/apps/templates/views/templates.html:56
 msgid "Sched. Desk / Stage"
-msgstr ""
+msgstr "スケジュールデスク/ステージ"
 
 #: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:27
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:49
 #: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:2
 #: scripts/apps/search/views/edit-time-interval.html:1
 msgid "Schedule"
-msgstr ""
+msgstr "スケジュール"
 
 #: scripts/apps/templates/views/template-editor-modal.html:175
 msgid "Schedule Desk"
-msgstr ""
+msgstr "スケジュールデスク"
 
 #: scripts/apps/templates/views/template-editor-modal.html:197
 msgid "Schedule Macro"
-msgstr ""
+msgstr "スケジュールマクロ"
 
 #: scripts/apps/templates/views/template-editor-modal.html:187
 msgid "Schedule Stage"
-msgstr ""
+msgstr "スケジュールステージ"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduledUpdates.tsx:98
 msgid "Schedule an update"
-msgstr ""
+msgstr "更新をスケジュール"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:84
 msgid "Schedule will be permanently deleted."
-msgstr ""
+msgstr "スケジュールは完全に削除されます。"
 
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:132
 #: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:25
@@ -14923,82 +14923,82 @@ msgstr ""
 #: ../superdesk-planning/client/utils/index.ts:357
 #: scripts/apps/search/components/fields/state.tsx:38
 msgid "Scheduled"
-msgstr ""
+msgstr "スケジュール済み"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:174
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:88
 msgid "Scheduled Date"
-msgstr ""
+msgstr "スケジュール日"
 
 #: scripts/apps/workspace/content/constants.ts:70
 msgid "Scheduled Desk Output"
-msgstr ""
+msgstr "スケジュールデスク出力"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:151
 msgid "Scheduled Export"
-msgstr ""
+msgstr "スケジュールエクスポート"
 
 #: scripts/apps/workspace/content/constants.ts:38
 msgid "Scheduled Time"
-msgstr ""
+msgstr "スケジュール時間"
 
 #: scripts/apps/templates/views/templates.html:68
 msgid "Scheduled Time(s)"
-msgstr ""
+msgstr "スケジュール時間"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduledUpdates.tsx:64
 #: ../superdesk-planning/client/utils/contentProfiles.ts:331
 msgid "Scheduled Updates"
-msgstr ""
+msgstr "スケジュール済み更新"
 
 #: scripts/apps/publish/views/publish-queue.html:113
 #: scripts/apps/templates/views/template-editor-modal.html:156
 msgid "Scheduled at"
-msgstr ""
+msgstr "スケジュール日時"
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:180
 msgid "Scheduled by"
-msgstr ""
+msgstr "スケジュール者"
 
 #: ../superdesk-planning/client/components/fields/common/PreviewFilterSchedule.tsx:46
 msgid "Scheduled export: {{ description }}"
-msgstr ""
+msgstr "スケジュールエクスポート：{{ description }}"
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:426
 msgid "Scheduled from {{start}} to {{end}}"
-msgstr ""
+msgstr "{{start}}から{{end}}までスケジュール"
 
 #: ../superdesk-planning/client/validators/planning.ts:320
 msgid "Scheduled updates have to be after the previous updates."
-msgstr ""
+msgstr "スケジュール済み更新は前の更新より後でなければなりません。"
 
 #: ../superdesk-planning/client/validators/planning.ts:324
 msgid "Scheduled updates should have a date/time."
-msgstr ""
+msgstr "スケジュール済み更新には日時が必要です。"
 
 #: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:73
 msgid "Scheduled:"
-msgstr ""
+msgstr "スケジュール済み："
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:51
 msgid "Scheduling"
-msgstr ""
+msgstr "スケジュール中"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:103
 msgid "Scheme details"
-msgstr ""
+msgstr "スキーム詳細"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:41
 msgid "Scheme name"
-msgstr ""
+msgstr "スキーム名"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:49
 msgid "Scheme rules"
-msgstr ""
+msgstr "スキームルール"
 
 #: scripts/apps/production-api-keys/config.ts:18
 msgid "Scopes"
-msgstr ""
+msgstr "スコープ"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentFilterPanel.tsx:131
 #: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:38
@@ -15042,155 +15042,155 @@ msgstr ""
 #: scripts/extensions/broadcasting/dist/src/page.js:131
 #: scripts/extensions/broadcasting/src/page.tsx:186
 msgid "Search"
-msgstr ""
+msgstr "検索"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:238
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:238
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:336
 msgid "Search Assets"
-msgstr ""
+msgstr "アセットを検索"
 
 #: ../superdesk-planning/client/components/Assignments/SubNavBar.tsx:72
 msgid "Search Assignments"
-msgstr ""
+msgstr "アサインメントを検索"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:432
 msgid "Search Categories"
-msgstr ""
+msgstr "カテゴリーを検索"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:480
 msgid "Search Content State"
-msgstr ""
+msgstr "コンテンツ状態を検索"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:396
 msgid "Search Content Type"
-msgstr ""
+msgstr "コンテンツタイプを検索"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:384
 msgid "Search Desks"
-msgstr ""
+msgstr "デスクを検索"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:536
 msgid "Search Enter Desk Actions"
-msgstr ""
+msgstr "デスク入場アクションを検索"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:557
 msgid "Search Exit Desk Actions"
-msgstr ""
+msgstr "デスク退場アクションを検索"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:86
 msgid "Search Filters"
-msgstr ""
+msgstr "フィルターを検索"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:444
 msgid "Search Genre"
-msgstr ""
+msgstr "ジャンルを検索"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:494
 msgid "Search Ingest Providers"
-msgstr ""
+msgstr "取り込みプロバイダーを検索"
 
 #: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:160
 msgid "Search OpenStreetMap"
-msgstr ""
+msgstr "OpenStreetMapを検索"
 
 #: scripts/apps/search-providers/directive.ts:92
 msgid "Search Provider deleted."
-msgstr ""
+msgstr "検索プロバイダーが削除されました。"
 
 #: scripts/apps/search-providers/directive.ts:53
 msgid "Search Provider saved."
-msgstr ""
+msgstr "検索プロバイダーが保存されました。"
 
 #: scripts/apps/search-providers/index.ts:37
 #: scripts/apps/search-providers/views/settings.html:4
 msgid "Search Providers"
-msgstr ""
+msgstr "検索プロバイダー"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:118
 msgid "Search Related Articles"
-msgstr ""
+msgstr "関連記事を検索"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:456
 msgid "Search Source"
-msgstr ""
+msgstr "ソースを検索"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:509
 msgid "Search Stages"
-msgstr ""
+msgstr "ステージを検索"
 
 #: ../superdesk-planning/client/components/fields/editor/FullText.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:87
 msgid "Search Text"
-msgstr ""
+msgstr "テキストを検索"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:468
 msgid "Search Urgency"
-msgstr ""
+msgstr "緊急度を検索"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:414
 #: ../superdesk-analytics/client/search/views/user-select.html:17
 msgid "Search Users"
-msgstr ""
+msgstr "ユーザーを検索"
 
 #: ../superdesk-analytics/client/email_report/views/email-recipients-input.html:9
 msgid "Search emails"
-msgstr ""
+msgstr "メールを検索"
 
 #: ../superdesk-planning/client/components/Contacts/SelectSearchContactsField/SelectListPopup.tsx:226
 msgid "Search for a contact"
-msgstr ""
+msgstr "連絡先を検索"
 
 #: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupInput.tsx:289
 msgid "Search for a location"
-msgstr ""
+msgstr "ロケーションを検索"
 
 #: scripts/apps/dashboard/world-clock/configuration.html:34
 msgid "Search for clock"
-msgstr ""
+msgstr "クロックを検索"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:91
 msgid "Search icons...."
-msgstr ""
+msgstr "アイコンを検索..."
 
 #: scripts/apps/content-api/index.ts:22
 msgid "Search items is content API"
-msgstr ""
+msgstr "コンテンツAPIでアイテムを検索"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:116
 #: ../superdesk-planning/client/components/Main/SubNavBar.tsx:29
 msgid "Search planning"
-msgstr ""
+msgstr "プランニングを検索"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:217
 msgid "Search provider contacts"
-msgstr ""
+msgstr "プロバイダー連絡先を検索"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-list.html:6
 msgid "Search saved reports"
-msgstr ""
+msgstr "保存済みレポートを検索"
 
 #: scripts/apps/search/views/saved-searches.html:3
 msgid "Search saved searches"
-msgstr ""
+msgstr "保存済み検索を検索"
 
 #: scripts/apps/search/views/save-search-dialog.html:18
 msgid "Search shortcut"
-msgstr ""
+msgstr "検索ショートカット"
 
 #: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:81
 msgid "Search templates"
-msgstr ""
+msgstr "テンプレートを検索"
 
 #: scripts/apps/search/directives/SaveSearch.ts:72
 msgid "Search was saved successfully"
-msgstr ""
+msgstr "検索が正常に保存されました"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:157
 #: scripts/core/ui/components/SearchBar/manual.tsx:37
 #: scripts/core/ui/components/SelectUser.tsx:101
 msgid "Search..."
-msgstr ""
+msgstr "検索..."
 
 #: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:31
 msgid "Search/Browse Locations"
@@ -15198,60 +15198,60 @@ msgstr ""
 
 #: scripts/core/ui/views/sd-timepicker-popup.html:21
 msgid "Seconds"
-msgstr ""
+msgstr "秒"
 
 #: scripts/apps/publish/views/amazon-sqs-fifo-config.html:50
 msgid "Secret Access Key"
-msgstr ""
+msgstr "シークレットアクセスキー"
 
 #: scripts/apps/publish/views/http-push-config.html:13
 msgid "Secret Token"
-msgstr ""
+msgstr "シークレットトークン"
 
 #: scripts/core/auth/secure-login.html:18
 msgid "Secure Log In"
-msgstr ""
+msgstr "セキュアログイン"
 
 #: scripts/apps/products/views/products.html:10
 #: scripts/apps/publish/views/subscribers.html:10
 #: scripts/core/views/sdSearchList.html:3
 msgid "Select"
-msgstr ""
+msgstr "選択"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:277
 msgid "Select Agenda"
-msgstr ""
+msgstr "アジェンダを選択"
 
 #: scripts/apps/search/views/multi-image-edit.html:25
 msgid "Select All"
-msgstr ""
+msgstr "すべて選択"
 
 #: scripts/extensions/sams/dist/src/components/assets/selectAssetModal.js:150
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/selectAssetModal.js:150
 #: scripts/extensions/sams/src/components/assets/selectAssetModal.tsx:162
 msgid "Select Asset(s)"
-msgstr ""
+msgstr "アセットを選択"
 
 #: ../superdesk-planning/client/components/Assignments/DesksSubNavDropDown.tsx:49
 msgid "Select Assignments From:"
-msgstr ""
+msgstr "アサインメントの選択元："
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:260
 msgid "Select Calendar"
-msgstr ""
+msgstr "カレンダーを選択"
 
 #: scripts/apps/vocabularies/components/drop-zone.tsx:76
 msgid "Select Files"
-msgstr ""
+msgstr "ファイルを選択"
 
 #: scripts/apps/archive/views/resend-configuration.html:10
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:55
 msgid "Select Subscribers"
-msgstr ""
+msgstr "配信先を選択"
 
 #: scripts/apps/workspace/views/workspace-dropdown.html:5
 msgid "Select Workspace"
-msgstr ""
+msgstr "ワークスペースを選択"
 
 #: scripts/apps/desks/views/desk-config-modal.html:179
 msgid ""
@@ -15266,295 +15266,295 @@ msgid ""
 "Select a default template for new articles. If you don't see any, first make "
 "sure that there is at least one content profile. Each time a profile is "
 "created, Superdesk creates a template with the same name."
-msgstr ""
+msgstr "新しい記事のデフォルトテンプレートを選択してください。表示されない場合は、少なくとも1つのコンテンツプロファイルがあることを確認してください。プロファイルが作成されるたびに、Superdeskは同じ名前のテンプレートを作成します。"
 
 #: scripts/core/ui/components/generic-form/input-types/desk_single_value.tsx:40
 msgid "Select a desk"
-msgstr ""
+msgstr "デスクを選択"
 
 #: scripts/core/ui/components/generic-form/input-types/macro_single_value.tsx:27
 #: scripts/core/ui/components/generic-form/input-types/stage_single_value.tsx:42
 msgid "Select a desk first"
-msgstr ""
+msgstr "先にデスクを選択してください"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:123
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:123
 #: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:240
 msgid "Select a show from the dropdown above."
-msgstr ""
+msgstr "上のドロップダウンからショーを選択してください。"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:149
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:149
 #: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:317
 msgid "Select a template from the sidebar."
-msgstr ""
+msgstr "サイドバーからテンプレートを選択してください。"
 
 #: scripts/core/ui/components/SelectUser.tsx:100
 #: scripts/core/ui/components/SelectUser.tsx:51
 msgid "Select a user"
-msgstr ""
+msgstr "ユーザーを選択"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-vocabulary/config.tsx:27
 msgid "Select a vocabulary"
-msgstr ""
+msgstr "ボキャブラリーを選択"
 
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:110
 msgid "Select a vocabulary for predefined snippets"
-msgstr ""
+msgstr "定義済みスニペット用のボキャブラリーを選択"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:332
 msgid "Select all"
-msgstr ""
+msgstr "すべて選択"
 
 #: scripts/apps/users/views/user-preferences.html:149
 msgid "Select all categories"
-msgstr ""
+msgstr "すべてのカテゴリーを選択"
 
 #: ../superdesk-planning/client/components/FulFilAssignmentModal/index.tsx:76
 msgid "Select an Assignment"
-msgstr ""
+msgstr "アサインメントを選択"
 
 #: scripts/apps/authoring-react/toolbar/multi-edit-toolbar-action.tsx:35
 msgid "Select articles"
-msgstr ""
+msgstr "記事を選択"
 
 #: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:70
 msgid "Select at most 1 file to upload."
-msgstr ""
+msgstr "アップロードするファイルは最大1つです。"
 
 #: scripts/apps/archive/controllers/UploadController.ts:233
 #: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:207
 msgid "Select at most {{maxUploads}} files to upload."
-msgstr ""
+msgstr "アップロードするファイルは最大{{maxUploads}}個です。"
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:20
 msgid "Select color"
-msgstr ""
+msgstr "色を選択"
 
 #: scripts/apps/authoring/compare-versions/views/compare-versions.html:12
 msgid "Select current version."
-msgstr ""
+msgstr "現在のバージョンを選択。"
 
 #: scripts/apps/search/views/edit-time-interval.html:5
 msgid "Select days"
-msgstr ""
+msgstr "日数を選択"
 
 #: scripts/apps/users/views/user-preferences.html:161
 msgid "Select default categories only"
-msgstr ""
+msgstr "デフォルトカテゴリーのみ選択"
 
 #: scripts/apps/authoring-react/toolbar/mark-for-desks/mark-for-desks-modal.tsx:43
 #: scripts/apps/master-desk/components/HeaderComponent.tsx:224
 msgid "Select desks"
-msgstr ""
+msgstr "デスクを選択"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:18
 msgid "Select desks for view"
-msgstr ""
+msgstr "表示するデスクを選択"
 
 #: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:41
 msgid "Select either Search or Browse the locations"
-msgstr ""
+msgstr "検索またはロケーションの参照を選択してください"
 
 #: scripts/extensions/predefinedTextField/dist/src/editor.js:34
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/editor.js:34
 #: scripts/extensions/predefinedTextField/src/editor.tsx:53
 msgid "Select from a predefined value"
-msgstr ""
+msgstr "定義済みの値から選択"
 
 #: scripts/apps/search/views/edit-time-interval.html:19
 msgid "Select hours"
-msgstr ""
+msgstr "時間を選択"
 
 #: ../superdesk-planning/client/components/SelectItemModal.tsx:29
 #: scripts/apps/authoring/multiedit/views/sd-multiedit-inner-dropdown.html:2
 msgid "Select item"
-msgstr ""
+msgstr "アイテムを選択"
 
 #: scripts/apps/monitoring/index.ts:117
 msgid "Select next item on focused stage or group"
-msgstr ""
+msgstr "フォーカス中のステージまたはグループで次のアイテムを選択"
 
 #: scripts/apps/publish-preview/previewModal.tsx:87
 msgid "Select preview target"
-msgstr ""
+msgstr "プレビュー対象を選択"
 
 #: scripts/apps/monitoring/index.ts:119
 msgid "Select previous item on focused stage or group"
-msgstr ""
+msgstr "フォーカス中のステージまたはグループで前のアイテムを選択"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:65
 msgid "Select saved searches for view"
-msgstr ""
+msgstr "表示する保存済み検索を選択"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/select-show.js:21
 #: scripts/extensions/broadcasting/dist/src/rundowns/components/select-show.js:21
 #: scripts/extensions/broadcasting/src/rundowns/components/select-show.tsx:53
 msgid "Select show"
-msgstr ""
+msgstr "ショーを選択"
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:7
 msgid "Select source"
-msgstr ""
+msgstr "ソースを選択"
 
 #: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:62
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:85
 #: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:85
 #: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:157
 msgid "Select template"
-msgstr ""
+msgstr "テンプレートを選択"
 
 #: scripts/apps/archive/views/upload.html:39
 msgid "Select them from folder"
-msgstr ""
+msgstr "フォルダーから選択"
 
 #: scripts/apps/authoring/authoring/components/video-thumbnail-editor.tsx:122
 msgid "Select thumbnail"
-msgstr ""
+msgstr "サムネイルを選択"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:63
 #: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:63
 #: scripts/extensions/auto-tagging-widget/src/new-item.tsx:141
 msgid "Select type"
-msgstr ""
+msgstr "タイプを選択"
 
 #: scripts/apps/authoring-react/toolbar/version-header.tsx:29
 msgid "Select version"
-msgstr ""
+msgstr "バージョンを選択"
 
 #: ../superdesk-planning/client/components/Events/EventMetadata/RelatedEventListItem.tsx:93
 #: ../superdesk-planning/client/components/RelatedPlannings/PlanningMetaData/RelatedPlanningListItem.tsx:101
 #: scripts/core/editor3/components/toolbar/FloatingCharacterCount.tsx:46
 msgid "Selected"
-msgstr ""
+msgstr "選択済み"
 
 #: scripts/core/views/sdSearchList.html:21
 msgid "Selected item"
-msgstr ""
+msgstr "選択したアイテム"
 
 #: scripts/core/views/sdSearchList.html:14
 msgid "Selected items"
-msgstr ""
+msgstr "選択したアイテム"
 
 #: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:77
 #: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:33
 msgid "Selected text:"
-msgstr ""
+msgstr "選択テキスト："
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:200
 msgid "Selections automatically removed"
-msgstr ""
+msgstr "選択が自動的に削除されました"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:39
 #: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:170
 msgid "Send"
-msgstr ""
+msgstr "送信"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:89
 msgid "Send & duplicate"
-msgstr ""
+msgstr "送信して複製"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/send-correction.tsx:13
 #: scripts/apps/authoring/views/authoring-topbar.html:214
 msgid "Send Correction"
-msgstr ""
+msgstr "修正を送信"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:117
 msgid "Send Email"
-msgstr ""
+msgstr "メールを送信"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:221
 msgid "Send Kill"
-msgstr ""
+msgstr "キルを送信"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:7
 msgid "Send Report via Email"
-msgstr ""
+msgstr "レポートをメールで送信"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:228
 msgid "Send Takedown"
-msgstr ""
+msgstr "テイクダウンを送信"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/send-and-duplicate.tsx:15
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/send-and-duplicate.tsx:16
 #: scripts/apps/authoring/views/authoring-topbar.html:86
 #: scripts/apps/authoring/views/authoring-topbar.html:87
 msgid "Send and duplicate"
-msgstr ""
+msgstr "送信して複製"
 
 #: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:157
 msgid "Send and open"
-msgstr ""
+msgstr "送信して開く"
 
 #: scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx:144
 msgid "Send correction"
-msgstr ""
+msgstr "修正を送信"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/send-kill-action.tsx:13
 msgid "Send kill"
-msgstr ""
+msgstr "キルを送信"
 
 #: scripts/core/lang/missing-translations-strings.ts:14
 msgid "Send notifications via email"
-msgstr ""
+msgstr "メールで通知を送信"
 
 #: scripts/apps/internal-destinations/InternalDestinations.tsx:70
 msgid "Send only after publish schedule"
-msgstr ""
+msgstr "公開スケジュール後にのみ送信"
 
 #: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:183
 msgid "Send package and items"
 msgid_plural "Send packages and items"
-msgstr[0] ""
+msgstr[0] "パッケージとアイテムを送信"
 
 #: scripts/apps/packaging/index.ts:110
 msgid "Send package to"
-msgstr ""
+msgstr "パッケージの送信先"
 
 #: scripts/apps/authoring/authoring/index.ts:277
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:201
 #: scripts/core/interactive-article-actions-panel/action-tabs.tsx:9
 msgid "Send to"
-msgstr ""
+msgstr "送信先"
 
 #: scripts/apps/authoring-react/article-widgets/send-to-publish/interactive-article-actions-widget.tsx:12
 #: scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx:20
 #: scripts/apps/authoring/views/authoring-topbar.html:400
 #: scripts/apps/authoring/views/authoring-topbar.html:401
 msgid "Send to / Publish"
-msgstr ""
+msgstr "送信/公開"
 
 #: scripts/apps/authoring/authoring/index.ts:292
 msgid "Send to Personal Space"
-msgstr ""
+msgstr "個人スペースに送信"
 
 #: scripts/apps/users/components/EmailNotificationPreferences.tsx:24
 msgid "Send {{name}} notifications"
-msgstr ""
+msgstr "{{name}}通知を送信"
 
 #: scripts/core/lang/missing-translations-strings.ts:22
 msgid "Sending"
-msgstr ""
+msgstr "送信中"
 
 #: scripts/apps/workspace/content/constants.ts:68
 msgid "Sent Desk Output"
-msgstr ""
+msgstr "デスク送信済み出力"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:443
 msgid "Sent From"
-msgstr ""
+msgstr "送信元"
 
 #: scripts/apps/monitoring/controllers/AggregateCtrl.ts:41
 msgid "Sent Items"
-msgstr ""
+msgstr "送信済みアイテム"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:436
 msgid "Sent To"
-msgstr ""
+msgstr "送信先"
 
 #: scripts/api/article-send.tsx:257
 msgid "Sent successfully"
-msgstr ""
+msgstr "送信成功"
 
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:16
 msgid "Sent/Queued as"
@@ -15562,28 +15562,28 @@ msgstr ""
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:89
 msgid "Sent/Queued as {{name}} to {{destination}} at {{date}}"
-msgstr ""
+msgstr "{{date}}に{{name}}として{{destination}}へ送信/キュー追加"
 
 #: scripts/apps/publish/views/publish-queue.html:104
 msgid "Sequence No"
-msgstr ""
+msgstr "シーケンス番号"
 
 #: scripts/apps/publish/views/subscribers.html:181
 msgid "Sequence Number Settings"
-msgstr ""
+msgstr "シーケンス番号設定"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateEventRepetitionsForm.tsx:111
 msgid "Series Start Date"
-msgstr ""
+msgstr "シリーズ開始日"
 
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:128
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:143
 msgid "Service"
-msgstr ""
+msgstr "サービス"
 
 #: scripts/apps/users/controllers/SessionsDeleteCommand.ts:13
 msgid "Sessions cleared"
-msgstr ""
+msgstr "セッションがクリアされました"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:192
 #: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:136
@@ -15595,54 +15595,54 @@ msgstr ""
 #: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:166
 #: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:191
 msgid "Set"
-msgstr ""
+msgstr "セット"
 
 #: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:132
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:132
 #: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:127
 msgid "Set Details"
-msgstr ""
+msgstr "セット詳細"
 
 #: scripts/extensions/sams/dist/src/components/attachments/samsAttachmentsList.js:116
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/samsAttachmentsList.js:116
 #: scripts/extensions/sams/src/components/attachments/samsAttachmentsList.tsx:129
 msgid "Set Disabled"
-msgstr ""
+msgstr "セット無効"
 
 #: scripts/apps/publish/views/amazon-sqs-fifo-config.html:42
 #: scripts/apps/publish/views/amazon-sqs-fifo-config.html:59
 #: scripts/apps/publish/views/ftp-config.html:12
 #: scripts/apps/publish/views/http-push-config.html:14
 msgid "Set and hidden thereafter"
-msgstr ""
+msgstr "設定後非表示"
 
 #: scripts/apps/users/views/settings-roles.html:50
 msgid "Set as default"
-msgstr ""
+msgstr "デフォルトに設定"
 
 #: scripts/extensions/sams/dist/src/api/sets.js:34
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:34
 #: scripts/extensions/sams/src/api/sets.ts:46
 msgid "Set created successfully"
-msgstr ""
+msgstr "セットが正常に作成されました"
 
 #: scripts/extensions/sams/dist/src/api/sets.js:77
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:77
 #: scripts/extensions/sams/src/api/sets.ts:98
 msgid "Set deleted successfully"
-msgstr ""
+msgstr "セットが正常に削除されました"
 
 #: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:90
 msgid "Set highlights"
-msgstr ""
+msgstr "ハイライトを設定"
 
 #: scripts/apps/archive/index.tsx:219
 msgid "Set label in current package"
-msgstr ""
+msgstr "現在のパッケージにラベルを設定"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:131
 msgid "Set maximum items per stages and saved searches for view"
-msgstr ""
+msgstr "表示するステージと保存済み検索ごとの最大アイテム数を設定"
 
 #: scripts/apps/monitoring/aggregate-widget/aggregate.ts:17
 msgid ""
@@ -15651,31 +15651,31 @@ msgid ""
 "sensible name, select a saved search or desk or its workflow stages. Monitor "
 "anything, anywhere, anytime. You can have as many Monitor widgets as you "
 "wish."
-msgstr ""
+msgstr "取り込みやプロダクション、デスク出力、ワークフローの任意の部分からトピックを追跡するさまざまなモニターを設定できます。分かりやすい名前を付けて、保存済み検索やデスクまたはそのワークフローステージを選択するだけです。いつでも、どこでも、何でもモニターできます。モニターウィジェットはいくつでも作成できます。"
 
 #: scripts/extensions/sams/dist/src/api/sets.js:57
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:57
 #: scripts/extensions/sams/src/api/sets.ts:76
 msgid "Set updated successfully"
-msgstr ""
+msgstr "セットが正常に更新されました"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/notifications/sets.js:45
 #: scripts/extensions/sams/dist/src/notifications/sets.js:45
 #: scripts/extensions/sams/src/notifications/sets.ts:50
 msgid "Set was deleted by another user."
-msgstr ""
+msgstr "セットは別のユーザーによって削除されました。"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/notifications/sets.js:25
 #: scripts/extensions/sams/dist/src/notifications/sets.js:25
 #: scripts/extensions/sams/src/notifications/sets.ts:28
 msgid "Set was updated by another user."
-msgstr ""
+msgstr "セットは別のユーザーによって更新されました。"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:176
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:176
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:206
 msgid "Sets"
-msgstr ""
+msgstr "セット"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:171
 #: scripts/apps/settings/index.ts:19 scripts/apps/settings/settings.tsx:32
@@ -15684,28 +15684,28 @@ msgstr ""
 #: scripts/extensions/broadcasting/dist/src/page.js:143
 #: scripts/extensions/broadcasting/src/page.tsx:204
 msgid "Settings"
-msgstr ""
+msgstr "設定"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:172
 msgid "Share Alternate"
-msgstr ""
+msgstr "共有（代替）"
 
 #: scripts/apps/search/views/item-preview.html:3
 msgid "Shift preview"
-msgstr ""
+msgstr "プレビューを移動"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:37
 msgid "Short"
-msgstr ""
+msgstr "短い"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:138
 msgid "Shortcuts"
-msgstr ""
+msgstr "ショートカット"
 
 #: ../superdesk-planning/client/validators/planning.ts:305
 #: ../superdesk-planning/client/validators/planning.ts:307
 msgid "Should be after the previous scheduled update/coverage"
-msgstr ""
+msgstr "前のスケジュール済み更新/取材の後でなければなりません"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:56
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:16
@@ -15715,87 +15715,87 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:31
 #: scripts/extensions/broadcasting/src/rundowns/components/select-show.tsx:35
 msgid "Show"
-msgstr ""
+msgstr "ショー"
 
 #: ../superdesk-planning/client/components/fields/related_events.tsx:46
 msgid "Show 1 event"
 msgid_plural "Show {{n}} events"
-msgstr[0] ""
+msgstr[0] "{{n}}件のイベントを表示"
 
 #: ../superdesk-planning/client/components/fields/related_plannings.tsx:35
 msgid "Show 1 planning item"
 msgid_plural "Show {{n}} planning items"
-msgstr[0] ""
+msgstr[0] "{{n}}件のプランニングアイテムを表示"
 
 #: scripts/apps/archive/views/provider-menu.html:9
 msgid "Show All"
-msgstr ""
+msgstr "すべて表示"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:121
 msgid "Show Bookmark"
-msgstr ""
+msgstr "ブックマークを表示"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:332
 msgid "Show Crops"
-msgstr ""
+msgstr "トリミングを表示"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:186
 msgid "Show Floating Character Count"
-msgstr ""
+msgstr "フローティング文字数を表示"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:352
 msgid "Show Image Title"
-msgstr ""
+msgstr "画像タイトルを表示"
 
 #: ../superdesk-planning/client/components/UI/Preview/ExpandableText.tsx:47
 #: scripts/apps/master-desk/components/HeaderComponent.tsx:226
 #: scripts/apps/master-desk/components/HeaderComponent.tsx:229
 msgid "Show all"
-msgstr ""
+msgstr "すべて表示"
 
 #: ../superdesk-planning/client/components/fields/editor/Language.tsx:96
 msgid "Show all language fields"
-msgstr ""
+msgstr "すべての言語フィールドを表示"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:93
 msgid "Show all messages"
-msgstr ""
+msgstr "すべてのメッセージを表示"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:19
 #: scripts/extensions/broadcasting/dist/src/shows/manage-shows.js:19
 #: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:31
 msgid "Show code"
-msgstr ""
+msgstr "コードを表示"
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:48
 msgid "Show crops for pictures"
-msgstr ""
+msgstr "画像のトリミングを表示"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:101
 msgid "Show error messages"
-msgstr ""
+msgstr "エラーメッセージを表示"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:302
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:302
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:509
 msgid "Show image suggestions"
-msgstr ""
+msgstr "画像候補を表示"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:30
 msgid "Show in embedded form"
-msgstr ""
+msgstr "埋め込みフォームで表示"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:263
 msgid "Show in preview"
-msgstr ""
+msgstr "プレビューで表示"
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:120
 msgid "Show input for editing description"
-msgstr ""
+msgstr "説明編集の入力欄を表示"
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:110
 msgid "Show input for editing title"
-msgstr ""
+msgstr "タイトル編集の入力欄を表示"
 
 #: ../superdesk-planning/client/components/Archive/ArchivePreview/index.tsx:42
 #: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:93
@@ -15803,14 +15803,14 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEventItem.tsx:94
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx:109
 msgid "Show less"
-msgstr ""
+msgstr "折りたたむ"
 
 #: ../superdesk-planning/client/components/Archive/ArchivePreview/index.tsx:42
 #: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:93
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEventItem.tsx:94
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx:109
 msgid "Show more"
-msgstr ""
+msgstr "もっと見る"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show.js:66
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:13
@@ -15819,28 +15819,28 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/shows/create-show.tsx:95
 #: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:25
 msgid "Show name"
-msgstr ""
+msgstr "ショー名"
 
 #: ../superdesk-planning/client/components/Location/index.tsx:54
 #: ../superdesk-planning/client/components/Locations/LocationsList.tsx:93
 msgid "Show on map"
-msgstr ""
+msgstr "地図で表示"
 
 #: scripts/apps/workspace/content/components/WidgetsConfig.tsx:57
 msgid "Show or hide the widgets in the right toolbar in the editor workspace."
-msgstr ""
+msgstr "エディターワークスペースの右ツールバーのウィジェットの表示/非表示を切り替えます。"
 
 #: scripts/apps/search/components/fields/nested-link.tsx:28
 msgid "Show previous items"
-msgstr ""
+msgstr "前のアイテムを表示"
 
 #: scripts/apps/search/index.ts:138
 msgid "Show search modal"
-msgstr ""
+msgstr "検索モーダルを表示"
 
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:3
 msgid "Show sent/queued items"
-msgstr ""
+msgstr "送信済み/キュー中のアイテムを表示"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:128
 msgid ""
@@ -15851,63 +15851,63 @@ msgstr ""
 #: scripts/apps/archive/views/item-crops.html:1
 #: scripts/apps/authoring-react/fields/media/media-carousel/image-crops.tsx:22
 msgid "Show/hide crops"
-msgstr ""
+msgstr "トリミングの表示/非表示"
 
 #: scripts/apps/users/views/change-avatar.html:17
 msgid "Shows your initials instead"
-msgstr ""
+msgstr "代わりにイニシャルを表示します"
 
 #: scripts/apps/authoring-react/field-adapters/sign_off.tsx:118
 #: scripts/apps/workspace/content/constants.ts:40
 #: scripts/core/lang/missing-translations-strings.ts:18
 msgid "Sign Off"
-msgstr ""
+msgstr "サインオフ"
 
 #: scripts/core/auth/login-modal.html:31
 msgid "Sign in as a different user."
-msgstr ""
+msgstr "別のユーザーとしてサインインしてください。"
 
 #: scripts/core/menu/views/menu.html:73
 msgid "Sign out"
-msgstr ""
+msgstr "サインアウト"
 
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:159
 #: scripts/apps/users/views/edit-form.html:254
 msgid "Sign-Off"
-msgstr ""
+msgstr "サインオフ"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:364
 #: scripts/apps/search/views/search-parameters.html:22
 msgid "Sign-off"
-msgstr ""
+msgstr "サインオフ"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:173
 #: scripts/apps/archive/views/metadata-view.html:45
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:303
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:124
 msgid "Signal"
-msgstr ""
+msgstr "シグナル"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:10
 msgid "Single Day"
-msgstr ""
+msgstr "1日"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:122
 msgid "Single Line"
-msgstr ""
+msgstr "1行"
 
 #: scripts/core/editor3/components/media/MediaBlock.tsx:13
 msgid "Single Usage"
-msgstr ""
+msgstr "単一使用"
 
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:57
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:214
 msgid "Single line"
-msgstr ""
+msgstr "1行"
 
 #: scripts/apps/vocabularies/constants.ts:48
 msgid "Single selection"
-msgstr ""
+msgstr "単一選択"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:120
 #: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:152
@@ -15922,19 +15922,19 @@ msgstr ""
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:177
 #: scripts/extensions/sams/src/utils/ui.tsx:103
 msgid "Size"
-msgstr ""
+msgstr "サイズ"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:247
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:247
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:320
 msgid "Size From:"
-msgstr ""
+msgstr "サイズ（開始）："
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:251
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:251
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:334
 msgid "Size To:"
-msgstr ""
+msgstr "サイズ（終了）："
 
 #: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:176
 #: scripts/extensions/sams/dist/src/components/assets/assetGridItem.js:125
@@ -15946,31 +15946,31 @@ msgstr ""
 #: scripts/extensions/sams/src/components/assets/assetGridItem.tsx:155
 #: scripts/extensions/sams/src/components/assets/assetListItem.tsx:137
 msgid "Size:"
-msgstr ""
+msgstr "サイズ："
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:41
 msgid "Skip"
-msgstr ""
+msgstr "スキップ"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:174
 msgid "Skip Next"
-msgstr ""
+msgstr "次をスキップ"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:175
 msgid "Skip Previous"
-msgstr ""
+msgstr "前をスキップ"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:203
 msgid "Skip config test"
-msgstr ""
+msgstr "設定テストをスキップ"
 
 #: scripts/apps/desks/views/desk-config-modal.html:59
 msgid "Slack Channel Name"
-msgstr ""
+msgstr "Slackチャンネル名"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:176
 msgid "Slideshow"
-msgstr ""
+msgstr "スライドショー"
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:18
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:66
@@ -16004,17 +16004,17 @@ msgstr ""
 #: scripts/apps/search/views/search-parameters.html:6
 #: scripts/apps/workspace/content/constants.ts:41
 msgid "Slugline"
-msgstr ""
+msgstr "スラッグライン"
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:4
 msgid "Slugline Match"
-msgstr ""
+msgstr "スラッグライン一致"
 
 #: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-tooltip.html:2
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:85
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateAssignmentForm.tsx:118
 msgid "Slugline:"
-msgstr ""
+msgstr "スラッグライン："
 
 #: scripts/apps/archive/views/item-preview.html:11
 #: scripts/apps/archive/views/metadata-view.html:194
@@ -16026,45 +16026,45 @@ msgstr ""
 #: scripts/apps/search/views/search-filters.html:130
 #: scripts/core/itemList/views/relatedItem-list-widget.html:34
 msgid "Sms"
-msgstr ""
+msgstr "SMS"
 
 #: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:24
 msgid "Some Coverages Assigned"
-msgstr ""
+msgstr "一部の取材が割り当て済み"
 
 #: scripts/apps/authoring/multiedit/multiedit.ts:85
 msgid "Some articles failed to unlock"
-msgstr ""
+msgstr "一部の記事のロック解除に失敗しました"
 
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:42
 #: ../superdesk-planning/client/planning-extension/src/extension.ts:57
 msgid "Some items are linked to in-progress planning coverage."
-msgstr ""
+msgstr "一部のアイテムは進行中のプランニング取材にリンクされています。"
 
 #: scripts/api/article-send.tsx:135
 msgid ""
 "Some packages contain the following published items that can not be sent:"
-msgstr ""
+msgstr "一部のパッケージに送信できない公開済みアイテムが含まれています："
 
 #: ../superdesk-planning/client/actions/main.ts:477
 msgid "Some related planning item post validation failed"
-msgstr ""
+msgstr "一部の関連プランニングアイテムの投稿検証に失敗しました"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:458
 msgid ""
 "Some selected items have not yet been posted. All selections must be visible "
 "to subscribers."
-msgstr ""
+msgstr "一部の選択されたアイテムがまだ投稿されていません。すべての選択は配信先に表示される必要があります。"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:53
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:53
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:124
 msgid "Some tags can not be displayed"
-msgstr ""
+msgstr "一部のタグを表示できません"
 
 #: scripts/core/upload/crop-directive.ts:57
 msgid "Sorry, but avatar must be at least 200x200 pixels big."
-msgstr ""
+msgstr "アバターは少なくとも200x200ピクセル必要です。"
 
 #: scripts/core/auth/login-modal.html:39
 #: scripts/core/auth/reset-password.html:29
@@ -16075,41 +16075,41 @@ msgstr ""
 
 #: scripts/core/upload/image-crop-directive.ts:251
 msgid "Sorry, but image must be at least {{width}}x{{height}}."
-msgstr ""
+msgstr "画像は少なくとも{{width}}x{{height}}必要です。"
 
 #: scripts/apps/authoring/attachments/AttachmentsWidget.tsx:38
 msgid ""
 "Sorry, but some files \"{{filenames}}\" are bigger than limit ({{limit}})"
-msgstr ""
+msgstr "ファイル「{{filenames}}」が制限（{{limit}}）を超えています"
 
 #: scripts/apps/templates/views/create-template.html:23
 msgid "Sorry, but template name must be unique."
-msgstr ""
+msgstr "テンプレート名は一意でなければなりません。"
 
 #: scripts/core/auth/login-modal.html:37
 #: scripts/core/auth/reset-password.html:28
 #: scripts/core/auth/reset-password.html:75
 #: scripts/core/auth/secure-login.html:29
 msgid "Sorry, but your account has been suspended."
-msgstr ""
+msgstr "アカウントが停止されています。"
 
 #: scripts/apps/workspace/views/edit-workspace-modal.html:23
 msgid "Sorry, given workspace name is in use"
-msgstr ""
+msgstr "指定されたワークスペース名は既に使用中です"
 
 #: scripts/apps/users/views/settings-roles.html:40
 msgid "Sorry, this role name already exists."
-msgstr ""
+msgstr "このロール名は既に存在します。"
 
 #: scripts/core/auth/login-modal.html:38
 msgid "Sorry, user not found."
-msgstr ""
+msgstr "ユーザーが見つかりません。"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:138
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:138
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:163
 msgid "Sort By"
-msgstr ""
+msgstr "並び替え"
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:28
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-preview.html:15
@@ -16117,47 +16117,47 @@ msgstr ""
 #: ../superdesk-analytics/client/production_time_report/views/production-time-report-preview.html:24
 #: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:28
 msgid "Sort Order"
-msgstr ""
+msgstr "並び順"
 
 #: scripts/apps/monitoring/views/monitoring-group-header.html:37
 #: scripts/apps/search/views/item-sortbar.html:12
 #: scripts/apps/search/views/item-sortbar.html:6
 msgid "Sort by"
-msgstr ""
+msgstr "並び替え"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:239
 msgid "Sort by:"
-msgstr ""
+msgstr "並び替え："
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:262
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:262
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:410
 msgid "Sort by: {{ field }}"
-msgstr ""
+msgstr "並び替え：{{ field }}"
 
 #: scripts/apps/search/views/item-sortbar.html:19
 msgid "Sort order"
-msgstr ""
+msgstr "並び順"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:266
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:266
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:424
 msgid "Sort order: Ascending"
-msgstr ""
+msgstr "並び順：昇順"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:267
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:267
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:425
 msgid "Sort order: Descending"
-msgstr ""
+msgstr "並び順：降順"
 
 #: scripts/apps/legal-archive/views/legal_archive.html:29
 msgid "Sorting"
-msgstr ""
+msgstr "並び替え"
 
 #: scripts/apps/monitoring/views/monitoring-group-header.html:28
 msgid "Sorting:"
-msgstr ""
+msgstr "並び替え："
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:586
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:455
@@ -16171,38 +16171,38 @@ msgstr ""
 #: scripts/apps/search-providers/views/search-provider-config.html:89
 #: scripts/apps/workspace/content/constants.ts:44
 msgid "Source"
-msgstr ""
+msgstr "ソース"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:85
 msgid "Source Name"
-msgstr ""
+msgstr "ソース名"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:3
 msgid "Source Type:"
-msgstr ""
+msgstr "ソースタイプ："
 
 #: scripts/apps/desks/views/desk-config-modal.html:44
 msgid "Source for User Created Articles"
-msgstr ""
+msgstr "ユーザー作成記事のソース"
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:9
 msgid "Source stats"
-msgstr ""
+msgstr "ソース統計"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/tag-popover.js:20
 #: scripts/extensions/auto-tagging-widget/dist/src/tag-popover.js:20
 #: scripts/extensions/auto-tagging-widget/src/tag-popover.tsx:29
 msgid "Source:"
-msgstr ""
+msgstr "ソース："
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:133
 #: scripts/apps/search/views/search-filters.html:44
 msgid "Sources"
-msgstr ""
+msgstr "ソース"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:361
 msgid "Spell Checker"
-msgstr ""
+msgstr "スペルチェッカー"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:442
 #: ../superdesk-analytics/client/utils.js:164
@@ -16214,39 +16214,39 @@ msgstr ""
 #: scripts/apps/archive/show-spike-dialog.tsx:61
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:189
 msgid "Spike"
-msgstr ""
+msgstr "スパイク"
 
 #: scripts/apps/archive/index.tsx:120
 msgid "Spike Item"
-msgstr ""
+msgstr "アイテムをスパイク"
 
 #: scripts/apps/monitoring/config.ts:29
 msgid "Spike Monitoring"
-msgstr ""
+msgstr "スパイクモニタリング"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:138
 msgid "Spike Planning Item"
-msgstr ""
+msgstr "プランニングアイテムをスパイク"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:146
 msgid "Spike State"
-msgstr ""
+msgstr "スパイク状態"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:104
 msgid "Spike all recurring events or just this one?"
-msgstr ""
+msgstr "すべての繰り返しイベントをスパイクしますか？それともこのイベントのみですか？"
 
 #: scripts/apps/monitoring/index.ts:127
 msgid "Spike item(s)"
-msgstr ""
+msgstr "アイテムをスパイク"
 
 #: ../superdesk-planning/client/constants/planning.ts:135
 msgid "Spike planning"
-msgstr ""
+msgstr "プランニングをスパイク"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:72
 msgid "Spike {{event}}"
-msgstr ""
+msgstr "{{event}}をスパイク"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:45
 #: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:40
@@ -16256,68 +16256,68 @@ msgstr ""
 #: scripts/apps/search/components/fields/state.tsx:36
 #: scripts/apps/search/constants.ts:14
 msgid "Spiked"
-msgstr ""
+msgstr "スパイク済み"
 
 #: scripts/apps/search/views/search-parameters.html:145
 msgid "Spiked Content"
-msgstr ""
+msgstr "スパイク済みコンテンツ"
 
 #: scripts/apps/monitoring/config.ts:40
 #: scripts/apps/monitoring/views/monitoring-view.html:257
 msgid "Spiked Items"
-msgstr ""
+msgstr "スパイク済みアイテム"
 
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:177
 msgid "Spiked Only"
-msgstr ""
+msgstr "スパイク済みのみ"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:221
 #: scripts/apps/authoring/versioning/history/views/history.html:63
 msgid "Spiked by"
-msgstr ""
+msgstr "スパイク者"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:4
 msgid "Spiked items"
-msgstr ""
+msgstr "スパイク済みアイテム"
 
 #: scripts/apps/search/views/search-parameters.html:153
 msgid "Spiked only content"
-msgstr ""
+msgstr "スパイク済みコンテンツのみ"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:108
 msgid "Spline"
-msgstr ""
+msgstr "スプライン"
 
 #: scripts/core/editor3/highlightsConfig.ts:83
 msgid "Split paragraph"
-msgstr ""
+msgstr "段落を分割"
 
 #: scripts/apps/desks/views/actionpicker.html:15
 #: scripts/apps/internal-destinations/InternalDestinations.tsx:48
 #: scripts/apps/workspace/content/constants.ts:45
 #: scripts/core/interactive-article-actions-panel/subcomponents/destination-select.tsx:87
 msgid "Stage"
-msgstr ""
+msgstr "ステージ"
 
 #: scripts/apps/desks/views/desk-config-modal.html:299
 msgid "Stage Details"
-msgstr ""
+msgstr "ステージ詳細"
 
 #: scripts/apps/desks/views/desk-config-modal.html:369
 msgid "Stage description"
-msgstr ""
+msgstr "ステージの説明"
 
 #: scripts/apps/desks/views/desk-config-modal.html:320
 msgid "Stage description:"
-msgstr ""
+msgstr "ステージの説明："
 
 #: scripts/apps/desks/directives/DeskeditStages.ts:190
 msgid "Stage has been modified elsewhere. Please reload the desks"
-msgstr ""
+msgstr "ステージが他で変更されました。デスクを再読み込みしてください"
 
 #: scripts/apps/desks/views/desk-config-modal.html:289
 msgid "Stage with name"
-msgstr ""
+msgstr "名前のステージ"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:624
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:157
@@ -16327,48 +16327,48 @@ msgstr ""
 #: scripts/apps/monitoring/views/monitoring-view.html:23
 #: scripts/apps/monitoring/views/monitoring-view.html:66
 msgid "Stages"
-msgstr ""
+msgstr "ステージ"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:177
 msgid "Star"
-msgstr ""
+msgstr "スター"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:178
 msgid "Star Empty"
-msgstr ""
+msgstr "スター（空）"
 
 #: scripts/apps/publish/views/subscribers.html:87
 msgid "Start Date"
-msgstr ""
+msgstr "開始日"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:18
 msgid "Start Time (inclusive)"
-msgstr ""
+msgstr "開始時間（含む）"
 
 #: ../superdesk-planning/client/constants/assignments.ts:191
 msgid "Start Working"
-msgstr ""
+msgstr "作業開始"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:174
 msgid "Start date cannot be greater than today"
-msgstr ""
+msgstr "開始日は本日より後にできません"
 
 #: ../superdesk-planning/client/validators/events.ts:76
 msgid "Start date is in the past"
-msgstr ""
+msgstr "開始日が過去です"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:160
 msgid "Start date is required"
-msgstr ""
+msgstr "開始日は必須です"
 
 #: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:31
 msgid "Start routing"
-msgstr ""
+msgstr "ルーティングを開始"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:87
 #: scripts/apps/search/views/item-searchbar.html:19
 msgid "Start search"
-msgstr ""
+msgstr "検索を開始"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:571
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:123
@@ -16392,7 +16392,7 @@ msgstr ""
 #: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:154
 #: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:186
 msgid "State"
-msgstr ""
+msgstr "状態"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:598
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:611
@@ -16407,7 +16407,7 @@ msgstr ""
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:145
 msgid "States"
-msgstr ""
+msgstr "状態"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:64
 #: scripts/apps/publish/views/publish-queue.html:115
@@ -16424,34 +16424,34 @@ msgstr ""
 #: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:124
 #: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:158
 msgid "Status"
-msgstr ""
+msgstr "ステータス"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx:233
 #: scripts/apps/contacts/views/list.html:38
 #: scripts/apps/publish/views/publish-queue.html:46
 #: scripts/apps/publish/views/subscribers.html:15
 msgid "Status:"
-msgstr ""
+msgstr "ステータス："
 
 #: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:112
 msgid "Status: Unassigned"
-msgstr ""
+msgstr "ステータス：未割り当て"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:143
 msgid "Status: {{ state }}"
-msgstr ""
+msgstr "ステータス：{{ state }}"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:11
 msgid "Status: {{filter}}"
-msgstr ""
+msgstr "ステータス：{{filter}}"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:179
 msgid "Stop"
-msgstr ""
+msgstr "停止"
 
 #: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:37
 msgid "Stop routing"
-msgstr ""
+msgstr "ルーティングを停止"
 
 #: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:254
 #: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:150
@@ -16460,7 +16460,7 @@ msgstr ""
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:342
 #: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:154
 msgid "Storage Destination"
-msgstr ""
+msgstr "ストレージ送信先"
 
 #: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:256
 #: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:153
@@ -16469,95 +16469,95 @@ msgstr ""
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:348
 #: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:159
 msgid "Storage Provider"
-msgstr ""
+msgstr "ストレージプロバイダー"
 
 #: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:243
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:243
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:311
 msgid "Storage Unit"
-msgstr ""
+msgstr "ストレージユニット"
 
 #: scripts/extensions/sams/dist/src/components/sets/setListItem.js:97
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListItem.js:97
 #: scripts/extensions/sams/src/components/sets/setListItem.tsx:85
 msgid "Storage:"
-msgstr ""
+msgstr "ストレージ："
 
 #: scripts/apps/publish/views/odbc-config.html:11
 #: scripts/apps/publish/views/odbc-config.html:9
 msgid "Stored Procedure"
-msgstr ""
+msgstr "ストアドプロシージャ"
 
 #: scripts/apps/products/views/product-test.html:9
 msgid "Story GUID"
-msgstr ""
+msgstr "記事GUID"
 
 #: scripts/apps/legal-archive/views/legal_archive.html:78
 #: scripts/apps/search/views/search-parameters.html:31
 msgid "Story Text"
-msgstr ""
+msgstr "記事テキスト"
 
 #: scripts/apps/archive/related-item-widget/relatedItem.ts:183
 msgid "Story is associated as update."
-msgstr ""
+msgstr "記事は更新として関連付けられています。"
 
 #: ../superdesk-planning/client/reducers/featuredPlanning.ts:177
 msgid "Story with slugline \"{{ slugline }}\" is added to the list"
-msgstr ""
+msgstr "スラッグライン「{{ slugline }}」の記事がリストに追加されました"
 
 #: ../superdesk-planning/client/reducers/featuredPlanning.ts:195
 #: ../superdesk-planning/client/reducers/featuredPlanning.ts:215
 msgid "Story with slugline \"{{ slugline }}\" is removed from the list"
-msgstr ""
+msgstr "スラッグライン「{{ slugline }}」の記事がリストから削除されました"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:180
 msgid "Stream"
-msgstr ""
+msgstr "ストリーム"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:534
 msgid "Street Address"
-msgstr ""
+msgstr "住所"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:533
 msgid "Street Address, PO Box, Company Name"
-msgstr ""
+msgstr "住所、私書箱、会社名"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:65
 msgid "Strength"
-msgstr ""
+msgstr "強度"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:181
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:40
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:78
 msgid "Strikethrough"
-msgstr ""
+msgstr "取り消し線"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:41
 msgid "Strong"
-msgstr ""
+msgstr "太字"
 
 #: scripts/apps/system-messages/components/system-messages-settings.tsx:49
 msgid "Style"
-msgstr ""
+msgstr "スタイル"
 
 #: ../superdesk-planning/client/utils/filters.ts:130
 msgid "Su"
-msgstr ""
+msgstr "日"
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:6
 #: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:6
 msgid "Subgroup By"
-msgstr ""
+msgstr "サブグループ化"
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-parameters.html:23
 msgid "Subgroup By:"
-msgstr ""
+msgstr "サブグループ化："
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:112
 #: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:112
 #: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:144
 msgid "Subitem attachments"
-msgstr ""
+msgstr "サブアイテム添付ファイル"
 
 #: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/index.js:13
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/index.js:13
@@ -16566,7 +16566,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/authoring-fields/subitems/index.tsx:30
 #: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:165
 msgid "Subitems"
-msgstr ""
+msgstr "サブアイテム"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:547
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:117
@@ -16577,25 +16577,25 @@ msgstr ""
 #: scripts/apps/search/constants.ts:15
 #: scripts/apps/workspace/content/constants.ts:46
 msgid "Subject"
-msgstr ""
+msgstr "件名"
 
 #: ../superdesk-planning/client/validators/planning.ts:109
 msgid "Subject is a required field"
-msgstr ""
+msgstr "件名は必須フィールドです"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:39
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:150
 msgid "Subject:"
-msgstr ""
+msgstr "件名："
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:162
 #: scripts/core/lang/missing-translations-strings.ts:12
 msgid "Subjects"
-msgstr ""
+msgstr "主題"
 
 #: ../superdesk-planning/client/components/fields/list/Subject.tsx:20
 msgid "Subjects:"
-msgstr ""
+msgstr "主題："
 
 #: scripts/core/editor3/components/annotations/AnnotationInput.tsx:287
 #: scripts/core/editor3/components/comments/CommentInput.tsx:97
@@ -16604,61 +16604,61 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:261
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:379
 msgid "Submit"
-msgstr ""
+msgstr "送信"
 
 #: ../superdesk-planning/client/utils/index.ts:396
 #: scripts/apps/search/components/fields/state.tsx:34
 msgid "Submitted"
-msgstr ""
+msgstr "送信済み"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:109
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:202
 msgid "Submitting...."
-msgstr ""
+msgstr "送信中..."
 
 #: scripts/apps/search/views/saved-search-subscribe.html:34
 #: scripts/apps/search/views/saved-searches.html:21
 #: scripts/apps/search/views/saved-searches.html:50
 msgid "Subscribe"
-msgstr ""
+msgstr "購読"
 
 #: scripts/apps/publish/views/publish-queue.html:109
 #: scripts/apps/search/constants.ts:20
 #: scripts/apps/search/views/search-parameters.html:181
 msgid "Subscriber"
-msgstr ""
+msgstr "配信先"
 
 #: scripts/apps/publish/views/subscribers.html:84
 msgid "Subscriber Schedule Settings"
-msgstr ""
+msgstr "配信先スケジュール設定"
 
 #: scripts/apps/publish/views/subscribers.html:156
 msgid "Subscriber codes"
-msgstr ""
+msgstr "配信先コード"
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:284
 msgid "Subscriber could not be initialized!"
-msgstr ""
+msgstr "配信先を初期化できませんでした。"
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:213
 msgid "Subscriber saved."
-msgstr ""
+msgstr "配信先が保存されました。"
 
 #: scripts/apps/publish/views/publish-queue.html:14
 msgid "Subscriber:"
-msgstr ""
+msgstr "配信先："
 
 #: scripts/apps/content-filters/views/filter-search-result.html:42
 #: scripts/apps/products/views/products-config-modal.html:16
 #: scripts/apps/publish/index.ts:41 scripts/apps/publish/views/settings.html:4
 msgid "Subscribers"
-msgstr ""
+msgstr "配信先"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:182
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:39
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:92
 msgid "Subscript"
-msgstr ""
+msgstr "下付き"
 
 #: ../superdesk-analytics/client/charts/views/chart-form-options.html:15
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:15
@@ -16668,35 +16668,35 @@ msgstr ""
 #: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:15
 #: ../superdesk-analytics/client/update_time_report/views/update-time-report-preview.html:6
 msgid "Subtitle"
-msgstr ""
+msgstr "サブタイトル"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:244
 #: ../superdesk-planning/client/components/fields/resources/locations.ts:40
 msgid "Suburb"
-msgstr ""
+msgstr "地区"
 
 #: scripts/apps/system-messages/components/system-messages-settings.tsx:27
 msgid "Success"
-msgstr ""
+msgstr "成功"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:183
 msgid "Suggestion"
-msgstr ""
+msgstr "提案"
 
 #: scripts/apps/authoring/track-changes/suggestions.ts:91
 #: scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx:84
 msgid "Suggestions"
-msgstr ""
+msgstr "提案"
 
 #: scripts/apps/authoring/suggest/SuggestView.html:8
 msgid "Suggestions will appear here once the article's body starts changing..."
-msgstr ""
+msgstr "記事の本文が変更され始めると、ここに提案が表示されます..."
 
 #: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:278
 #: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:29
 #: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:32
 msgid "Sum"
-msgstr ""
+msgstr "合計"
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/main-panel.js:18
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary-widget.js:48
@@ -16705,68 +16705,68 @@ msgstr ""
 #: scripts/extensions/ai-widget/src/main-panel.tsx:35
 #: scripts/extensions/ai-widget/src/summary/summary-widget.tsx:70
 msgid "Summary"
-msgstr ""
+msgstr "サマリー"
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:106
 msgid "Sun"
-msgstr ""
+msgstr "日"
 
 #: ../superdesk-planning/client/utils/events.tsx:1460
 #: scripts/core/datetime/datetime.ts:296
 msgid "Sunday"
-msgstr ""
+msgstr "日曜日"
 
 #: scripts/apps/contacts/controllers/ContactsController.ts:33
 msgid "Superdesk Contacts Management"
-msgstr ""
+msgstr "Superdesk連絡先管理"
 
 #: scripts/core/menu/views/superdesk-view.html:50
 msgid "Superdesk is experiencing network connection issues:/"
-msgstr ""
+msgstr "Superdeskにネットワーク接続の問題が発生しています。"
 
 #: scripts/core/menu/views/menu.html:114
 msgid "Superdesk logo"
-msgstr ""
+msgstr "Superdeskロゴ"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:184
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:38
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:93
 msgid "Superscript"
-msgstr ""
+msgstr "上付き"
 
 #: scripts/apps/desks/directives/DeskConfigModal.ts:37
 #: scripts/apps/monitoring/directives/utils.ts:103
 #: scripts/apps/users/directives/UserPreferencesDirective.ts:31
 msgid "Swimlane View"
-msgstr ""
+msgstr "スイムレーン表示"
 
 #: ../superdesk-planning/client/components/fields/editor/Language.tsx:111
 msgid "Switch Metadata Language"
-msgstr ""
+msgstr "メタデータ言語を切り替え"
 
 #: scripts/apps/authoring-react/multi-edit-modal.tsx:115
 msgid "Switch article"
-msgstr ""
+msgstr "記事を切り替え"
 
 #: scripts/apps/authoring-react/authoring-swtich.tsx:16
 msgid "Switch authoring"
-msgstr ""
+msgstr "オーサリングを切り替え"
 
 #: scripts/apps/authoring-react/authoring-swtich.tsx:18
 msgid "Switch authoring?"
-msgstr ""
+msgstr "オーサリングを切り替えますか？"
 
 #: scripts/apps/monitoring/index.ts:111
 msgid "Switch between grouped/single desk view"
-msgstr ""
+msgstr "グループ/個別デスク表示を切り替え"
 
 #: scripts/apps/monitoring/index.ts:109
 msgid "Switch between grouped/single stage view"
-msgstr ""
+msgstr "グループ/個別ステージ表示を切り替え"
 
 #: scripts/core/menu/views/menu.html:38
 msgid "Switch to feature preview"
-msgstr ""
+msgstr "機能プレビューに切り替え"
 
 #: scripts/apps/archive/views/list.html:20
 #: scripts/apps/contacts/views/list.html:6
@@ -16775,7 +16775,7 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:270
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:439
 msgid "Switch to grid view"
-msgstr ""
+msgstr "グリッド表示に切り替え"
 
 #: scripts/apps/archive/views/list.html:21
 #: scripts/apps/contacts/views/list.html:7
@@ -16784,16 +16784,16 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:271
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:440
 msgid "Switch to list view"
-msgstr ""
+msgstr "リスト表示に切り替え"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:185
 msgid "Switches"
-msgstr ""
+msgstr "スイッチ"
 
 #: scripts/apps/system-messages/components/system-messages-settings.tsx:148
 #: scripts/apps/system-messages/index.ts:34
 msgid "System Message"
-msgstr ""
+msgstr "システムメッセージ"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:140
 msgid "T"
@@ -16819,7 +16819,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/validators/events.ts:25
 msgid "TIMEZONE is a required field"
-msgstr ""
+msgstr "タイムゾーンは必須フィールドです"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:83
 msgid "TU"
@@ -16827,34 +16827,34 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:41
 msgid "Tab"
-msgstr ""
+msgstr "タブ"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:42
 msgid "Tab As Spaces"
-msgstr ""
+msgstr "タブをスペースに"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:93
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:186
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:33
 #: scripts/core/editor3/components/toolbar/index.tsx:310
 msgid "Table"
-msgstr ""
+msgstr "テーブル"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:191
 msgid "Table Header"
-msgstr ""
+msgstr "テーブルヘッダー"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:192
 msgid "Table Header Large"
-msgstr ""
+msgstr "テーブルヘッダー（大）"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:193
 msgid "Table Header List"
-msgstr ""
+msgstr "テーブルヘッダーリスト"
 
 #: scripts/apps/authoring-react/fields/tag-input/index.tsx:26
 msgid "Tag-input (authoring-react)"
-msgstr ""
+msgstr "タグ入力（authoring-react）"
 
 #: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:83
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:40
@@ -16871,34 +16871,34 @@ msgstr ""
 #: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:171
 #: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:196
 msgid "Tags"
-msgstr ""
+msgstr "タグ"
 
 #: scripts/apps/authoring-react/field-adapters/anpa_take_key.ts:20
 #: scripts/apps/workspace/content/constants.ts:10
 msgid "Take Key"
-msgstr ""
+msgstr "テイクキー"
 
 #: scripts/apps/users/controllers/ChangeAvatarController.ts:7
 msgid "Take a picture"
-msgstr ""
+msgstr "写真を撮影"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:132
 msgid "Take created by"
-msgstr ""
+msgstr "テイク作成者"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:418
 msgid "Take created by {{user}}"
-msgstr ""
+msgstr "{{user}}がテイクを作成"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:299
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:120
 msgid "Take key"
-msgstr ""
+msgstr "テイクキー"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:471
 #: scripts/apps/authoring/versioning/history/views/history.html:160
 msgid "Take link is removed"
-msgstr ""
+msgstr "テイクリンクが削除されました"
 
 #: ../superdesk-analytics/client/utils.js:163
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/takedown-action.tsx:10
@@ -16906,104 +16906,104 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-topbar.html:138
 #: scripts/apps/authoring/views/authoring-topbar.html:139
 msgid "Takedown"
-msgstr ""
+msgstr "テイクダウン"
 
 #: scripts/apps/authoring/authoring/index.ts:333
 msgid "Takedown item"
-msgstr ""
+msgstr "アイテムをテイクダウン"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:577
 msgid "Takedowns"
-msgstr ""
+msgstr "テイクダウン"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:50
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:90
 msgid "Taken Down"
-msgstr ""
+msgstr "テイクダウン済み"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:427
 msgid "Taken as a rewrite of"
-msgstr ""
+msgstr "書き直し対象"
 
 #: scripts/core/itemList/views/relatedItem-list-widget.html:31
 msgid "Takes"
-msgstr ""
+msgstr "テイク"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:187
 msgid "Takes Package"
-msgstr ""
+msgstr "テイクパッケージ"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:540
 msgid "Tansa is not responding. You can continue editing or publish the story."
-msgstr ""
+msgstr "Tansaが応答していません。編集を続行するか、記事を公開できます。"
 
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:105
 msgid "Target"
-msgstr ""
+msgstr "ターゲット"
 
 #: scripts/apps/archive/views/metadata-view.html:151
 #: scripts/apps/products/views/products-config-modal.html:76
 msgid "Target Regions"
-msgstr ""
+msgstr "ターゲット地域"
 
 #: scripts/apps/archive/views/metadata-view.html:156
 msgid "Target Subscriber Types"
-msgstr ""
+msgstr "ターゲット配信先タイプ"
 
 #: scripts/apps/archive/views/metadata-view.html:146
 #: scripts/apps/templates/views/template-editor-modal.html:135
 msgid "Target Subscribers"
-msgstr ""
+msgstr "ターゲット配信先"
 
 #: scripts/apps/publish/views/subscribers.html:130
 msgid "Target Type"
-msgstr ""
+msgstr "ターゲットタイプ"
 
 #: scripts/apps/publish/views/subscribers.html:5
 msgid "Target Type:"
-msgstr ""
+msgstr "ターゲットタイプ："
 
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:67
 msgid "Target Types"
-msgstr ""
+msgstr "ターゲットタイプ"
 
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:131
 msgid "Target regions"
-msgstr ""
+msgstr "ターゲット地域"
 
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:106
 msgid "Target subscribers"
-msgstr ""
+msgstr "ターゲット配信先"
 
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:148
 msgid "Target types"
-msgstr ""
+msgstr "ターゲットタイプ"
 
 #: scripts/apps/publish/views/subscribers.html:163
 msgid "Targetable by users"
-msgstr ""
+msgstr "ユーザーがターゲット可能"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:188
 #: scripts/apps/dashboard/workspace-tasks/tasks.ts:405
 #: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:2
 msgid "Tasks"
-msgstr ""
+msgstr "タスク"
 
 #: scripts/core/lang/missing-translations-strings.ts:20
 msgid "Tasks Management"
-msgstr ""
+msgstr "タスク管理"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:58
 #: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:58
 #: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:74
 msgid "Tech. title"
-msgstr ""
+msgstr "技術タイトル"
 
 #: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/subitems-view-edit.js:46
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.js:46
 #: scripts/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.tsx:101
 msgid "Technical information"
-msgstr ""
+msgstr "技術情報"
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:19
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:72
@@ -17013,25 +17013,25 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:136
 #: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:210
 msgid "Template"
-msgstr ""
+msgstr "テンプレート"
 
 #: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:49
 msgid "Template Content"
-msgstr ""
+msgstr "テンプレートコンテンツ"
 
 #: scripts/apps/templates/views/template-editor-modal.html:46
 msgid "Template Type"
-msgstr ""
+msgstr "テンプレートタイプ"
 
 #: ../superdesk-planning/client/actions/events/api.ts:842
 msgid "Template already exists. Do you want to overwrite it?"
-msgstr ""
+msgstr "テンプレートは既に存在します。上書きしますか？"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:93
 #: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:93
 #: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:206
 msgid "Template based settings"
-msgstr ""
+msgstr "テンプレートベースの設定"
 
 #: ../superdesk-planning/client/actions/events/api.ts:796
 #: ../superdesk-planning/client/components/Events/ManageEventTemplatesModal.tsx:72
@@ -17041,40 +17041,40 @@ msgstr ""
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:187
 #: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:384
 msgid "Template name"
-msgstr ""
+msgstr "テンプレート名"
 
 #: scripts/apps/templates/directives/TemplatesDirective.ts:248
 msgid "Template saved."
-msgstr ""
+msgstr "テンプレートが保存されました。"
 
 #: scripts/apps/templates/views/templates.html:45
 msgid "Template type"
-msgstr ""
+msgstr "テンプレートタイプ"
 
 #: scripts/apps/authoring-react/toolbar/template-modal.tsx:117
 msgid "Template will be updated"
-msgstr ""
+msgstr "テンプレートが更新されます"
 
 #: scripts/apps/templates/index.ts:46
 #: scripts/apps/templates/views/templates.html:3
 msgid "Templates"
-msgstr ""
+msgstr "テンプレート"
 
 #: scripts/apps/authoring-react/field-adapters/usageterms.ts:20
 msgid "Terms of use"
-msgstr ""
+msgstr "利用規約"
 
 #: scripts/apps/content-filters/views/manage-filters.html:138
 msgid "Test"
-msgstr ""
+msgstr "テスト"
 
 #: scripts/apps/content-filters/views/manage-filters.html:19
 msgid "Test Filter Against Content"
-msgstr ""
+msgstr "コンテンツに対してフィルターをテスト"
 
 #: scripts/apps/products/views/product-test.html:24
 msgid "Test Products"
-msgstr ""
+msgstr "プロダクトをテスト"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:189
 #: ../superdesk-planning/client/utils/index.ts:587
@@ -17085,105 +17085,105 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/utils/assets.js:119
 #: scripts/extensions/sams/src/utils/assets.ts:150
 msgid "Text"
-msgstr ""
+msgstr "テキスト"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:190
 msgid "Text Format"
-msgstr ""
+msgstr "テキスト形式"
 
 #: ../superdesk-planning/client/utils/filters.ts:142
 msgid "Th"
-msgstr ""
+msgstr "木"
 
 #: ../superdesk-planning/client/actions/agenda.ts:407
 msgid "The Agenda you were viewing was deleted!"
-msgstr ""
+msgstr "表示していたアジェンダが削除されました。"
 
 #: ../superdesk-planning/client/actions/assignments/notifications.ts:22
 msgid "The Assignment you were viewing was removed."
-msgstr ""
+msgstr "表示していたアサインメントが削除されました。"
 
 #: ../superdesk-planning/client/actions/eventsPlanning/notifications.ts:39
 msgid "The Event and Planning filter you were viewing is deleted!"
-msgstr ""
+msgstr "表示していたイベントとプランニングフィルターが削除されました。"
 
 #: ../superdesk-planning/client/actions/eventsPlanning/notifications.ts:16
 msgid "The Event and Planning filter you were viewing is modified!"
-msgstr ""
+msgstr "表示していたイベントとプランニングフィルターが変更されました。"
 
 #: ../superdesk-planning/client/actions/events/notifications.ts:123
 msgid "The Event was spiked"
-msgstr ""
+msgstr "イベントがスパイクされました"
 
 #: ../superdesk-planning/client/actions/events/notifications.ts:152
 msgid "The Event was unspiked"
-msgstr ""
+msgstr "イベントのスパイクが解除されました"
 
 #: ../superdesk-planning/client/actions/main.ts:1410
 msgid "The Event you were editing was unlocked"
-msgstr ""
+msgstr "編集中のイベントのロックが解除されました"
 
 #: ../superdesk-planning/client/actions/main.ts:1405
 msgid "The Event you were editing was unlocked by \"{{ userName }}\""
-msgstr ""
+msgstr "編集中のイベントのロックが「{{ userName }}」によって解除されました"
 
 #: ../superdesk-planning/client/actions/main.ts:1399
 msgid "The Event you were editing was updated via ingest"
-msgstr ""
+msgstr "編集中のイベントが取り込みにより更新されました"
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:214
 msgid "The Events and Planning view filter is deleted."
-msgstr ""
+msgstr "イベントとプランニングの表示フィルターが削除されました。"
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:187
 msgid "The Events and Planning view filter is {{action}}."
-msgstr ""
+msgstr "イベントとプランニングの表示フィルターが{{action}}されました。"
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:196
 msgid "The Events and Planning view filter with this name already exists"
-msgstr ""
+msgstr "この名前のイベントとプランニングの表示フィルターは既に存在します"
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:37
 msgid "The Planning Item(s) has been spiked."
-msgstr ""
+msgstr "プランニングアイテムがスパイクされました。"
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:59
 msgid "The Planning Item(s) has been unspiked."
-msgstr ""
+msgstr "プランニングアイテムのスパイクが解除されました。"
 
 #: ../superdesk-planning/client/actions/planning/notifications.ts:218
 msgid "The Planning item was spiked"
-msgstr ""
+msgstr "プランニングアイテムがスパイクされました"
 
 #: ../superdesk-planning/client/actions/planning/notifications.ts:251
 msgid "The Planning item was unspiked"
-msgstr ""
+msgstr "プランニングアイテムのスパイクが解除されました"
 
 #: ../superdesk-planning/client/actions/main.ts:1411
 msgid "The Planning item you were editing was unlocked"
-msgstr ""
+msgstr "編集中のプランニングアイテムのロックが解除されました"
 
 #: ../superdesk-planning/client/actions/main.ts:1406
 msgid "The Planning item you were editing was unlocked by \"{{ userName }}\""
-msgstr ""
+msgstr "編集中のプランニングアイテムのロックが「{{ userName }}」によって解除されました"
 
 #: ../superdesk-planning/client/actions/main.ts:1400
 msgid "The Planning item you were editing was updated via ingest"
-msgstr ""
+msgstr "編集中のプランニングアイテムが取り込みにより更新されました"
 
 #: scripts/apps/products/views/products-config-modal.html:31
 msgid ""
 "The Product ID can be copied and used as Superdesk Newshub product query."
-msgstr ""
+msgstr "プロダクトIDはコピーしてSuperdesk Newshubのプロダクトクエリとして使用できます。"
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:278
 msgid "The Saved Report you are using was deleted!"
-msgstr ""
+msgstr "使用中の保存済みレポートが削除されました。"
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:270
 msgid ""
 "The Saved Report you are using was updated! Please re-select the Saved Report"
-msgstr ""
+msgstr "使用中の保存済みレポートが更新されました。保存済みレポートを再選択してください"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:52
 msgid ""
@@ -17195,185 +17195,185 @@ msgstr ""
 
 #: scripts/core/auth/reset-password.html:74
 msgid "The activation token is not valid."
-msgstr ""
+msgstr "アクティベーショントークンが無効です。"
 
 #: scripts/core/editor3/components/annotations/AnnotationInput.tsx:220
 #: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:85
 msgid "The annotation will be deleted. Are you sure?"
-msgstr ""
+msgstr "注釈が削除されます。よろしいですか？"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:107
 msgid "The assignment has been accepted"
-msgstr ""
+msgstr "アサインメントが承認されました"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:105
 msgid "The assignment has been accepted by"
-msgstr ""
+msgstr "アサインメントの承認者"
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:541
 msgid "The assignment has been reverted."
-msgstr ""
+msgstr "アサインメントが元に戻されました。"
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:463
 msgid "The assignment was reassigned."
-msgstr ""
+msgstr "アサインメントが再割り当てされました。"
 
 #: scripts/core/editor3/components/comments/CommentPopup.tsx:151
 msgid "The comment will be deleted. Are you sure?"
-msgstr ""
+msgstr "コメントが削除されます。よろしいですか？"
 
 #: ../superdesk-planning/client/components/UI/Form/InputArray/index.tsx:94
 msgid "The coverage has been removed"
-msgstr ""
+msgstr "取材が削除されました"
 
 #: ../superdesk-planning/client/constants/tooltips.ts:29
 msgid "The event has been killed"
-msgstr ""
+msgstr "イベントがキルされました"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:64
 msgid "The event(s) have been spiked"
-msgstr ""
+msgstr "イベントがスパイクされました"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:81
 msgid "The event(s) have been unspiked"
-msgstr ""
+msgstr "イベントのスパイクが解除されました"
 
 #: scripts/apps/archive/controllers/file-upload-error-modal.tsx:31
 msgid "The file was not uploaded"
 msgid_plural "Some files were not uploaded"
-msgstr[0] ""
+msgstr[0] "一部のファイルがアップロードされませんでした"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:112
 msgid "The following Events are in use and will not be spiked:"
-msgstr ""
+msgstr "次のイベントは使用中のためスパイクされません："
 
 #: scripts/extensions/predefinedTextField/dist/src/config.js:66
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:66
 #: scripts/extensions/predefinedTextField/src/config.tsx:106
 msgid "The following placeholders are available to be used in definitions:"
-msgstr ""
+msgstr "次のプレースホルダーが定義で使用できます："
 
 #: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:246
 #: scripts/apps/relations/directives/RelatedItemsDirective.ts:141
 msgid "The following status is not allowed in this field: {{status}}"
-msgstr ""
+msgstr "このフィールドでは次のステータスは許可されていません：{{status}}"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:121
 msgid "The helper text must not exceed 120 characters."
-msgstr ""
+msgstr "ヘルパーテキストは120文字を超えてはなりません。"
 
 #: scripts/core/helpers/crud-manager-http.tsx:52
 msgid "The item has been created."
-msgstr ""
+msgstr "アイテムが作成されました。"
 
 #: scripts/core/helpers/crud-manager-http.tsx:97
 msgid "The item has been deleted."
-msgstr ""
+msgstr "アイテムが削除されました。"
 
 #: scripts/core/helpers/crud-manager-http.tsx:86
 msgid "The item has been updated."
-msgstr ""
+msgstr "アイテムが更新されました。"
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:30
 msgid "The item is read-only."
-msgstr ""
+msgstr "アイテムは読み取り専用です。"
 
 #: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:207
 #: ../superdesk-planning/client/controllers/FulfilAssignmentController.tsx:173
 msgid "The item was unlocked by \"{{ username }}\""
-msgstr ""
+msgstr "アイテムのロックが「{{ username }}」によって解除されました"
 
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:396
 msgid "The item with unsaved changes must be closed before you can filter."
-msgstr ""
+msgstr "フィルターを適用するには、未保存の変更があるアイテムを閉じてください。"
 
 #: ../superdesk-planning/client/api/locations.ts:24
 msgid "The location has been created"
-msgstr ""
+msgstr "ロケーションが作成されました"
 
 #: ../superdesk-planning/client/api/locations.ts:62
 msgid "The location has been updated"
-msgstr ""
+msgstr "ロケーションが更新されました"
 
 #: scripts/apps/users/views/change-avatar.html:33
 msgid "The minimum image resolution is 200x200 pixels."
-msgstr ""
+msgstr "最小画像解像度は200x200ピクセルです。"
 
 #: scripts/apps/desks/views/desk-config-modal.html:61
 msgid ""
 "The name of a Slack channel associated with this desk, the # is not required"
-msgstr ""
+msgstr "このデスクに関連付けるSlackチャンネル名。#は不要です"
 
 #: scripts/api/article-send.tsx:113
 msgid ""
 "The package \"{{name}}\" contains the following published items that can not "
 "be sent:"
-msgstr ""
+msgstr "パッケージ「{{name}}」には送信できない公開済みアイテムが含まれています："
 
 #: scripts/apps/authoring-react/authoring-swtich.tsx:19
 msgid "The page needs to be reloaded in order to do that."
-msgstr ""
+msgstr "この操作を行うにはページを再読み込みする必要があります。"
 
 #: scripts/apps/users/directives/ChangePasswordDirective.ts:21
 #: scripts/core/auth/login-modal-directive.ts:75
 msgid "The password has been changed."
-msgstr ""
+msgstr "パスワードが変更されました。"
 
 #: scripts/apps/users/directives/ResetPasswordDirective.ts:18
 msgid "The password has been reset."
-msgstr ""
+msgstr "パスワードがリセットされました。"
 
 #: scripts/apps/publish/views/email-config.html:35
 msgid "The rendition to attach to the email"
-msgstr ""
+msgstr "メールに添付するレンディション"
 
 #: scripts/core/editor3/components/comments/CommentPopup.tsx:155
 msgid "The reply will be deleted. Are you sure?"
-msgstr ""
+msgstr "返信が削除されます。よろしいですか？"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:23
 #: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:23
 #: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:64
 msgid "The show {{name}} has been successfully created"
-msgstr ""
+msgstr "ショー{{name}}が正常に作成されました"
 
 #: scripts/apps/archive/controllers/file-upload-error-modal.tsx:61
 msgid "The size of {{filename}} is {{width}}x{{height}}"
-msgstr ""
+msgstr "{{filename}}のサイズは{{width}}x{{height}}です"
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:401
 msgid ""
 "The subscriber is currently inactive, but the schedule from {{start}} to "
 "{{end}} is valid. The subscriber will be activated on save."
-msgstr ""
+msgstr "配信先は現在無効ですが、{{start}}から{{end}}までのスケジュールは有効です。保存時に配信先が有効になります。"
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:383
 msgid ""
 "The subscriber is set to start on {{date}}, but the Active switch will "
 "override this and activate the subscriber on save."
-msgstr ""
+msgstr "配信先は{{date}}に開始するよう設定されていますが、有効スイッチがこれを上書きし、保存時に配信先を有効にします。"
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:391
 msgid ""
 "The subscriber schedule ended on {{date}}, but the Active switch will keep "
 "the subscriber active on save."
-msgstr ""
+msgstr "配信先のスケジュールは{{date}}に終了しましたが、有効スイッチにより保存時に配信先は有効のまま維持されます。"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:39
 msgid ""
 "The use of Highcharts is provided under a license with the following details:"
-msgstr ""
+msgstr "Highchartsの使用は、次の詳細のライセンスに基づいて提供されています："
 
 #: scripts/apps/dashboard/user-activity/user-activity.ts:14
 msgid ""
 "The user activity widget provides information about user activity. Using the "
 "widget, editors can search and select a user. Upon selection a list of "
 "content items is shown categorized as follows:"
-msgstr ""
+msgstr "ユーザーアクティビティウィジェットは、ユーザーのアクティビティ情報を提供します。このウィジェットを使用して、エディターはユーザーを検索・選択できます。選択すると、次のカテゴリーに分類されたコンテンツアイテムのリストが表示されます："
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:226
 msgid "The values should be unique for {{uniqueField}}"
-msgstr ""
+msgstr "{{uniqueField}}の値は一意でなければなりません"
 
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:55
 msgid ""
@@ -17382,161 +17382,161 @@ msgid ""
 msgid_plural ""
 "The vocabulary {{name}} can't be deleted because it is currently used in the "
 "following Content Profiles:"
-msgstr[0] ""
+msgstr[0] "ボキャブラリー{{name}}は次のコンテンツプロファイルで使用中のため削除できません："
 
 #: ../superdesk-planning/client/actions/main.ts:468
 msgid "The {{ itemType }} has been posted"
-msgstr ""
+msgstr "{{ itemType }}が投稿されました"
 
 #: ../superdesk-planning/client/actions/main.ts:318
 msgid "The {{ itemType }} has been saved"
-msgstr ""
+msgstr "{{ itemType }}が保存されました"
 
 #: ../superdesk-planning/client/actions/main.ts:396
 msgid "The {{ itemType }} has been unposted"
-msgstr ""
+msgstr "{{ itemType }}の投稿が取り消されました"
 
 #: scripts/apps/users/views/user-preferences.html:257
 msgid "Themes"
-msgstr ""
+msgstr "テーマ"
 
 #: scripts/apps/contacts/components/ItemList.tsx:180
 #: scripts/apps/master-desk/components/ListItemsComponent.tsx:45
 #: scripts/apps/search/components/ItemList.tsx:523
 #: scripts/core/itemList/LazyLoader.tsx:216
 msgid "There are currently no items"
-msgstr ""
+msgstr "現在アイテムはありません"
 
 #: scripts/validate-instance-configuration.tsx:108
 msgid "There are issues with instance configuration"
-msgstr ""
+msgstr "インスタンス設定に問題があります"
 
 #: scripts/api/highlights.ts:37
 msgid "There are items locked or not published. Do you want to continue?"
-msgstr ""
+msgstr "ロック中または未公開のアイテムがあります。続行しますか？"
 
 #: ../superdesk-planning/client/components/ItemActionsMenu/ActionsMenuPopup.tsx:91
 msgid "There are no actions available."
-msgstr ""
+msgstr "利用可能なアクションがありません。"
 
 #: ../superdesk-planning/client/constants/assignments.ts:207
 msgid "There are no assignments completed"
-msgstr ""
+msgstr "完了したアサインメントはありません"
 
 #: ../superdesk-planning/client/constants/assignments.ts:213
 msgid "There are no assignments for today"
-msgstr ""
+msgstr "本日のアサインメントはありません"
 
 #: ../superdesk-planning/client/constants/assignments.ts:204
 msgid "There are no assignments in progress"
-msgstr ""
+msgstr "進行中のアサインメントはありません"
 
 #: ../superdesk-planning/client/constants/assignments.ts:201
 msgid "There are no assignments to do"
-msgstr ""
+msgstr "実行すべきアサインメントはありません"
 
 #: scripts/apps/authoring-react/fields/media/difference.tsx:29
 msgid "There are no changes"
-msgstr ""
+msgstr "変更はありません"
 
 #: ../superdesk-planning/client/constants/assignments.ts:210
 msgid "There are no current assignments"
-msgstr ""
+msgstr "現在のアサインメントはありません"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/FiltersList.tsx:52
 msgid "There are no events and planing view filters."
-msgstr ""
+msgstr "イベントとプランニングの表示フィルターはありません。"
 
 #: ../superdesk-planning/client/constants/assignments.ts:216
 msgid "There are no future assignments"
-msgstr ""
+msgstr "今後のアサインメントはありません"
 
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:586
 msgid "There are no items matching the search."
-msgstr ""
+msgstr "検索に一致するアイテムはありません。"
 
 #: scripts/core/ui/components/virtual-lists/virtual-list.tsx:206
 msgid "There are no items yet"
-msgstr ""
+msgstr "アイテムはまだありません"
 
 #: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:566
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:594
 msgid "There are no items yet."
-msgstr ""
+msgstr "アイテムはまだありません。"
 
 #: scripts/apps/search-providers/directive.ts:24
 msgid "There are no providers available."
-msgstr ""
+msgstr "利用可能なプロバイダーがありません。"
 
 #: scripts/core/editor3/components/links/AttachmentList.tsx:83
 msgid ""
 "There are no public attachments yet. Upload some first using Attachments "
 "widget."
-msgstr ""
+msgstr "公開添付ファイルはまだありません。先に添付ファイルウィジェットを使用してアップロードしてください。"
 
 #: scripts/apps/authoring-react/article-widgets/suggestions.tsx:208
 msgid "There are no resolved suggestions"
-msgstr ""
+msgstr "解決済みの提案はありません"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:173
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:173
 #: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:333
 msgid "There are no rundowns yet"
-msgstr ""
+msgstr "ランダウンはまだありません"
 
 #: scripts/apps/master-desk/components/UsersComponent.tsx:150
 msgid "There are no users assigned to this desk"
-msgstr ""
+msgstr "このデスクに割り当てられたユーザーはいません"
 
 #: scripts/apps/authoring/metadata/views/prefered-cv-items-config.html:15
 msgid "There are no vocabularies configured."
-msgstr ""
+msgstr "ボキャブラリーが設定されていません。"
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:58
 msgid "There are some unsaved changes, do you want to save and publish it now?"
-msgstr ""
+msgstr "未保存の変更があります。保存して今すぐ公開しますか？"
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:70
 msgid "There are some unsaved changes, do you want to save and send it now?"
-msgstr ""
+msgstr "未保存の変更があります。保存して今すぐ送信しますか？"
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:45
 msgid "There are some unsaved changes, do you want to save it now?"
-msgstr ""
+msgstr "未保存の変更があります。今すぐ保存しますか？"
 
 #: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:71
 msgid "There are some unsaved changes, go to the article to save changes?"
-msgstr ""
+msgstr "未保存の変更があります。記事に移動して変更を保存しますか？"
 
 #: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:35
 msgid "There are some unsaved changes, save it now?"
-msgstr ""
+msgstr "未保存の変更があります。今すぐ保存しますか？"
 
 #: scripts/core/auth/auth.ts:241
 msgid "There are some unsaved changes. Please save them before signing out."
-msgstr ""
+msgstr "未保存の変更があります。サインアウト前に保存してください。"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:163
 msgid "There are unsaved changes, but the form is invalid"
-msgstr ""
+msgstr "未保存の変更がありますが、フォームが無効です"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:113
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:170
 msgid "There are unsaved changes."
-msgstr ""
+msgstr "未保存の変更があります。"
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:28
 msgid ""
 "There are unsaved changes. If you navigate away, your changes will be lost."
-msgstr ""
+msgstr "未保存の変更があります。移動すると変更が失われます。"
 
 #: ../superdesk-planning/client/actions/assignments/notifications.ts:350
 msgid "There is a {{ type }} assignment '{{ slugline }}' {{ state }}"
-msgstr ""
+msgstr "{{ type }}のアサインメント「{{ slugline }}」が{{ state }}です"
 
 #: scripts/apps/archive/related-item-widget/relatedItem.ts:194
 msgid "There is an error. Failed to associate update."
-msgstr ""
+msgstr "エラーが発生しました。更新の関連付けに失敗しました。"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:40
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/utils/handle-unsaved-rundown-changes.js:18
@@ -17545,204 +17545,204 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:90
 #: scripts/extensions/broadcasting/src/utils/handle-unsaved-rundown-changes.ts:23
 msgid "There is an item open in editing mode. Discard changes?"
-msgstr ""
+msgstr "編集モードで開いているアイテムがあります。変更を破棄しますか？"
 
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:269
 msgid "There is an update assignment for this story due at ''."
-msgstr ""
+msgstr "この記事の更新アサインメントの期限があります。"
 
 #: scripts/apps/publish/views/subscribers.html:296
 msgid "There is no token for subscriber."
-msgstr ""
+msgstr "配信先のトークンがありません。"
 
 #: scripts/apps/highlights/controllers/HighlightsConfig.ts:60
 msgid "There was a problem while saving highlights configuration"
-msgstr ""
+msgstr "ハイライト設定の保存中に問題が発生しました"
 
 #: scripts/apps/users/controllers/ChangeAvatarController.ts:51
 #: scripts/apps/users/controllers/ChangeAvatarController.ts:63
 msgid "There was a problem with your upload"
-msgstr ""
+msgstr "アップロードに問題がありました"
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:42
 msgid "There was a problem, Planning item not spiked!"
-msgstr ""
+msgstr "問題が発生しました。プランニングアイテムがスパイクされませんでした。"
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:63
 msgid "There was a problem, Planning item not unspiked!"
-msgstr ""
+msgstr "問題が発生しました。プランニングアイテムのスパイクが解除されませんでした。"
 
 #: scripts/apps/desks/directives/DeskeditBasic.ts:61
 msgid "There was a problem, desk not created/updated."
-msgstr ""
+msgstr "問題が発生しました。デスクが作成/更新されませんでした。"
 
 #: scripts/apps/desks/controllers/DeskConfigController.ts:106
 msgid "There was a problem, desk not saved. Refresh Desks."
-msgstr ""
+msgstr "問題が発生しました。デスクが保存されませんでした。デスクを更新してください。"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:50
 msgid "There was a problem, dictionary not created/updated."
-msgstr ""
+msgstr "問題が発生しました。辞書が作成/更新されませんでした。"
 
 #: scripts/apps/search/directives/ItemGlobalSearch.ts:59
 #: scripts/apps/search/directives/ItemGlobalSearch.ts:91
 msgid "There was a problem, item can not open."
-msgstr ""
+msgstr "問題が発生しました。アイテムを開けません。"
 
 #: scripts/apps/desks/directives/DeskeditPeople.ts:66
 msgid "There was a problem, members not saved. Refresh Desks."
-msgstr ""
+msgstr "問題が発生しました。メンバーが保存されませんでした。デスクを更新してください。"
 
 #: scripts/apps/desks/views/desk-config-modal.html:291
 msgid "There was a problem, stage not created/updated."
-msgstr ""
+msgstr "問題が発生しました。ステージが作成/更新されませんでした。"
 
 #: scripts/apps/desks/directives/DeskeditStages.ts:241
 msgid "There was a problem, stage was not deleted."
-msgstr ""
+msgstr "問題が発生しました。ステージが削除されませんでした。"
 
 #: scripts/apps/search/components/ErrorBox.tsx:7
 msgid "There was an error archiving this item"
-msgstr ""
+msgstr "このアイテムのアーカイブ中にエラーが発生しました"
 
 #: ../superdesk-planning/client/actions/multiSelect.ts:255
 msgid "There was an error when exporting."
-msgstr ""
+msgstr "エクスポート中にエラーが発生しました。"
 
 #: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:195
 msgid "There was an error when saving the contact."
-msgstr ""
+msgstr "連絡先の保存中にエラーが発生しました。"
 
 #: scripts/apps/users/directives/UserEditDirective.ts:268
 msgid "There was an error when saving the user account."
-msgstr ""
+msgstr "ユーザーアカウントの保存中にエラーが発生しました。"
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary.js:22
 #: scripts/extensions/ai-widget/dist/src/summary/summary.js:22
 #: scripts/extensions/ai-widget/src/summary/summary.tsx:45
 msgid "There was an error when trying to generate a summary."
-msgstr ""
+msgstr "サマリーの生成中にエラーが発生しました。"
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:32
 #: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:32
 #: scripts/extensions/ai-widget/src/translations/translations-body.tsx:70
 msgid "There was an error when trying to generate a translation."
-msgstr ""
+msgstr "翻訳の生成中にエラーが発生しました。"
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines.js:23
 #: scripts/extensions/ai-widget/dist/src/headlines/headlines.js:23
 #: scripts/extensions/ai-widget/src/headlines/headlines.tsx:49
 msgid "There was an error when trying to generate headlines."
-msgstr ""
+msgstr "見出しの生成中にエラーが発生しました。"
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:219
 msgid "There was an error, could not delete Events and Planning view filter."
-msgstr ""
+msgstr "エラーが発生しました。イベントとプランニングの表示フィルターを削除できませんでした。"
 
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:92
 msgid "There was an error. Content filter cannot be deleted."
-msgstr ""
+msgstr "エラーが発生しました。コンテンツフィルターを削除できません。"
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:262
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:477
 msgid "There was an error. Failed to generate update."
-msgstr ""
+msgstr "エラーが発生しました。更新の生成に失敗しました。"
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:281
 msgid "There was an error. Failed to remove link."
-msgstr ""
+msgstr "エラーが発生しました。リンクの削除に失敗しました。"
 
 #: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:463
 msgid "There was an error. Failed to save the area of interest."
-msgstr ""
+msgstr "エラーが発生しました。注目エリアの保存に失敗しました。"
 
 #: scripts/apps/content-filters/controllers/FilterConditionsController.ts:128
 msgid "There was an error. Filter condition cannot be deleted."
-msgstr ""
+msgstr "エラーが発生しました。フィルター条件を削除できません。"
 
 #: scripts/apps/users/directives/UserRolesDirective.ts:68
 msgid "There was an error. Role cannot be deleted."
-msgstr ""
+msgstr "エラーが発生しました。ロールを削除できません。"
 
 #: scripts/apps/ingest/directives/IngestRoutingContent.ts:55
 msgid "There was an error. Routing scheme cannot be deleted."
-msgstr ""
+msgstr "エラーが発生しました。ルーティングスキームを削除できません。"
 
 #: scripts/apps/ingest/directives/IngestRulesContent.ts:54
 msgid "There was an error. Rule set cannot be deleted."
-msgstr ""
+msgstr "エラーが発生しました。ルールセットを削除できません。"
 
 #: scripts/apps/templates/directives/TemplatesDirective.ts:371
 msgid "There was an error. Template cannot be deleted."
-msgstr ""
+msgstr "エラーが発生しました。テンプレートを削除できません。"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:162
 msgid "Third"
-msgstr ""
+msgstr "第3"
 
 #: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:259
 msgid "This Coverage"
-msgstr ""
+msgstr "この取材"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:261
 msgid ""
 "This Event is scheduled to occur after the end date of its recurring cycle!"
-msgstr ""
+msgstr "このイベントは繰り返しサイクルの終了日より後に発生するようスケジュールされています。"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:28
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:21
 msgid "This Month"
-msgstr ""
+msgstr "今月"
 
 #: scripts/core/editor3/components/embeds/EmbedInput.tsx:92
 msgid "This URL could not be embedded."
-msgstr ""
+msgstr "このURLを埋め込めませんでした。"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:23
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:15
 #: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:26
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:160
 msgid "This Week"
-msgstr ""
+msgstr "今週"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:32
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:27
 msgid "This Year"
-msgstr ""
+msgstr "今年"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:277
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:365
 #: ../superdesk-planning/client/constants/events.ts:174
 msgid "This and all future events"
-msgstr ""
+msgstr "このイベントとすべての将来のイベント"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:276
 msgid "This and all future planning"
-msgstr ""
+msgstr "このプランニングとすべての将来のプランニング"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:587
 msgid ""
 "This article contains unresolved comments.Click on Cancel to go back to "
 "editing toresolve those comments or OK to ignore and proceed with publishing"
-msgstr ""
+msgstr "この記事には未解決のコメントがあります。キャンセルをクリックして編集に戻りコメントを解決するか、OKをクリックして無視して公開を続行してください"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:25
 msgid "This event is a recurring event!"
-msgstr ""
+msgstr "このイベントは繰り返しイベントです。"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:84
 msgid "This event is a recurring event. Post all recurring events"
-msgstr ""
+msgstr "このイベントは繰り返しイベントです。すべての繰り返しイベントを投稿"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:271
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:362
 #: ../superdesk-planning/client/constants/events.ts:173
 msgid "This event only"
-msgstr ""
+msgstr "このイベントのみ"
 
 #: scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts:58
 msgid "This field is read-only"
-msgstr ""
+msgstr "このフィールドは読み取り専用です"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:181
 #: ../superdesk-planning/client/validators/assignments.tsx:8
@@ -17761,11 +17761,11 @@ msgstr ""
 #: ../superdesk-planning/client/validators/profile.ts:85
 #: scripts/core/ui/ui.ts:1108
 msgid "This field is required"
-msgstr ""
+msgstr "このフィールドは必須です"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:190
 msgid "This field is required by the system"
-msgstr ""
+msgstr "このフィールドはシステムで必須です"
 
 #: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:72
 #: scripts/apps/contacts/components/Form/MultiTextInput.tsx:34
@@ -17775,115 +17775,115 @@ msgstr ""
 #: scripts/apps/users/views/edit-form.html:85
 #: scripts/apps/users/views/edit-form.html:97
 msgid "This field is required."
-msgstr ""
+msgstr "このフィールドは必須です。"
 
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:92
 msgid ""
 "This field will initialize with the value of specified field when toggled "
 "from \"off\" to \"on\". Only plain-text gets copied. Formatting options or "
 "links are not preserved."
-msgstr ""
+msgstr "「オフ」から「オン」に切り替えると、指定されたフィールドの値で初期化されます。プレーンテキストのみコピーされます。書式オプションやリンクは保持されません。"
 
 #: scripts/apps/templates/directives/TemplatesDirective.ts:358
 msgid "This is a default template of the following desk(s): {{deskNames}}."
-msgstr ""
+msgstr "これは次のデスクのデフォルトテンプレートです：{{deskNames}}。"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:351
 msgid "This is a recurring event."
-msgstr ""
+msgstr "これは繰り返しイベントです。"
 
 #: scripts/apps/authoring/views/theme-select.html:38
 #: scripts/apps/authoring/views/theme-select.html:89
 msgid "This is the headline"
-msgstr ""
+msgstr "これは見出しです"
 
 #: scripts/apps/authoring-react/fields/media/editor.tsx:175
 msgid "This item is already added"
-msgstr ""
+msgstr "このアイテムは既に追加されています"
 
 #: scripts/apps/relations/directives/RelatedItemsDirective.ts:154
 msgid "This item is already added as related."
-msgstr ""
+msgstr "このアイテムは既に関連として追加されています。"
 
 #: scripts/apps/authoring/authoring/controllers/AssociationController.ts:211
 msgid "This item is already added."
-msgstr ""
+msgstr "このアイテムは既に追加されています。"
 
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:26
 #: ../superdesk-planning/client/planning-extension/src/extension.ts:40
 msgid "This item is linked to in-progress planning coverage."
-msgstr ""
+msgstr "このアイテムは進行中のプランニング取材にリンクされています。"
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:118
 msgid "This item was locked by {{username}}."
-msgstr ""
+msgstr "このアイテムは{{username}}によってロックされました。"
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:101
 msgid "This item was unlocked by {{username}}."
-msgstr ""
+msgstr "このアイテムは{{username}}によってロック解除されました。"
 
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:249
 msgid "This item will be permanently deleted."
-msgstr ""
+msgstr "このアイテムは完全に削除されます。"
 
 #: scripts/core/editor3/components/BaseUnstyledComponent.tsx:130
 msgid "This link is not embeddable."
-msgstr ""
+msgstr "このリンクは埋め込みできません。"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModalSubnav.tsx:66
 msgid "This list contains unposted changes!"
-msgstr ""
+msgstr "このリストには未投稿の変更があります。"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:270
 msgid "This planning only"
-msgstr ""
+msgstr "このプランニングのみ"
 
 #: scripts/apps/archive/views/preview.html:100
 msgid "This story has been rewritten by:"
-msgstr ""
+msgstr "この記事の書き直し者："
 
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:112
 msgid ""
 "This vocabulary is not currently used in any Content Profile and can be "
 "safely removed."
-msgstr ""
+msgstr "このボキャブラリーは現在どのコンテンツプロファイルでも使用されていないため、安全に削除できます。"
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:42
 msgid "This week"
-msgstr ""
+msgstr "今週"
 
 #: scripts/core/lang/missing-translations-strings.ts:46
 msgid ""
 "This widget allows you to create literally any content view you may need in "
 "Superdesk, be it production or ingest. All you need is to select a desk, its "
 "stages or a saved search. Name your view once you are done. Enjoy!"
-msgstr ""
+msgstr "このウィジェットを使用すると、Superdeskで必要なあらゆるコンテンツビューを作成できます。プロダクションでも取り込みでも、デスク、そのステージ、または保存済み検索を選択するだけです。完了したらビューに名前を付けてください。"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:83
 msgid "This will also post the related event's entire recurring series"
-msgstr ""
+msgstr "関連イベントのすべての繰り返しシリーズも投稿されます"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:118
 msgid "This will also postpone the following planning items"
-msgstr ""
+msgstr "次のプランニングアイテムも延期されます"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:105
 msgid "This will also remove linked assignments if any"
-msgstr ""
+msgstr "リンクされたアサインメントがある場合は削除されます"
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:762
 msgid ""
 "This will also remove other linked assignments (if any, for story updates). "
 "Are you sure?"
-msgstr ""
+msgstr "他のリンクされたアサインメント（記事更新用がある場合）も削除されます。よろしいですか？"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:51
 msgid "This will also {{action}} the following events"
-msgstr ""
+msgstr "次のイベントも{{action}}されます"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:39
 msgid "This will also {{action}} the following planning items"
-msgstr ""
+msgstr "次のプランニングアイテムも{{action}}されます"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:119
 msgid ""
@@ -17893,38 +17893,38 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/convertToRecurringEventForm.tsx:152
 msgid "This will create new events in the remote ({{timeZone}}) timezone"
-msgstr ""
+msgstr "リモート（{{timeZone}}）タイムゾーンで新しいイベントが作成されます"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:269
 msgid "This will create the new event in the remote ({{timeZone}}) timezone"
-msgstr ""
+msgstr "リモート（{{timeZone}}）タイムゾーンで新しいイベントが作成されます"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:222
 msgid "This will mark as rescheduled the following planning items"
-msgstr ""
+msgstr "次のプランニングアイテムが再スケジュール済みとしてマークされます"
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:553
 msgid ""
 "This will unlink the text item associated with the assignment. Are you sure ?"
-msgstr ""
+msgstr "アサインメントに関連付けられたテキストアイテムのリンクが解除されます。よろしいですか？"
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:111
 msgid "Thu"
-msgstr ""
+msgstr "木"
 
 #: scripts/apps/authoring/authoring/components/video-thumbnail-editor.tsx:117
 msgid "Thumbnail"
-msgstr ""
+msgstr "サムネイル"
 
 #: scripts/apps/archive/views/related-items-preview.html:12
 #: scripts/apps/relations/views/related-items.html:30
 msgid "Thumbnail for related item"
-msgstr ""
+msgstr "関連アイテムのサムネイル"
 
 #: ../superdesk-planning/client/utils/events.tsx:1457
 #: scripts/core/datetime/datetime.ts:293
 msgid "Thursday"
-msgstr ""
+msgstr "木曜日"
 
 #: ../superdesk-planning/client/components/UI/DateTime.tsx:49
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:355
@@ -17932,24 +17932,24 @@ msgstr ""
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:79
 #: scripts/apps/search/views/edit-time-interval.html:15
 msgid "Time"
-msgstr ""
+msgstr "時間"
 
 #: scripts/apps/authoring-react/fields/time/index.tsx:20
 msgid "Time (authoring-react)"
-msgstr ""
+msgstr "時間（authoring-react）"
 
 #: scripts/core/editor3/components/media/MediaBlock.tsx:15
 msgid "Time Restricted"
-msgstr ""
+msgstr "時間制限あり"
 
 #: ../superdesk-planning/client/components/Events/EventDateTime.tsx:59
 msgid "Time TBC"
-msgstr ""
+msgstr "時間未定"
 
 #: scripts/apps/archive/views/metadata-view.html:141
 #: scripts/core/ui/views/sd-timezone.html:1
 msgid "Time Zone"
-msgstr ""
+msgstr "タイムゾーン"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:52
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:64
@@ -17964,19 +17964,19 @@ msgstr ""
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:59
 #: scripts/extensions/datetimeField/src/editor.tsx:101
 msgid "Time cannot be empty"
-msgstr ""
+msgstr "時間は空にできません"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:50
 #: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:50
 #: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:92
 msgid "Time from"
-msgstr ""
+msgstr "時間（開始）"
 
 #: scripts/extensions/datetimeField/dist/src/config.js:33
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:33
 #: scripts/extensions/datetimeField/src/config.tsx:57
 msgid "Time increment steps"
-msgstr ""
+msgstr "時間増分ステップ"
 
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/template-editor.js:20
 #: scripts/extensions/datetimeField/dist/src/template-editor.js:20
@@ -17990,39 +17990,39 @@ msgstr ""
 
 #: scripts/apps/profiling/views/profiling.html:34
 msgid "Time per call"
-msgstr ""
+msgstr "コールあたりの時間"
 
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:344
 msgid "Time picker"
-msgstr ""
+msgstr "時間選択"
 
 #: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:315
 msgid "Time spent producing content"
-msgstr ""
+msgstr "コンテンツ製作に費やした時間"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:62
 #: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:62
 #: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:125
 msgid "Time to"
-msgstr ""
+msgstr "時間（終了）"
 
 #: scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx:113
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx:180
 msgid "Time zone"
-msgstr ""
+msgstr "タイムゾーン"
 
 #: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:559
 msgid "Timeline"
-msgstr ""
+msgstr "タイムライン"
 
 #: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-tooltip.html:4
 msgid "Times:"
-msgstr ""
+msgstr "時間："
 
 #: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:249
 #: scripts/core/lang/missing-translations-strings.ts:34
 msgid "Timezone"
-msgstr ""
+msgstr "タイムゾーン"
 
 #: ../superdesk-analytics/client/charts/views/chart-form-options.html:3
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:11
@@ -18046,14 +18046,14 @@ msgstr ""
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:15
 #: scripts/extensions/predefinedTextField/src/config.tsx:23
 msgid "Title"
-msgstr ""
+msgstr "タイトル"
 
 #: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:125
 #: scripts/apps/authoring/views/item-association.html:70
 #: scripts/apps/authoring/views/item-carousel.html:93
 #: scripts/core/editor3/components/media/MediaBlock.tsx:163
 msgid "Title:"
-msgstr ""
+msgstr "タイトル："
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:50
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:262
@@ -18061,14 +18061,14 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/EndDateTime.tsx:33
 #: ../superdesk-planning/client/components/fields/preview/index.ts:75
 msgid "To"
-msgstr ""
+msgstr "宛先"
 
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:357
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:379
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:65
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:87
 msgid "To Be Confirmed"
-msgstr ""
+msgstr "未確定"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/to-desk.tsx:13
 #: scripts/apps/authoring/views/authoring-topbar.html:55
@@ -18077,48 +18077,48 @@ msgstr ""
 #: scripts/apps/search/constants.ts:13
 #: scripts/apps/search/views/search-parameters.html:115
 msgid "To Desk"
-msgstr ""
+msgstr "宛先デスク"
 
 #: ../superdesk-planning/client/constants/assignments.ts:200
 #: scripts/apps/dashboard/workspace-tasks/tasks.ts:9
 #: scripts/apps/master-desk/components/AssignmentsComponent.tsx:40
 msgid "To Do"
-msgstr ""
+msgstr "TODO"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:195
 msgid "To Lowercase"
-msgstr ""
+msgstr "小文字に変換"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:196
 msgid "To Uppercase"
-msgstr ""
+msgstr "大文字に変換"
 
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:70
 msgid ""
 "To delete this vocabulary, you must first remove it from all Content "
 "Profiles listed above."
-msgstr ""
+msgstr "このボキャブラリーを削除するには、上記のすべてのコンテンツプロファイルから先に削除してください。"
 
 #: scripts/core/editor3/components/embeds/EmbedInput.tsx:152
 msgid "To get a responsive embed code, paste a URL."
-msgstr ""
+msgstr "レスポンシブな埋め込みコードを取得するには、URLを貼り付けてください。"
 
 #: scripts/apps/authoring-react/fields/media/difference.tsx:72
 msgid ""
 "To see detailed differences, compare primary and secondary items visually"
-msgstr ""
+msgstr "詳細な差分を確認するには、プライマリとセカンダリのアイテムを視覚的に比較してください"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:18
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:129
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:31
 msgid "To:"
-msgstr ""
+msgstr "宛先："
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-footer.js:40
 #: scripts/extensions/ai-widget/dist/src/translations/translations-footer.js:40
 #: scripts/extensions/ai-widget/src/translations/translations-footer.tsx:65
 msgid "To: {{ language }}"
-msgstr ""
+msgstr "宛先：{{ language }}"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:18
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:9
@@ -18137,101 +18137,101 @@ msgstr ""
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/correspondent-availability/filters.js:59
 #: scripts/extensions/availability-manager/src/correspondent-availability/filters.tsx:71
 msgid "Today"
-msgstr ""
+msgstr "今日"
 
 #: ../superdesk-planning/client/constants/assignments.ts:212
 msgid "Todays Assignments"
-msgstr ""
+msgstr "本日のアサインメント"
 
 #: scripts/core/editor3/highlightsConfig.ts:78
 msgid "Toggle"
-msgstr ""
+msgstr "切り替え"
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:88
 msgid "Toggle Header"
-msgstr ""
+msgstr "ヘッダーを切り替え"
 
 #: scripts/apps/authoring/widgets/widgets.ts:519
 msgid "Toggle Nth widget, where 'N' is order of widget it appears"
-msgstr ""
+msgstr "N番目のウィジェットを切り替え（Nはウィジェットの表示順）"
 
 #: scripts/apps/authoring/views/article-edit.html:456
 #: scripts/apps/authoring/views/article-edit.html:457
 msgid "Toggle Sign-Off lock"
-msgstr ""
+msgstr "サインオフロックを切り替え"
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:89
 msgid "Toggle Suggestions Mode"
-msgstr ""
+msgstr "提案モードを切り替え"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:142
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:54
 msgid "Toggle advanced Filters"
-msgstr ""
+msgstr "詳細フィルターを切り替え"
 
 #: scripts/core/editor3/highlightsConfig.ts:43
 msgid "Toggle bold"
-msgstr ""
+msgstr "太字を切り替え"
 
 #: scripts/apps/authoring-react/authoring-section/get-field-container.tsx:70
 msgid "Toggle field"
-msgstr ""
+msgstr "フィールドを切り替え"
 
 #: scripts/apps/search/views/search.html:3
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:249
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:249
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:376
 msgid "Toggle filters"
-msgstr ""
+msgstr "フィルターを切り替え"
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:90
 msgid "Toggle formatting marks"
-msgstr ""
+msgstr "書式マークを切り替え"
 
 #: scripts/apps/archive/views/preview.html:79
 msgid "Toggle header info"
-msgstr ""
+msgstr "ヘッダー情報を切り替え"
 
 #: scripts/core/editor3/highlightsConfig.ts:49
 msgid "Toggle italic"
-msgstr ""
+msgstr "斜体を切り替え"
 
 #: scripts/core/menu/views/menu.html:15
 msgid "Toggle main menu"
-msgstr ""
+msgstr "メインメニューを切り替え"
 
 #: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:343
 msgid "Toggle search"
-msgstr ""
+msgstr "検索を切り替え"
 
 #: scripts/apps/search/index.ts:139
 msgid "Toggle search view"
-msgstr ""
+msgstr "検索表示を切り替え"
 
 #: scripts/core/editor3/highlightsConfig.ts:73
 msgid "Toggle strikethrough"
-msgstr ""
+msgstr "取り消し線を切り替え"
 
 #: scripts/core/editor3/highlightsConfig.ts:61
 msgid "Toggle subscript"
-msgstr ""
+msgstr "下付きを切り替え"
 
 #: scripts/core/editor3/highlightsConfig.ts:67
 msgid "Toggle superscript"
-msgstr ""
+msgstr "上付きを切り替え"
 
 #: scripts/apps/authoring-react/toolbar-components/integration-wrapper/toggle-theme-button.tsx:13
 #: scripts/apps/authoring/views/authoring.html:33
 msgid "Toggle theme"
-msgstr ""
+msgstr "テーマを切り替え"
 
 #: scripts/core/editor3/highlightsConfig.ts:55
 msgid "Toggle underline"
-msgstr ""
+msgstr "下線を切り替え"
 
 #: scripts/apps/publish/views/subscribers.html:311
 msgid "Token expiry"
-msgstr ""
+msgstr "トークン有効期限"
 
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:103
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DateInputPopup.tsx:213
@@ -18240,40 +18240,40 @@ msgstr ""
 #: scripts/apps/vocabularies/services/VocabularyService.ts:131
 #: scripts/core/ui/components/Form/DateInput/DateInputPopup.tsx:195
 msgid "Tomorrow"
-msgstr ""
+msgstr "明日"
 
 #: ../superdesk-planning/client/validators/profile.ts:61
 msgid "Too long"
-msgstr ""
+msgstr "長すぎます"
 
 #: scripts/apps/authoring/attachments/AttachmentsWidget.tsx:24
 msgid "Too many files selected. Only 1 file is allowed"
 msgid_plural "Too many files selected. Only {{count}} files are allowed"
-msgstr[0] ""
+msgstr[0] "ファイルの選択数が多すぎます。最大{{count}}ファイルまでです"
 
 #: ../superdesk-planning/client/validators/profile.ts:58
 #: ../superdesk-planning/client/validators/profile.ts:59
 msgid "Too many {{ name }}"
-msgstr ""
+msgstr "{{ name }}が多すぎます"
 
 #: ../superdesk-planning/client/validators/profile.ts:103
 msgid "Too short"
-msgstr ""
+msgstr "短すぎます"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:432
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:440
 msgid "Total"
-msgstr ""
+msgstr "合計"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:257
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:257
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:394
 msgid "Total Assets: {{ total }}"
-msgstr ""
+msgstr "アセット合計：{{ total }}"
 
 #: scripts/apps/profiling/views/profiling.html:33
 msgid "Total time"
-msgstr ""
+msgstr "合計時間"
 
 #: scripts/apps/search/views/item-sortbar.html:2
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:732
@@ -18281,11 +18281,11 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:259
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:402
 msgid "Total:"
-msgstr ""
+msgstr "合計："
 
 #: scripts/core/lang/missing-translations-strings.ts:21
 msgid "Transformation Rules Management"
-msgstr ""
+msgstr "変換ルール管理"
 
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:244
 #: scripts/apps/authoring-react/toolbar/translate-modal.tsx:100
@@ -18298,27 +18298,27 @@ msgstr ""
 #: scripts/extensions/ai-widget/src/translations/translations-footer.tsx:81
 #: scripts/extensions/ai-widget/src/translations/translations-widget.tsx:83
 msgid "Translate"
-msgstr ""
+msgstr "翻訳"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:352
 msgid "Translate item to"
-msgstr ""
+msgstr "アイテムの翻訳先"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:196
 #: scripts/apps/authoring/versioning/history/views/history.html:41
 msgid "Translated by"
-msgstr ""
+msgstr "翻訳者"
 
 #: scripts/apps/authoring-react/article-widgets/translations/translations.tsx:63
 #: scripts/apps/authoring/translations/translationsWidget.tsx:53
 #: scripts/apps/authoring/views/authoring-header.html:81
 msgid "Translated from"
-msgstr ""
+msgstr "翻訳元"
 
 #: scripts/apps/search/components/fields/translations.tsx:58
 #: scripts/apps/search/components/fields/translations.tsx:72
 msgid "Translation"
-msgstr ""
+msgstr "翻訳"
 
 #: scripts/apps/authoring-react/article-widgets/translations/translations.tsx:14
 #: scripts/apps/authoring/translations/index.ts:12
@@ -18329,20 +18329,20 @@ msgstr ""
 #: scripts/extensions/ai-widget/dist/src/main-panel.js:22
 #: scripts/extensions/ai-widget/src/main-panel.tsx:45
 msgid "Translations"
-msgstr ""
+msgstr "翻訳"
 
 #: scripts/apps/publish/views/publish-queue.html:114
 msgid "Transmitted at"
-msgstr ""
+msgstr "送信日時"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:197
 msgid "Trash"
-msgstr ""
+msgstr "ゴミ箱"
 
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:33
 #: ../superdesk-planning/client/components/fields/preview/base/utils.ts:16
 msgid "True"
-msgstr ""
+msgstr "真"
 
 #: scripts/core/auth/login-modal.html:48
 #: scripts/core/auth/reset-password.html:38
@@ -18353,29 +18353,29 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/filters.ts:136
 msgid "Tu"
-msgstr ""
+msgstr "火"
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:109
 msgid "Tue"
-msgstr ""
+msgstr "火"
 
 #: ../superdesk-planning/client/utils/events.tsx:1455
 #: scripts/core/datetime/datetime.ts:291
 msgid "Tuesday"
-msgstr ""
+msgstr "火曜日"
 
 #: scripts/core/menu/views/menu.html:39
 msgid "Turn off feature preview"
-msgstr ""
+msgstr "機能プレビューをオフにする"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:198
 #: scripts/apps/users/views/edit-form.html:329
 msgid "Twitter"
-msgstr ""
+msgstr "Twitter"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:199
 msgid "Twitter Circle"
-msgstr ""
+msgstr "Twitter（丸）"
 
 #: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:36
 #: scripts/apps/archive/views/metadata-view.html:207
@@ -18390,22 +18390,22 @@ msgstr ""
 #: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:146
 #: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:178
 msgid "Type"
-msgstr ""
+msgstr "タイプ"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:80
 #: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:80
 #: scripts/extensions/auto-tagging-widget/src/new-item.tsx:191
 msgid "Type is required."
-msgstr ""
+msgstr "タイプは必須です。"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:89
 msgid "Type to search or create a new label"
-msgstr ""
+msgstr "検索するか新しいラベルを作成"
 
 #: scripts/apps/authoring-react/generic-widgets/comments/CommentsWidget.tsx:184
 #: scripts/core/editor3/components/comments/CommentTextArea.tsx:122
 msgid "Type your comment..."
-msgstr ""
+msgstr "コメントを入力..."
 
 #: ../superdesk-planning/client/components/fields/list/ItemType.tsx:18
 #: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:173
@@ -18418,15 +18418,15 @@ msgstr ""
 #: scripts/extensions/sams/src/components/assets/assetGridItem.tsx:147
 #: scripts/extensions/sams/src/components/assets/assetListItem.tsx:131
 msgid "Type:"
-msgstr ""
+msgstr "タイプ："
 
 #: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:139
 msgid "Type: {{ type }}"
-msgstr ""
+msgstr "タイプ：{{ type }}"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:152
 msgid "Type: {{type}}"
-msgstr ""
+msgstr "タイプ：{{type}}"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:121
 msgid "U"
@@ -18456,25 +18456,25 @@ msgstr ""
 
 #: scripts/core/editor3/components/embeds/EmbedInput.tsx:95
 msgid "URL not found."
-msgstr ""
+msgstr "URLが見つかりません。"
 
 #: scripts/apps/vocabularies/views/settings.html:34
 msgid "URLs"
-msgstr ""
+msgstr "URL"
 
 #: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:211
 msgid "Uknown validation error"
-msgstr ""
+msgstr "不明な検証エラー"
 
 #: scripts/core/lang/missing-translations-strings.ts:21
 msgid "Un Spike"
-msgstr ""
+msgstr "スパイク解除"
 
 #: scripts/extensions/sams/dist/src/components/assets/uploadAssetModal.js:148
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/uploadAssetModal.js:148
 #: scripts/extensions/sams/src/components/assets/uploadAssetModal.tsx:122
 msgid "Unable to find Asset associated with the file!"
-msgstr ""
+msgstr "ファイルに関連するアセットが見つかりません。"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/index.tsx:227
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:208
@@ -18482,7 +18482,7 @@ msgstr ""
 #: scripts/apps/dashboard/workspace-tasks/views/assignee-view.html:8
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:50
 msgid "Unassigned"
-msgstr ""
+msgstr "未割り当て"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:56
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:72
@@ -18491,26 +18491,26 @@ msgstr ""
 #: scripts/extensions/availability-manager/src/utils.ts:59
 #: scripts/extensions/availability-manager/src/utils.ts:75
 msgid "Unavailable"
-msgstr ""
+msgstr "利用不可"
 
 #: scripts/core/views/sdselect.html:14
 msgid "Uncheck all"
-msgstr ""
+msgstr "すべてのチェックを外す"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:200
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:30
 msgid "Underline"
-msgstr ""
+msgstr "下線"
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:77
 msgid "Underline (Ctrl+U)"
-msgstr ""
+msgstr "下線（Ctrl+U）"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:201
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:43
 #: scripts/core/editor3/components/toolbar/index.tsx:462
 msgid "Undo"
-msgstr ""
+msgstr "元に戻す"
 
 #: scripts/apps/archive/views/metadata-view.html:203
 #: scripts/apps/content-filters/views/production-test-view.html:19
@@ -18519,87 +18519,87 @@ msgstr ""
 #: scripts/apps/search/constants.ts:10
 #: scripts/apps/search/views/search-parameters.html:42
 msgid "Unique Name"
-msgstr ""
+msgstr "ユニーク名"
 
 #: scripts/apps/search/views/item-globalsearch.html:11
 msgid "Unique Name/ID/GUID"
-msgstr ""
+msgstr "ユニーク名/ID/GUID"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:405
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:197
 msgid "Unique name"
-msgstr ""
+msgstr "ユニーク名"
 
 #: scripts/core/ui/constants.ts:5
 msgid "Unknow error occured. Try repeating the action or reloading the page."
-msgstr ""
+msgstr "不明なエラーが発生しました。操作を再試行するかページを再読み込みしてください。"
 
 #: scripts/apps/search/services/TagService.ts:198
 msgid "Unknown"
-msgstr ""
+msgstr "不明"
 
 #: scripts/apps/archive/directives/ArchivedItemKill.ts:39
 msgid "Unknown Error: Cannot kill the item"
-msgstr ""
+msgstr "不明なエラー：アイテムをキルできません"
 
 #: scripts/apps/archive/directives/ResendItem.ts:45
 msgid "Unknown Error: Cannot resend the item"
-msgstr ""
+msgstr "不明なエラー：アイテムを再送できません"
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:436
 msgid "Unknown Error: Item not published."
-msgstr ""
+msgstr "不明なエラー：アイテムが公開されませんでした。"
 
 #: scripts/apps/desks/controllers/DeskConfigController.ts:69
 msgid "Unknown Error: There was a problem, desk was not deleted."
-msgstr ""
+msgstr "不明なエラー：問題が発生しました。デスクが削除されませんでした。"
 
 #: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:73
 msgid "Unknown Type ({{qcode}})"
-msgstr ""
+msgstr "不明なタイプ（{{qcode}}）"
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:365
 msgid "Unknown error occured, Try descheduling again."
-msgstr ""
+msgstr "不明なエラーが発生しました。スケジュール解除を再試行してください。"
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:302
 msgid ""
 "Unknown error occured. Try publishing the item from the article edit view."
-msgstr ""
+msgstr "不明なエラーが発生しました。記事編集画面からアイテムを公開してください。"
 
 #: scripts/api/article-send.tsx:248
 msgid "Unknown error occurred"
-msgstr ""
+msgstr "不明なエラーが発生しました"
 
 #: ../superdesk-analytics/client/utils.js:161
 msgid "Unlink"
-msgstr ""
+msgstr "リンク解除"
 
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:140
 #: ../superdesk-planning/client/planning-extension/src/extension.ts:188
 #: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:155
 msgid "Unlink as Coverage"
-msgstr ""
+msgstr "取材としてのリンクを解除"
 
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEventItem.tsx:75
 msgid "Unlink related event"
-msgstr ""
+msgstr "関連イベントのリンクを解除"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx:90
 msgid "Unlink related planning"
-msgstr ""
+msgstr "関連プランニングのリンクを解除"
 
 #: scripts/apps/archive/index.tsx:310
 msgid "Unlink update"
-msgstr ""
+msgstr "更新のリンクを解除"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:148
 msgid "Unlinked by"
-msgstr ""
+msgstr "リンク解除者"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:456
 msgid "Unlinked by {{user}}"
-msgstr ""
+msgstr "{{user}}がリンクを解除"
 
 #: ../superdesk-analytics/client/utils.js:171
 #: ../superdesk-planning/client/components/LockContainer/LockContainerPopup.tsx:42
@@ -18610,64 +18610,64 @@ msgstr ""
 #: scripts/apps/authoring-react/subcomponents/lock-info.tsx:58
 #: scripts/apps/authoring/views/authoring-topbar.html:22
 msgid "Unlock"
-msgstr ""
+msgstr "ロック解除"
 
 #: scripts/core/lang/missing-translations-strings.ts:21
 msgid "Unlock content"
-msgstr ""
+msgstr "コンテンツのロックを解除"
 
 #: scripts/apps/authoring/authoring/index.ts:468
 msgid "Unlock current item"
-msgstr ""
+msgstr "現在のアイテムのロックを解除"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:202
 #: scripts/apps/authoring/views/article-edit.html:461
 msgid "Unlocked"
-msgstr ""
+msgstr "ロック解除済み"
 
 #: ../superdesk-analytics/client/utils.js:173
 #: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:22
 #: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:22
 #: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:77
 msgid "Unmark"
-msgstr ""
+msgstr "マーク解除"
 
 #: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions.js:21
 #: scripts/extensions/markForUser/dist/src/get-article-actions.js:21
 #: scripts/extensions/markForUser/src/get-article-actions.tsx:23
 msgid "Unmark user"
-msgstr ""
+msgstr "ユーザーのマークを解除"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:102
 msgid "Unmarked by"
-msgstr ""
+msgstr "マーク解除者"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:336
 msgid "Unmarked from desk({{x}}) by {{user}}"
-msgstr ""
+msgstr "{{user}}がデスク（{{x}}）からマークを解除"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:302
 msgid "Unmarked from highlight({{x}}) by {{user}}"
-msgstr ""
+msgstr "{{user}}がハイライト（{{x}}）からマークを解除"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:203
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:27
 msgid "Unordered List"
-msgstr ""
+msgstr "箇条書きリスト"
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:86
 msgid "Unordered list"
-msgstr ""
+msgstr "箇条書きリスト"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:119
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:122
 #: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:382
 msgid "Unpost"
-msgstr ""
+msgstr "投稿取り消し"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:78
 msgid "Unpost all recurring events or just this one?"
-msgstr ""
+msgstr "すべての繰り返しイベントの投稿を取り消しますか？それともこのイベントのみですか？"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:14
 #: scripts/apps/authoring/authoring/index.ts:426
@@ -18675,24 +18675,24 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-topbar.html:147
 #: scripts/apps/authoring/views/authoring-topbar.html:148
 msgid "Unpublish"
-msgstr ""
+msgstr "公開を取り消す"
 
 #: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:69
 msgid "Unpublish related items:"
-msgstr ""
+msgstr "関連アイテムの公開を取り消す："
 
 #: scripts/apps/search/components/fields/state.tsx:44
 msgid "Unpublished"
-msgstr ""
+msgstr "未公開"
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:190
 msgid "Unpublished by"
-msgstr ""
+msgstr "公開取り消し者"
 
 #: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:168
 #: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:3
 msgid "Unresolved"
-msgstr ""
+msgstr "未解決"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:499
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:123
@@ -18700,7 +18700,7 @@ msgstr ""
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:712
 #: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:18
 msgid "Unsaved changes"
-msgstr ""
+msgstr "未保存の変更"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:438
 #: ../superdesk-analytics/client/utils.js:165
@@ -18716,48 +18716,48 @@ msgstr ""
 #: scripts/core/interactive-article-actions-panel/action-tabs.tsx:15
 #: scripts/core/interactive-article-actions-panel/actions/unspike-action.tsx:76
 msgid "Unspike"
-msgstr ""
+msgstr "スパイク解除"
 
 #: scripts/apps/archive/index.tsx:134
 msgid "Unspike Item"
-msgstr ""
+msgstr "アイテムのスパイクを解除"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:143
 msgid "Unspike Planning Item"
-msgstr ""
+msgstr "プランニングアイテムのスパイクを解除"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikeEventForm.tsx:99
 msgid "Unspike all recurring events or just this one?"
-msgstr ""
+msgstr "すべての繰り返しイベントのスパイクを解除しますか？それともこのイベントのみですか？"
 
 #: ../superdesk-planning/client/constants/planning.ts:136
 msgid "Unspike planning"
-msgstr ""
+msgstr "プランニングのスパイクを解除"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:78
 msgid "Unspike {{event}}"
-msgstr ""
+msgstr "{{event}}のスパイクを解除"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:49
 msgid "Unspiked"
-msgstr ""
+msgstr "スパイク解除済み"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:237
 #: scripts/apps/authoring/versioning/history/views/history.html:74
 msgid "Unspiked by"
-msgstr ""
+msgstr "スパイク解除者"
 
 #: scripts/apps/search/views/saved-search-subscribe.html:29
 msgid "Unsubscribe"
-msgstr ""
+msgstr "購読解除"
 
 #: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:227
 msgid "Unsubscribe desk"
-msgstr ""
+msgstr "デスクの購読を解除"
 
 #: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:215
 msgid "Unsubscribe user"
-msgstr ""
+msgstr "ユーザーの購読を解除"
 
 #: scripts/validate-instance-configuration.tsx:32
 msgid ""
@@ -18776,7 +18776,7 @@ msgstr ""
 #: scripts/apps/workspace/views/workspace-dropdown.html:6
 #: scripts/core/utils.tsx:452
 msgid "Untitled"
-msgstr ""
+msgstr "無題"
 
 #: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:138
 #: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:401
@@ -18788,71 +18788,71 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-topbar.html:120
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:231
 msgid "Update"
-msgstr ""
+msgstr "更新"
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:256
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:470
 msgid "Update Created."
-msgstr ""
+msgstr "更新が作成されました。"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:4
 msgid "Update Cycle:"
-msgstr ""
+msgstr "更新サイクル："
 
 #: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:200
 msgid "Update Due:"
-msgstr ""
+msgstr "更新期限："
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:114
 #: ../superdesk-planning/client/constants/events.ts:164
 msgid "Update Repetitions"
-msgstr ""
+msgstr "繰り返しを更新"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:113
 msgid "Update Repetitions of the Series"
-msgstr ""
+msgstr "シリーズの繰り返しを更新"
 
 #: ../superdesk-analytics/client/update_time_report/controllers/UpdateTimeReportController.js:162
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeReportPreview.js:21
 #: ../superdesk-analytics/client/update_time_report/index.js:50
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:93
 msgid "Update Time"
-msgstr ""
+msgstr "更新時間"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/assignCalendarForm.tsx:96
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:352
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:355
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:298
 msgid "Update all recurring events or just this one?"
-msgstr ""
+msgstr "すべての繰り返しイベントを更新しますか？それともこのイベントのみですか？"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:258
 msgid "Update all recurring planning or just this one?"
-msgstr ""
+msgstr "すべての繰り返しプランニングを更新しますか？それともこのプランニングのみですか？"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:121
 msgid "Update every"
-msgstr ""
+msgstr "更新間隔"
 
 #: scripts/validate-instance-configuration.tsx:42
 msgid "Update or disable incompatible extensions."
-msgstr ""
+msgstr "互換性のない拡張機能を更新または無効にしてください。"
 
 #: scripts/apps/search/views/saved-search-subscribe.html:33
 msgid "Update subscription"
-msgstr ""
+msgstr "サブスクリプションを更新"
 
 #: ../superdesk-planning/client/constants/events.ts:160
 msgid "Update time"
-msgstr ""
+msgstr "更新時間"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:90
 msgid "Update time of {{event}}"
-msgstr ""
+msgstr "{{event}}の時間を更新"
 
 #: scripts/apps/search/components/fields/update.tsx:17
 msgid "Update {{sequence}}"
-msgstr ""
+msgstr "更新{{sequence}}"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:44
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:130
@@ -18879,31 +18879,31 @@ msgstr ""
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:174
 #: scripts/extensions/sams/src/utils/ui.tsx:107
 msgid "Updated"
-msgstr ""
+msgstr "更新済み"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:129
 msgid "Updated Fields:"
-msgstr ""
+msgstr "更新されたフィールド："
 
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:68
 msgid "Updated In"
-msgstr ""
+msgstr "更新先"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:104
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:104
 #: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:178
 msgid "Updated at {{date}}"
-msgstr ""
+msgstr "{{date}}に更新"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:129
 #: scripts/apps/authoring/versioning/history/views/history.html:18
 msgid "Updated by"
-msgstr ""
+msgstr "更新者"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:119
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:135
 msgid "Updated fields:"
-msgstr ""
+msgstr "更新されたフィールド："
 
 #: scripts/extensions/sams/dist/src/components/assets/assetListItem.js:114
 #: scripts/extensions/sams/dist/src/components/common/versionUserDateLines.js:98
@@ -18915,26 +18915,26 @@ msgstr ""
 #: scripts/extensions/sams/src/components/common/versionUserDateLines.tsx:52
 #: scripts/extensions/sams/src/components/sets/setListItem.tsx:80
 msgid "Updated {{ datetime }}"
-msgstr ""
+msgstr "更新日時：{{ datetime }}"
 
 #: scripts/extensions/sams/dist/src/components/common/versionUserDateLines.js:99
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/versionUserDateLines.js:70
 #: scripts/extensions/sams/src/components/common/versionUserDateLines.tsx:57
 msgid "Updated {{ datetime }} by"
-msgstr ""
+msgstr "{{ datetime }}に更新者："
 
 #: scripts/apps/contacts/components/ContactFooter.tsx:18
 msgid "Updated:"
-msgstr ""
+msgstr "更新済み："
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:576
 msgid "Updates"
-msgstr ""
+msgstr "更新"
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:34
 msgid ""
 "Updates can only be created for text items. The type of this item is {{type}}"
-msgstr ""
+msgstr "更新はテキストアイテムのみ作成できます。このアイテムのタイプは{{type}}です"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:205
 #: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:136
@@ -18943,15 +18943,15 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:233
 #: scripts/extensions/sams/src/containers/FileUploadModal.tsx:295
 msgid "Upload"
-msgstr ""
+msgstr "アップロード"
 
 #: scripts/apps/vocabularies/views/settings.html:9
 msgid "Upload Config"
-msgstr ""
+msgstr "設定をアップロード"
 
 #: scripts/apps/archive/controllers/UploadController.ts:165
 msgid "Upload Error:"
-msgstr ""
+msgstr "アップロードエラー："
 
 #: scripts/extensions/sams/dist/src/components/assets/uploadAssetModal.js:190
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:245
@@ -18960,61 +18960,61 @@ msgstr ""
 #: scripts/extensions/sams/src/components/assets/uploadAssetModal.tsx:200
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:358
 msgid "Upload New Asset(s)"
-msgstr ""
+msgstr "新しいアセットをアップロード"
 
 #: scripts/apps/vocabularies/components/UploadConfigModal.tsx:69
 msgid "Upload config"
-msgstr ""
+msgstr "設定をアップロード"
 
 #: scripts/apps/users/controllers/ChangeAvatarController.ts:6
 msgid "Upload from computer"
-msgstr ""
+msgstr "コンピューターからアップロード"
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:243
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:243
 #: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:342
 msgid "Upload image"
-msgstr ""
+msgstr "画像をアップロード"
 
 #: scripts/apps/archive/index.tsx:106
 #: scripts/apps/search/views/multi-image-edit.html:12
 #: scripts/core/ui/components/content-create-dropdown/initial-view.tsx:210
 msgid "Upload media"
-msgstr ""
+msgstr "メディアをアップロード"
 
 #: scripts/apps/authoring/views/item-carousel.html:166
 msgid "Upload new"
-msgstr ""
+msgstr "新規アップロード"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetListPanel.js:62
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetListPanel.js:62
 #: scripts/extensions/sams/src/components/assets/assetListPanel.tsx:36
 msgid "Upload new Assets or change your search filters"
-msgstr ""
+msgstr "新しいアセットをアップロードするか検索フィルターを変更してください"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:256
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:256
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:351
 msgid "Uploaded From:"
-msgstr ""
+msgstr "アップロード元："
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:258
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:258
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:361
 msgid "Uploaded To:"
-msgstr ""
+msgstr "アップロード先："
 
 #: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:119
 msgid "Uploading {{current}} of {{total}}"
-msgstr ""
+msgstr "{{total}}中{{current}}をアップロード中"
 
 #: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:118
 msgid "Uploading..."
-msgstr ""
+msgstr "アップロード中..."
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:18
 msgid "Uppercase"
-msgstr ""
+msgstr "大文字"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:560
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:139
@@ -19041,33 +19041,33 @@ msgstr ""
 #: scripts/apps/search/tests/search.spec.ts:249
 #: scripts/apps/workspace/content/constants.ts:48
 msgid "Urgency"
-msgstr ""
+msgstr "緊急度"
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:10
 msgid "Urgency stats"
-msgstr ""
+msgstr "緊急度統計"
 
 #: ../superdesk-planning/client/components/fields/urgency.tsx:21
 msgid "Urgency:"
-msgstr ""
+msgstr "緊急度："
 
 #: scripts/apps/authoring-react/fields/urls/index.tsx:20
 msgid "Urls (authoring-react)"
-msgstr ""
+msgstr "URL（authoring-react）"
 
 #: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:76
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:76
 #: scripts/extensions/sams/src/components/sets/setListPanel.tsx:72
 msgid "Usable Sets"
-msgstr ""
+msgstr "利用可能なセット"
 
 #: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:85
 msgid "Usage"
-msgstr ""
+msgstr "使用"
 
 #: scripts/apps/workspace/content/constants.ts:49
 msgid "Usage Terms"
-msgstr ""
+msgstr "使用条件"
 
 #: scripts/apps/archive/views/metadata-associateditem-view.html:40
 #: scripts/apps/archive/views/metadata-view.html:181
@@ -19075,54 +19075,54 @@ msgstr ""
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:35
 #: scripts/apps/templates/views/template-editor-modal.html:113
 msgid "Usage terms"
-msgstr ""
+msgstr "使用条件"
 
 #: scripts/apps/authoring/views/confirm-media-associated.html:17
 msgid "Use Media"
-msgstr ""
+msgstr "メディアを使用"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:111
 msgid "Use Togglebox"
-msgstr ""
+msgstr "トグルボックスを使用"
 
 #: scripts/apps/publish/views/ftp-config.html:18
 msgid "Use Transport Layer Security (FTPS)"
-msgstr ""
+msgstr "トランスポート層セキュリティ（FTPS）を使用"
 
 #: scripts/apps/users/controllers/ChangeAvatarController.ts:8
 msgid "Use a Web URL"
-msgstr ""
+msgstr "Web URLを使用"
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:238
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:238
 #: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:329
 msgid "Use current frame"
-msgstr ""
+msgstr "現在のフレームを使用"
 
 #: scripts/extensions/predefinedTextField/dist/src/editor.js:59
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/editor.js:59
 #: scripts/extensions/predefinedTextField/src/editor.tsx:98
 msgid "Use custom value"
-msgstr ""
+msgstr "カスタム値を使用"
 
 #: scripts/apps/publish/views/subscribers.html:210
 msgid "Use priority queue for transmission."
-msgstr ""
+msgstr "送信に優先キューを使用。"
 
 #: scripts/apps/content-filters/views/manage-filters.html:135
 msgid "Use the article GUID for testing."
-msgstr ""
+msgstr "テストには記事のGUIDを使用してください。"
 
 #: scripts/extensions/annotationsLibrary/dist/src/AnnotationSelectSingleItem.js:14
 #: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.js:14
 #: scripts/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.tsx:36
 msgid "Use this"
-msgstr ""
+msgstr "これを使用"
 
 #: scripts/apps/search/components/fields/used.tsx:16
 #: scripts/apps/search/views/item-preview.html:21
 msgid "Used"
-msgstr ""
+msgstr "使用済み"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:508
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:114
@@ -19132,67 +19132,67 @@ msgstr ""
 #: scripts/apps/authoring/metadata/views/metadata-terms.html:52
 #: scripts/apps/users/views/user-privileges.html:18
 msgid "User"
-msgstr ""
+msgstr "ユーザー"
 
 #: ../superdesk-analytics/client/user_activity_report/index.js:46
 #: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:340
 #: scripts/apps/dashboard/user-activity/user-activity.ts:37
 msgid "User Activity"
-msgstr ""
+msgstr "ユーザーアクティビティ"
 
 #: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:185
 msgid "User Activity - {{username}}"
-msgstr ""
+msgstr "ユーザーアクティビティ - {{username}}"
 
 #: scripts/apps/users/config.ts:38
 #: scripts/core/lang/missing-translations-strings.ts:21
 msgid "User Management"
-msgstr ""
+msgstr "ユーザー管理"
 
 #: scripts/apps/users/import/views/import-user.html:28
 msgid "User Profile to Import"
-msgstr ""
+msgstr "インポートするユーザープロファイル"
 
 #: scripts/apps/users/config.ts:66 scripts/apps/users/views/settings.html:4
 msgid "User Roles"
-msgstr ""
+msgstr "ユーザーロール"
 
 #: scripts/apps/users/directives/UserPrivilegesDirective.ts:32
 msgid "User not found."
-msgstr ""
+msgstr "ユーザーが見つかりません。"
 
 #: scripts/apps/users/directives/UserPreferencesDirective.ts:163
 msgid "User preferences could not be saved..."
-msgstr ""
+msgstr "ユーザー設定を保存できませんでした..."
 
 #: scripts/apps/users/directives/UserPreferencesDirective.ts:159
 msgid "User preferences saved"
-msgstr ""
+msgstr "ユーザー設定が保存されました"
 
 #: scripts/apps/users/directives/UserRolesDirective.ts:35
 msgid "User role created."
-msgstr ""
+msgstr "ユーザーロールが作成されました。"
 
 #: scripts/apps/users/directives/UserPrivilegesDirective.ts:55
 msgid "User role not found."
-msgstr ""
+msgstr "ユーザーロールが見つかりません。"
 
 #: scripts/apps/users/directives/UserRolesDirective.ts:37
 msgid "User role updated."
-msgstr ""
+msgstr "ユーザーロールが更新されました。"
 
 #: scripts/apps/users/controllers/UserResolver.ts:12
 msgid "User was not found, sorry."
-msgstr ""
+msgstr "ユーザーが見つかりません。"
 
 #: scripts/apps/users/directives/UserEditDirective.ts:266
 msgid "User was not found. The account might have been deleted."
-msgstr ""
+msgstr "ユーザーが見つかりません。アカウントが削除された可能性があります。"
 
 #: ../superdesk-analytics/client/user_activity_report/views/item-timeline-tooltip.html:2
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:102
 msgid "User:"
-msgstr ""
+msgstr "ユーザー："
 
 #: scripts/apps/ingest/views/settings/searchConfig.html:2
 #: scripts/apps/publish/views/ftp-config.html:7
@@ -19200,7 +19200,7 @@ msgstr ""
 #: scripts/apps/search-providers/views/search-provider-config.html:109
 #: scripts/apps/users/views/list.html:34
 msgid "Username"
-msgstr ""
+msgstr "ユーザー名"
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:115
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:413
@@ -19209,50 +19209,50 @@ msgstr ""
 #: scripts/apps/production-api-keys/config.ts:25
 #: scripts/apps/users/views/list.html:2
 msgid "Users"
-msgstr ""
+msgstr "ユーザー"
 
 #: scripts/apps/users/config.ts:56
 msgid "Users Profile"
-msgstr ""
+msgstr "ユーザープロファイル"
 
 #: scripts/apps/users/views/edit.html:9
 msgid "Users Profile:"
-msgstr ""
+msgstr "ユーザープロファイル："
 
 #: scripts/core/lang/missing-translations-strings.ts:13
 msgid "Users archive view format"
-msgstr ""
+msgstr "ユーザーのアーカイブ表示形式"
 
 #: scripts/apps/archive/views/export.html:17
 #: scripts/apps/archive/views/export.html:18
 #: scripts/apps/authoring-react/toolbar/export-modal.tsx:104
 msgid "Validate"
-msgstr ""
+msgstr "検証"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:299
 msgid "Validate Characters"
-msgstr ""
+msgstr "文字を検証"
 
 #: scripts/apps/authoring-react/fields/date/config.tsx:53
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:147
 msgid "Value"
-msgstr ""
+msgstr "値"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:282
 msgid "Value must be greater than or equal to 2."
-msgstr ""
+msgstr "値は2以上でなければなりません。"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:284
 msgid "Value must be less than or equal to 99."
-msgstr ""
+msgstr "値は99以下でなければなりません。"
 
 #: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:207
 msgid "Value must be unique"
-msgstr ""
+msgstr "値は一意でなければなりません"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:79
 msgid "Value type"
-msgstr ""
+msgstr "値タイプ"
 
 #: scripts/apps/content-filters/views/filter-search.html:26
 #: scripts/apps/content-filters/views/filter-search.html:30
@@ -19260,33 +19260,33 @@ msgstr ""
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:83
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:88
 msgid "Values"
-msgstr ""
+msgstr "値"
 
 #: scripts/apps/archive/views/metadata-view.html:85
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:366
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:163
 msgid "Version"
-msgstr ""
+msgstr "バージョン"
 
 #: scripts/apps/archive/views/metadata-view.html:110
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:397
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:186
 msgid "Version creator"
-msgstr ""
+msgstr "バージョン作成者"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:76
 msgid "Version: {{n}}"
-msgstr ""
+msgstr "バージョン：{{n}}"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/index.tsx:40
 #: scripts/apps/authoring/versioning/versioning.ts:8
 #: scripts/apps/authoring/versioning/views/versioning.html:3
 msgid "Versions"
-msgstr ""
+msgstr "バージョン"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/index.tsx:15
 msgid "Versions and item history"
-msgstr ""
+msgstr "バージョンとアイテム履歴"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:207
 #: ../superdesk-planning/client/utils/index.ts:591
@@ -19296,7 +19296,7 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/utils/assets.js:110
 #: scripts/extensions/sams/src/utils/assets.ts:144
 msgid "Video"
-msgstr ""
+msgstr "動画"
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditor.js:306
 #: scripts/extensions/videoEditor/dist/src/VideoEditor.js:80
@@ -19305,114 +19305,114 @@ msgstr ""
 #: scripts/extensions/videoEditor/src/VideoEditor.tsx:134
 #: scripts/extensions/videoEditor/src/VideoEditor.tsx:422
 msgid "Video is editing, please wait..."
-msgstr ""
+msgstr "動画を編集中です。お待ちください..."
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:235
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:235
 #: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:322
 msgid "Video thumbnail"
-msgstr ""
+msgstr "動画サムネイル"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:74
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:74
 #: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:57
 msgid "Videos only"
-msgstr ""
+msgstr "動画のみ"
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:28
 msgid "View Latest Item Version"
-msgstr ""
+msgstr "最新アイテムバージョンを表示"
 
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:120
 msgid "View Original"
-msgstr ""
+msgstr "オリジナルを表示"
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:33
 msgid "View Original Image"
-msgstr ""
+msgstr "オリジナル画像を表示"
 
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:131
 msgid "View Update"
-msgstr ""
+msgstr "更新を表示"
 
 #: scripts/apps/monitoring/index.ts:120
 msgid "View an item"
-msgstr ""
+msgstr "アイテムを表示"
 
 #: ../superdesk-analytics/client/index.js:95
 msgid "View analytics reports"
-msgstr ""
+msgstr "アナリティクスレポートを表示"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:168
 msgid "View associated event"
-msgstr ""
+msgstr "関連イベントを表示"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:155
 msgid "View duplicate event"
-msgstr ""
+msgstr "複製されたイベントを表示"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:140
 msgid "View duplicate planning item"
-msgstr ""
+msgstr "複製されたプランニングアイテムを表示"
 
 #: scripts/apps/users/views/user-preferences.html:14
 #: scripts/apps/users/views/user-preferences.html:43
 msgid "View formats"
-msgstr ""
+msgstr "表示形式"
 
 #: scripts/apps/users/views/list.html:67
 msgid "View full profile"
-msgstr ""
+msgstr "完全なプロファイルを表示"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:516
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:106
 msgid "View item"
-msgstr ""
+msgstr "アイテムを表示"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:403
 msgid "View linked item"
-msgstr ""
+msgstr "リンクされたアイテムを表示"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:13
 msgid "View name"
-msgstr ""
+msgstr "ビュー名"
 
 #: scripts/core/menu/views/menu.html:49
 msgid "View notifications"
-msgstr ""
+msgstr "通知を表示"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:165
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:189
 #: ../superdesk-planning/client/components/fields/state.tsx:32
 msgid "View original event"
-msgstr ""
+msgstr "元のイベントを表示"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:152
 msgid "View original planning item"
-msgstr ""
+msgstr "元のプランニングアイテムを表示"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:143
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:204
 msgid "View planning item"
-msgstr ""
+msgstr "プランニングアイテムを表示"
 
 #: scripts/core/menu/views/menu.html:58
 msgid "View profile details"
-msgstr ""
+msgstr "プロファイル詳細を表示"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:177
 msgid "View rescheduled event"
-msgstr ""
+msgstr "再スケジュールされたイベントを表示"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:58
 msgid "View schedules"
-msgstr ""
+msgstr "スケジュールを表示"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:155
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:180
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:205
 msgid "View source item"
-msgstr ""
+msgstr "ソースアイテムを表示"
 
 #: scripts/apps/contacts/index.ts:23
 msgid "View/Manage media contacts"
@@ -19422,36 +19422,36 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/index.tsx:226
 #: scripts/apps/vocabularies/views/settings.html:16
 msgid "Vocabularies"
-msgstr ""
+msgstr "ボキャブラリー"
 
 #: scripts/core/lang/missing-translations-strings.ts:22
 msgid "Vocabularies Management"
-msgstr ""
+msgstr "ボキャブラリー管理"
 
 #: scripts/apps/authoring-react/fields/dropdown/config-main.tsx:82
 msgid "Vocabulary"
-msgstr ""
+msgstr "ボキャブラリー"
 
 #: ../superdesk-planning/client/planning-extension/src/extension.ts:283
 msgid "Vocabulary `locators` is not configured!"
-msgstr ""
+msgstr "ボキャブラリー`locators`が設定されていません。"
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:101
 msgid "Vocabulary saved successfully"
-msgstr ""
+msgstr "ボキャブラリーが正常に保存されました"
 
 #: scripts/apps/users/views/user-preferences.html:20
 #: scripts/apps/users/views/user-preferences.html:248
 msgid "Vocabulary values"
-msgstr ""
+msgstr "ボキャブラリーの値"
 
 #: scripts/apps/vocabularies/controllers/VocabularyConfigController.ts:243
 msgid "Vocabulary was deleted."
-msgstr ""
+msgstr "ボキャブラリーが削除されました。"
 
 #: scripts/validate-instance-configuration.tsx:56
 msgid "Vocabulary with ID \"categories\" is required"
-msgstr ""
+msgstr "ID「categories」のボキャブラリーが必要です"
 
 #: ../superdesk-planning/client/components/Main/CalendarNavigation.tsx:56
 msgid "W"
@@ -19459,7 +19459,7 @@ msgstr ""
 
 #: scripts/apps/content-filters/controllers/FilterConditionsController.ts:44
 msgid "WARNING unknown filter condition value: {{ value }}"
-msgstr ""
+msgstr "警告：不明なフィルター条件値：{{ value }}"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:91
 msgid "WE"
@@ -19478,15 +19478,15 @@ msgstr[0] ""
 #: scripts/core/auth/auth.ts:242
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:387
 msgid "Warning"
-msgstr ""
+msgstr "警告"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:208
 msgid "Warning Sign"
-msgstr ""
+msgstr "警告マーク"
 
 #: ../superdesk-planning/client/utils/filters.ts:139
 msgid "We"
-msgstr ""
+msgstr "水"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:48
 msgid ""
@@ -19494,20 +19494,20 @@ msgid ""
 "address you have provided. Your data will be kept secure and it won't be "
 "used for any other purpose. You may opt-out of receiving further email "
 "communications at any time."
-msgstr ""
+msgstr "ご提供いただいたメールアドレスにSuperdeskの開発に関する更新情報をお送りすることがあります。データは安全に保管され、他の目的には使用されません。メール配信はいつでも停止できます。"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:38
 msgid "Weak"
-msgstr ""
+msgstr "弱い"
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:110
 msgid "Wed"
-msgstr ""
+msgstr "水"
 
 #: ../superdesk-planning/client/utils/events.tsx:1456
 #: scripts/core/datetime/datetime.ts:292
 msgid "Wednesday"
-msgstr ""
+msgstr "水曜日"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:160
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:80
@@ -19515,55 +19515,55 @@ msgstr ""
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/constants.js:35
 #: scripts/extensions/availability-manager/src/constants.ts:43
 msgid "Week"
-msgstr ""
+msgstr "週"
 
 #: ../superdesk-planning/client/components/fields/editor/Days.tsx:32
 msgid "Week Days"
-msgstr ""
+msgstr "曜日"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:31
 msgid "Week(s)"
-msgstr ""
+msgstr "週"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:37
 #: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:23
 msgid "Weekly"
-msgstr ""
+msgstr "毎週"
 
 #: ../superdesk-planning/client/utils/filters.ts:48
 msgid "Weekly @ {{ time }} to {{ desk }}"
-msgstr ""
+msgstr "毎週{{ time }}に{{ desk }}へ"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:71
 msgid "Weekly on {{days}} at {{hour}}"
-msgstr ""
+msgstr "毎週{{days}}の{{hour}}に"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:4
 msgid "Welcome to Superdesk"
-msgstr ""
+msgstr "Superdeskへようこそ"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:2
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:9
 msgid "When"
-msgstr ""
+msgstr "条件"
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:38
 #: scripts/apps/highlights/views/highlights_config_modal.html:47
 msgid "When creating a highlights package"
-msgstr ""
+msgstr "ハイライトパッケージ作成時"
 
 #: scripts/apps/publish/views/subscribers.html:204
 msgid "When enabled it can send multiple items at the same time."
-msgstr ""
+msgstr "有効にすると、複数のアイテムを同時に送信できます。"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:55
 msgid "White"
-msgstr ""
+msgstr "白"
 
 #: scripts/apps/dashboard/views/widget.html:11
 #: scripts/apps/dashboard/views/widget.html:12
 msgid "Widget settings"
-msgstr ""
+msgstr "ウィジェット設定"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:8
 msgid ""
@@ -19572,12 +19572,12 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:95
 msgid "Widgets"
-msgstr ""
+msgstr "ウィジェット"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:58
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:156
 msgid "Width"
-msgstr ""
+msgstr "幅"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:102
 msgid ""
@@ -19591,7 +19591,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/NoCoverage.tsx:15
 msgid "Without Coverage"
-msgstr ""
+msgstr "取材なし"
 
 #: scripts/apps/archive/views/metadata-view.html:17
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:288
@@ -19599,248 +19599,248 @@ msgstr ""
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:108
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:112
 msgid "Word Count"
-msgstr ""
+msgstr "語数"
 
 #: scripts/apps/desks/views/desk-config-modal.html:232
 msgid "Work stages"
-msgstr ""
+msgstr "ワーキングステージ"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:100
 msgid "Work started"
-msgstr ""
+msgstr "作業開始"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:101
 msgid "Work started on coverage"
-msgstr ""
+msgstr "取材の作業開始"
 
 #: scripts/core/activity/activity.ts:22
 msgid "Workflow"
-msgstr ""
+msgstr "ワークフロー"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:171
 msgid "Workflow State"
-msgstr ""
+msgstr "ワークフロー状態"
 
 #: ../superdesk-planning/client/components/fields/index.tsx:229
 msgid "Workflow States"
-msgstr ""
+msgstr "ワークフロー状態"
 
 #: scripts/apps/desks/views/desk-config-modal.html:305
 #: scripts/apps/desks/views/desk-config-modal.html:358
 #: scripts/apps/workspace/content/constants.ts:55
 msgid "Working Stage"
-msgstr ""
+msgstr "ワーキングステージ"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/working-hours-grid-labels.js:16
 #: scripts/extensions/availability-manager/dist/src/settings/working-hours-grid-labels.js:16
 #: scripts/extensions/availability-manager/src/settings/working-hours-grid-labels.tsx:25
 msgid "Working hours"
-msgstr ""
+msgstr "勤務時間"
 
 #: scripts/apps/archive/index.tsx:94 scripts/apps/dashboard/index.ts:53
 #: scripts/apps/dashboard/views/workspace.html:24
 #: scripts/apps/dashboard/workspace-tasks/tasks.ts:376
 #: scripts/apps/ingest/index.ts:72 scripts/apps/stream/index.ts:18
 msgid "Workspace"
-msgstr ""
+msgstr "ワークスペース"
 
 #: scripts/apps/workspace/views/edit-workspace-modal.html:15
 msgid "Workspace name"
-msgstr ""
+msgstr "ワークスペース名"
 
 #: scripts/apps/workspace/views/workspace-dropdown.html:1
 msgid "Workspace:"
-msgstr ""
+msgstr "ワークスペース："
 
 #: scripts/apps/dashboard/world-clock/world-clock.ts:209
 #: scripts/core/lang/missing-translations-strings.ts:44
 msgid "World Clock"
-msgstr ""
+msgstr "世界時計"
 
 #: scripts/apps/dashboard/world-clock/world-clock.ts:42
 msgid "World clock added: {{zone}}"
-msgstr ""
+msgstr "世界時計を追加：{{zone}}"
 
 #: scripts/apps/dashboard/world-clock/world-clock.ts:44
 msgid "World clock removed: {{zone}}"
-msgstr ""
+msgstr "世界時計を削除：{{zone}}"
 
 #: scripts/apps/dashboard/world-clock/world-clock.ts:221
 #: scripts/core/lang/missing-translations-strings.ts:45
 msgid "World clock widget"
-msgstr ""
+msgstr "世界時計ウィジェット"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:339
 msgid "XMP File"
-msgstr ""
+msgstr "XMPファイル"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:33
 msgid "Year(s)"
-msgstr ""
+msgstr "年"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:61
 msgid "Yellow"
-msgstr ""
+msgstr "黄"
 
 #: scripts/core/ui/components/generic-form/input-types/checkbox.tsx:10
 #: scripts/core/ui/components/generic-form/input-types/yes-no.tsx:6
 msgid "Yes"
-msgstr ""
+msgstr "はい"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:16
 #: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:16
 #: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:38
 msgid "Yes, create a template"
-msgstr ""
+msgstr "はい、テンプレートを作成"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:17
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:8
 msgid "Yesterday"
-msgstr ""
+msgstr "昨日"
 
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:106
 msgid ""
 "You are about to delete the vocabulary {{name}}. This action can't be undone."
-msgstr ""
+msgstr "ボキャブラリー{{name}}を削除しようとしています。この操作は元に戻せません。"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:109
 msgid ""
 "You are changing you personal preferences. If you would like to set the "
 "default order for the desk, you can do so from the settings page."
-msgstr ""
+msgstr "個人設定を変更しています。デスクのデフォルトの並び順を設定する場合は、設定ページから行えます。"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:249
 msgid "You are creating a new planning item."
-msgstr ""
+msgstr "新しいプランニングアイテムを作成しています。"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:73
 msgid "You are currently managing featured story in another session"
-msgstr ""
+msgstr "別のセッションで特集記事を管理中です"
 
 #: scripts/validate-instance-configuration.tsx:38
 msgid "You are likely running an outdated version of auto tagging extension."
-msgstr ""
+msgstr "自動タグ付け拡張機能の古いバージョンを使用している可能性があります。"
 
 #: scripts/apps/workspace/content/services/ContentService.ts:71
 msgid "You are not allowed to create an article there."
-msgstr ""
+msgstr "そこに記事を作成する権限がありません。"
 
 #: scripts/apps/workspace/content/services/ContentService.ts:69
 msgid "You are not allowed to create article on readonly stage."
-msgstr ""
+msgstr "読み取り専用ステージに記事を作成する権限がありません。"
 
 #: ../superdesk-planning/client/utils/events.tsx:510
 msgid ""
 "You are trying to add multiple related events when only one is allowed. Only "
 "the first event({{name}}) will be added."
-msgstr ""
+msgstr "関連イベントは1つのみ許可されていますが、複数追加しようとしています。最初のイベント（{{name}}）のみ追加されます。"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageForm.tsx:233
 msgid "You can associate only one XMP file"
-msgstr ""
+msgstr "XMPファイルは1つのみ関連付けできます"
 
 #: scripts/apps/desks/views/desk-config-modal.html:134
 msgid ""
 "You can choose the default content view of your desk. Use only if you want "
 "to override individual users' monitoring view preferences. Select \"none\" "
 "if you want to let users decide."
-msgstr ""
+msgstr "デスクのデフォルトコンテンツビューを選択できます。個々のユーザーのモニタリング表示設定を上書きする場合にのみ使用してください。ユーザーに任せる場合は「なし」を選択してください。"
 
 #: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:148
 msgid ""
 "You can either completely block further writing after the characterlimit is "
 "reached or highlight exceeding characters in red."
-msgstr ""
+msgstr "文字数制限に達した後に入力を完全にブロックするか、超過した文字を赤でハイライトすることができます。"
 
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:154
 msgid "You can't multi-edit, because these articles can't be edited"
-msgstr ""
+msgstr "これらの記事は編集できないため、複数編集できません"
 
 #: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:35
 msgid "You cannot change workflow status"
-msgstr ""
+msgstr "ワークフロー状態を変更できません"
 
 #: scripts/core/menu/notifications/views/notifications.html:13
 msgid "You don't have any notifications"
-msgstr ""
+msgstr "通知はありません"
 
 #: scripts/apps/monitoring/views/item-actions-menu.html:44
 msgid "You don't have the privileges to perform any action"
-msgstr ""
+msgstr "アクションを実行する権限がありません"
 
 #: scripts/apps/search/views/saved-search-subscribe.html:12
 msgid "You have chosen to subscribe to"
-msgstr ""
+msgstr "購読対象に選択しました"
 
 #: scripts/api/highlights.ts:53 scripts/apps/search/MultiImageEdit.ts:173
 msgid "You have unsaved changes, do you want to continue?"
-msgstr ""
+msgstr "未保存の変更があります。続行しますか？"
 
 #: scripts/apps/desks/controllers/DeskConfigController.ts:93
 msgid "You have unsaved changes. Do you want to save them now?"
-msgstr ""
+msgstr "未保存の変更があります。今すぐ保存しますか？"
 
 #: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:76
 msgid "You have unsaved changes. What would you like to do?"
-msgstr ""
+msgstr "未保存の変更があります。どうしますか？"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:242
 msgid ""
 "You made changes to this planning item that is part of a recurring event."
-msgstr ""
+msgstr "繰り返しイベントの一部であるこのプランニングアイテムに変更を加えました。"
 
 #: scripts/apps/production-api-keys/config.ts:40
 msgid ""
 "Your Client ID and Client Secret will be generated when you save. Make sure "
 "to copy the Client Secret immediately. It will only be shown once and it "
 "cannot be retrieved later."
-msgstr ""
+msgstr "保存時にクライアントIDとクライアントシークレットが生成されます。クライアントシークレットはすぐにコピーしてください。一度しか表示されず、後から取得できません。"
 
 #: scripts/apps/users/import/views/import-user.html:11
 msgid "Your Credentials"
-msgstr ""
+msgstr "認証情報"
 
 #: scripts/apps/users/views/edit-form.html:198
 msgid "Your Slack user name without the leading @"
-msgstr ""
+msgstr "先頭の@を除いたSlackユーザー名"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:500
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:124
 #: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:84
 msgid "Your changes will be lost if you close now. What would you like to do?"
-msgstr ""
+msgstr "今閉じると変更が失われます。どうしますか？"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:285
 msgid "Your changes will be lost if you switch now. What would you like to do?"
-msgstr ""
+msgstr "今切り替えると変更が失われます。どうしますか？"
 
 #: scripts/apps/dashboard/world-clock/configuration.html:12
 msgid "Your clock"
-msgstr ""
+msgstr "あなたの時計"
 
 #: scripts/core/auth/login-modal.html:71
 msgid "Your password has expired. Please change your password."
-msgstr ""
+msgstr "パスワードの有効期限が切れました。パスワードを変更してください。"
 
 #: scripts/core/auth/login-modal.html:4
 msgid "Your session has expired."
-msgstr ""
+msgstr "セッションの有効期限が切れました。"
 
 #: scripts/apps/vocabularies/components/UploadComplete.tsx:8
 msgid "Your upload was successful"
-msgstr ""
+msgstr "アップロードが成功しました"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:209
 msgid "Zoom In"
-msgstr ""
+msgstr "拡大"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:210
 msgid "Zoom Out"
-msgstr ""
+msgstr "縮小"
 
 #: scripts/apps/search/views/saved-searches.html:11
 msgid "[Global]"
-msgstr ""
+msgstr "[グローバル]"
 
 #: scripts/apps/authoring-react/fields/media/constants.ts:8
 #: scripts/apps/authoring/media/MediaMetadataView.tsx:16
@@ -19859,55 +19859,55 @@ msgstr ""
 #: scripts/core/editor3/components/media/MediaBlock.tsx:301
 #: scripts/core/editor3/components/media/MediaBlock.tsx:306
 msgid "[No Value]"
-msgstr ""
+msgstr "[値なし]"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:103
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:97
 msgid "a Recurring Event"
-msgstr ""
+msgstr "繰り返しイベント"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:51
 msgid "a lower case letter (a-z)"
-msgstr ""
+msgstr "小文字（a-z）"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:53
 msgid "a number (0-9)"
-msgstr ""
+msgstr "数字（0-9）"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:54
 msgid "a special character (!@#$%^&...)"
-msgstr ""
+msgstr "特殊文字（!@#$%^&...）"
 
 #: scripts/apps/users/views/edit-form.html:36
 msgid "active"
-msgstr ""
+msgstr "有効"
 
 #: scripts/core/lang/missing-translations-strings.ts:38
 msgid "added new task {{subject}} of type {{type}}"
-msgstr ""
+msgstr "タイプ{{type}}の新しいタスク{{subject}}を追加しました"
 
 #: scripts/core/lang/missing-translations-strings.ts:35
 msgid "added new {{type}} item about \"{{subject}}\""
-msgstr ""
+msgstr "「{{subject}}」に関する新しい{{type}}アイテムを追加しました"
 
 #: scripts/core/lang/missing-translations-strings.ts:35
 msgid "added new {{type}} item with empty header/title"
-msgstr ""
+msgstr "空のヘッダー/タイトルで新しい{{type}}アイテムを追加しました"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:78
 msgid "added to workflow"
-msgstr ""
+msgstr "ワークフローに追加済み"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:167
 #: scripts/apps/users/views/user-preferences.html:147
 #: scripts/core/utils.tsx:342
 msgid "all"
-msgstr ""
+msgstr "すべて"
 
 #: scripts/apps/desks/views/desk-config-modal.html:289
 #: scripts/apps/highlights/views/highlights_config_modal.html:15
 msgid "already exists"
-msgstr ""
+msgstr "既に存在します"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:103
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:120
@@ -19917,41 +19917,41 @@ msgstr ""
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:91
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:97
 msgid "an Event"
-msgstr ""
+msgstr "イベント"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:52
 msgid "an upper case letter (A-Z)"
-msgstr ""
+msgstr "大文字（A-Z）"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:56
 msgid "and"
-msgstr ""
+msgstr "および"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:45
 msgid "and '{{ user }}'"
-msgstr ""
+msgstr "および「{{ user }}」"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:90
 msgid "annotation"
-msgstr ""
+msgstr "注釈"
 
 #: scripts/core/lang/missing-translations-strings.ts:13
 msgid "archive"
-msgstr ""
+msgstr "アーカイブ"
 
 #: scripts/apps/search/components/ItemContainer.tsx:20
 msgid "archived"
-msgstr ""
+msgstr "アーカイブ済み"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:140
 msgid "as rewrite of"
-msgstr ""
+msgstr "書き直し対象"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:45
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:17
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:22
 msgid "at"
-msgstr ""
+msgstr "に"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:401
 #: scripts/apps/archive/controllers/UploadController.ts:330
@@ -19960,20 +19960,20 @@ msgstr ""
 #: scripts/core/lang/missing-translations-strings.ts:9
 #: scripts/core/utils.tsx:281 scripts/core/utils.tsx:349
 msgid "audio"
-msgstr ""
+msgstr "音声"
 
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-article.html:7
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:7
 msgid "author"
-msgstr ""
+msgstr "著者"
 
 #: scripts/core/lang/missing-translations-strings.ts:27
 msgid "authoring"
-msgstr ""
+msgstr "オーサリング"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:83
 msgid "bold"
-msgstr ""
+msgstr "太字"
 
 #: ../superdesk-planning/client/components/UI/Form/FileInput.tsx:205
 #: scripts/core/ui/components/Form/FileInput.tsx:137
@@ -19984,11 +19984,11 @@ msgstr ""
 #: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:195
 #: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:219
 msgid "browse"
-msgstr ""
+msgstr "参照"
 
 #: scripts/apps/search/components/SelectBox.tsx:68
 msgid "bulk actions"
-msgstr ""
+msgstr "一括操作"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:43
 #: ../superdesk-planning/client/components/AuditInformation/index.tsx:110
@@ -20003,222 +20003,222 @@ msgstr ""
 #: scripts/apps/authoring/versioning/versions/views/versions.html:7
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:2
 msgid "by"
-msgstr ""
+msgstr "者"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:210
 msgid "by {{user}}"
-msgstr ""
+msgstr "{{user}}が"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:223
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:223
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:284
 msgid "cancel"
-msgstr ""
+msgstr "キャンセル"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:88
 msgid "cancelled"
-msgstr ""
+msgstr "キャンセル済み"
 
 #: scripts/core/lang/missing-translations-strings.ts:14
 msgid "categories"
-msgstr ""
+msgstr "カテゴリー"
 
 #: scripts/apps/users/views/edit-form.html:211
 msgid "change password"
-msgstr ""
+msgstr "パスワードを変更"
 
 #: scripts/core/menu/notifications/views/notifications.html:42
 msgid ""
 "changed the following original item. Please make sure to update the "
 "corresponding translated item accordingly"
-msgstr ""
+msgstr "次の元のアイテムが変更されました。対応する翻訳アイテムも更新してください"
 
 #: scripts/apps/authoring/authoring/components/CharacterCount.tsx:30
 #: scripts/apps/authoring/authoring/components/CharacterCount.tsx:64
 #: scripts/apps/authoring/authoring/directives/CharacterCount.ts:13
 #: scripts/core/editor3/components/toolbar/FloatingCharacterCount.tsx:48
 msgid "characters"
-msgstr ""
+msgstr "文字"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:583
 msgid "city"
-msgstr ""
+msgstr "都市"
 
 #: scripts/core/ui/components/virtual-lists/select.tsx:176
 msgid "clear"
-msgstr ""
+msgstr "クリア"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:50
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:50
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:116
 msgid "close"
-msgstr ""
+msgstr "閉じる"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:41
 msgid "closed"
-msgstr ""
+msgstr "クローズ"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:112
 msgid "color"
-msgstr ""
+msgstr "色"
 
 #: scripts/core/editor3/components/toolbar/TableControls.tsx:102
 msgid "column"
-msgstr ""
+msgstr "列"
 
 #: scripts/core/menu/notifications/views/notifications.html:31
 msgid "commented on"
-msgstr ""
+msgstr "コメント"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:91
 msgid "comments"
-msgstr ""
+msgstr "コメント"
 
 #: scripts/core/lang/missing-translations-strings.ts:13
 msgid "compact"
-msgstr ""
+msgstr "コンパクト"
 
 #: scripts/core/lang/missing-translations-strings.ts:9
 #: scripts/core/utils.tsx:283
 msgid "composite"
-msgstr ""
+msgstr "複合"
 
 #: scripts/apps/users/views/edit-form.html:390
 msgid "confirm"
-msgstr ""
+msgstr "確認"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:69
 msgid "confirmed"
-msgstr ""
+msgstr "確認済み"
 
 #: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:181
 msgid "contact saved."
-msgstr ""
+msgstr "連絡先が保存されました。"
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "content"
-msgstr ""
+msgstr "コンテンツ"
 
 #: scripts/core/lang/missing-translations-strings.ts:12
 msgid "corrected"
-msgstr ""
+msgstr "修正済み"
 
 #: scripts/apps/search/components/fields/update.tsx:15
 msgid "correction sequence"
-msgstr ""
+msgstr "修正シーケンス"
 
 #: scripts/apps/authoring/metadata/views/meta-place-directive.html:20
 msgid "country"
-msgstr ""
+msgstr "国"
 
 #: scripts/core/lang/missing-translations-strings.ts:34
 msgid "create"
-msgstr ""
+msgstr "作成"
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:189
 msgid "created"
-msgstr ""
+msgstr "作成済み"
 
 #: ../superdesk-planning/client/actions/agenda.ts:240
 msgid "created  planning item."
-msgstr ""
+msgstr "プランニングアイテムを作成しました。"
 
 #: ../superdesk-planning/client/actions/agenda.ts:229
 msgid "created / planning item(s)"
-msgstr ""
+msgstr "プランニングアイテムを作成"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:42
 #: ../superdesk-planning/client/components/RelatedPlannings/index.tsx:102
 msgid "created by"
-msgstr ""
+msgstr "作成者"
 
 #: scripts/core/lang/missing-translations-strings.ts:36
 msgid "created new version {{version}} for item {{type}} about \"{{subject}}\""
-msgstr ""
+msgstr "「{{subject}}」に関する{{type}}アイテムの新バージョン{{version}}を作成しました"
 
 #: scripts/core/lang/missing-translations-strings.ts:42
 msgid "created user {{user}}"
-msgstr ""
+msgstr "ユーザー{{user}}を作成しました"
 
 #: scripts/apps/users/views/edit-form.html:379
 msgid "current"
-msgstr ""
+msgstr "現在"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:86
 msgid "custom blocks"
-msgstr ""
+msgstr "カスタムブロック"
 
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:17
 msgid "custom vocabulary"
-msgstr ""
+msgstr "カスタムボキャブラリー"
 
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:8
 msgid "date"
-msgstr ""
+msgstr "日付"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:41
 #: scripts/apps/desks/views/content-expiry.html:3
 msgid "day"
-msgstr ""
+msgstr "日"
 
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:11
 #: scripts/apps/authoring-react/fields/date/config.tsx:83
 #: scripts/apps/desks/views/content-expiry.html:32
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:153
 msgid "days"
-msgstr ""
+msgstr "日"
 
 #: scripts/apps/users/views/settings-privileges.html:16
 #: scripts/apps/users/views/settings-roles.html:15
 #: scripts/apps/users/views/user-preferences.html:159
 msgid "default"
-msgstr ""
+msgstr "デフォルト"
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:21
 msgid "default template"
-msgstr ""
+msgstr "デフォルトテンプレート"
 
 #: scripts/core/lang/missing-translations-strings.ts:26
 msgid "desk Output"
-msgstr ""
+msgstr "デスク出力"
 
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:9
 #: scripts/apps/authoring/versioning/versions/views/versions.html:13
 #: scripts/apps/search/components/ItemContainer.tsx:13
 #: scripts/core/itemList/views/relatedItem-list-widget.html:38
 msgid "desk:"
-msgstr ""
+msgstr "デスク："
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:272
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:272
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:455
 msgid "details"
-msgstr ""
+msgstr "詳細"
 
 #: scripts/apps/users/views/edit-form.html:34
 #: scripts/apps/users/views/user-list-item.html:15
 msgid "disabled"
-msgstr ""
+msgstr "無効"
 
 #: scripts/core/lang/missing-translations-strings.ts:36
 msgid "disabled user {{user}}"
-msgstr ""
+msgstr "ユーザー{{user}}を無効にしました"
 
 #: scripts/apps/authoring/macros/views/macros-replace.html:9
 msgid "done"
-msgstr ""
+msgstr "完了"
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "draft"
-msgstr ""
+msgstr "下書き"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:42
 msgid "due"
-msgstr ""
+msgstr "期限"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:58
 msgid "duplicate id"
-msgstr ""
+msgstr "重複ID"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:463
 msgid "e.g. @cityofsydney"
@@ -20259,79 +20259,79 @@ msgstr ""
 #: scripts/apps/contacts/constants.ts:49
 #: scripts/apps/users/views/edit-form.html:131
 msgid "email"
-msgstr ""
+msgstr "メール"
 
 #: scripts/apps/archive/views/item-state.html:6
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:225
 msgid "embargo"
-msgstr ""
+msgstr "エンバーゴ"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:93
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:9
 msgid "embed"
-msgstr ""
+msgstr "埋め込み"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:94
 msgid "embed articles"
-msgstr ""
+msgstr "記事を埋め込み"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:97
 #: scripts/extensions/availability-manager/dist/src/utils.js:97
 #: scripts/extensions/availability-manager/src/utils.ts:100
 msgid "end time"
-msgstr ""
+msgstr "終了時間"
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "error"
-msgstr ""
+msgstr "エラー"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:71
 msgid "event"
-msgstr ""
+msgstr "イベント"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:71
 msgid "events"
-msgstr ""
+msgstr "イベント"
 
 #: scripts/apps/publish/views/ftp-config.html:26
 msgid "example"
-msgstr ""
+msgstr "例"
 
 #: scripts/apps/archive/views/item-preview.html:19
 #: scripts/apps/archive/views/preview.html:116
 #: scripts/apps/search/components/MediaInfo.tsx:37
 #: scripts/apps/search/components/fields/expiry.tsx:15
 msgid "expires"
-msgstr ""
+msgstr "有効期限"
 
 #: scripts/apps/publish/views/subscribers.html:276
 msgid "expires:"
-msgstr ""
+msgstr "有効期限："
 
 #: scripts/apps/contacts/constants.ts:51
 msgid "facebook"
-msgstr ""
+msgstr "Facebook"
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "failed"
-msgstr ""
+msgstr "失敗"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:435
 msgid "fax"
-msgstr ""
+msgstr "ファックス"
 
 #: scripts/core/lang/missing-translations-strings.ts:14
 msgid "feature"
-msgstr ""
+msgstr "フィーチャー"
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "fetched"
-msgstr ""
+msgstr "取得済み"
 
 #: scripts/apps/archive/views/fetched-desks.html:2
 #: scripts/apps/search/components/FetchedDesksInfo.tsx:75
 msgid "fetched in"
-msgstr ""
+msgstr "取得先"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/form-validation.js:11
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/form-validation.js:20
@@ -20343,20 +20343,20 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/form-validation.ts:18
 #: scripts/extensions/broadcasting/src/form-validation.ts:22
 msgid "field can not be empty"
-msgstr ""
+msgstr "フィールドは空にできません"
 
 #: scripts/api/article-fetch.tsx:135
 msgid "file name"
-msgstr ""
+msgstr "ファイル名"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:230
 msgid "first"
-msgstr ""
+msgstr "最初"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:275
 #: scripts/apps/users/views/edit-form.html:82
 msgid "first name"
-msgstr ""
+msgstr "名"
 
 #: ../superdesk-planning/client/utils/tests/index_test.ts:208
 msgid "foo"
@@ -20364,148 +20364,148 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/events.tsx:1428
 msgid "for"
-msgstr ""
+msgstr "対象"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:9
 msgid "for \"{{currentDesk.name}}\" Desk"
-msgstr ""
+msgstr "デスク「{{currentDesk.name}}」用"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:2
 msgid "for \"{{name}}\" Desk"
-msgstr ""
+msgstr "デスク「{{name}}」用"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:42
 msgid "for '{{ desk }}'"
-msgstr ""
+msgstr "「{{ desk }}」用"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:97
 msgid "for desk"
-msgstr ""
+msgstr "デスク用"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:94
 msgid "for highlight"
-msgstr ""
+msgstr "ハイライト用"
 
 #: ../superdesk-planning/client/utils/events.tsx:1428
 msgid "for {{ repeatCount }} repeats"
-msgstr ""
+msgstr "{{ repeatCount }}回の繰り返し"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:87
 msgid "formatting marks"
-msgstr ""
+msgstr "書式マーク"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:36
 #: scripts/apps/authoring/versioning/history/views/history.html:47
 #: scripts/apps/authoring/versioning/history/views/history.html:69
 msgid "from"
-msgstr ""
+msgstr "から"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:28
 msgid "from content"
-msgstr ""
+msgstr "コンテンツから"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:95
 msgid "from coverage assignment by"
-msgstr ""
+msgstr "取材アサインメントから"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:122
 msgid "from highlight"
-msgstr ""
+msgstr "ハイライトから"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:361
 msgid "from highlight: {{x}}"
-msgstr ""
+msgstr "ハイライト{{x}}から"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:238
 msgid "from {{from}} to {{to}}"
-msgstr ""
+msgstr "{{from}}から{{to}}まで"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:228
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:244
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:260
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:276
 msgid "from:"
-msgstr ""
+msgstr "開始："
 
 #: scripts/apps/users/views/edit-form.html:73
 msgid "full name"
-msgstr ""
+msgstr "氏名"
 
 #: scripts/core/itemList/views/relatedItem-list-widget.html:42
 msgid "genre:"
-msgstr ""
+msgstr "ジャンル："
 
 #: scripts/core/ui/components/UserPopup/UserPopup.tsx:27
 msgid "go to profile"
-msgstr ""
+msgstr "プロファイルへ移動"
 
 #: scripts/core/utils.tsx:285 scripts/core/utils.tsx:345
 msgid "graphic"
-msgstr ""
+msgstr "グラフィック"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:66
 msgid "h1"
-msgstr ""
+msgstr "見出し1"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:67
 msgid "h2"
-msgstr ""
+msgstr "見出し2"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:68
 msgid "h3"
-msgstr ""
+msgstr "見出し3"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:69
 msgid "h4"
-msgstr ""
+msgstr "見出し4"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:70
 msgid "h5"
-msgstr ""
+msgstr "見出し5"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:71
 msgid "h6"
-msgstr ""
+msgstr "見出し6"
 
 #: scripts/api/article-fetch.tsx:137
 msgid "height"
-msgstr ""
+msgstr "高さ"
 
 #: scripts/core/views/sdSlider.html:3
 msgid "high"
-msgstr ""
+msgstr "高"
 
 #: scripts/core/lang/missing-translations-strings.ts:34
 msgid "highlights"
-msgstr ""
+msgstr "ハイライト"
 
 #: scripts/core/utils.tsx:347
 msgid "highlights package"
-msgstr ""
+msgstr "ハイライトパッケージ"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:255
 msgid "honorific"
-msgstr ""
+msgstr "敬称"
 
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:5
 #: scripts/apps/highlights/views/highlights_config_modal.html:45
 msgid "hours"
-msgstr ""
+msgstr "時間"
 
 #: scripts/apps/desks/views/content-expiry.html:4
 #: scripts/apps/desks/views/content-expiry.html:40
 msgid "hr"
-msgstr ""
+msgstr "時間"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:162
 msgid "hrs"
-msgstr ""
+msgstr "時間"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extension.js:26
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/extension.js:26
 #: scripts/extensions/auto-tagging-widget/src/extension.tsx:28
 msgid "iMatrics"
-msgstr ""
+msgstr "iMatrics"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:270
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:50
@@ -20514,7 +20514,7 @@ msgstr ""
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:111
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:444
 msgid "iMatrics service error"
-msgstr ""
+msgstr "iMatricsサービスエラー"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:54
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:54
@@ -20522,112 +20522,112 @@ msgstr ""
 msgid ""
 "iMatrics service has returned tags referencing parents that do not exist in "
 "the response."
-msgstr ""
+msgstr "iMatricsサービスがレスポンスに存在しない親を参照するタグを返しました。"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extension.js:10
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/extension.js:10
 #: scripts/extensions/auto-tagging-widget/src/extension.tsx:11
 msgid "iMatrics tagging"
-msgstr ""
+msgstr "iMatricsタグ付け"
 
 #: scripts/apps/archive/controllers/UploadController.ts:322
 #: scripts/apps/authoring-react/fields/media/editor.tsx:147
 #: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:196
 msgid "image"
-msgstr ""
+msgstr "画像"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/ImageTaggingComponent/ImageTaggingComponent.js:198
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:198
 #: scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.tsx:279
 msgid "image suggestions ({{n}})"
-msgstr ""
+msgstr "画像候補（{{n}}）"
 
 #: scripts/core/ui/views/sd-timepicker-popup.html:4
 msgid "in 1 h"
-msgstr ""
+msgstr "1時間後"
 
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:126
 #: scripts/core/ui/components/Form/TimeInput/TimeInputPopup.tsx:98
 msgid "in 1 hr"
-msgstr ""
+msgstr "1時間後"
 
 #: scripts/core/ui/views/sd-timepicker-popup.html:5
 msgid "in 2 h"
-msgstr ""
+msgstr "2時間後"
 
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:130
 #: scripts/core/ui/components/Form/TimeInput/TimeInputPopup.tsx:102
 msgid "in 2 hrs"
-msgstr ""
+msgstr "2時間後"
 
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:122
 #: scripts/core/ui/components/Form/TimeInput/TimeInputPopup.tsx:94
 #: scripts/core/ui/views/sd-timepicker-popup.html:3
 msgid "in 30 min"
-msgstr ""
+msgstr "30分後"
 
 #: ../superdesk-planning/client/components/RelatedPlannings/index.tsx:76
 msgid "in agenda"
-msgstr ""
+msgstr "アジェンダ内"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:72
 msgid "in the last 24 hours."
-msgstr ""
+msgstr "過去24時間内。"
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "in-progress"
-msgstr ""
+msgstr "進行中"
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "in_progress"
-msgstr ""
+msgstr "進行中"
 
 #: scripts/apps/users/views/edit-form.html:35
 #: scripts/apps/users/views/user-list-item.html:16
 msgid "inactive"
-msgstr ""
+msgstr "無効"
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "ingested"
-msgstr ""
+msgstr "取り込み済み"
 
 #: scripts/apps/contacts/constants.ts:52
 msgid "instagram"
-msgstr ""
+msgstr "Instagram"
 
 #: scripts/extensions/sams/dist/src/components/attachments/samsAttachmentsList.js:114
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/samsAttachmentsList.js:114
 #: scripts/extensions/sams/src/components/attachments/samsAttachmentsList.tsx:121
 msgid "internal"
-msgstr ""
+msgstr "内部"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:82
 msgid "italic"
-msgstr ""
+msgstr "斜体"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:429
 msgid "item"
-msgstr ""
+msgstr "アイテム"
 
 #: scripts/apps/archive/related-item-widget/relatedItem.ts:166
 msgid "item metadata associated."
-msgstr ""
+msgstr "アイテムメタデータが関連付けられました。"
 
 #: scripts/apps/master-desk/components/OverviewComponent.tsx:235
 msgid "items in production"
-msgstr ""
+msgstr "プロダクション中のアイテム"
 
 #: scripts/apps/master-desk/components/AssignmentsComponent.tsx:168
 msgid "items in total"
-msgstr ""
+msgstr "アイテム合計"
 
 #: scripts/core/lang/missing-translations-strings.ts:12
 msgid "killed"
-msgstr ""
+msgstr "キル済み"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:111
 msgid "label"
-msgstr ""
+msgstr "ラベル"
 
 #: scripts/apps/packaging/views/sd-package-item-preview.html:24
 msgid "label: <b>{{label.name}}</b>"
@@ -20635,106 +20635,106 @@ msgstr ""
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:232
 msgid "last"
-msgstr ""
+msgstr "最後"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:296
 #: scripts/apps/users/views/edit-form.html:94
 msgid "last name"
-msgstr ""
+msgstr "姓"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:80
 msgid "last update and last item arrived."
-msgstr ""
+msgstr "最終更新と最後のアイテム到着。"
 
 #: scripts/apps/authoring/authoring/directives/ReadingTime.ts:20
 #: scripts/apps/authoring/authoring/directives/ReadingTime.ts:54
 msgid "less than one minute read"
-msgstr ""
+msgstr "1分未満の読了時間"
 
 #: scripts/apps/authoring/authoring/components/line-count.tsx:21
 msgid "line"
 msgid_plural "lines"
-msgstr[0] ""
+msgstr[0] "行"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:77
 msgid "link"
-msgstr ""
+msgstr "リンク"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:143
 msgid "linked to"
-msgstr ""
+msgstr "リンク先"
 
 #: scripts/apps/contacts/views/search-results.html:4
 #: scripts/apps/content-api/views/search-results.html:4
 #: scripts/apps/legal-archive/views/legal_archive.html:107
 #: scripts/apps/search/views/search-results.html:6
 msgid "loading"
-msgstr ""
+msgstr "読み込み中"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/ImageTaggingComponent/ImageTaggingComponent.js:197
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:197
 #: scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.tsx:278
 msgid "loading image suggestions..."
-msgstr ""
+msgstr "画像候補を読み込み中..."
 
 #: ../superdesk-planning/client/components/Main/ListPanel.tsx:435
 msgid "loading more items..."
-msgstr ""
+msgstr "さらにアイテムを読み込み中..."
 
 #: scripts/apps/desks/directives/DeskeditPeople.ts:13
 #: scripts/apps/desks/directives/DeskeditStages.ts:92
 #: scripts/core/ui/components/virtual-lists/virtual-list.tsx:255
 msgid "loading..."
-msgstr ""
+msgstr "読み込み中..."
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:560
 msgid "locality"
-msgstr ""
+msgstr "地域"
 
 #: scripts/apps/search/components/ItemContainer.tsx:16
 msgid "location:"
-msgstr ""
+msgstr "ロケーション："
 
 #: scripts/core/views/sdSlider.html:2
 msgid "low"
-msgstr ""
+msgstr "低"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:100
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:31
 msgid "lowercase"
-msgstr ""
+msgstr "小文字"
 
 #: scripts/apps/packaging/services/PackagesService.ts:24
 #: scripts/apps/packaging/services/PackagesService.ts:55
 msgid "main"
-msgstr ""
+msgstr "メイン"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:390
 msgid "make this mode the default"
-msgstr ""
+msgstr "このモードをデフォルトにする"
 
 #: scripts/core/views/sdSearchList.html:17
 msgid "many"
-msgstr ""
+msgstr "多い"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:76
 msgid "media"
-msgstr ""
+msgstr "メディア"
 
 #: scripts/core/menu/notifications/views/notifications.html:35
 msgid "mentioned you"
-msgstr ""
+msgstr "あなたをメンション"
 
 #: scripts/core/lang/missing-translations-strings.ts:13
 msgid "mgrid"
-msgstr ""
+msgstr "mgrid"
 
 #: scripts/apps/desks/views/content-expiry.html:48
 #: scripts/apps/desks/views/content-expiry.html:5
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:133
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:174
 msgid "min"
-msgstr ""
+msgstr "分"
 
 #: scripts/extensions/datetimeField/dist/src/config.js:31
 #: scripts/extensions/datetimeField/dist/src/config.js:52
@@ -20743,47 +20743,47 @@ msgstr ""
 #: scripts/extensions/datetimeField/src/config.tsx:100
 #: scripts/extensions/datetimeField/src/config.tsx:51
 msgid "minutes"
-msgstr ""
+msgstr "分"
 
 #: scripts/apps/authoring/macros/views/macros-widget.html:31
 msgid "miscellaneous"
-msgstr ""
+msgstr "その他"
 
 #: scripts/apps/contacts/constants.ts:47
 msgid "mobile"
-msgstr ""
+msgstr "携帯"
 
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:23
 #: scripts/apps/authoring-react/fields/date/config.tsx:85
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:155
 msgid "months"
-msgstr ""
+msgstr "か月"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:85
 msgid "multi-line quote"
-msgstr ""
+msgstr "複数行引用"
 
 #: scripts/apps/search/views/saved-search-subscribe.html:23
 msgid "never"
-msgstr ""
+msgstr "しない"
 
 #: scripts/apps/users/views/edit-form.html:385
 msgid "new"
-msgstr ""
+msgstr "新規"
 
 #: scripts/core/ui/components/content-create-dropdown/content-create-dropdown.tsx:17
 msgid "new item"
-msgstr ""
+msgstr "新しいアイテム"
 
 #: scripts/apps/authoring/macros/views/macros-replace.html:8
 #: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:444
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:832
 msgid "next"
-msgstr ""
+msgstr "次"
 
 #: scripts/apps/content-filters/controllers/FilterSearchController.ts:112
 msgid "no results found"
-msgstr ""
+msgstr "結果が見つかりません"
 
 #: scripts/apps/profiling/views/profiling.html:10
 #: scripts/apps/publish/views/publish-queue.html:18
@@ -20792,25 +20792,25 @@ msgstr ""
 #: scripts/apps/publish/views/publish-queue.html:64
 #: scripts/apps/users/views/user-preferences.html:153
 msgid "none"
-msgstr ""
+msgstr "なし"
 
 #: scripts/core/interactive-article-actions-panel/subcomponents/controlled-vocabulary-select.tsx:95
 msgid "not"
-msgstr ""
+msgstr "否定"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:650
 msgid "notes"
-msgstr ""
+msgstr "メモ"
 
 #: scripts/core/lang/missing-translations-strings.ts:13
 msgid "notifications"
-msgstr ""
+msgstr "通知"
 
 #: scripts/core/list/views/sdPagination.html:15
 #: scripts/core/list/views/sdPaginationAlt.html:2
 #: scripts/core/views/sdSearchList.html:15
 msgid "of"
-msgstr ""
+msgstr "の"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:63
 #: ../superdesk-planning/client/utils/events.tsx:1467
@@ -20819,113 +20819,113 @@ msgstr ""
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:22
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:11
 msgid "on"
-msgstr ""
+msgstr "オン"
 
 #: ../superdesk-planning/client/utils/events.tsx:1443
 msgid "on all week (including weekends)"
-msgstr ""
+msgstr "週全日（週末を含む）"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:100
 msgid "on assignment by"
-msgstr ""
+msgstr "アサインメント担当者"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:23
 msgid "on the"
-msgstr ""
+msgstr "の"
 
 #: ../superdesk-planning/client/utils/events.tsx:1440
 msgid "on week days"
-msgstr ""
+msgstr "平日"
 
 #: scripts/apps/authoring/authoring/components/text-statistics.tsx:22
 msgid "one word"
 msgid_plural "{{x}} words"
-msgstr[0] ""
+msgstr[0] "{{x}}語"
 
 #: scripts/core/editor3/components/article-embed/article-embed.tsx:32
 msgid "open in a new window"
-msgstr ""
+msgstr "新しいウィンドウで開く"
 
 #: scripts/extensions/markForUser/dist/src/extension.js:48
 #: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/extension.js:48
 #: scripts/extensions/markForUser/src/extension.tsx:55
 msgid "open item"
-msgstr ""
+msgstr "アイテムを開く"
 
 #: scripts/apps/archive/views/upload.html:38
 #: scripts/core/auth/login-modal.html:53
 msgid "or"
-msgstr ""
+msgstr "または"
 
 #: scripts/apps/users/views/change-avatar.html:31
 msgid "or Select from computer"
-msgstr ""
+msgstr "またはコンピューターから選択"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:73
 #: scripts/core/editor3/helpers/highlights.ts:67
 msgid "ordered list"
-msgstr ""
+msgstr "番号付きリスト"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:320
 #: scripts/apps/contacts/constants.ts:71
 msgid "organisation"
-msgstr ""
+msgstr "組織"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:624
 msgid "other"
-msgstr ""
+msgstr "その他"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:400
 #: scripts/core/utils.tsx:346
 msgid "package"
-msgstr ""
+msgstr "パッケージ"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:60
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:60
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:139
 msgid "parent ID"
-msgstr ""
+msgstr "親ID"
 
 #: scripts/apps/ingest/views/settings/searchConfig.html:7
 #: scripts/apps/users/import/views/import-user.html:19
 #: scripts/core/auth/login-modal.html:16
 msgid "password"
-msgstr ""
+msgstr "パスワード"
 
 #: scripts/core/auth/login-modal.html:81
 #: scripts/core/auth/reset-password.html:54
 msgid "passwords must be same"
-msgstr ""
+msgstr "パスワードは一致する必要があります"
 
 #: scripts/apps/users/views/user-list-item.html:17
 msgid "pending"
-msgstr ""
+msgstr "保留中"
 
 #: scripts/apps/contacts/constants.ts:48
 msgid "phone"
-msgstr ""
+msgstr "電話"
 
 #: scripts/apps/users/views/edit-form.html:177
 msgid "phone number"
-msgstr ""
+msgstr "電話番号"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:399
 #: scripts/core/lang/missing-translations-strings.ts:9
 #: scripts/core/utils.tsx:287 scripts/core/utils.tsx:344
 msgid "picture"
-msgstr ""
+msgstr "画像"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:75
 msgid "planning item"
-msgstr ""
+msgstr "プランニングアイテム"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:75
 msgid "planning items"
-msgstr ""
+msgstr "プランニングアイテム"
 
 #: scripts/apps/users/views/edit-form.html:141
 msgid "please provide a valid email address"
-msgstr ""
+msgstr "有効なメールアドレスを入力してください"
 
 #: scripts/apps/users/views/edit-form.html:121
 msgid ""
@@ -20935,318 +20935,318 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:121
 msgid "post"
-msgstr ""
+msgstr "投稿"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:570
 msgid "postcode"
-msgstr ""
+msgstr "郵便番号"
 
 #: ../superdesk-planning/client/utils/history.tsx:84
 msgid "posted"
-msgstr ""
+msgstr "投稿済み"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:74
 msgid "pre"
-msgstr ""
+msgstr "整形済み"
 
 #: scripts/core/editor3/helpers/highlights.ts:68 scripts/core/utils.tsx:289
 msgid "preformatted"
-msgstr ""
+msgstr "整形済みテキスト"
 
 #: scripts/apps/authoring/macros/views/macros-replace.html:7
 #: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:443
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:831
 msgid "prev"
-msgstr ""
+msgstr "前"
 
 #: scripts/apps/publish-preview/previewModal.tsx:122
 msgid "preview"
-msgstr ""
+msgstr "プレビュー"
 
 #: scripts/core/lang/missing-translations-strings.ts:25
 msgid "production"
-msgstr ""
+msgstr "プロダクション"
 
 #: scripts/apps/users/import/views/import-user.html:31
 msgid "profile"
-msgstr ""
+msgstr "プロファイル"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:233
 msgid "public"
-msgstr ""
+msgstr "公開"
 
 #: scripts/core/lang/missing-translations-strings.ts:9
 msgid "publish"
-msgstr ""
+msgstr "公開"
 
 #: scripts/core/lang/missing-translations-strings.ts:12
 msgid "published"
-msgstr ""
+msgstr "公開済み"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:59
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:59
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:138
 msgid "qcode"
-msgstr ""
+msgstr "Qコード"
 
 #: scripts/apps/authoring/macros/views/macros-widget.html:14
 msgid "quick list"
-msgstr ""
+msgstr "クイックリスト"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:75
 #: scripts/core/editor3/helpers/highlights.ts:65
 msgid "quote"
-msgstr ""
+msgstr "引用"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:98
 msgid "redo"
-msgstr ""
+msgstr "やり直し"
 
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:10
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:7
 msgid "related content"
-msgstr ""
+msgstr "関連コンテンツ"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:89
 msgid "remove all format"
-msgstr ""
+msgstr "すべての書式を削除"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:88
 msgid "remove format"
-msgstr ""
+msgstr "書式を削除"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:111
 msgid "removed desk"
-msgstr ""
+msgstr "デスクを削除"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:108
 msgid "removed highlight"
-msgstr ""
+msgstr "ハイライトを削除"
 
 #: scripts/core/lang/missing-translations-strings.ts:37
 msgid "removed item {{type}} about {{subject}}"
-msgstr ""
+msgstr "「{{subject}}」に関する{{type}}アイテムを削除しました"
 
 #: scripts/apps/authoring/macros/views/macros-replace.html:6
 msgid "replace"
-msgstr ""
+msgstr "置換"
 
 #: scripts/core/lang/missing-translations-strings.ts:43
 msgid "replaced item {{type}} about {{subject}}"
-msgstr ""
+msgstr "「{{subject}}」に関する{{type}}アイテムを置換しました"
 
 #: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:181
 #: scripts/core/editor3/directive.tsx:452
 msgid "required"
-msgstr ""
+msgstr "必須"
 
 #: scripts/apps/users/views/edit-form.html:208
 msgid "reset password"
-msgstr ""
+msgstr "パスワードをリセット"
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "retrying"
-msgstr ""
+msgstr "再試行中"
 
 #: scripts/apps/authoring/versioning/versions/views/versions.html:20
 msgid "revert"
-msgstr ""
+msgstr "元に戻す"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:72
 msgid "reverted"
-msgstr ""
+msgstr "元に戻されました"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:182
 msgid "rewrite id"
-msgstr ""
+msgstr "書き直しID"
 
 #: scripts/core/lang/missing-translations-strings.ts:41
 msgid "role {{role}} is granted new privileges: Please re-login."
-msgstr ""
+msgstr "ロール{{role}}に新しい権限が付与されました。再ログインしてください。"
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "routed"
-msgstr ""
+msgstr "ルーティング済み"
 
 #: scripts/core/editor3/components/toolbar/TableControls.tsx:90
 msgid "row"
-msgstr ""
+msgstr "行"
 
 #: scripts/core/lang/missing-translations-strings.ts:12
 msgid "scheduled"
-msgstr ""
+msgstr "スケジュール済み"
 
 #: scripts/core/lang/missing-translations-strings.ts:26
 msgid "scheduled Desk Output"
-msgstr ""
+msgstr "スケジュールデスク出力"
 
 #: scripts/core/lang/missing-translations-strings.ts:25
 msgid "search"
-msgstr ""
+msgstr "検索"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:118
 msgid "search provider password"
-msgstr ""
+msgstr "検索プロバイダーパスワード"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:110
 msgid "search provider username"
-msgstr ""
+msgstr "検索プロバイダーユーザー名"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:144
 msgid "sec"
-msgstr ""
+msgstr "秒"
 
 #: scripts/core/views/sdSearchList.html:5
 msgid "selected"
-msgstr ""
+msgstr "選択済み"
 
 #: scripts/apps/search/components/SelectBox.tsx:63
 msgid "selection not allowed"
-msgstr ""
+msgstr "選択できません"
 
 #: scripts/core/lang/missing-translations-strings.ts:9
 msgid "send"
-msgstr ""
+msgstr "送信"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:20
 msgid "since"
-msgstr ""
+msgstr "以降"
 
 #: scripts/apps/content-filters/controllers/FilterSearchController.ts:31
 msgid "single value is required"
-msgstr ""
+msgstr "単一の値が必要です"
 
 #: scripts/core/lang/missing-translations-strings.ts:32
 msgid "slugline"
-msgstr ""
+msgstr "スラッグライン"
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "sluglines"
-msgstr ""
+msgstr "スラッグライン"
 
 #: scripts/apps/users/views/edit-form.html:146
 msgid "sorry, a user with this email already exists"
-msgstr ""
+msgstr "このメールアドレスのユーザーは既に存在します"
 
 #: scripts/apps/users/views/edit-form.html:119
 msgid "sorry, this username is already taken."
-msgstr ""
+msgstr "このユーザー名は既に使用されています。"
 
 #: scripts/apps/search/components/MediaInfo.tsx:26
 msgid "source"
-msgstr ""
+msgstr "ソース"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:90
 msgid "source of the search provider"
-msgstr ""
+msgstr "検索プロバイダーのソース"
 
 #: scripts/core/lang/missing-translations-strings.ts:12
 msgid "spiked"
-msgstr ""
+msgstr "スパイク済み"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:91
 msgid "spiked and unlinked"
-msgstr ""
+msgstr "スパイク済みでリンク解除"
 
 #: scripts/core/lang/missing-translations-strings.ts:26
 msgid "stage"
-msgstr ""
+msgstr "ステージ"
 
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:10
 #: scripts/apps/authoring/versioning/versions/views/versions.html:14
 #: scripts/core/itemList/views/relatedItem-list-widget.html:39
 msgid "stage:"
-msgstr ""
+msgstr "ステージ："
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:94
 #: scripts/extensions/availability-manager/dist/src/utils.js:94
 #: scripts/extensions/availability-manager/src/utils.ts:98
 msgid "start time"
-msgstr ""
+msgstr "開始時間"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:100
 #: scripts/extensions/availability-manager/dist/src/utils.js:100
 #: scripts/extensions/availability-manager/src/utils.ts:102
 msgid ""
 "start time cannot be greater than end time ({{start_time}} - {{end_time}})"
-msgstr ""
+msgstr "開始時間は終了時間より後にできません（{{start_time}} - {{end_time}}）"
 
 #: scripts/apps/authoring/metadata/views/meta-place-directive.html:19
 msgid "state, region, ..."
-msgstr ""
+msgstr "都道府県、地域..."
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:109
 #: scripts/extensions/availability-manager/dist/src/utils.js:109
 #: scripts/extensions/availability-manager/src/utils.ts:114
 msgid "status"
-msgstr ""
+msgstr "ステータス"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:80
 msgid "strikethrough"
-msgstr ""
+msgstr "取り消し線"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:83
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "submitted"
-msgstr ""
+msgstr "送信済み"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:79
 msgid "subscript"
-msgstr ""
+msgstr "下付き"
 
 #: scripts/core/lang/missing-translations-strings.ts:32
 msgid "subscription"
-msgstr ""
+msgstr "サブスクリプション"
 
 #: scripts/apps/search/views/saved-search-manage-subscribers.html:16
 #: scripts/apps/search/views/search-panel.html:43
 msgid "subscriptions"
-msgstr ""
+msgstr "サブスクリプション"
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "success"
-msgstr ""
+msgstr "成功"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:92
 msgid "suggestions"
-msgstr ""
+msgstr "提案"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:78
 msgid "superscript"
-msgstr ""
+msgstr "上付き"
 
 #: scripts/apps/legal-archive/views/legal_archive.html:16
 msgid "switch to grid view"
-msgstr ""
+msgstr "グリッド表示に切り替え"
 
 #: scripts/apps/legal-archive/views/legal_archive.html:17
 msgid "switch to list view"
-msgstr ""
+msgstr "リスト表示に切り替え"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:95
 msgid "tab"
-msgstr ""
+msgstr "タブ"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:96
 msgid "tab as space"
-msgstr ""
+msgstr "タブをスペースに"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:84
 msgid "table"
-msgstr ""
+msgstr "テーブル"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:58
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:58
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:137
 msgid "tag name"
-msgstr ""
+msgstr "タグ名"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:398
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:6
 #: scripts/core/lang/missing-translations-strings.ts:9
 #: scripts/core/utils.tsx:291 scripts/core/utils.tsx:343
 msgid "text"
-msgstr ""
+msgstr "テキスト"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:84
 #: scripts/apps/authoring/versioning/history/views/history.html:83
@@ -21255,131 +21255,131 @@ msgstr ""
 #: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:61
 #: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:121
 msgid "to"
-msgstr ""
+msgstr "まで"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:41
 msgid "to '{{ desk }}'"
-msgstr ""
+msgstr "「{{ desk }}」へ"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:75
 msgid "to coverage assignment by"
-msgstr ""
+msgstr "取材アサインメント担当者へ"
 
 #: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:150
 msgid "toggle difference"
-msgstr ""
+msgstr "差分の切り替え"
 
 #: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:134
 msgid "toggle primary"
-msgstr ""
+msgstr "プライマリの切り替え"
 
 #: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:142
 msgid "toggle secondary"
-msgstr ""
+msgstr "セカンダリの切り替え"
 
 #: scripts/apps/authoring/views/authoring-header.html:85
 msgid "translations"
-msgstr ""
+msgstr "翻訳"
 
 #: scripts/apps/contacts/constants.ts:50
 msgid "twitter"
-msgstr ""
+msgstr "Twitter"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:81
 msgid "underline"
-msgstr ""
+msgstr "下線"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:97
 msgid "undo"
-msgstr ""
+msgstr "元に戻す"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:72
 #: scripts/core/editor3/helpers/highlights.ts:66
 msgid "unordered list"
-msgstr ""
+msgstr "箇条書きリスト"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:121
 msgid "unpost"
-msgstr ""
+msgstr "投稿取り消し"
 
 #: ../superdesk-planning/client/utils/history.tsx:87
 msgid "unposted"
-msgstr ""
+msgstr "未投稿"
 
 #: ../superdesk-planning/client/utils/events.tsx:1413
 msgid "until {{until}}"
-msgstr ""
+msgstr "{{until}}まで"
 
 #: scripts/core/lang/missing-translations-strings.ts:27
 msgid "update"
-msgstr ""
+msgstr "更新"
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:189
 #: ../superdesk-planning/client/components/Agendas/AgendaListItem.tsx:47
 #: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:140
 #: scripts/apps/search/components/MediaInfo.tsx:32
 msgid "updated"
-msgstr ""
+msgstr "更新済み"
 
 #: scripts/core/lang/missing-translations-strings.ts:40
 msgid "updated Ingest Channel {{name}}"
-msgstr ""
+msgstr "取り込みチャンネル{{name}}を更新しました"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:25
 msgid "updated fields"
-msgstr ""
+msgstr "更新されたフィールド"
 
 #: scripts/core/lang/missing-translations-strings.ts:38
 msgid "updated task {{subject}} for item {{type}}"
-msgstr ""
+msgstr "{{type}}アイテムのタスク{{subject}}を更新しました"
 
 #: scripts/core/lang/missing-translations-strings.ts:34
 msgid "uploaded media {{name}}"
-msgstr ""
+msgstr "メディア{{name}}をアップロードしました"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:30
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:99
 msgid "uppercase"
-msgstr ""
+msgstr "大文字"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:98
 msgid "url of the search provider"
-msgstr ""
+msgstr "検索プロバイダーのURL"
 
 #: scripts/core/lang/missing-translations-strings.ts:37
 msgid "user {{user}} has been added to desk {{desk}}: Please re-login."
-msgstr ""
+msgstr "ユーザー{{user}}がデスク{{desk}}に追加されました。再ログインしてください。"
 
 #: scripts/core/lang/missing-translations-strings.ts:41
 msgid "user {{user}} is granted new privileges: Please re-login."
-msgstr ""
+msgstr "ユーザー{{user}}に新しい権限が付与されました。再ログインしてください。"
 
 #: scripts/core/lang/missing-translations-strings.ts:42
 msgid "user {{user}} is updated to administrator: Please re-login."
-msgstr ""
+msgstr "ユーザー{{user}}が管理者に更新されました。再ログインしてください。"
 
 #: scripts/apps/ingest/views/settings/searchConfig.html:3
 #: scripts/apps/users/import/views/import-user.html:14
 #: scripts/apps/users/views/edit-form.html:106
 #: scripts/core/auth/login-modal.html:15
 msgid "username"
-msgstr ""
+msgstr "ユーザー名"
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "users"
-msgstr ""
+msgstr "ユーザー"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/form-validation.js:27
 #: scripts/extensions/broadcasting/dist/src/form-validation.js:27
 #: scripts/extensions/broadcasting/src/form-validation.ts:26
 msgid "value must be greater than zero"
-msgstr ""
+msgstr "値は0より大きくなければなりません"
 
 #: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:241
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:241
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:304
 msgid "value of 0 will disable this restriction"
-msgstr ""
+msgstr "0を設定するとこの制限が無効になります"
 
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-article.html:5
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:13
@@ -21401,19 +21401,19 @@ msgstr ""
 #: scripts/apps/authoring/versioning/history/views/history.html:91
 #: scripts/apps/authoring/versioning/versions/views/versions.html:18
 msgid "version"
-msgstr ""
+msgstr "バージョン"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:117
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:121
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:260
 msgid "version {{n}}"
-msgstr ""
+msgstr "バージョン{{n}}"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:161
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:176
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:238
 msgid "version: {{n}}"
-msgstr ""
+msgstr "バージョン：{{n}}"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:402
 #: scripts/apps/archive/controllers/UploadController.ts:326
@@ -21422,54 +21422,54 @@ msgstr ""
 #: scripts/core/lang/missing-translations-strings.ts:9
 #: scripts/core/utils.tsx:293 scripts/core/utils.tsx:348
 msgid "video"
-msgstr ""
+msgstr "動画"
 
 #: scripts/apps/desks/views/settings.html:77
 msgid "view all"
-msgstr ""
+msgstr "すべて表示"
 
 #: scripts/core/notification/notification.ts:231
 msgid ""
 "vocabulary has been updated. Please re-login to see updated vocabulary values"
-msgstr ""
+msgstr "ボキャブラリーが更新されました。更新された値を確認するには再ログインしてください"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:448
 msgid "website"
-msgstr ""
+msgstr "ウェブサイト"
 
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:17
 #: scripts/apps/authoring-react/fields/date/config.tsx:84
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:154
 msgid "weeks"
-msgstr ""
+msgstr "週間"
 
 #: scripts/api/article-fetch.tsx:136
 msgid "width"
-msgstr ""
+msgstr "幅"
 
 #: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:110
 #: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:95
 msgid "with"
-msgstr ""
+msgstr "含む"
 
 #: scripts/apps/authoring/track-changes/views/suggestions-widget.html:27
 msgid "with:"
-msgstr ""
+msgstr "含む："
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:112
 #: scripts/extensions/availability-manager/dist/src/utils.js:112
 #: scripts/extensions/availability-manager/src/utils.ts:118
 msgid "working hours are not set"
-msgstr ""
+msgstr "勤務時間が設定されていません"
 
 #: scripts/apps/search/components/ItemContainer.tsx:17
 msgid "workspace"
-msgstr ""
+msgstr "ワークスペース"
 
 #: scripts/apps/authoring-react/fields/date/config.tsx:86
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:156
 msgid "years"
-msgstr ""
+msgstr "年"
 
 #: scripts/apps/dashboard/views/configuration.html:2
 msgid "{{ 'Configuration' }}"
@@ -21489,17 +21489,17 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:78
 msgid "{{ count }} {{ type }} selected"
-msgstr ""
+msgstr "{{ count }}件の{{ type }}を選択中"
 
 #: ../superdesk-planning/client/actions/main.ts:325
 msgid "{{ itemType }} created"
-msgstr ""
+msgstr "{{ itemType }}が作成されました"
 
 #: ../superdesk-planning/client/validators/index.ts:119
 #: ../superdesk-planning/client/validators/planning.ts:170
 #: ../superdesk-planning/client/validators/planning.ts:210
 msgid "{{ key }} is a required field"
-msgstr ""
+msgstr "{{ key }}は必須フィールドです"
 
 #: scripts/apps/authoring/macros/views/macros-widget.html:17
 #: scripts/apps/authoring/macros/views/macros-widget.html:26
@@ -21511,15 +21511,15 @@ msgstr ""
 #: scripts/apps/search/views/multi-action-bar.html:4
 msgid "{{ multi.count}} Item selected"
 msgid_plural "{{ multi.count}} Items selected"
-msgstr[0] ""
+msgstr[0] "{{ multi.count}}件選択中"
 
 #: ../superdesk-planning/client/components/fields/calendars.tsx:45
 msgid "{{ name }} (disabled)"
-msgstr ""
+msgstr "{{ name }}（無効）"
 
 #: ../superdesk-planning/client/components/fields/editor/base/multilingualText.tsx:150
 msgid "{{ name }} ({{ language }})"
-msgstr ""
+msgstr "{{ name }}（{{ language }}）"
 
 #: ../superdesk-planning/client/validators/assignments.tsx:9
 #: ../superdesk-planning/client/validators/profile.ts:108
@@ -21527,15 +21527,15 @@ msgstr ""
 #: ../superdesk-planning/client/validators/profile.ts:78
 #: ../superdesk-planning/client/validators/profile.ts:86
 msgid "{{ name }} is a required field"
-msgstr ""
+msgstr "{{ name }}は必須フィールドです"
 
 #: ../superdesk-planning/client/validators/profile.ts:62
 msgid "{{ name }} is too long"
-msgstr ""
+msgstr "{{ name }}が長すぎます"
 
 #: ../superdesk-planning/client/validators/profile.ts:104
 msgid "{{ name }} is too short"
-msgstr ""
+msgstr "{{ name }}が短すぎます"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:117
 #: scripts/apps/monitoring/views/aggregate-settings.html:138
@@ -21544,7 +21544,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/assignments/notifications.ts:371
 msgid "{{ type }} assignment '{{ slugline }}' is deleted"
-msgstr ""
+msgstr "{{ type }}アサインメント「{{ slugline }}」が削除されました"
 
 #: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:4
 msgid "{{ widget.configuration.label || widget.label }}"
@@ -21556,7 +21556,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Archive/ArchivePreview/ArchivePreviewMetadataList.tsx:16
 msgid "{{ wordCount }} words"
-msgstr ""
+msgstr "{{ wordCount }}語"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:25
 msgid "{{:: monitoring.getGroupLabel(card, aggregate.settings.type)}}"
@@ -21568,27 +21568,27 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:118
 msgid "{{action}} {{event}}"
-msgstr ""
+msgstr "{{action}} {{event}}"
 
 #: ../superdesk-planning/client/components/Main/ItemEditorModal/EditorModalPanel.tsx:166
 msgid "{{action}} {{type}}"
-msgstr ""
+msgstr "{{action}} {{type}}"
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:370
 msgid "{{count}} articles have been descheduled"
-msgstr ""
+msgstr "{{count}}件の記事のスケジュールが解除されました"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:224
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:224
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:287
 msgid "{{count}} item selected"
 msgid_plural "{{count}} items selected"
-msgstr[0] ""
+msgstr[0] "{{count}}件選択中"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:123
 #: ../superdesk-analytics/client/utils.js:196
 msgid "{{days}} days"
-msgstr ""
+msgstr "{{days}}日"
 
 #: scripts/apps/users/views/edit-form.html:144
 msgid "{{error.email}}"
@@ -21610,11 +21610,11 @@ msgstr ""
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:112
 msgid "{{field}} (optional)"
-msgstr ""
+msgstr "{{field}}（任意）"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:384
 msgid "{{field}} cannot be earlier than now!"
-msgstr ""
+msgstr "{{field}}は現在より前にできません。"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:109
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:94
@@ -21626,28 +21626,28 @@ msgstr ""
 #: scripts/extensions/availability-manager/src/utils.ts:114
 #: scripts/extensions/availability-manager/src/utils.ts:98
 msgid "{{field}} cannot be empty"
-msgstr ""
+msgstr "{{field}}は空にできません"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:372
 msgid "{{field}} date is required!"
-msgstr ""
+msgstr "{{field}}の日付は必須です。"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:380
 msgid "{{field}} is not a valid date!"
-msgstr ""
+msgstr "{{field}}は有効な日付ではありません。"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:376
 msgid "{{field}} time is required!"
-msgstr ""
+msgstr "{{field}}の時間は必須です。"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:118
 #: ../superdesk-analytics/client/utils.js:202
 msgid "{{hours}} hours"
-msgstr ""
+msgstr "{{hours}}時間"
 
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:99
 msgid "{{hours}} hours, {{minutes}} minutes"
-msgstr ""
+msgstr "{{hours}}時間{{minutes}}分"
 
 #: ../superdesk-analytics/client/charts/views/chart-colour-picker.html:2
 msgid "{{label | translate}}"
@@ -21660,45 +21660,45 @@ msgstr ""
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:105
 #: ../superdesk-analytics/client/utils.js:208
 msgid "{{minutes}} minutes"
-msgstr ""
+msgstr "{{minutes}}分"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:133
 msgid "{{months}} months"
-msgstr ""
+msgstr "{{months}}か月"
 
 #: scripts/apps/publish/views/publish-queue.html:84
 msgid "{{multiSelectCount}} Item selected"
 msgid_plural "{{multiSelectCount}} Items selected"
-msgstr[0] ""
+msgstr[0] "{{multiSelectCount}}件選択中"
 
 #: scripts/apps/authoring/authoring/directives/WordCount.html:1
 msgid "{{numWords}} words"
-msgstr ""
+msgstr "{{numWords}}語"
 
 #: scripts/api/article-fetch.tsx:117
 msgid "{{n}} images can not be fetched because they are too small."
 msgid_plural "One image can not be fetched because it is too small."
-msgstr[0] ""
+msgstr[0] "小さすぎるため取得できない画像があります。"
 
 #: scripts/apps/authoring-react/fields/media/difference.tsx:41
 msgid "{{n}} items added"
-msgstr ""
+msgstr "{{n}}件のアイテムが追加されました"
 
 #: scripts/apps/authoring-react/fields/media/difference.tsx:54
 msgid "{{n}} items modified"
-msgstr ""
+msgstr "{{n}}件のアイテムが変更されました"
 
 #: scripts/apps/authoring-react/fields/media/difference.tsx:62
 msgid "{{n}} items re-ordered"
-msgstr ""
+msgstr "{{n}}件のアイテムが並び替えられました"
 
 #: scripts/apps/authoring-react/fields/media/difference.tsx:47
 msgid "{{n}} items removed"
-msgstr ""
+msgstr "{{n}}件のアイテムが削除されました"
 
 #: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:105
 msgid "{{n}} of {{total}} matches"
-msgstr ""
+msgstr "{{total}}件中{{n}}件一致"
 
 #: scripts/apps/users/views/edit-form.html:65
 msgid "{{roles[user.role].name}}"
@@ -21706,7 +21706,7 @@ msgstr ""
 
 #: ../superdesk-analytics/client/utils.js:213
 msgid "{{seconds}} seconds"
-msgstr ""
+msgstr "{{seconds}}秒"
 
 #: scripts/apps/users/views/edit.html:19
 msgid "{{section.label}}"
@@ -21714,11 +21714,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/confirmAddingRelatedItems.tsx:44
 msgid "{{some}} of {{total}} items can not be added as related"
-msgstr ""
+msgstr "{{total}}件中{{some}}件のアイテムを関連として追加できません"
 
 #: scripts/core/lang/missing-translations-strings.ts:40
 msgid "{{status}} Ingest Channel {{name}}"
-msgstr ""
+msgstr "取り込みチャンネル{{name}}を{{status}}"
 
 #: scripts/apps/archive/views/metadata-associateditem-view.html:1
 msgid "{{title}}"
@@ -21732,45 +21732,45 @@ msgstr ""
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:44
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:45
 msgid "{{update.date}} - {{update.operation}} by {{update.user}}"
-msgstr ""
+msgstr "{{update.date}} - {{update.user}}が{{update.operation}}"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:128
 msgid "{{weeks}} weeks"
-msgstr ""
+msgstr "{{weeks}}週間"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:124
 #: scripts/extensions/sams/dist/src/utils/ui.js:124
 #: scripts/extensions/sams/src/utils/ui.tsx:119
 msgid "{{width}} * {{height}}"
-msgstr ""
+msgstr "{{width}} * {{height}}"
 
 #: scripts/apps/authoring-react/fields/media/media-metadata.tsx:44
 msgid "{{width}} x {{height}} px"
-msgstr ""
+msgstr "{{width}} x {{height}} px"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:55
 msgid "{{wordsCount}} word"
 msgid_plural "{{ $count}} words"
-msgstr[0] ""
+msgstr[0] "{{ $count}}語"
 
 #: scripts/extensions/datetimeField/dist/src/editor.js:76
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:81
 #: scripts/extensions/datetimeField/src/editor.tsx:140
 msgid "{{x}} hour"
 msgid_plural "{{x}} hours"
-msgstr[0] ""
+msgstr[0] "{{x}}時間"
 
 #: scripts/apps/search/components/fields/linesCount.tsx:14
 msgid "{{x}} lines"
-msgstr ""
+msgstr "{{x}}行"
 
 #: scripts/extensions/datetimeField/dist/src/editor.js:79
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:84
 #: scripts/extensions/datetimeField/src/editor.tsx:149
 msgid "{{x}} min"
-msgstr ""
+msgstr "{{x}}分"
 
 #: scripts/apps/authoring/authoring/directives/ReadingTime.ts:22
 #: scripts/apps/authoring/authoring/directives/ReadingTime.ts:52
 msgid "{{x}} min read"
-msgstr ""
+msgstr "{{x}}分で読了"

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -656,7 +656,7 @@ export function AuthoringDirective(
 
             $scope.showCustomButtons = () => {
                 return $scope.toDeskAvailable || $scope.closeAndContinueAvailable
-                    || $scope.publishAndContinueAvailable || $scope.publishAvailable  || $scope.sendAndDuplicateEnabled;
+                    || $scope.publishAndContinueAvailable || $scope.publishAvailable || $scope.sendAndDuplicateEnabled;
             };
 
             $scope.saveAndContinue = function(customButtonAction, showConfirm) {

--- a/scripts/apps/users/views/edit-form.html
+++ b/scripts/apps/users/views/edit-form.html
@@ -235,7 +235,7 @@
                                     <select class="sd-input__select" ng-focus="focused()" ng-model="user.language" name="user_language" id="user_language" ng-options="lang.code as lang.nativeName for lang in languages"></select>
                                     <div class="sd-input__message-box">
                                         <div class="sd-input__hint">
-                                            <a href="https://explore.transifex.com/sourcefabric/superdesk/" target="_blank">{{ :: "Help us translate Superdesk" | translate }}</a>
+                                            <a href="https://explore.transifex.com/sourcefabric/superdesk/" target="_blank" rel="noopener noreferrer">{{ :: "Help us translate Superdesk" | translate }}</a>
                                         </div>
                                     </div>
                                 </div>

--- a/scripts/apps/users/views/edit-form.html
+++ b/scripts/apps/users/views/edit-form.html
@@ -235,7 +235,7 @@
                                     <select class="sd-input__select" ng-focus="focused()" ng-model="user.language" name="user_language" id="user_language" ng-options="lang.code as lang.nativeName for lang in languages"></select>
                                     <div class="sd-input__message-box">
                                         <div class="sd-input__hint">
-                                            <a href="https://www.transifex.com/projects/p/superdesk/" target="_blank">{{ :: "Help us translate Superdesk" | translate }}</a>
+                                            <a href="https://explore.transifex.com/sourcefabric/superdesk/" target="_blank">{{ :: "Help us translate Superdesk" | translate }}</a>
                                         </div>
                                     </div>
                                 </div>

--- a/tasks/gettext-next-batch.js
+++ b/tasks/gettext-next-batch.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 const fs = require('fs');
 const path = require('path');
 

--- a/tasks/gettext-next-batch.js
+++ b/tasks/gettext-next-batch.js
@@ -1,0 +1,233 @@
+const fs = require('fs');
+const path = require('path');
+
+function printUsage() {
+    console.error('Usage: npm run gettext-next-batch -- <language-code> [--limit <number>]');
+}
+
+function parseArgs(argv) {
+    const args = argv.slice(2);
+    const languageCode = args[0];
+    let limit = 50;
+
+    for (let i = 1; i < args.length; i++) {
+        if (args[i] === '--limit') {
+            const value = Number(args[i + 1]);
+
+            if (!Number.isInteger(value) || value < 1) {
+                console.error(`Invalid limit: ${args[i + 1]}`);
+                process.exit(1);
+            }
+
+            limit = value;
+            i++;
+        } else {
+            console.error(`Unknown argument: ${args[i]}`);
+            printUsage();
+            process.exit(1);
+        }
+    }
+
+    return {languageCode, limit};
+}
+
+function unquotePoString(input) {
+    return JSON.parse(input);
+}
+
+function parsePoString(lines, startIndex) {
+    let index = startIndex;
+    let value = '';
+
+    while (index < lines.length) {
+        const trimmed = lines[index].trim();
+
+        if (!trimmed.startsWith('"')) {
+            break;
+        }
+
+        value += unquotePoString(trimmed);
+        index++;
+    }
+
+    return {value, nextIndex: index};
+}
+
+function parsePoEntries(content) {
+    const lines = content.split(/\r?\n/);
+    const entries = [];
+    let current = null;
+    let obsolete = false;
+
+    function finishEntry() {
+        if (current != null && current.msgid != null) {
+            current.obsolete = obsolete;
+            entries.push(current);
+        }
+
+        current = null;
+        obsolete = false;
+    }
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+
+        if (line.trim() === '') {
+            finishEntry();
+            continue;
+        }
+
+        if (line.startsWith('#~')) {
+            obsolete = true;
+            continue;
+        }
+
+        if (line.startsWith('#:')) {
+            current = current ?? {references: [], comments: [], msgstr: {}};
+            current.references.push(line);
+            continue;
+        }
+
+        if (line.startsWith('#')) {
+            current = current ?? {references: [], comments: [], msgstr: {}};
+            current.comments.push(line);
+            continue;
+        }
+
+        if (line.startsWith('msgctxt ')) {
+            current = current ?? {references: [], comments: [], msgstr: {}};
+            const parsed = parsePoString(lines, i + 1);
+
+            current.msgctxt = unquotePoString(line.slice('msgctxt '.length)) + parsed.value;
+            i = parsed.nextIndex - 1;
+            continue;
+        }
+
+        if (line.startsWith('msgid_plural ')) {
+            current = current ?? {references: [], comments: [], msgstr: {}};
+            const parsed = parsePoString(lines, i + 1);
+
+            current.msgidPlural = unquotePoString(line.slice('msgid_plural '.length)) + parsed.value;
+            i = parsed.nextIndex - 1;
+            continue;
+        }
+
+        if (line.startsWith('msgid ')) {
+            finishEntry();
+            current = {references: [], comments: [], msgstr: {}};
+            const parsed = parsePoString(lines, i + 1);
+
+            current.msgid = unquotePoString(line.slice('msgid '.length)) + parsed.value;
+            i = parsed.nextIndex - 1;
+            continue;
+        }
+
+        const msgstrMatch = line.match(/^msgstr(?:\[(\d+)])? (".*")$/);
+
+        if (msgstrMatch != null) {
+            current = current ?? {references: [], comments: [], msgstr: {}};
+            const key = msgstrMatch[1] ?? '0';
+            const parsed = parsePoString(lines, i + 1);
+
+            current.msgstr[key] = unquotePoString(msgstrMatch[2]) + parsed.value;
+            i = parsed.nextIndex - 1;
+        }
+    }
+
+    finishEntry();
+
+    return entries;
+}
+
+function getPlaceholders(input) {
+    return Array.from(input.matchAll(/{{.*?}}/g), (match) => match[0]);
+}
+
+function isHtmlHeavy(input) {
+    return /<\/?[a-z][\s\S]*>/i.test(input);
+}
+
+function isLikelyNonTranslatable(input) {
+    return /^[\d\s.,:;+\-/()[\]%#_A-Z]+$/.test(input)
+        || /^\d+\s?(B|KB|MB|GB|TB|h|ms|s|min|px|%)$/i.test(input)
+        || /^\d+(st|nd|rd|th)$/i.test(input)
+        || /^[A-Z][A-Za-z_]+(?:\/[A-Z][A-Za-z_ ]+)+$/.test(input);
+}
+
+function formatPoString(value) {
+    return JSON.stringify(value);
+}
+
+const {languageCode, limit} = parseArgs(process.argv);
+
+if (languageCode == null || languageCode.trim() === '') {
+    printUsage();
+    process.exit(1);
+}
+
+const lang = languageCode.trim();
+
+if (!/^[A-Za-z0-9_.@-]+$/.test(lang)) {
+    console.error(`Invalid language code: ${lang}`);
+    process.exit(1);
+}
+
+const poFile = path.join(__dirname, '..', 'po', `${lang}.po`);
+
+if (!fs.existsSync(poFile)) {
+    console.error(`PO file not found for language "${lang}": ${poFile}`);
+    process.exit(1);
+}
+
+const entries = parsePoEntries(fs.readFileSync(poFile, 'utf8'));
+const activeEntries = entries.filter((entry) => !entry.obsolete && entry.msgid !== '');
+const missingEntries = activeEntries.filter((entry) => {
+    const msgstrValues = Object.values(entry.msgstr);
+
+    return msgstrValues.length > 0 && msgstrValues.some((value) => value === '');
+});
+const translatableMissingEntries = missingEntries.filter((entry) => (
+    !isLikelyNonTranslatable(entry.msgid)
+    && !isHtmlHeavy(entry.msgid)
+));
+const selectedEntries = translatableMissingEntries.slice(0, limit);
+
+console.log(`Language: ${lang}`);
+console.log(`PO file: po/${lang}.po`);
+console.log(`Total active untranslated entries: ${missingEntries.length}`);
+console.log(`Likely safe untranslated entries: ${translatableMissingEntries.length}`);
+console.log(`Selected batch size: ${selectedEntries.length}`);
+console.log('');
+
+selectedEntries.forEach((entry, index) => {
+    const placeholders = Array.from(new Set([
+        ...getPlaceholders(entry.msgid),
+        ...(entry.msgidPlural == null ? [] : getPlaceholders(entry.msgidPlural)),
+    ]));
+
+    console.log(`--- Entry ${index + 1} ---`);
+
+    entry.references.forEach((line) => console.log(line));
+
+    if (entry.msgctxt != null) {
+        console.log(`msgctxt ${formatPoString(entry.msgctxt)}`);
+    }
+
+    console.log(`msgid ${formatPoString(entry.msgid)}`);
+
+    if (entry.msgidPlural != null) {
+        console.log(`msgid_plural ${formatPoString(entry.msgidPlural)}`);
+    }
+
+    Object.keys(entry.msgstr).sort((a, b) => Number(a) - Number(b)).forEach((key) => {
+        const prefix = entry.msgidPlural == null ? 'msgstr' : `msgstr[${key}]`;
+
+        console.log(`${prefix} ${formatPoString(entry.msgstr[key])}`);
+    });
+
+    if (placeholders.length > 0) {
+        console.log(`placeholders: ${placeholders.join(', ')}`);
+    }
+
+    console.log('');
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -448,6 +448,7 @@ function getDefaults(grunt) {
             'uk_UA',
             'pt_BR',
             'pl',
+            'ja',
         ],
 
         userOnlineMinutes: 15,


### PR DESCRIPTION
### Purpose
Add Japanese glossary guidance for AI-assisted translation updates.

- Add `docs/i18n/ja-glossary.md`
- Define initial Japanese terminology for common Superdesk UI and editorial terms
- Add tone and consistency rules for Japanese translations
- Mark context-sensitive terms for human review
- Update the user preferences Transifex link to the current Sourcefabric project
- Added `ja.po` with AI translated strings (partially). 

### Final Translation Report

  #### Statistics:
  - Translated: 4021 entries (93.5%)
  - Remaining untranslated: 281 entries (6.5%)
    - 52 "likely safe" (mostly template-expression-only entries like `{{field.display_name}}, {{macro.label}}`)
    - 229 skipped for safety (multiline with embedded \n, pure template expressions, ambiguous entries)
  - Total entries: 4302

  #### Validation:
  - msgfmt --check: passed (no errors)
  - grunt nggettext_compile: passed
  - Placeholder preservation: 0 mismatches
  - No existing translations overwritten

  #### Consistently skipped entries (all batches):
  - `''` is currently managing featured stories... - ambiguous empty-quote placeholder
  - `12:00am, :00am, :00pm` - time format fragments
  - `C & C, S & D, P & C` - ambiguous abbreviations
  - `~15` multiline entries with embedded `\n` and heavy whitespace indentation
  - Edit "' + schedule.name + '" Schedule - JS string concatenation artifact
  - foo - test/placeholder value
  - `~30` entries that are pure AngularJS template expressions (e.g., `{{field.display_name}}, {{ ::action.title }}`)
  - Placeholder example text (e.g., e.g. @cityofsydney, e.g. http://www.website.com)

  #### Categories needing human review:
  1. Ordinal update labels (第2版 through 第20版)
  2. Coverage/取材 - context-sensitive glossary term
  3. Assignment/アサインメント - katakana per glossary
  4. The 52 "likely safe" remaining entries (mostly template expressions)

Fixes [SDESK-7906]



[SDESK-7906]: https://sofab.atlassian.net/browse/SDESK-7906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ