### PR TITLE
SDESK-7894 - Align shortcut enablement with dirty state for sd-editor3 fields

### DIFF
--- a/scripts/apps/authoring-bridge/authoring-api-common.ts
+++ b/scripts/apps/authoring-bridge/authoring-api-common.ts
@@ -40,7 +40,7 @@ export interface IAuthoringApiCommon {
 export const authoringApiCommon: IAuthoringApiCommon = {
     checkShortcutButtonAvailability: (item: IArticle, dirty?: boolean, personal?: boolean): boolean => {
         if (personal) {
-            return appConfig?.features?.publishFromPersonal && item.state !== 'draft';
+            return appConfig?.features?.publishFromPersonal && (item.state !== 'draft' || dirty);
         }
 
         return item.task && item.task.desk && item.state !== 'draft' || dirty;

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -219,21 +219,34 @@ export function AuthoringDirective(
                 getDeskStage();
                 getCurrentTemplate();
                 $scope.$watch('item', () => {
-                    $scope.toDeskEnabled = appConfig.features?.customAuthoringTopbar?.toDesk
-                        && !sdApi.navigation.isPersonalSpace()
+                    $scope.toDeskAvailable = appConfig.features?.customAuthoringTopbar?.toDesk
+                        && !sdApi.navigation.isPersonalSpace();
+
+                    $scope.toDeskEnabled = $scope.toDeskAvailable
                         && authoringApiCommon.checkShortcutButtonAvailability($scope.item, $scope.dirty);
 
-                    $scope.closeAndContinueEnabled = sdApi.article.showCloseAndContinue($scope.item, $scope.dirty);
+                    $scope.closeAndContinueAvailable = appConfig.features?.customAuthoringTopbar?.closeAndContinue
+                        && !sdApi.navigation.isPersonalSpace();
 
-                    $scope.publishEnabled = appConfig.features?.customAuthoringTopbar?.publish
-                        && sdApi.article.canPublishOnDesk($scope.deskType)
+                    $scope.closeAndContinueEnabled = $scope.closeAndContinueAvailable
+                        && sdApi.article.showCloseAndContinue($scope.item, $scope.dirty);
+
+                    $scope.publishAvailable = appConfig.features?.customAuthoringTopbar?.publish
+                        && sdApi.article.canPublishOnDesk($scope.deskType);
+
+                    $scope.publishEnabled = $scope.publishAvailable
                         && authoringApiCommon.checkShortcutButtonAvailability(
                             $scope.item,
                             false,
                             sdApi.navigation.isPersonalSpace(),
                         );
 
-                    $scope.publishAndContinueEnabled = sdApi.article.showPublishAndContinue($scope.item, $scope.dirty);
+                    $scope.publishAndContinueAvailable = appConfig.features?.customAuthoringTopbar?.publishAndContinue
+                        && !sdApi.navigation.isPersonalSpace()
+                        && sdApi.article.canPublishOnDesk($scope.deskType);
+
+                    $scope.publishAndContinueEnabled = $scope.publishAndContinueAvailable
+                        && sdApi.article.showPublishAndContinue($scope.item, $scope.dirty);
                 }, true);
             });
 
@@ -621,8 +634,8 @@ export function AuthoringDirective(
             }
 
             $scope.showCustomButtons = () => {
-                return $scope.toDeskEnabled || $scope.closeAndContinueEnabled
-                    || $scope.publishAndContinueEnabled || $scope.publishEnabled;
+                return $scope.toDeskAvailable || $scope.closeAndContinueAvailable
+                    || $scope.publishAndContinueAvailable || $scope.publishAvailable;
             };
 
             $scope.saveAndContinue = function(customButtonAction, showConfirm) {

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -237,7 +237,7 @@ export function AuthoringDirective(
                     $scope.publishEnabled = $scope.publishAvailable
                         && authoringApiCommon.checkShortcutButtonAvailability(
                             $scope.item,
-                            false,
+                            $scope.dirty,
                             sdApi.navigation.isPersonalSpace(),
                         );
 

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -100,10 +100,10 @@ export function AuthoringDirective(
             const UNIQUE_NAME_ERROR = gettext('Error: Unique Name is not unique.');
 
             $scope.eventListenersToRemoveOnUnmount = [];
-            $scope.toDeskEnabled = false; // Send an Item to a desk
-            $scope.closeAndContinueEnabled = false; // Create an update of an item and Close the item.
-            $scope.publishEnabled = false; // publish an item
-            $scope.publishAndContinueEnabled = false; // Publish an item and Create an update.
+            $scope.toDeskEnabled = () => false; // Send an Item to a desk
+            $scope.closeAndContinueEnabled = () => false; // Create an update of an item and Close the item.
+            $scope.publishEnabled = () => false; // publish an item
+            $scope.publishAndContinueEnabled = () => false; // Publish an item and Create an update.
 
             $scope.requestEditor3DirectivesToGenerateHtml = [];
 
@@ -222,32 +222,32 @@ export function AuthoringDirective(
                     $scope.toDeskAvailable = appConfig.features?.customAuthoringTopbar?.toDesk
                         && !sdApi.navigation.isPersonalSpace();
 
-                    $scope.toDeskEnabled = $scope.toDeskAvailable
-                        && authoringApiCommon.checkShortcutButtonAvailability($scope.item, $scope.dirty);
-
                     $scope.closeAndContinueAvailable = appConfig.features?.customAuthoringTopbar?.closeAndContinue
                         && !sdApi.navigation.isPersonalSpace();
-
-                    $scope.closeAndContinueEnabled = $scope.closeAndContinueAvailable
-                        && sdApi.article.showCloseAndContinue($scope.item, $scope.dirty);
 
                     $scope.publishAvailable = appConfig.features?.customAuthoringTopbar?.publish
                         && sdApi.article.canPublishOnDesk($scope.deskType);
 
-                    $scope.publishEnabled = $scope.publishAvailable
-                        && authoringApiCommon.checkShortcutButtonAvailability(
-                            $scope.item,
-                            $scope.dirty,
-                            sdApi.navigation.isPersonalSpace(),
-                        );
-
                     $scope.publishAndContinueAvailable = appConfig.features?.customAuthoringTopbar?.publishAndContinue
                         && !sdApi.navigation.isPersonalSpace()
                         && sdApi.article.canPublishOnDesk($scope.deskType);
-
-                    $scope.publishAndContinueEnabled = $scope.publishAndContinueAvailable
-                        && sdApi.article.showPublishAndContinue($scope.item, $scope.dirty);
                 }, true);
+
+                $scope.publishEnabled = () => $scope.publishAvailable
+                    && authoringApiCommon.checkShortcutButtonAvailability(
+                        $scope.item,
+                        $scope.save_enabled(),
+                        sdApi.navigation.isPersonalSpace(),
+                    );
+
+                $scope.publishAndContinueEnabled = () => $scope.publishAndContinueAvailable
+                    && sdApi.article.showPublishAndContinue($scope.item, $scope.save_enabled());
+
+                $scope.toDeskEnabled = () => $scope.toDeskAvailable
+                    && authoringApiCommon.checkShortcutButtonAvailability($scope.item, $scope.save_enabled());
+
+                $scope.closeAndContinueEnabled = () => $scope.closeAndContinueAvailable
+                    && sdApi.article.showCloseAndContinue($scope.item, $scope.save_enabled());
             });
 
             /**

--- a/scripts/apps/authoring/views/authoring-topbar.html
+++ b/scripts/apps/authoring/views/authoring-topbar.html
@@ -49,8 +49,9 @@
         ng-show="_editable && itemActions.save && (action === 'edit' || isCorrection(item))"
       >
         <button
-                ng-if="toDeskEnabled"
+                ng-if="toDeskAvailable"
                 class="btn sd-overflow-ellipsis btn--custom"
+                ng-disabled="!toDeskEnabled"
                 ng-click="saveAndContinue(sendToNextStage, false)"
                 aria-label="{{ 'To Desk' | translate }}"
                 title="{{ :: 'To Desk' | translate }}">
@@ -58,8 +59,9 @@
                 <span class="btn__text--short" translate>T D</span>
         </button>
         <button
-                ng-if="closeAndContinueEnabled"
+                ng-if="closeAndContinueAvailable"
                 class="btn sd-overflow-ellipsis btn--custom"
+                ng-disabled="!closeAndContinueEnabled"
                 ng-click="saveAndContinue(closeAndContinue, false)"
                 aria-label="{{ 'Close and Continue' | translate }}"
                 title="{{ 'Close and Continue' | translate }}">
@@ -67,9 +69,10 @@
                 <span class="btn__text--short" translate>C & C</span>
         </button>
         <button
-                ng-if="publishEnabled"
+                ng-if="publishAvailable"
                 class="btn btn--custom btn--publish"
                 type="submit"
+                ng-disabled="!publishEnabled"
                 ng-click="saveAndContinue(publish, true)"
                 aria-label="{{ :: 'Publish' | translate }}"
                 title="{{ :: 'Publish' | translate }}">
@@ -77,8 +80,9 @@
                 <span class="btn__text--short" translate>P</span>
         </button>
         <button
-                ng-if="publishAndContinueEnabled"
+                ng-if="publishAndContinueAvailable"
                 class="btn sd-overflow-ellipsis btn--custom btn--publish-plus"
+                ng-disabled="!publishAndContinueEnabled"
                 ng-click="saveAndContinue(publishAndContinue, true)"
                 aria-label="{{ :: 'Publish and Continue' | translate }}"
                 title="{{ :: 'Publish and Continue' | translate }}">

--- a/scripts/apps/authoring/views/authoring-topbar.html
+++ b/scripts/apps/authoring/views/authoring-topbar.html
@@ -51,7 +51,7 @@
         <button
                 ng-if="toDeskAvailable"
                 class="btn sd-overflow-ellipsis btn--custom"
-                ng-disabled="!toDeskEnabled"
+                ng-disabled="!toDeskEnabled()"
                 ng-click="saveAndContinue(sendToNextStage, false)"
                 aria-label="{{ 'To Desk' | translate }}"
                 title="{{ :: 'To Desk' | translate }}">
@@ -61,7 +61,7 @@
         <button
                 ng-if="closeAndContinueAvailable"
                 class="btn sd-overflow-ellipsis btn--custom"
-                ng-disabled="!closeAndContinueEnabled"
+                ng-disabled="!closeAndContinueEnabled()"
                 ng-click="saveAndContinue(closeAndContinue, false)"
                 aria-label="{{ 'Close and Continue' | translate }}"
                 title="{{ 'Close and Continue' | translate }}">
@@ -72,7 +72,7 @@
                 ng-if="publishAvailable"
                 class="btn btn--custom btn--publish"
                 type="submit"
-                ng-disabled="!publishEnabled"
+                ng-disabled="!publishEnabled()"
                 ng-click="saveAndContinue(publish, true)"
                 aria-label="{{ :: 'Publish' | translate }}"
                 title="{{ :: 'Publish' | translate }}">
@@ -82,7 +82,7 @@
         <button
                 ng-if="publishAndContinueAvailable"
                 class="btn sd-overflow-ellipsis btn--custom btn--publish-plus"
-                ng-disabled="!publishAndContinueEnabled"
+                ng-disabled="!publishAndContinueEnabled()"
                 ng-click="saveAndContinue(publishAndContinue, true)"
                 aria-label="{{ :: 'Publish and Continue' | translate }}"
                 title="{{ :: 'Publish and Continue' | translate }}">


### PR DESCRIPTION
### Purpose
This PR builds on PR #5159  and removes the delay in shortcut being enabled for sd-editor3 fields. 

### What has changed
- To `Desk`, `Close and Continue`, `Publish`, and `Publish and Continue` now re-evaluate their enabled state immediately from the current authoring state which removes the lag caused by the older watch-based shortcut update path.
- Header fields like slugline already update through direct Angular `ng-change="autosave(item)"`, so they enable immediately as soon as the item becomes dirty.
- Content fields like headline and body text go through sd-editor3, which reaches Angular through the React/Redux bridge, so this change makes those shortcut buttons update at the same time

### Steps to test
1. Open a new article with shortcut buttons enabled.
2. Change a direct Angular header field like `slugline`.
3. Verify shortcut fields are enabled immediately.
4. Ignore and start a new article. Change an sd-editor3 content field like `headline` or `body_html`.
5. Verify the same buttons enable immediately, without waiting for the older delayed shortcut update path.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I reviewed my code
- [X] I tested all affected functionality and made sure it works

Resolves: [SDESK-7894](https://sofab.atlassian.net/browse/SDESK-7894)


[SDESK-7894]: https://sofab.atlassian.net/browse/SDESK-7894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ