### PR TITLE
[STT-1657] - Spell checking unavailable in stories created from highlight templates

### DIFF
--- a/scripts/apps/authoring/views/authoring-topbar.html
+++ b/scripts/apps/authoring/views/authoring-topbar.html
@@ -257,7 +257,7 @@
         </button>
 
         <div id="authoring-extra-dropdown"
-             ng-if="item._type !== 'legal_archive' && item._type !== 'archived' && !highlight && item.state !== 'spiked' && buttonsToHide['article-edit--topbar--actions'] !== true"
+             ng-if="item._type !== 'legal_archive' && item._type !== 'archived' && item.state !== 'spiked' && buttonsToHide['article-edit--topbar--actions'] !== true"
              class="dropdown pull-left strict" dropdown>
             <button
               id="more-actions"


### PR DESCRIPTION
### Purpose
This PR restores the authoring actions menu in highlight workspace so spell checking is available again.

### What has changed
- Removed the !highlight guard from the authoring topbar overflow menu

### Steps to test
1. Go to Highlights workspace. 
2. Create a new story
3. Confirm the 3-dot actions menu is visible in the topbar.
4. Open the menu and verify all options are available.

### Screenshots
<img width="645" height="510" alt="image" src="https://github.com/user-attachments/assets/c3eec040-9089-4d18-ab9a-2234cd30460f" />

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I reviewed my code
- [X] I tested all affected functionality and made sure it works

Resolves: [STT-1657](https://sofab.atlassian.net/browse/STT-1657)


[STT-1657]: https://sofab.atlassian.net/browse/STT-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ