### PR TITLE
[SDANSA-584] Fix Authoring top bar line count bug

### DIFF
--- a/scripts/apps/authoring/authoring/authoring-topbar2-react.tsx
+++ b/scripts/apps/authoring/authoring/authoring-topbar2-react.tsx
@@ -42,7 +42,7 @@ interface IState {
 /**
  * Only used from angular based authoring view
  */
-export class AuthoringTopbar2React extends React.PureComponent<IProps, IState> {
+export class AuthoringTopbar2React extends React.Component<IProps, IState> {
     constructor(props: IProps) {
         super(props);
 
@@ -71,23 +71,6 @@ export class AuthoringTopbar2React extends React.PureComponent<IProps, IState> {
         if (this.props.action === 'view') {
             this.fetchArticleFromServer();
         }
-    }
-    shouldComponentUpdate(nextProps: IProps, nextState: IState) {
-        for (const key of Object.keys(this.props)) {
-            if (key === 'children') continue;
-
-            if (this.props[key] !== nextProps[key]) {
-                return true;
-            }
-        }
-
-        for (const key of Object.keys(this.state)) {
-            if (this.state[key] !== nextState[key]) {
-                return true;
-            }
-        }
-
-        return false;
     }
     render() {
         if (this.props.action === 'view' && typeof this.state.articleOriginal === 'undefined') {


### PR DESCRIPTION
### Purpose
Replace PureComponent + custom shouldComponentUpdate with plain Component. The Angular authoring view mutates the article object in place, so the reference equality checks in shouldComponentUpdate always returned false, preventing toolbar widgets from re-rendering on content edits. Child widgets remain PureComponent, so they still skip unnecessary renders via the existing spread `({...this.props.article})` in render().

[SDANSA-584]


[SDANSA-584]: https://sofab.atlassian.net/browse/SDANSA-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ