### PR TITLE
[SDANSA-584] Fix toolbar widgets flickering on content edits

### DIFF
--- a/scripts/apps/authoring/authoring/authoring-topbar2-react.tsx
+++ b/scripts/apps/authoring/authoring/authoring-topbar2-react.tsx
@@ -9,22 +9,15 @@ import {CreatedInfo} from './created-info';
 import {ModifiedInfo} from './modified-info';
 import {AuthoringToolbar} from 'apps/authoring-react/subcomponents/authoring-toolbar';
 
-const getDefaultToolbarItems = (item: IArticle): Array<ITopBarWidget<IArticle>> => [{
+
+const defaultToolbarItems: Array<ITopBarWidget<IArticle>> = [{
     availableOffline: true,
-    component: () => (
-        <CreatedInfo
-            entity={item}
-        />
-    ),
+    component: CreatedInfo,
     group: 'start',
     priority: 1,
 }, {
     availableOffline: true,
-    component: () => (
-        <ModifiedInfo
-            entity={item}
-        />
-    ),
+    component: ModifiedInfo,
     group: 'start',
     priority: 2,
 }];
@@ -77,7 +70,7 @@ export class AuthoringTopbar2React extends React.Component<IProps, IState> {
             return null; // fetching article from the server
         }
 
-        const articleDisplayWidgets = getDefaultToolbarItems(this.props.article).concat(
+        const articleDisplayWidgets = defaultToolbarItems.concat(
             flatMap(
                 Object.values(extensions),
                 (extension) => extension.activationResult?.contributions?.authoringTopbar2Widgets ?? [],


### PR DESCRIPTION
### Purpose
`AuthoringTopbar2React` used inline arrow functions as widget components, creating new component references on every render. Combined with a `shouldComponentUpdate` that blocked all re-renders (to hide the flicker),  toolbar widgets never updated during editing (removed here https://github.com/superdesk/superdesk-client-core/pull/5164).

Replace inline functions with stable component references (`CreatedInfo` and `ModifiedInfo` directly). Widgets now update on every digest cycle without flickering.

[SDANSA-584]


[SDANSA-584]: https://sofab.atlassian.net/browse/SDANSA-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ