### PR TITLE
[SDESK-7894] - Align shortcut enablement with dirty state for sd-editor3 fields

### DIFF
--- a/scripts/apps/authoring-bridge/authoring-api-common.ts
+++ b/scripts/apps/authoring-bridge/authoring-api-common.ts
@@ -40,7 +40,7 @@ export interface IAuthoringApiCommon {
 export const authoringApiCommon: IAuthoringApiCommon = {
     checkShortcutButtonAvailability: (item: IArticle, dirty?: boolean, personal?: boolean): boolean => {
         if (personal) {
-            return appConfig?.features?.publishFromPersonal && item.state !== 'draft';
+            return appConfig?.features?.publishFromPersonal && (item.state !== 'draft' || dirty);
         }
 
         return item.task && item.task.desk && item.state !== 'draft' || dirty;

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -100,12 +100,11 @@ export function AuthoringDirective(
             const UNIQUE_NAME_ERROR = gettext('Error: Unique Name is not unique.');
 
             $scope.eventListenersToRemoveOnUnmount = [];
-            $scope.toDeskEnabled = false; // Send an Item to a desk
-            $scope.closeAndContinueEnabled = false; // Create an update of an item and Close the item.
-
-            $scope.publishEnabled = false; // publish an item
-            $scope.publishAndContinueEnabled = false; // Publish an item and Create an update.
             $scope.sendAndDuplicateEnabled = false; // setting initial value, true value will be set asynchronously
+            $scope.toDeskEnabled = () => false; // Send an Item to a desk
+            $scope.closeAndContinueEnabled = () => false; // Create an update of an item and Close the item.
+            $scope.publishEnabled = () => false; // publish an item
+            $scope.publishAndContinueEnabled = () => false; // Publish an item and Create an update.
 
             $scope.requestEditor3DirectivesToGenerateHtml = [];
 
@@ -238,32 +237,32 @@ export function AuthoringDirective(
                     $scope.toDeskAvailable = appConfig.features?.customAuthoringTopbar?.toDesk
                         && !sdApi.navigation.isPersonalSpace();
 
-                    $scope.toDeskEnabled = $scope.toDeskAvailable
-                        && authoringApiCommon.checkShortcutButtonAvailability($scope.item, $scope.dirty);
-
                     $scope.closeAndContinueAvailable = appConfig.features?.customAuthoringTopbar?.closeAndContinue
                         && !sdApi.navigation.isPersonalSpace();
-
-                    $scope.closeAndContinueEnabled = $scope.closeAndContinueAvailable
-                        && sdApi.article.showCloseAndContinue($scope.item, $scope.dirty);
 
                     $scope.publishAvailable = appConfig.features?.customAuthoringTopbar?.publish
                         && sdApi.article.canPublishOnDesk($scope.deskType);
 
-                    $scope.publishEnabled = $scope.publishAvailable
-                        && authoringApiCommon.checkShortcutButtonAvailability(
-                            $scope.item,
-                            $scope.dirty,
-                            sdApi.navigation.isPersonalSpace(),
-                        );
-
                     $scope.publishAndContinueAvailable = appConfig.features?.customAuthoringTopbar?.publishAndContinue
                         && !sdApi.navigation.isPersonalSpace()
                         && sdApi.article.canPublishOnDesk($scope.deskType);
-
-                    $scope.publishAndContinueEnabled = $scope.publishAndContinueAvailable
-                        && sdApi.article.showPublishAndContinue($scope.item, $scope.dirty);
                 }, true);
+
+                $scope.publishEnabled = () => $scope.publishAvailable
+                    && authoringApiCommon.checkShortcutButtonAvailability(
+                        $scope.item,
+                        $scope.save_enabled(),
+                        sdApi.navigation.isPersonalSpace(),
+                    );
+
+                $scope.publishAndContinueEnabled = () => $scope.publishAndContinueAvailable
+                    && sdApi.article.showPublishAndContinue($scope.item, $scope.save_enabled());
+
+                $scope.toDeskEnabled = () => $scope.toDeskAvailable
+                    && authoringApiCommon.checkShortcutButtonAvailability($scope.item, $scope.save_enabled());
+
+                $scope.closeAndContinueEnabled = () => $scope.closeAndContinueAvailable
+                    && sdApi.article.showCloseAndContinue($scope.item, $scope.save_enabled());
             });
 
             /**

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -100,7 +100,7 @@ export function AuthoringDirective(
             const UNIQUE_NAME_ERROR = gettext('Error: Unique Name is not unique.');
 
             $scope.eventListenersToRemoveOnUnmount = [];
-            $scope.sendAndDuplicateEnabled = false; // setting initial value, true value will be set asynchronously
+            $scope.sendAndDuplicateEnabled = () => false; // setting initial value, true value will be set asynchronously
             $scope.toDeskEnabled = () => false; // Send an Item to a desk
             $scope.closeAndContinueEnabled = () => false; // Create an update of an item and Close the item.
             $scope.publishEnabled = () => false; // publish an item
@@ -228,9 +228,6 @@ export function AuthoringDirective(
                 $scope.itemActions = authoring.itemActions($scope.origItem, userDesks);
 
                 // (depends on desks being initialized)
-                $scope.sendAndDuplicateEnabled = appConfig.features?.customAuthoringTopbar?.sendAndDuplicate != null
-                    && getSendAndDuplicateTarget() != null;
-
                 getLabelForFieldId = _getLabelForFieldId;
 
                 $scope.$watch('item', () => {
@@ -246,6 +243,9 @@ export function AuthoringDirective(
                     $scope.publishAndContinueAvailable = appConfig.features?.customAuthoringTopbar?.publishAndContinue
                         && !sdApi.navigation.isPersonalSpace()
                         && sdApi.article.canPublishOnDesk($scope.deskType);
+
+                    $scope.sendAndDuplicateAvailable = appConfig.features?.customAuthoringTopbar?.sendAndDuplicate != null
+                        && getSendAndDuplicateTarget() != null;
                 }, true);
 
                 $scope.publishEnabled = () => $scope.publishAvailable
@@ -263,6 +263,10 @@ export function AuthoringDirective(
 
                 $scope.closeAndContinueEnabled = () => $scope.closeAndContinueAvailable
                     && sdApi.article.showCloseAndContinue($scope.item, $scope.save_enabled());
+
+                // (depends on desks being initialized)
+                $scope.sendAndDuplicateEnabled = () => $scope.sendAndDuplicateAvailable
+                    && getSendAndDuplicateTarget() != null;
             });
 
             /**
@@ -655,7 +659,7 @@ export function AuthoringDirective(
 
             $scope.showCustomButtons = () => {
                 return $scope.toDeskAvailable || $scope.closeAndContinueAvailable
-                    || $scope.publishAndContinueAvailable || $scope.publishAvailable || $scope.sendAndDuplicateEnabled;
+                    || $scope.publishAndContinueAvailable || $scope.publishAvailable || $scope.sendAndDuplicateAvailable;
             };
 
             $scope.saveAndContinue = function(customButtonAction, showConfirm) {

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -253,7 +253,7 @@ export function AuthoringDirective(
                     $scope.publishEnabled = $scope.publishAvailable
                         && authoringApiCommon.checkShortcutButtonAvailability(
                             $scope.item,
-                            false,
+                            $scope.dirty,
                             sdApi.navigation.isPersonalSpace(),
                         );
 

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -100,7 +100,7 @@ export function AuthoringDirective(
             const UNIQUE_NAME_ERROR = gettext('Error: Unique Name is not unique.');
 
             $scope.eventListenersToRemoveOnUnmount = [];
-            $scope.sendAndDuplicateEnabled = () => false; // setting initial value, true value will be set asynchronously
+            $scope.sendAndDuplicateEnabled = () => false; // initial value until desks load
             $scope.toDeskEnabled = () => false; // Send an Item to a desk
             $scope.closeAndContinueEnabled = () => false; // Create an update of an item and Close the item.
             $scope.publishEnabled = () => false; // publish an item
@@ -244,7 +244,8 @@ export function AuthoringDirective(
                         && !sdApi.navigation.isPersonalSpace()
                         && sdApi.article.canPublishOnDesk($scope.deskType);
 
-                    $scope.sendAndDuplicateAvailable = appConfig.features?.customAuthoringTopbar?.sendAndDuplicate != null
+                    $scope.sendAndDuplicateAvailable =
+                        appConfig.features?.customAuthoringTopbar?.sendAndDuplicate != null
                         && getSendAndDuplicateTarget() != null;
                 }, true);
 
@@ -659,7 +660,8 @@ export function AuthoringDirective(
 
             $scope.showCustomButtons = () => {
                 return $scope.toDeskAvailable || $scope.closeAndContinueAvailable
-                    || $scope.publishAndContinueAvailable || $scope.publishAvailable || $scope.sendAndDuplicateAvailable;
+                    || $scope.publishAndContinueAvailable || $scope.publishAvailable
+                    || $scope.sendAndDuplicateAvailable;
             };
 
             $scope.saveAndContinue = function(customButtonAction, showConfirm) {

--- a/scripts/apps/authoring/views/authoring-topbar.html
+++ b/scripts/apps/authoring/views/authoring-topbar.html
@@ -51,7 +51,7 @@
         <button
                 ng-if="toDeskAvailable"
                 class="btn sd-overflow-ellipsis btn--custom"
-                ng-disabled="!toDeskEnabled"
+                ng-disabled="!toDeskEnabled()"
                 ng-click="saveAndContinue(sendToNextStage, false)"
                 aria-label="{{ 'To Desk' | translate }}"
                 title="{{ :: 'To Desk' | translate }}">
@@ -62,7 +62,7 @@
         <button
                 ng-if="closeAndContinueAvailable"
                 class="btn sd-overflow-ellipsis btn--custom"
-                ng-disabled="!closeAndContinueEnabled"
+                ng-disabled="!closeAndContinueEnabled()"
                 ng-click="saveAndContinue(closeAndContinue, false)"
                 aria-label="{{ 'Close and Continue' | translate }}"
                 title="{{ 'Close and Continue' | translate }}">
@@ -74,7 +74,7 @@
                 ng-if="publishAvailable"
                 class="btn btn--custom btn--publish"
                 type="submit"
-                ng-disabled="!publishEnabled"
+                ng-disabled="!publishEnabled()"
                 ng-click="saveAndContinue(publish, true)"
                 aria-label="{{ :: 'Publish' | translate }}"
                 title="{{ :: 'Publish' | translate }}">
@@ -96,7 +96,7 @@
         <button
                 ng-if="publishAndContinueAvailable"
                 class="btn sd-overflow-ellipsis btn--custom btn--publish-plus"
-                ng-disabled="!publishAndContinueEnabled"
+                ng-disabled="!publishAndContinueEnabled()"
                 ng-click="saveAndContinue(publishAndContinue, true)"
                 aria-label="{{ :: 'Publish and Continue' | translate }}"
                 title="{{ :: 'Publish and Continue' | translate }}">

--- a/scripts/apps/authoring/views/authoring-topbar.html
+++ b/scripts/apps/authoring/views/authoring-topbar.html
@@ -45,7 +45,7 @@
     <div class="subnav__stretch-bar sd-overflow-ellipsis" ng-if="showCustomButtons()" style="min-width: 150px;">
       <div
         class="subnav__button-stack subnav__button-stack--custom-buttons sd-overflow-ellipsis"
-        ng-if="$root.config.features.customAuthoringTopbar != null && ($root.config.features.customAuthoringTopbar.toDesk === true || $root.config.features.customAuthoringTopbar.publish === true || $root.config.features.customAuthoringTopbar.publishAndContinue == true || sendAndDuplicateEnabled)"
+        ng-if="$root.config.features.customAuthoringTopbar != null && ($root.config.features.customAuthoringTopbar.toDesk === true || $root.config.features.customAuthoringTopbar.publish === true || $root.config.features.customAuthoringTopbar.publishAndContinue == true || $root.config.features.customAuthoringTopbar.sendAndDuplicate != null)"
         ng-show="_editable && itemActions.save && (action === 'edit' || isCorrection(item))"
       >
         <button
@@ -83,8 +83,9 @@
         </button>
 
         <button
-          ng-if="sendAndDuplicateEnabled"
+          ng-if="sendAndDuplicateAvailable"
           class="btn sd-overflow-ellipsis btn--custom"
+          ng-disabled="!sendAndDuplicateEnabled()"
           ng-click="sendAndDuplicate()"
           aria-label="{{ :: 'Send and duplicate' | translate }}"
           title="{{ 'Send and duplicate' | translate }}"


### PR DESCRIPTION
### Purpose
This PR is a cherry-pick of this [PR](https://github.com/superdesk/superdesk-client-core/pull/5162) but with support for the `sendAndDuplicate` shortcut too which isn't available in release/2.10

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [issue-number]
