### PR TITLE
SDESK-7894 - Enable Publish shortcut on dirty state for desk and personal space

### DIFF
--- a/scripts/apps/authoring-bridge/authoring-api-common.ts
+++ b/scripts/apps/authoring-bridge/authoring-api-common.ts
@@ -40,7 +40,7 @@ export interface IAuthoringApiCommon {
 export const authoringApiCommon: IAuthoringApiCommon = {
     checkShortcutButtonAvailability: (item: IArticle, dirty?: boolean, personal?: boolean): boolean => {
         if (personal) {
-            return appConfig?.features?.publishFromPersonal && item.state !== 'draft';
+            return appConfig?.features?.publishFromPersonal && (item.state !== 'draft' || dirty);
         }
 
         return item.task && item.task.desk && item.state !== 'draft' || dirty;

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -219,21 +219,34 @@ export function AuthoringDirective(
                 getDeskStage();
                 getCurrentTemplate();
                 $scope.$watch('item', () => {
-                    $scope.toDeskEnabled = appConfig.features?.customAuthoringTopbar?.toDesk
-                        && !sdApi.navigation.isPersonalSpace()
+                    $scope.toDeskAvailable = appConfig.features?.customAuthoringTopbar?.toDesk
+                        && !sdApi.navigation.isPersonalSpace();
+
+                    $scope.toDeskEnabled = $scope.toDeskAvailable
                         && authoringApiCommon.checkShortcutButtonAvailability($scope.item, $scope.dirty);
 
-                    $scope.closeAndContinueEnabled = sdApi.article.showCloseAndContinue($scope.item, $scope.dirty);
+                    $scope.closeAndContinueAvailable = appConfig.features?.customAuthoringTopbar?.closeAndContinue
+                        && !sdApi.navigation.isPersonalSpace();
 
-                    $scope.publishEnabled = appConfig.features?.customAuthoringTopbar?.publish
-                        && sdApi.article.canPublishOnDesk($scope.deskType)
+                    $scope.closeAndContinueEnabled = $scope.closeAndContinueAvailable
+                        && sdApi.article.showCloseAndContinue($scope.item, $scope.dirty);
+
+                    $scope.publishAvailable = appConfig.features?.customAuthoringTopbar?.publish
+                        && sdApi.article.canPublishOnDesk($scope.deskType);
+
+                    $scope.publishEnabled = $scope.publishAvailable
                         && authoringApiCommon.checkShortcutButtonAvailability(
                             $scope.item,
                             false,
                             sdApi.navigation.isPersonalSpace(),
                         );
 
-                    $scope.publishAndContinueEnabled = sdApi.article.showPublishAndContinue($scope.item, $scope.dirty);
+                    $scope.publishAndContinueAvailable = appConfig.features?.customAuthoringTopbar?.publishAndContinue
+                        && !sdApi.navigation.isPersonalSpace()
+                        && sdApi.article.canPublishOnDesk($scope.deskType);
+
+                    $scope.publishAndContinueEnabled = $scope.publishAndContinueAvailable
+                        && sdApi.article.showPublishAndContinue($scope.item, $scope.dirty);
                 }, true);
             });
 
@@ -621,8 +634,8 @@ export function AuthoringDirective(
             }
 
             $scope.showCustomButtons = () => {
-                return $scope.toDeskEnabled || $scope.closeAndContinueEnabled
-                    || $scope.publishAndContinueEnabled || $scope.publishEnabled;
+                return $scope.toDeskAvailable || $scope.closeAndContinueAvailable
+                    || $scope.publishAndContinueAvailable || $scope.publishAvailable;
             };
 
             $scope.saveAndContinue = function(customButtonAction, showConfirm) {

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -237,7 +237,7 @@ export function AuthoringDirective(
                     $scope.publishEnabled = $scope.publishAvailable
                         && authoringApiCommon.checkShortcutButtonAvailability(
                             $scope.item,
-                            false,
+                            $scope.dirty,
                             sdApi.navigation.isPersonalSpace(),
                         );
 

--- a/scripts/apps/authoring/views/authoring-topbar.html
+++ b/scripts/apps/authoring/views/authoring-topbar.html
@@ -49,8 +49,9 @@
         ng-show="_editable && itemActions.save && (action === 'edit' || isCorrection(item))"
       >
         <button
-                ng-if="toDeskEnabled"
+                ng-if="toDeskAvailable"
                 class="btn sd-overflow-ellipsis btn--custom"
+                ng-disabled="!toDeskEnabled"
                 ng-click="saveAndContinue(sendToNextStage, false)"
                 aria-label="{{ 'To Desk' | translate }}"
                 title="{{ :: 'To Desk' | translate }}">
@@ -58,8 +59,9 @@
                 <span class="btn__text--short" translate>T D</span>
         </button>
         <button
-                ng-if="closeAndContinueEnabled"
+                ng-if="closeAndContinueAvailable"
                 class="btn sd-overflow-ellipsis btn--custom"
+                ng-disabled="!closeAndContinueEnabled"
                 ng-click="saveAndContinue(closeAndContinue, false)"
                 aria-label="{{ 'Close and Continue' | translate }}"
                 title="{{ 'Close and Continue' | translate }}">
@@ -67,9 +69,10 @@
                 <span class="btn__text--short" translate>C & C</span>
         </button>
         <button
-                ng-if="publishEnabled"
+                ng-if="publishAvailable"
                 class="btn btn--custom btn--publish"
                 type="submit"
+                ng-disabled="!publishEnabled"
                 ng-click="saveAndContinue(publish, true)"
                 aria-label="{{ :: 'Publish' | translate }}"
                 title="{{ :: 'Publish' | translate }}">
@@ -77,8 +80,9 @@
                 <span class="btn__text--short" translate>P</span>
         </button>
         <button
-                ng-if="publishAndContinueEnabled"
+                ng-if="publishAndContinueAvailable"
                 class="btn sd-overflow-ellipsis btn--custom btn--publish-plus"
+                ng-disabled="!publishAndContinueEnabled"
                 ng-click="saveAndContinue(publishAndContinue, true)"
                 aria-label="{{ :: 'Publish and Continue' | translate }}"
                 title="{{ :: 'Publish and Continue' | translate }}">


### PR DESCRIPTION
### Purpose
This PR builds on top of [Display Publishing shortcuts on opening authoring](https://github.com/superdesk/superdesk-client-core/pull/5156) and fixes an issue where the **Publish** shortcut button remained disabled until the item was manually saved.

### What has changed
- Changed `publishEnabled` to pass `$scope.dirty` instead of the hardcoded `false`

### Steps to test
1. Start a new article
2. Confirm Publish button is visible but disabled 
3. Type something to trigger autosave and confirm Publish button becomes enabled/active similar to Publish & Continue.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I reviewed my code
- [X] I tested all affected functionality and made sure it works

Resolves: [SDESK-7894](https://sofab.atlassian.net/browse/SDESK-7894)


[SDESK-7894]: https://sofab.atlassian.net/browse/SDESK-7894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ