### PR TITLE
Fix select/deselect issues with data population and form clearing with multiple images editing

### DIFF
--- a/scripts/apps/search/MultiImageEdit.ts
+++ b/scripts/apps/search/MultiImageEdit.ts
@@ -73,6 +73,7 @@ export function MultiImageEditController(
             $scope.images.forEach((image) => {
                 image.selected = true;
             });
+            updateMetadata();
         }
     };
 
@@ -81,6 +82,7 @@ export function MultiImageEditController(
             $scope.images.forEach((image) => {
                 image.selected = false;
             });
+            updateMetadata();
         }
     };
 

--- a/scripts/core/ui/components/PlainTextEditor/PlainTextEditor.tsx
+++ b/scripts/core/ui/components/PlainTextEditor/PlainTextEditor.tsx
@@ -139,8 +139,11 @@ export class PlainTextEditor extends React.Component<IProps, IState> {
      * This version works fine and we can still handle our own selection state
      * */
     UNSAFE_componentWillReceiveProps(props: IProps) {
-        if (this.lastComputedValue !== props.value) {
-            this.setState({editorState: updateStateWithValue(props.value || '', this.state.editorState)});
+        const newValue = props.value || '';
+
+        if (this.lastComputedValue !== newValue) {
+            this.lastComputedValue = newValue;
+            this.setState({editorState: updateStateWithValue(newValue, this.state.editorState)});
         }
     }
 


### PR DESCRIPTION
### Purpose
Fix two bugs in the multi-image upload/edit modal that cause the metadata form to display stale or empty values.

1. After deselecting and re-selecting the same image, fields edited via the plain-text editor (Title, Slugline, Byline, etc.) would not repopulate.
2. Clicking the "Deselect All" button did not clear the metadata form (the form correctly cleared only when items were deselected one by one).

### What has changed

**`scripts/core/ui/components/PlainTextEditor/PlainTextEditor.tsx`**
- `UNSAFE_componentWillReceiveProps` now updates the internal `lastComputedValue` tracker whenever it accepts a new value from props. Previously it only updated the visible `editorState`, leaving `lastComputedValue` stale. This caused the editor to wrongly skip updates when the prop value cycled `X → empty → X`, since the stale tracker matched the new value and the editor concluded it had nothing to do.
- The comparison normalizes `undefined`/`null` to `''` so an already-empty editor doesn't trigger a redundant `setState` when the prop becomes nullish.

**`scripts/apps/search/MultiImageEdit.ts`**
- `selectAll()` and `unselectAll()` now call `updateMetadata()` after toggling the `selected` flags, so the form is rebuilt from the current selection — matching the behavior of `selectImage()` (single click on a thumbnail).

### Steps to test

**Bug 1 — title not repopulating after deselect/reselect cycle**
1. Open the multi-image upload modal and add several images.
2. With all images selected (default), edit the Title field, e.g. type `MyTitle`.
3. Click "Deselect All".
4. Click one image to select it — the form should show `MyTitle`.
5. Click the same image again to deselect it — the form should clear.
6. Click the same image once more to reselect it.
7. **Expected:** the Title field shows `MyTitle` again. (Before the fix it stayed blank.)
8. Repeat the same flow with other plain-text fields (Slugline, Byline, Description, Alt text) to confirm.

**Bug 2 — Deselect All not clearing the form**
1. Open the multi-image upload modal with multiple images, all selected by default.
2. Edit the Title (and any other fields) so the form has values.
3. Click "Deselect All".
4. **Expected:** the form clears (matching the behavior of deselecting items one by one). Before the fix, the form retained its values.
5. Click "Select All" — the form should repopulate, showing `(multiple values)` placeholders for fields that differ between items.

**Regression checks for shared `PlainTextEditor`:**
- Single-image metadata edit (Change Image dialog) — typing and saving works as before.
- Item carousel caption — switch between carousel items and confirm the caption shown matches the active item.
- Embedded media caption inside the editor (editor3 `MediaBlock`) — typing, undo/redo, and saving work as expected.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7900](https://sofab.atlassian.net/browse/SDESK-7900)



[SDESK-7900]: https://sofab.atlassian.net/browse/SDESK-7900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ