### PR TITLE
Add Node 24 to tests matrix in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['22']
+        node-version: ['22', '24']
 
     runs-on: ubuntu-latest
 
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['22']
+        node-version: ['22', '24']
         shardIndex: [1, 2]
         shardTotal: [2]
     defaults:
@@ -103,7 +103,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['22']
+        node-version: ['22', '24']
         suite: [a, b]
     defaults:
       run:


### PR DESCRIPTION
### Purpose
This pull request updates the test workflow configuration to expand Node.js version coverage. The main change is that all test jobs in `.github/workflows/tests.yml` will now run against both Node.js 22 and Node.js 24, instead of just Node.js 22.

