### PR TITLE
[SDESK-7907] Localize user-facing strings with gettext

### DIFF
--- a/scripts/api/highlights.ts
+++ b/scripts/api/highlights.ts
@@ -31,7 +31,7 @@ function exportHighlight(id: IArticle['_id'], hasUnsavedChanges: boolean): Promi
             payload: {package: id},
         })
             .then(ng.get('authoringWorkspace').edit)
-            .then(() => notify.success('Export successful.'))
+            .then(() => notify.success(gettext('Export successful.')))
             .catch((response) => {
                 if (response.internal_error === 403) {
                     ui.confirm(gettext('There are items locked or not published. Do you want to continue?'))

--- a/scripts/apps/authoring-react/toolbar-components/angular-integration/close-icon-button.tsx
+++ b/scripts/apps/authoring-react/toolbar-components/angular-integration/close-icon-button.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {IArticle} from 'superdesk-api';
 import {IconButton} from 'superdesk-ui-framework/react';
+import {gettext} from 'core/utils';
 import {useInlineToolbarContext} from './inline-toolbar-context';
 
 export const CloseIconButtonComponent: React.ComponentType<{entity: IArticle}> = () => {
@@ -8,7 +9,7 @@ export const CloseIconButtonComponent: React.ComponentType<{entity: IArticle}> =
 
     return (
         <IconButton
-            ariaValue="Close"
+            ariaValue={gettext('Close')}
             icon="close-small"
             onClick={() => exposed?.initiateClosing()}
             style="outline"

--- a/scripts/apps/authoring-react/widget-header-component.tsx
+++ b/scripts/apps/authoring-react/widget-header-component.tsx
@@ -52,7 +52,7 @@ export class WidgetHeaderComponent extends React.PureComponent<IWidgetIntegratio
                             {!pinned && (
                                 <IconButton
                                     icon="close-small"
-                                    ariaValue="Close"
+                                    ariaValue={gettext('Close')}
                                     onClick={() => this.props.closeWidget()}
                                 />
                             )}

--- a/scripts/apps/authoring/views/article-edit.html
+++ b/scripts/apps/authoring/views/article-edit.html
@@ -68,7 +68,7 @@
             ng-model="item.sms_message"
             ng-change="autosave(item)"
             ng-disabled="!_editable || schema.sms.readonly === true"
-            placeholder="Add sms message here"
+            placeholder="{{ 'Add sms message here' | translate }}"
             sd-focus-element
             sd-auto-height
             data-append-element=".field"
@@ -201,7 +201,7 @@
              data-item="item"
              data-fieldprefix="dateline"
              data-field="located"
-             placeholder="Add location"
+             placeholder="{{ 'Add location' | translate }}"
              data-postprocessing="updateDateline(item, city)"
              sd-focus-element
              data-element="input"
@@ -216,7 +216,7 @@
                     tabindex="{{editor.dateline.order}}"
                     ng-disabled="!item.dateline.located || !_editable || schema.dateline.readonly === true"
                     ng-change="resetNumberOfDays(true, dateline.month)"
-                    placeholder="Choose month"
+                    placeholder="{{ 'Choose month' | translate }}"
                     ng-model="dateline.month"
                     sd-focus-element
                     data-append-element=".field"
@@ -231,7 +231,7 @@
                     ng-options="day for day in daysInMonth"
                     ng-disabled="!item.dateline.located || !_editable || schema.dateline.readonly === true"
                     ng-change="modifyDatelineDate(dateline.day)"
-                    placeholder="Choose day"
+                    placeholder="{{ 'Choose day' | translate }}"
                     ng-model="dateline.day"
                     sd-focus-element
                     tabindex="{{editor.dateline.order}}"
@@ -467,7 +467,7 @@
            ng-model="item.sign_off"
            ng-change="autosave(item)"
            ng-show="editSignOff"
-           placeholder="Sign off"
+           placeholder="{{ 'Sign off' | translate }}"
            sd-focus-element
            data-append-element=".field"
            data-append-class="active"

--- a/scripts/apps/authoring/views/item-carousel.html
+++ b/scripts/apps/authoring/views/item-carousel.html
@@ -132,7 +132,7 @@
                     ng-model="carouselItem[carouselItem.fieldId].headline"
                     class="sd-media-carousel__media-title"
                     data-onchange="onchange()"
-                    data-placeholder="Add title"
+                    data-placeholder="{{ 'Add title' | translate }}"
                     data-disabled="!editable"
                     data-textarea="false"
                     data-sync="true"

--- a/scripts/apps/contacts/components/Form/ProfileDetail.tsx
+++ b/scripts/apps/contacts/components/Form/ProfileDetail.tsx
@@ -500,7 +500,7 @@ export class ProfileDetail extends React.PureComponent<IProps, IState> {
                                 onChange={onChange}
                                 type="text"
                                 readOnly={readOnly}
-                                placeholder="username"
+                                placeholder={gettext('username')}
                             />
                         </LineInput>
                     </Row>
@@ -524,7 +524,7 @@ export class ProfileDetail extends React.PureComponent<IProps, IState> {
                                 onChange={onChange}
                                 type="text"
                                 readOnly={readOnly}
-                                placeholder="username"
+                                placeholder={gettext('username')}
                             />
                         </LineInput>
                     </Row>
@@ -614,7 +614,7 @@ export class ProfileDetail extends React.PureComponent<IProps, IState> {
                                     value={contact?.contact_state?.name || contact.contact_state}
                                     onChange={onChange}
                                     type="text"
-                                    placeholder="State/Province or Region"
+                                    placeholder={gettext('State/Province or Region')}
                                     readOnly={readOnly}
                                 />
                             </LineInput>

--- a/scripts/apps/contacts/components/Form/SelectFieldSearchInput/index.tsx
+++ b/scripts/apps/contacts/components/Form/SelectFieldSearchInput/index.tsx
@@ -4,6 +4,7 @@ import {DebounceInput} from 'react-debounce-input';
 import {Row, LineInput, Label} from '../';
 import {SelectFieldPopup} from './SelectFieldPopup';
 import {isEmpty} from 'lodash';
+import {gettext} from 'core/utils';
 
 export class SelectFieldSearchInput extends React.Component<any, any> {
     static propTypes: any;
@@ -98,7 +99,7 @@ export class SelectFieldSearchInput extends React.Component<any, any> {
                                 minLength={1}
                                 debounceTimeout={500}
                                 onChange={this.filterDataList}
-                                placeholder="Search"
+                                placeholder={gettext('Search')}
                             />
 
                             {this.state.openFilterList && (

--- a/scripts/apps/dashboard/world-clock/configuration.html
+++ b/scripts/apps/dashboard/world-clock/configuration.html
@@ -1,6 +1,6 @@
 <div ng-controller="WorldClockConfigController" class="widget-config world-clock">
     <div sd-wizard>
-        <div sd-wizard-step data-title="Your clock" data-code="your-clock">
+        <div sd-wizard-step data-title="{{ 'Your clock' | translate }}" data-code="your-clock">
             <div class="sd-margin-b--3">
                 <label class="form-label">{{'Clock type'|translate}}</label>
                 <div class="button-group button-group--start">
@@ -21,7 +21,7 @@
                 </div>
             </div>
         </div>
-        <div sd-wizard-step data-title="Available clocks" data-code="available-clocks">
+        <div sd-wizard-step data-title="{{ 'Available clocks' | translate }}" data-code="available-clocks">
             <div class="form__group form__group--default form__group--mb-2 sd-margin-t--0-5">
                 <div class="form__item">
                     <div class="sd-input">

--- a/scripts/apps/ingest/views/settings/ingest-rules-content.html
+++ b/scripts/apps/ingest/views/settings/ingest-rules-content.html
@@ -46,12 +46,12 @@
                     </div>
                     <div class="form__row-item">
                         <div class="sd-line-input sd-line-input--boxed sd-line-input--no-label sd-line-input--no-margin">
-                            <input class="sd-line-input__input" type="text" placeholder="old" ng-model="rule.old" required>
+                            <input class="sd-line-input__input" type="text" placeholder="{{ 'old' | translate }}" ng-model="rule.old" required>
                         </div>
                     </div>
                     <div class="form__row-item">
                         <div class="sd-line-input sd-line-input--boxed sd-line-input--no-label sd-line-input--no-margin">
-                            <input class="sd-line-input__input" type="text" placeholder="new" ng-model="rule.new">
+                            <input class="sd-line-input__input" type="text" placeholder="{{ 'new' | translate }}" ng-model="rule.new">
                         </div>
                     </div>
 

--- a/scripts/apps/master-desk/components/FilterPanelComponent.tsx
+++ b/scripts/apps/master-desk/components/FilterPanelComponent.tsx
@@ -106,7 +106,7 @@ export class FilterPanelComponent extends React.Component<IProps, IState> {
                                             <input
                                                 className="sd-inset-search__input"
                                                 type="text"
-                                                placeholder="Search desk"
+                                                placeholder={gettext('Search desk')}
                                                 value={this.state.desk}
                                                 onChange={this.handleDeskChange}
                                             />

--- a/scripts/apps/packaging/views/sd-package-item-preview.html
+++ b/scripts/apps/packaging/views/sd-package-item-preview.html
@@ -20,7 +20,7 @@
       <div ng-hide=":: data.headline || data.slugline || data.description_text" translate>Blank headline received</div>
     </div>
     <div>
-      <span ng-if="data.pubstatus === 'canceled'" title="unpublished" class="state-label state-unpublished">unpublished</span>
+      <span ng-if="data.pubstatus === 'canceled'" title="{{ 'unpublished' | translate }}" class="state-label state-unpublished">unpublished</span>
       <span ng-if="label" class="state-label state-in_progress" translate>label: <b>{{label.name}}</b></span></span>
       <span class="package-item__item-creator">
         Created <time sd-datetime data-date="data.firstcreated" data-from-now="true"></time>

--- a/scripts/apps/packaging/views/sd-package-item-preview.html
+++ b/scripts/apps/packaging/views/sd-package-item-preview.html
@@ -20,7 +20,7 @@
       <div ng-hide=":: data.headline || data.slugline || data.description_text" translate>Blank headline received</div>
     </div>
     <div>
-      <span ng-if="data.pubstatus === 'canceled'" title="{{ 'unpublished' | translate }}" class="state-label state-unpublished">unpublished</span>
+      <span ng-if="data.pubstatus === 'canceled'" title="{{ 'unpublished' | translate }}" class="state-label state-unpublished" translate>unpublished</span>
       <span ng-if="label" class="state-label state-in_progress" translate>label: <b>{{label.name}}</b></span></span>
       <span class="package-item__item-creator">
         Created <time sd-datetime data-date="data.firstcreated" data-from-now="true"></time>

--- a/scripts/apps/packaging/views/search.html
+++ b/scripts/apps/packaging/views/search.html
@@ -31,7 +31,7 @@
                     <p><span class="keyword" ng-if="pitem.slugline">{{ pitem.slugline }}</span>{{pitem.headline || pitem.type}}</p>
                     <ul class="item-functions" ng-if="!itemInPackage(pitem) && !pitem.multi">
                     <li class="dropdown group-select" dropdown>
-                        <button title="Add to package" class="dropdown__toggle" dropdown__toggle>
+                        <button title="{{ 'Add to package' | translate }}" class="dropdown__toggle" dropdown__toggle>
                             <i class="icon-package-plus"></i>
                         </button>
                         <ul class="dropdown__menu pull-right">

--- a/scripts/apps/search/directives/SearchResults.ts
+++ b/scripts/apps/search/directives/SearchResults.ts
@@ -473,7 +473,7 @@ export function SearchResults(
                                     processPreview(item);
                                 }
                             }, (error) => {
-                                notify.error('Detailed informations is not found for the item : ' + item.guid);
+                                notify.error(gettext('Detailed information is not found for the item : ') + item.guid);
                                 processPreview(item);
                             });
                         } else {

--- a/scripts/apps/search/views/item-globalsearch.html
+++ b/scripts/apps/search/views/item-globalsearch.html
@@ -9,7 +9,7 @@
                         <fieldset>
                             <div class="field">
                                <label translate>Unique Name/ID/GUID</label>
-                               <div class="control" title="Prefix Unique Name with #">
+                               <div class="control" title="{{ 'Prefix Unique Name with #' | translate }}">
                                    <input type="text" ng-keyup="openOnEnter($event)" ng-model="meta.unique_name" tabindex="1" sd-autofocus ng-if="flags.enabled">
                                </div>
                             </div>

--- a/scripts/apps/users/views/mentions-menu.html
+++ b/scripts/apps/users/views/mentions-menu.html
@@ -5,7 +5,7 @@
             <span>{{:: user.item.display_name }}</span>
         </div>
         <div ng-if="user.type == 'desk'">
-            <i class="icon-tasks" title="Desk"></i>
+            <i class="icon-tasks" title="{{ 'Desk' | translate }}"></i>
             <span>{{:: user.item.name }}</span>
         </div>
     </li>

--- a/scripts/apps/workspace/content/controllers/ContentProfilesController.ts
+++ b/scripts/apps/workspace/content/controllers/ContentProfilesController.ts
@@ -285,7 +285,7 @@ export function ContentProfilesController($scope: IScope, $location, notify, con
      * @description Queries the user for confirmation and deletes the content profile.
      */
     this.delete = function(item) {
-        modal.confirm('Are you sure you want to delete this profile?').then(() => {
+        modal.confirm(gettext('Are you sure you want to delete this profile?')).then(() => {
             content.removeProfile(item)
                 .then(refreshList.bind(this, false), reportError)
                 .then(this.toggleEdit.bind(this, null));

--- a/scripts/core/editor3/components/comments/CommentPopup.tsx
+++ b/scripts/core/editor3/components/comments/CommentPopup.tsx
@@ -201,7 +201,7 @@ export class CommentPopup extends React.Component<any, any> {
                                     this.setState({replyFieldFocused: true});
                                 }}
                                 singleLine={false}
-                                placeholder={'Reply'}
+                                placeholder={gettext('Reply')}
                                 maxHeight={189} // 10 lines
                             />
                             {

--- a/scripts/core/editor3/components/thin-spaces/ThinSpaceDecorator.tsx
+++ b/scripts/core/editor3/components/thin-spaces/ThinSpaceDecorator.tsx
@@ -2,6 +2,7 @@ import React, {CSSProperties} from 'react';
 import {ContentBlock, ContentState} from 'draft-js';
 import {IPropsDraftDecorator} from 'core/editor3/draftjs-types';
 import {THIN_SPACE_CHAR} from 'core/editor3/constants';
+import {gettext} from 'core/utils';
 
 class ThinSpaceComponent extends React.Component<IPropsDraftDecorator> {
     render() {
@@ -28,7 +29,7 @@ class ThinSpaceComponent extends React.Component<IPropsDraftDecorator> {
             <span
                 className="whitespace-pre text-sm font-bold place-items-center"
                 style={wrapperStyle}
-                title="Thin space"
+                title={gettext('Thin space')}
             >
                 <span style={contentStyle}>{this.props.children}</span>
                 <span

--- a/scripts/core/interactive-article-actions-panel/actions/publish-action.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/publish-action.tsx
@@ -118,7 +118,7 @@ export class PublishAction extends React.PureComponent<IProps, IState> {
                             .then(() => {
                                 ng.get('authoringWorkspace').close();
                                 ng.get('$rootScope').$applyAsync(); // required for authoring close to take effect
-                                notify.success('Item published.');
+                                notify.success(gettext('Item published.'));
                             });
                     });
                 });

--- a/scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx
@@ -59,7 +59,7 @@ export class SendCorrectionAction extends React.Component<IProps, IState> {
                     'correct',
                 ).then(() => {
                     ng.get('authoringWorkspace').close();
-                    notify.success('Correction sent');
+                    notify.success(gettext('Correction sent'));
                 });
             })
             .catch(() => {

--- a/scripts/core/ui/components/Form/LinkInput.tsx
+++ b/scripts/core/ui/components/Form/LinkInput.tsx
@@ -123,7 +123,7 @@ export class LinkInput extends React.Component<any, any> {
                         field={field}
                         value={value}
                         onChange={onChange}
-                        placeholder="Paste link"
+                        placeholder={gettext('Paste link')}
                         readOnly={readOnly}
                         paddingInlineEnd60
                         autoFocus

--- a/scripts/core/ui/components/SearchBar/index.tsx
+++ b/scripts/core/ui/components/SearchBar/index.tsx
@@ -106,7 +106,7 @@ export default class SearchBar extends React.Component<IProps, IState> {
                                 <button
                                     className="search-start visible"
                                     onClick={() => this.props.onSearch(this.state.searchInputValue)}
-                                    aria-label="Start search"
+                                    aria-label={gettext('Start search')}
                                 >
                                     <i className="icon-chevron-right-thin" />
                                 </button>

--- a/scripts/core/ui/components/SearchField/index.tsx
+++ b/scripts/core/ui/components/SearchField/index.tsx
@@ -4,6 +4,7 @@ import {DebounceInput} from 'react-debounce-input';
 import {uniqueId} from 'lodash';
 import {KEYCODES} from '../constants';
 import {onEventCapture} from '../utils';
+import {gettext} from 'core/utils';
 
 /**
  * @ngdoc react
@@ -58,7 +59,7 @@ export default class SearchField extends React.Component<any, any> {
                 onChange={this.onSearchChange.bind(this)}
                 onClick={this.onSearchClick.bind(this)}
                 id={_uniqueId}
-                placeholder="Search"
+                placeholder={gettext('Search')}
                 className="sd-line-input__input"
                 type="text"
                 onKeyDown={(event) => {

--- a/scripts/core/ui/views/sd-timezone.html
+++ b/scripts/core/ui/views/sd-timezone.html
@@ -7,7 +7,7 @@
         search="searchTimeZones(term)"
         select="selectTimeZone(item)"
         always-visible="tzSearchTerm"
-        placeholder="ie. Europe/London">
+        placeholder="{{ 'ie. Europe/London' | translate }}">
         <li class="typeahead-item--padded" typeahead-item="tz" ng-repeat="tz in matchingTimeZones track by tz">{{ ::getTimezoneLabel(tz)}}</li>
         <li class="typeahead-item--padded" ng-show="tzSearchTerm && matchingTimeZones.length === 0"
             class="no-match"

--- a/scripts/extensions/ai-widget/src/extension.ts
+++ b/scripts/extensions/ai-widget/src/extension.ts
@@ -10,7 +10,12 @@ const extension: IExtension = {
         const hasConfiguredServices = Object.keys(configuration).length > 0;
 
         if (hasConfiguredServices === false) {
-            superdesk.ui.notify.error(superdesk.localization.gettext('You haven\'t registered any services for the Ai Assistant Widget!'), 5000);
+            const {gettext} = superdesk.localization;
+
+            superdesk.ui.notify.error(
+                gettext('You haven\'t registered any services for the Ai Assistant Widget!'),
+                5000,
+            );
             return Promise.resolve({});
         }
 

--- a/scripts/extensions/ai-widget/src/extension.ts
+++ b/scripts/extensions/ai-widget/src/extension.ts
@@ -10,7 +10,7 @@ const extension: IExtension = {
         const hasConfiguredServices = Object.keys(configuration).length > 0;
 
         if (hasConfiguredServices === false) {
-            superdesk.ui.notify.error('You haven\'t registered any services for the Ai Assistant Widget!', 5000);
+            superdesk.ui.notify.error(superdesk.localization.gettext('You haven\'t registered any services for the Ai Assistant Widget!'), 5000);
             return Promise.resolve({});
         }
 

--- a/scripts/extensions/broadcasting/src/page.tsx
+++ b/scripts/extensions/broadcasting/src/page.tsx
@@ -318,7 +318,7 @@ export class RundownsPage extends React.PureComponent<IProps, IState> {
                                     <Layout.LeftPanel open={this.state.filtersOpen}>
                                         <Layout.Panel side="left" background="grey">
                                             <Layout.PanelHeader
-                                                title="Advanced filters"
+                                                title={gettext('Advanced filters')}
                                                 onClose={() => {
                                                     this.setState({filtersOpen: false});
                                                 }}

--- a/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit-rundown-item.ts
+++ b/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit-rundown-item.ts
@@ -109,7 +109,9 @@ function getRundownItemAuthoringStorage(id: IRundownItem['_id']): IAuthoringStor
         },
         closeAuthoring: (_current, _original, hasUnsavedChanges, _cancelAutosave, doClose) => {
             if (hasUnsavedChanges) {
-                return superdesk.ui.confirm(superdesk.localization.gettext('Discard unsaved changes?')).then((confirmed) => {
+                const {gettext} = superdesk.localization;
+
+                return superdesk.ui.confirm(gettext('Discard unsaved changes?')).then((confirmed) => {
                     if (confirmed) {
                         doClose();
                     }
@@ -197,7 +199,9 @@ function getRundownItemCreationAuthoringStorage(
             return Promise.resolve(contentProfile);
         },
         closeAuthoring: (_current, _original, _hasUnsavedChanges, _cancelAutosave, doClose) => {
-            return superdesk.ui.confirm(superdesk.localization.gettext('Discard unsaved changes?')).then((confirmed) => {
+            const {gettext} = superdesk.localization;
+
+            return superdesk.ui.confirm(gettext('Discard unsaved changes?')).then((confirmed) => {
                 if (confirmed) {
                     doClose();
                 }

--- a/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit-rundown-item.ts
+++ b/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit-rundown-item.ts
@@ -109,7 +109,7 @@ function getRundownItemAuthoringStorage(id: IRundownItem['_id']): IAuthoringStor
         },
         closeAuthoring: (_current, _original, hasUnsavedChanges, _cancelAutosave, doClose) => {
             if (hasUnsavedChanges) {
-                return superdesk.ui.confirm('Discard unsaved changes?').then((confirmed) => {
+                return superdesk.ui.confirm(superdesk.localization.gettext('Discard unsaved changes?')).then((confirmed) => {
                     if (confirmed) {
                         doClose();
                     }
@@ -197,7 +197,7 @@ function getRundownItemCreationAuthoringStorage(
             return Promise.resolve(contentProfile);
         },
         closeAuthoring: (_current, _original, _hasUnsavedChanges, _cancelAutosave, doClose) => {
-            return superdesk.ui.confirm('Discard unsaved changes?').then((confirmed) => {
+            return superdesk.ui.confirm(superdesk.localization.gettext('Discard unsaved changes?')).then((confirmed) => {
                 if (confirmed) {
                     doClose();
                 }

--- a/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit.ts
+++ b/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit.ts
@@ -60,7 +60,7 @@ function getRundownItemTemplateAuthoringStorage(
             const warnAboutLosingChanges = isCreationMode || hasUnsavedChanges;
 
             if (warnAboutLosingChanges) {
-                return superdesk.ui.confirm('Discard unsaved changes?').then((confirmed) => {
+                return superdesk.ui.confirm(superdesk.localization.gettext('Discard unsaved changes?')).then((confirmed) => {
                     if (confirmed) {
                         doClose();
                     }

--- a/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit.ts
+++ b/scripts/extensions/broadcasting/src/rundowns/prepare-create-edit.ts
@@ -60,7 +60,9 @@ function getRundownItemTemplateAuthoringStorage(
             const warnAboutLosingChanges = isCreationMode || hasUnsavedChanges;
 
             if (warnAboutLosingChanges) {
-                return superdesk.ui.confirm(superdesk.localization.gettext('Discard unsaved changes?')).then((confirmed) => {
+                const {gettext} = superdesk.localization;
+
+                return superdesk.ui.confirm(gettext('Discard unsaved changes?')).then((confirmed) => {
                     if (confirmed) {
                         doClose();
                     }


### PR DESCRIPTION
### Purpose
Replace hardcoded user-facing strings with localization helpers across the codebase. Added `gettext` imports in `React/TSX` files and replaced string literals (placeholders, aria labels, titles, notifications, confirmations, tooltips, etc.) with `gettext(...)` or Angular `| translate` filters. 
Also updated extension notifications/confirmations (`superdesk.ui`) to use localized messages. 
No functional changes intended, prepares UI for internationalization.

[SDESK-7907]


[SDESK-7907]: https://sofab.atlassian.net/browse/SDESK-7907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ