### PR TITLE
Fixing spiked items not appearing in Sent personal items

### DIFF
--- a/scripts/apps/monitoring/services/CardsService.ts
+++ b/scripts/apps/monitoring/services/CardsService.ts
@@ -76,7 +76,7 @@ export function CardsService(search, session, desks, $location) {
 
         if (card.type === 'spike' || card.type === 'spike-personal') {
             params.spike = 'only';
-        } else if (card.type === 'personal' && card.sent) {
+        } else if (card.type === 'sent') {
             params.spike = 'include';
         } else if (card.type === 'sentDeskOutput') {
             params.spike = 'include';


### PR DESCRIPTION
## Summary

Fix spiked items not appearing in the **Sent** view of Personal space.

The condition at `CardsService.getCriteriaParams` for setting `params.spike = 'include'`
checked `card.type === 'personal' && card.sent`, but the Sent group in Personal space
is registered with `type: 'sent'` (see `AggregateCtrl.personalGroups`) and `card.sent`
is never assigned anywhere in the codebase — so the branch was dead and the Sent view
fell through to the default `exclude spiked` filter in `SearchService`.

Changed the condition to `card.type === 'sent'`, which is exclusively the Personal Sent
view (its filter at `CardsService.setQueryFilterForCardType` keys on
`session.identity._id`, so it can't be reused as a generic sent card).

## Changes

- `scripts/apps/monitoring/services/CardsService.ts`: match the actual card type used
  by the Personal Sent group so spiked items are included in its results.

Fixes: [SDESK-7920](https://sofab.atlassian.net/browse/SDESK-7920)

[SDESK-7920]: https://sofab.atlassian.net/browse/SDESK-7920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ