### PR TITLE
I18n/sr cyrillic

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,6 +49,38 @@ module.exports = function(grunt) {
         'webpack-dev-server:ui-guide',
     ]);
 
+    // Compile PO files to runtime JSON catalogs (gettext.js flat format with metadata under "" key).
+    // Used by scripts/init.ts and scripts/reload-language.ts. Production build runs the equivalent
+    // step via build-tools' build-root-repo command; this grunt task lets `grunt server` produce
+    // them too. Invokes gettext.js's shipped po2json CLI directly so we don't have to depend on
+    // @superdesk/build-tools at runtime (it's a devDependency and may not be installed when this
+    // Gruntfile is consumed from another project).
+    grunt.registerTask('po-to-json', 'Compile po/*.po to dist/languages/*.json', function() {
+        var fs = require('fs');
+        var distDir = grunt.config.get('distDir');
+        var poDir = path.join(__dirname, 'po');
+        var jsonDir = path.join(process.cwd(), distDir, 'languages');
+        var po2json = path.join(
+            path.dirname(require.resolve('gettext.js/package.json')),
+            'bin',
+            'po2json'
+        );
+
+        fs.mkdirSync(jsonDir, {recursive: true});
+
+        fs.readdirSync(poDir).forEach(function(filename) {
+            var poFile = path.join(poDir, filename);
+
+            if (!filename.endsWith('.po') || fs.statSync(poFile).isDirectory()) {
+                return;
+            }
+
+            var jsonFile = path.join(jsonDir, filename.replace('.po', '.json'));
+
+            execSync(`node "${po2json}" "${poFile}" "${jsonFile}"`, {stdio: 'inherit'});
+        });
+    });
+
     // Development server
     grunt.registerTask('server', [
         'clean',
@@ -56,6 +88,7 @@ module.exports = function(grunt) {
         'copy:index',
         'copy:config',
         'copy:locales',
+        'po-to-json',
         'ngtemplates:gen-apps',
         'ngtemplates:dev',
         'webpack-dev-server:start',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,6 +49,17 @@ module.exports = function(grunt) {
         'webpack-dev-server:ui-guide',
     ]);
 
+    // Compile PO files to runtime JSON catalogs (gettext.js flat format with metadata under "" key).
+    // Used by scripts/init.ts and scripts/reload-language.ts. Production build runs this via
+    // build-tools' build-root-repo command; this grunt task lets `grunt server` produce them too.
+    grunt.registerTask('po-to-json', 'Compile po/*.po to dist/languages/*.json', function() {
+        var poDir = path.join(__dirname, 'po');
+        var jsonDir = path.join(process.cwd(), config.distDir, 'languages');
+        var compileTranslationsPoToJson = require('@superdesk/build-tools/src/po-to-json');
+
+        compileTranslationsPoToJson(poDir, jsonDir);
+    });
+
     // Development server
     grunt.registerTask('server', [
         'clean',
@@ -56,6 +67,7 @@ module.exports = function(grunt) {
         'copy:index',
         'copy:config',
         'copy:locales',
+        'po-to-json',
         'ngtemplates:gen-apps',
         'ngtemplates:dev',
         'webpack-dev-server:start',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,17 +49,6 @@ module.exports = function(grunt) {
         'webpack-dev-server:ui-guide',
     ]);
 
-    // Compile PO files to runtime JSON catalogs (gettext.js flat format with metadata under "" key).
-    // Used by scripts/init.ts and scripts/reload-language.ts. Production build runs this via
-    // build-tools' build-root-repo command; this grunt task lets `grunt server` produce them too.
-    grunt.registerTask('po-to-json', 'Compile po/*.po to dist/languages/*.json', function() {
-        var poDir = path.join(__dirname, 'po');
-        var jsonDir = path.join(process.cwd(), config.distDir, 'languages');
-        var compileTranslationsPoToJson = require('@superdesk/build-tools/src/po-to-json');
-
-        compileTranslationsPoToJson(poDir, jsonDir);
-    });
-
     // Development server
     grunt.registerTask('server', [
         'clean',
@@ -67,7 +56,6 @@ module.exports = function(grunt) {
         'copy:index',
         'copy:config',
         'copy:locales',
-        'po-to-json',
         'ngtemplates:gen-apps',
         'ngtemplates:dev',
         'webpack-dev-server:start',

--- a/docs/i18n/sr-glossary.md
+++ b/docs/i18n/sr-glossary.md
@@ -1,0 +1,122 @@
+---
+name: sr-glossary
+description: Serbian Cyrillic glossary for AI-assisted translations. Reviewed and confirmed by Serbian language expert.
+type: reference
+---
+
+# Serbian Cyrillic Glossary
+
+Use neutral Serbian Cyrillic (Вукова ћирилица). Prefer consistency over stylistic variation. This glossary will later be transliterated to Latin (`sr_Latn`) using a standard Вук mapping.
+
+## Core product terms
+
+| English | Serbian Cyrillic | Notes |
+|---|---|---|
+| article | чланак | |
+| item | ставка | |
+| news item | ставка вести | also acceptable: `вест` |
+| content | садржај | |
+| headline | наслов | |
+| subhead | поднаслов | |
+| abstract | сажетак | |
+| body | тело | article body |
+| lead | увод | article lead paragraph |
+| byline | потпис | |
+| dateline | датумска линија | |
+| caption | натпис | for media/images; alternative: `потпис слике` |
+| keyword | кључна реч | |
+| tag | ознака | |
+| slugline | слаглајн | transliterated journalist jargon |
+| desk | деск | editorial unit (e.g. politics desk, sports desk) |
+| stage | фаза | workflow stage |
+| workspace | радни простор | |
+| assignment | задатак | work assignment |
+| planning | планирање | |
+| event | догађај | |
+| coverage | извештавање | reporting coverage of an event |
+| story | прича | |
+| package | пакет | bundled content |
+| template | шаблон | |
+| preview | преглед | |
+| publish | објавити | imperative: `Објави` |
+| unpublish | повући објаву | "retract publication" |
+| schedule | заказати | imperative: `Закажи` |
+| scheduled | заказано | | |
+| save | сачувати | imperative: `Сачувај` |
+| close | затворити | imperative: `Затвори` |
+| open | отворити | imperative: `Отвори` |
+| edit | уредити | imperative: `Уреди` |
+| delete | обрисати | imperative: `Обриши` |
+| remove | уклонити | imperative: `Уклони` |
+| add | додати | imperative: `Додај` |
+| create | креирати | imperative: `Креирај` |
+| cancel | отказати | imperative: `Откажи` |
+| confirm | потврдити | imperative: `Потврди` |
+| submit | послати | imperative: `Пошаљи` |
+| filter | филтер | |
+| search | претрага | noun; verb `претражити`, imperative `Претражи` |
+| vocabulary | вокабулар | distinct from `dictionary`; coded value sets (topics, priorities) |
+| dictionary | речник | language dictionary (spell-check) |
+| settings | подешавања | |
+| preferences | поставке | |
+| user | корисник | |
+| group | група | |
+| role | улога | |
+| permission | дозвола | |
+| language | језик | |
+| translation | превод | |
+| translate | превести | imperative: `Преведи` |
+| profile | профил | |
+| content profile | профил садржаја | |
+
+## Common UI labels
+
+| English | Serbian Cyrillic | Notes |
+|---|---|---|
+| OK | У реду | |
+| Yes | Да | |
+| No | Не | |
+| Name | Назив / Име | |
+| Date | Датум | |
+| Time | Време | |
+| Status | Статус | |
+| Type | Тип | alternative: `Врста` |
+| Value | Вредност | |
+| Default | Подразумевано | |
+| None | Ниједан / Ништа | |
+| All | Сви / Све | |
+| Required | Обавезно | |
+| Optional | Опционо | |
+| Loading… | Учитавање… | |
+| Error | Грешка | |
+| Warning | Упозорење | |
+| Success | Успех | alternative: `Урађено` |
+| Info | Информација | alternative: `Обавештење` |
+
+## Tone
+
+- Keep labels short and UI-friendly.
+- Use imperative verbs for action buttons: `Сачувај`, `Затвори`, `Објави`, `Откажи`, `Обриши`.
+- Keep product names untranslated: **Superdesk**, **Newshub**, etc.
+- Keep technical identifiers and field codes untranslated (e.g. `slug`, `guid`, `urgency`, field names in API).
+- Prefer neutral Serbian. Do not use regionalisms.
+- Use Ekavian pronunciation (standard in Serbia): `време` not `вријеме`, `мрежа` not `мрежа` (same), `превод` not `пријевод`.
+
+## Consistency rules
+
+- Preserve established translations already present in `po/sr.po` once a baseline exists.
+- Do not translate placeholders (`{{name}}`, `{{ count }}`, `{{user.full_name}}`).
+- Do not translate field identifiers, system codes, or internal keys.
+- If a source term is ambiguous or journalism-domain specific and not in this glossary, leave it untranslated and flag for manual review rather than guessing.
+- When a source string contains both UI terms and journalism jargon, prefer the UI translation for button/label context and the journalism term for content context.
+
+## Placeholders and formatting
+
+- Preserve every `{{...}}` exactly, including internal spacing.
+- Preserve HTML tags and markup exactly.
+- Preserve plural structures exactly (`msgstr[n]` slots).
+- Serbian has 3 plural forms (one, few, other). The POT plural forms header will determine the expected slots — do not add or remove slots.
+
+## Script note
+
+This glossary is Cyrillic-first. A mechanical Cyrillic → Latin transliteration (Вук mapping: а→a, б→b, в→v, г→g, д→d, ђ→đ, е→e, ж→ž, з→z, и→i, ј→j, к→k, л→l, љ→lj, м→m, н→n, њ→nj, о→o, п→p, р→r, с→s, т→t, ћ→ć, у→u, ф→f, х→h, ц→c, ч→č, џ→dž, ш→š) will produce the `sr_Latn` variant later.

--- a/docs/i18n/sr-glossary.md
+++ b/docs/i18n/sr-glossary.md
@@ -29,6 +29,9 @@ Use neutral Serbian Cyrillic (Вукова ћирилица). Prefer consistency
 | slugline | слаглајн | transliterated journalist jargon |
 | desk | деск | editorial unit (e.g. politics desk, sports desk) |
 | stage | фаза | workflow stage |
+| spike (verb) | преместити у корпу | journalism: move article to discard bin. Decline `корпа` per case (`у корпу` / `у корпи` / `мониторинг корпе`) |
+| spike (noun) | корпа | the discard bin itself |
+| spiked | у корпи | item state |
 | workspace | радни простор | |
 | assignment | задатак | work assignment |
 | planning | планирање | |

--- a/docs/i18n/sr-glossary.md
+++ b/docs/i18n/sr-glossary.md
@@ -50,7 +50,7 @@ Use neutral Serbian Cyrillic (Вукова ћирилица). Prefer consistency
 | publish | објавити | imperative: `Објави` |
 | unpublish | повући објаву | "retract publication" |
 | schedule | заказати | imperative: `Закажи` |
-| scheduled | заказано | | |
+| scheduled | заказано | |
 | save | сачувати | imperative: `Сачувај` |
 | close | затворити | imperative: `Затвори` |
 | open | отворити | imperative: `Отвори` |
@@ -109,7 +109,7 @@ Use neutral Serbian Cyrillic (Вукова ћирилица). Prefer consistency
 - Keep product names untranslated: **Superdesk**, **Newshub**, etc.
 - Keep technical identifiers and field codes untranslated (e.g. `slug`, `guid`, `urgency`, field names in API).
 - Prefer neutral Serbian. Do not use regionalisms.
-- Use Ekavian pronunciation (standard in Serbia): `време` not `вријеме`, `мрежа` not `мрежа` (same), `превод` not `пријевод`.
+- Use Ekavian pronunciation (standard in Serbia): `време` not `вријеме`, `превод` not `пријевод`.
 
 ## Consistency rules
 

--- a/docs/i18n/sr-glossary.md
+++ b/docs/i18n/sr-glossary.md
@@ -32,6 +32,12 @@ Use neutral Serbian Cyrillic (Вукова ћирилица). Prefer consistency
 | spike (verb) | преместити у корпу | journalism: move article to discard bin. Decline `корпа` per case (`у корпу` / `у корпи` / `мониторинг корпе`) |
 | spike (noun) | корпа | the discard bin itself |
 | spiked | у корпи | item state |
+| ingest | пријем | automatic feed-based content reception. Decline: `пријема` (gen), `пријему` (loc) — e.g. `Канали пријема`, `Извори пријема` |
+| feeding service | фид сервис | newsroom feed service |
+| feed parser | парсер фида | RSS/feed parser |
+| routing (scheme/rules) | рутирање | content routing — `Шема рутирања`, `правила рутирања`, `Започни рутирање`, `Рутирано са` |
+| filter statement | критеријум филтера | not `изјава филтера` |
+| highlight (noun) | истицање | featured-content list (not text-highlight) |
 | workspace | радни простор | |
 | assignment | задатак | work assignment |
 | planning | планирање | |

--- a/po/sr.po
+++ b/po/sr.po
@@ -12079,7 +12079,7 @@ msgstr "Отвори претрагу"
 
 #: scripts/apps/workspace/index.ts:36
 msgid "Open spike"
-msgstr "Отвори кош"
+msgstr "Отвори корпу"
 
 #: scripts/apps/workspace/index.ts:35
 msgid "Open tasks"
@@ -16264,7 +16264,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/config.ts:29
 msgid "Spike Monitoring"
-msgstr "Мониторинг коша"
+msgstr "Мониторинг корпе"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:138
 msgid "Spike Planning Item"
@@ -16280,7 +16280,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/index.ts:127
 msgid "Spike item(s)"
-msgstr "Премести ставку(е) у кош"
+msgstr "Премести ставку(е) у корпу"
 
 #: ../superdesk-planning/client/constants/planning.ts:135
 msgid "Spike planning"
@@ -16298,7 +16298,7 @@ msgstr ""
 #: scripts/apps/search/components/fields/state.tsx:36
 #: scripts/apps/search/constants.ts:14
 msgid "Spiked"
-msgstr "У кошу"
+msgstr "У корпи"
 
 #: scripts/apps/search/views/search-parameters.html:145
 msgid "Spiked Content"
@@ -16307,7 +16307,7 @@ msgstr ""
 #: scripts/apps/monitoring/config.ts:40
 #: scripts/apps/monitoring/views/monitoring-view.html:257
 msgid "Spiked Items"
-msgstr "Ставке у кошу"
+msgstr "Ставке у корпи"
 
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:177
 msgid "Spiked Only"
@@ -16320,7 +16320,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/monitoring-view.html:4
 msgid "Spiked items"
-msgstr "Ставке у кошу"
+msgstr "Ставке у корпи"
 
 #: scripts/apps/search/views/search-parameters.html:153
 msgid "Spiked only content"

--- a/po/sr.po
+++ b/po/sr.po
@@ -181,9 +181,9 @@ msgstr "1 месец"
 #: ../superdesk-planning/client/components/fields/with-more-items.tsx:52
 msgid "1 more item"
 msgid_plural "{{n}} more items"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Још 1 ставка"
+msgstr[1] "Још {{n}} ставке"
+msgstr[2] "Још {{n}} ставки"
 
 #: ../superdesk-analytics/client/utils.js:210
 msgid "1 second"
@@ -229,7 +229,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:44
 #: ../superdesk-planning/client/utils/filters.ts:81
 msgid "10th"
-msgstr ""
+msgstr "10."
 
 #: scripts/core/lang/missing-translations-strings.ts:28
 msgid "10th update"
@@ -238,7 +238,7 @@ msgstr "10. ажурирање"
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:45
 #: ../superdesk-planning/client/utils/filters.ts:83
 msgid "11th"
-msgstr ""
+msgstr "11."
 
 #: scripts/core/lang/missing-translations-strings.ts:28
 msgid "11th update"
@@ -255,7 +255,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:46
 #: ../superdesk-planning/client/utils/filters.ts:85
 msgid "12th"
-msgstr ""
+msgstr "12."
 
 #: scripts/core/lang/missing-translations-strings.ts:29
 msgid "12th update"
@@ -264,7 +264,7 @@ msgstr "12. ажурирање"
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:47
 #: ../superdesk-planning/client/utils/filters.ts:87
 msgid "13th"
-msgstr ""
+msgstr "13."
 
 #: scripts/core/lang/missing-translations-strings.ts:29
 msgid "13th update"
@@ -273,7 +273,7 @@ msgstr "13. ажурирање"
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:48
 #: ../superdesk-planning/client/utils/filters.ts:89
 msgid "14th"
-msgstr ""
+msgstr "14."
 
 #: scripts/core/lang/missing-translations-strings.ts:29
 msgid "14th update"
@@ -282,7 +282,7 @@ msgstr "14. ажурирање"
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:49
 #: ../superdesk-planning/client/utils/filters.ts:91
 msgid "15th"
-msgstr ""
+msgstr "15."
 
 #: scripts/core/lang/missing-translations-strings.ts:29
 msgid "15th update"
@@ -291,7 +291,7 @@ msgstr "15. ажурирање"
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:50
 #: ../superdesk-planning/client/utils/filters.ts:93
 msgid "16th"
-msgstr ""
+msgstr "16."
 
 #: scripts/core/lang/missing-translations-strings.ts:29
 msgid "16th update"
@@ -299,7 +299,7 @@ msgstr "16. ажурирање"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:51
 msgid "17th"
-msgstr ""
+msgstr "17."
 
 #: scripts/core/lang/missing-translations-strings.ts:29
 msgid "17th update"
@@ -307,7 +307,7 @@ msgstr "17. ажурирање"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:52
 msgid "18th"
-msgstr ""
+msgstr "18."
 
 #: scripts/core/lang/missing-translations-strings.ts:30
 msgid "18th update"
@@ -316,7 +316,7 @@ msgstr "18. ажурирање"
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:53
 #: ../superdesk-planning/client/utils/filters.ts:99
 msgid "19th"
-msgstr ""
+msgstr "19."
 
 #: scripts/core/lang/missing-translations-strings.ts:30
 msgid "19th update"
@@ -349,7 +349,7 @@ msgstr "200 минимум"
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:54
 #: ../superdesk-planning/client/utils/filters.ts:101
 msgid "20th"
-msgstr ""
+msgstr "20."
 
 #: scripts/core/lang/missing-translations-strings.ts:30
 msgid "20th update"
@@ -358,17 +358,17 @@ msgstr "20. ажурирање"
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:55
 #: ../superdesk-planning/client/utils/filters.ts:103
 msgid "21st"
-msgstr ""
+msgstr "21."
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:56
 #: ../superdesk-planning/client/utils/filters.ts:105
 msgid "22nd"
-msgstr ""
+msgstr "22."
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:57
 #: ../superdesk-planning/client/utils/filters.ts:107
 msgid "23rd"
-msgstr ""
+msgstr "23."
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:19
 msgid "24 Hours"
@@ -377,7 +377,7 @@ msgstr "24 сата"
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:58
 #: ../superdesk-planning/client/utils/filters.ts:109
 msgid "24th"
-msgstr ""
+msgstr "24."
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:187
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:187
@@ -394,27 +394,27 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:59
 #: ../superdesk-planning/client/utils/filters.ts:111
 msgid "25th"
-msgstr ""
+msgstr "25."
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:60
 #: ../superdesk-planning/client/utils/filters.ts:113
 msgid "26th"
-msgstr ""
+msgstr "26."
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:61
 #: ../superdesk-planning/client/utils/filters.ts:115
 msgid "27th"
-msgstr ""
+msgstr "27."
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:62
 #: ../superdesk-planning/client/utils/filters.ts:117
 msgid "28th"
-msgstr ""
+msgstr "28."
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:36
 #: ../superdesk-planning/client/utils/filters.ts:65
 msgid "2nd"
-msgstr ""
+msgstr "2."
 
 #: scripts/core/lang/missing-translations-strings.ts:27
 msgid "2nd update"
@@ -423,7 +423,7 @@ msgstr "2. ажурирање"
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:37
 #: ../superdesk-planning/client/utils/filters.ts:67
 msgid "3rd"
-msgstr ""
+msgstr "3."
 
 #: scripts/core/lang/missing-translations-strings.ts:27
 msgid "3rd update"
@@ -440,7 +440,7 @@ msgstr "48 сати"
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:38
 #: ../superdesk-planning/client/utils/filters.ts:69
 msgid "4th"
-msgstr ""
+msgstr "4."
 
 #: scripts/core/lang/missing-translations-strings.ts:27
 msgid "4th update"
@@ -471,7 +471,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:39
 #: ../superdesk-planning/client/utils/filters.ts:71
 msgid "5th"
-msgstr ""
+msgstr "5."
 
 #: scripts/core/lang/missing-translations-strings.ts:27
 msgid "5th update"
@@ -488,7 +488,7 @@ msgstr "6 месеци"
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:40
 #: ../superdesk-planning/client/utils/filters.ts:73
 msgid "6th"
-msgstr ""
+msgstr "6."
 
 #: scripts/core/lang/missing-translations-strings.ts:28
 msgid "6th update"
@@ -501,7 +501,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:41
 #: ../superdesk-planning/client/utils/filters.ts:75
 msgid "7th"
-msgstr ""
+msgstr "7."
 
 #: scripts/core/lang/missing-translations-strings.ts:28
 msgid "7th update"
@@ -510,7 +510,7 @@ msgstr "7. ажурирање"
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:42
 #: ../superdesk-planning/client/utils/filters.ts:77
 msgid "8th"
-msgstr ""
+msgstr "8."
 
 #: scripts/core/lang/missing-translations-strings.ts:28
 msgid "8th update"
@@ -519,7 +519,7 @@ msgstr "8. ажурирање"
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:43
 #: ../superdesk-planning/client/utils/filters.ts:79
 msgid "9th"
-msgstr ""
+msgstr "9."
 
 #: scripts/core/lang/missing-translations-strings.ts:28
 msgid "9th update"
@@ -612,7 +612,7 @@ msgstr "ДОДАЈ РЕЧ"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:35
 msgid "AMP"
-msgstr ""
+msgstr "AMP"
 
 #: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:88
 #: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:97
@@ -629,7 +629,7 @@ msgstr "ANPA категорија"
 
 #: ../superdesk-planning/client/components/fields/list/Categories.tsx:19
 msgid "ANPA Category:"
-msgstr ""
+msgstr "ANPA категорија:"
 
 #: scripts/core/lang/missing-translations-strings.ts:31
 msgid "ANPA Take Key"
@@ -805,7 +805,7 @@ msgstr "Виџет тока активности"
 #: ../superdesk-planning/client/components/fields/editor/AdHocPlanning.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:41
 msgid "Ad Hoc Planning"
-msgstr ""
+msgstr "Ад хок планирање"
 
 #: scripts/apps/authoring-react/fields/date/config.tsx:109
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:239
@@ -881,11 +881,11 @@ msgstr "Додај критеријум филтера"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:28
 msgid "Add Gallery"
-msgstr ""
+msgstr "Додај галерију"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:29
 msgid "Add Image"
-msgstr ""
+msgstr "Додај слику"
 
 #: scripts/apps/ingest/views/dashboard/ingest-sources-list.html:1
 msgid "Add Ingest Sources"
@@ -1251,7 +1251,7 @@ msgstr "Додавање повезаних ставки које нису об�
 #: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:49
 #: ../superdesk-planning/client/components/fields/resources/locations.ts:24
 msgid "Address"
-msgstr ""
+msgstr "Адреса"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:541
 msgid "Address line 1"
@@ -1263,7 +1263,7 @@ msgstr "Адреса 2"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:30
 msgid "Adjust"
-msgstr ""
+msgstr "Подеси"
 
 #: scripts/apps/authoring/views/change-image.html:239
 msgid "Adjust colours"
@@ -1374,7 +1374,7 @@ msgstr "Агенда додељена ставци планирања."
 
 #: ../superdesk-planning/client/components/fields/agendas.tsx:29
 msgid "Agenda:"
-msgstr ""
+msgstr "Агенда:"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:201
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/agendas-field.ts:27
@@ -1472,19 +1472,19 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:31
 msgid "Align Center"
-msgstr ""
+msgstr "Поравнај по средини"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:32
 msgid "Align Justify"
-msgstr ""
+msgstr "Обострано поравнај"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:33
 msgid "Align Left"
-msgstr ""
+msgstr "Поравнај лево"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:34
 msgid "Align Right"
-msgstr ""
+msgstr "Поравнај десно"
 
 #: scripts/apps/authoring/metadata/views/metadata-terms.html:76
 #: scripts/apps/contacts/services/ContactsService.ts:55
@@ -1507,7 +1507,7 @@ msgstr "Сва извештавања су отказана"
 
 #: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:25
 msgid "All Coverages Assigned"
-msgstr ""
+msgstr "Сва извештавања додељена"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:64
 #: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:12
@@ -1516,7 +1516,7 @@ msgstr "Цео дан"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:136
 msgid "All Day Toggle"
-msgstr ""
+msgstr "Прекидач за цео дан"
 
 #: ../superdesk-planning/client/components/Assignments/DesksSubNavDropDown.tsx:21
 msgid "All Desks"
@@ -1802,7 +1802,7 @@ msgstr ""
 #: ../superdesk-analytics/client/index.js:94
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:36
 msgid "Analytics"
-msgstr ""
+msgstr "Аналитика"
 
 #: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:121
 #: scripts/core/editor3/components/toolbar/index.tsx:410
@@ -1878,7 +1878,7 @@ msgstr "Примењени глобални филтери блокирања"
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:243
 #: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:563
 msgid "Apply"
-msgstr ""
+msgstr "Примени"
 
 #: scripts/apps/master-desk/components/FilterPanelComponent.tsx:171
 msgid "Apply Filters"
@@ -2052,19 +2052,19 @@ msgstr "Да ли сте сигурни да желите да повучете 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:236
 #: ../superdesk-planning/client/components/fields/resources/locations.ts:32
 msgid "Area"
-msgstr ""
+msgstr "Област"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:38
 msgid "Arrow Left"
-msgstr ""
+msgstr "Стрелица лево"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:39
 msgid "Arrow Right"
-msgstr ""
+msgstr "Стрелица десно"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:40
 msgid "Arrow Small"
-msgstr ""
+msgstr "Мала стрелица"
 
 #: scripts/apps/users/views/user-preferences.html:103
 msgid "Article Defaults"
@@ -2091,11 +2091,11 @@ msgstr "Тип(ови) чланка"
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/RelatedArticlesListComponent.tsx:105
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/RelatedArticlesListComponent.tsx:122
 msgid "Article Type: text"
-msgstr ""
+msgstr "Тип чланка: текст"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/RelatedArticlesListComponent.tsx:100
 msgid "Article Type: {{articleType}}"
-msgstr ""
+msgstr "Тип чланка: {{articleType}}"
 
 #: ../superdesk-planning/client/utils/assignments.ts:504
 #: scripts/apps/authoring/authoring/directives/AuthoringHeaderDirective.ts:70
@@ -2124,7 +2124,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:304
 msgid "Article preview"
-msgstr ""
+msgstr "Преглед чланка"
 
 #: ../superdesk-planning/client/actions/multiSelect.ts:236
 msgid "Article was created."
@@ -2457,7 +2457,7 @@ msgstr "Садржај задатака"
 
 #: ../superdesk-planning/client/components/fields/editor/XMPFile.tsx:53
 msgid "Associate an XMP file"
-msgstr ""
+msgstr "Повежи XMP датотеку"
 
 #: scripts/apps/search/components/Associations.tsx:40
 msgid "Associated"
@@ -2532,7 +2532,7 @@ msgstr "Прилог"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:44
 msgid "Attachment Large"
-msgstr ""
+msgstr "Велики прилог"
 
 #: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/planning-attachments/index.tsx:24
 #: scripts/apps/authoring-react/field-adapters/attachments.ts:16
@@ -2741,11 +2741,11 @@ msgstr "Назад на листу корисника"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:46
 msgid "Backward Thin"
-msgstr ""
+msgstr "Уназад танко"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:47
 msgid "Ban Circle"
-msgstr ""
+msgstr "Круг забране"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:87
 msgid "Bar"
@@ -2773,7 +2773,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:48
 msgid "Bell"
-msgstr ""
+msgstr "Звоно"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:39
 msgid "Better"
@@ -2839,7 +2839,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:49
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:32
 msgid "Bold"
-msgstr ""
+msgstr "Подебљано"
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:75
 msgid "Bold (Ctrl+B)"
@@ -2873,7 +2873,7 @@ msgstr "Емисија"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:51
 msgid "Broadcast Create"
-msgstr ""
+msgstr "Креирај емисију"
 
 #: scripts/extensions/broadcasting/dist/src/extension.js:19
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/extension.js:19
@@ -2892,7 +2892,7 @@ msgstr "Зграда, апартман, стан, спрат, итд."
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:52
 msgid "Business"
-msgstr ""
+msgstr "Бизнис"
 
 #: scripts/core/lang/missing-translations-strings.ts:31
 msgid "By"
@@ -2967,11 +2967,11 @@ msgstr "ПРИЛАГОЂЕНИ РАДНИ ПРОСТОРИ"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:53
 msgid "Calendar"
-msgstr ""
+msgstr "Календар"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:54
 msgid "Calendar List"
-msgstr ""
+msgstr "Листа календара"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:922
 msgid "Calendar assigned to the event"
@@ -2979,7 +2979,7 @@ msgstr "Календар додељен догађају"
 
 #: ../superdesk-planning/client/components/fields/calendars.tsx:52
 msgid "Calendar:"
-msgstr ""
+msgstr "Календар:"
 
 #: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:37
 msgid "Calendar: {{activeCalendarName}}"
@@ -3230,7 +3230,7 @@ msgstr "Откажи извештавање"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:53
 msgid "Cancel planning items with Event"
-msgstr ""
+msgstr "Откажи ставке планирања са догађајем"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:84
 msgid "Cancel {{event}}"
@@ -3256,7 +3256,7 @@ msgstr "Не можете додати саму ставку као повеза
 msgid ""
 "Cannot change workflow status if the coverage is part of an expired planning "
 "item"
-msgstr ""
+msgstr "Није могуће променити статус радног тока ако је извештавање део истекле ставке планирања"
 
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:35
 msgid "Cannot delete vocabulary"
@@ -3436,19 +3436,19 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:55
 msgid "Chevron Down Thin"
-msgstr ""
+msgstr "Шеврон доле танко"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:56
 msgid "Chevron Left Thin"
-msgstr ""
+msgstr "Шеврон лево танко"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:57
 msgid "Chevron Right Thin"
-msgstr ""
+msgstr "Шеврон десно танко"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:58
 msgid "Chevron Up Thin"
-msgstr ""
+msgstr "Шеврон горе танко"
 
 #: scripts/apps/authoring/metadata/views/metadata-terms.html:36
 msgid "Choose entire category"
@@ -3483,7 +3483,7 @@ msgstr "Град"
 #: ../superdesk-planning/client/components/Locations/LocationsList.tsx:118
 #: ../superdesk-planning/client/components/fields/resources/locations.ts:48
 msgid "City/Town"
-msgstr ""
+msgstr "Град/насеље"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:274
 msgid "Clean Pasted HTML"
@@ -3512,7 +3512,7 @@ msgstr "Очисти"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:59
 msgid "Clear All"
-msgstr ""
+msgstr "Очисти све"
 
 #: scripts/apps/search/views/search-parameters.html:261
 msgid "Clear Edge"
@@ -3531,11 +3531,11 @@ msgstr "Очисти филтере"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:60
 msgid "Clear Format"
-msgstr ""
+msgstr "Очисти форматирање"
 
 #: ../superdesk-planning/client/components/UI/SearchBox.tsx:118
 msgid "Clear Search"
-msgstr ""
+msgstr "Очисти претрагу"
 
 #: scripts/apps/master-desk/components/FilterBarComponent.tsx:34
 msgid "Clear all filters"
@@ -3593,7 +3593,7 @@ msgstr "Кликните на дугме \"+\" у горњем десном уг
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:160
 msgid "Click the Plus button to add languages"
-msgstr ""
+msgstr "Кликните на дугме плус да бисте додали језике"
 
 #: scripts/apps/users/views/change-avatar.html:38
 msgid ""
@@ -3702,7 +3702,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:61
 msgid "Close Small"
-msgstr ""
+msgstr "Мало затвори"
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary-widget.js:47
 #: scripts/extensions/ai-widget/dist/src/summary/summary-widget.js:47
@@ -3712,7 +3712,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:62
 msgid "Close Thick"
-msgstr ""
+msgstr "Дебело затвори"
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-widget.js:43
 #: scripts/extensions/ai-widget/dist/src/translations/translations-widget.js:43
@@ -3768,7 +3768,7 @@ msgstr "Затварање није успело"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:63
 msgid "Code"
-msgstr ""
+msgstr "Код"
 
 #: ../superdesk-planning/client/components/UI/CollapseBox.tsx:175
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:64
@@ -3799,7 +3799,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:42
 #: ../superdesk-planning/client/components/fields/editor/ItemType.tsx:18
 msgid "Combined"
-msgstr ""
+msgstr "Комбиновано"
 
 #: scripts/apps/publish/views/subscribers.html:158
 msgid "Comma separated values"
@@ -3825,7 +3825,7 @@ msgstr "Коментари"
 
 #: ../superdesk-planning/client/components/fields/index.tsx:223
 msgid "Common"
-msgstr ""
+msgstr "Уобичајено"
 
 #: scripts/apps/monitoring/directives/utils.ts:95
 #: scripts/apps/search/views/search.html:22
@@ -3884,7 +3884,7 @@ msgstr "Завршено"
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:66
 #: ../superdesk-planning/client/utils/index.ts:595
 msgid "Composite"
-msgstr ""
+msgstr "Композитни"
 
 #: scripts/apps/legal-archive/index.ts:38
 msgid "Confidential data"
@@ -4084,7 +4084,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/ContentTemplate.tsx:82
 msgid "Content Template"
-msgstr ""
+msgstr "Шаблон садржаја"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:321
 #: scripts/apps/publish/views/publish-queue.html:107
@@ -4393,7 +4393,7 @@ msgstr "Детаљи доделе извештавања"
 #: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:37
 #: ../superdesk-planning/client/components/fields/preview/index.ts:45
 msgid "Coverage Assignment Status"
-msgstr ""
+msgstr "Статус доделе извештавања"
 
 #: ../superdesk-planning/client/utils/assignments.ts:206
 msgid "Coverage Contact"
@@ -4466,11 +4466,11 @@ msgstr "Извештавање је додато у радни ток"
 
 #: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:28
 msgid "Coverage must be assigned to a desk"
-msgstr ""
+msgstr "Извештавање мора бити додељено деску"
 
 #: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:24
 msgid "Coverage must be in draft status"
-msgstr ""
+msgstr "Извештавање мора бити у статусу нацрта"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:25
 msgid "Coverage of type {{ type }} created"
@@ -4494,7 +4494,7 @@ msgstr "Извештавање уклоњено"
 
 #: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:20
 msgid "Coverage was cancelled"
-msgstr ""
+msgstr "Извештавање је отказано"
 
 #: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:77
 #: ../superdesk-planning/client/components/Coverages/CoverageArrayInput.tsx:199
@@ -4750,11 +4750,11 @@ msgstr "Креирано"
 
 #: ../superdesk-planning/client/components/UI/List/CreatedUpdatedColumn.tsx:28
 msgid "Created : {{ datetime }}"
-msgstr ""
+msgstr "Креирано: {{ datetime }}"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:154
 msgid "Created From"
-msgstr ""
+msgstr "Креирано од"
 
 #: scripts/core/lang/missing-translations-strings.ts:39
 msgid "Created Ingest Channel {{name}}"
@@ -4762,7 +4762,7 @@ msgstr "Креиран канал пријема {{name}}"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:158
 msgid "Created To"
-msgstr ""
+msgstr "Креирано до"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:105
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:105
@@ -4839,7 +4839,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/DatesGroup.tsx:80
 msgid "Creation date"
-msgstr ""
+msgstr "Датум креирања"
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:17
 #: scripts/apps/search/constants.ts:11
@@ -4879,7 +4879,7 @@ msgstr "Критичне грешке"
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:68
 #: scripts/apps/authoring/views/change-image.html:205
 msgid "Crop"
-msgstr ""
+msgstr "Исеци"
 
 #: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:181
 msgid "Crop coordinates are not defined for {{cropName}} picture crop."
@@ -4964,7 +4964,7 @@ msgstr "Прилагодите своје виџете и приказе"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:69
 msgid "Cut"
-msgstr ""
+msgstr "Исеци"
 
 #: ../superdesk-planning/client/components/Main/CalendarNavigation.tsx:46
 msgid "D"
@@ -5052,7 +5052,7 @@ msgstr "Датум креирања"
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:2
 #: ../superdesk-planning/client/components/fields/preview/index.ts:142
 msgid "Date Filter"
-msgstr ""
+msgstr "Филтер датума"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:3
 msgid "Date Filter:"
@@ -5061,7 +5061,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:108
 #: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:16
 msgid "Date Filters"
-msgstr ""
+msgstr "Филтери датума"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:180
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:94
@@ -5127,7 +5127,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/index.tsx:232
 #: ../superdesk-planning/client/utils/contentProfiles.ts:265
 msgid "Dates"
-msgstr ""
+msgstr "Датуми"
 
 #: scripts/extensions/datetimeField/dist/src/extension.js:20
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/extension.js:20
@@ -5152,7 +5152,7 @@ msgstr "Дан"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:29
 msgid "Day of the Month"
-msgstr ""
+msgstr "Дан у месецу"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:30
 msgid "Day(s)"
@@ -5194,7 +5194,7 @@ msgstr "Подразумевани деск"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:147
 msgid "Default Duration"
-msgstr ""
+msgstr "Подразумевано трајање"
 
 #: scripts/apps/users/views/user-preferences.html:232
 msgid "Default Events & Planning Filter"
@@ -5212,7 +5212,7 @@ msgstr "Подразумевана тема"
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:236
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:208
 msgid "Default Value"
-msgstr ""
+msgstr "Подразумевана вредност"
 
 #: scripts/apps/users/views/settings-roles.html:54
 msgid "Default author roles"
@@ -5229,7 +5229,7 @@ msgstr "Подразумевани шаблон деска"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:189
 msgid "Default language"
-msgstr ""
+msgstr "Подразумевани језик"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:69
 msgid "Default language is a required field"
@@ -5354,7 +5354,7 @@ msgstr "Обрисати ставку?"
 #: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:226
 #: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:230
 msgid "Delete link"
-msgstr ""
+msgstr "Обриши линк"
 
 #: scripts/apps/search/views/saved-searches.html:16
 #: scripts/apps/search/views/saved-searches.html:45
@@ -5799,7 +5799,7 @@ msgstr "Приказује активне пречице на тастатури
 #: ../superdesk-planning/client/components/fields/editor/NoContentLinking.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/Flags.tsx:30
 msgid "Do not link content updates"
-msgstr ""
+msgstr "Не повезуј ажурирања садржаја"
 
 #: scripts/apps/vocabularies/constants.ts:56
 msgid "Do not show"
@@ -5922,11 +5922,11 @@ msgstr "Готово"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:71
 msgid "Dots"
-msgstr ""
+msgstr "Тачке"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:72
 msgid "Dots Vertical"
-msgstr ""
+msgstr "Тачке вертикално"
 
 #: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:269
 #: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:67
@@ -5937,11 +5937,11 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/utils/assets.js:45
 #: scripts/extensions/sams/src/utils/assets.ts:57
 msgid "Download"
-msgstr ""
+msgstr "Преузми"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:74
 msgid "Download Alternate"
-msgstr ""
+msgstr "Алтернативно преузимање"
 
 #: scripts/apps/vocabularies/views/vocabulary-config.html:84
 msgid "Download config"
@@ -6002,7 +6002,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:101
 msgid "Drop events here"
-msgstr ""
+msgstr "Пустите догађаје овде"
 
 #: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:87
 msgid "Drop files here to upload"
@@ -6025,7 +6025,7 @@ msgstr "Пустите ставке овде или кликните за отп
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:184
 msgid "Drop planning items here"
-msgstr ""
+msgstr "Пустите ставке планирања овде"
 
 #: scripts/apps/authoring-react/fields/dropdown/index.ts:21
 msgid "Dropdown (authoring-react)"
@@ -6033,11 +6033,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:174
 msgid "Dropped item is not a planning item"
-msgstr ""
+msgstr "Пуштена ставка није ставка планирања"
 
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:164
 msgid "Dropped item is not an event"
-msgstr ""
+msgstr "Пуштена ставка није догађај"
 
 #: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/ScheduledUpdateForm.tsx:169
 #: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:235
@@ -6371,7 +6371,7 @@ msgstr "Уреди изворе пријема"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:75
 msgid "Edit Line"
-msgstr ""
+msgstr "Уреди линију"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:190
 msgid "Edit Location"
@@ -6585,7 +6585,7 @@ msgstr "Уређивање"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:124
 msgid "Editor 3"
-msgstr ""
+msgstr "Уређивач 3"
 
 #: scripts/apps/authoring-react/fields/editor3/index.tsx:57
 msgid "Editor3 (authoring-react)"
@@ -6606,7 +6606,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:253
 msgid "Ednote"
-msgstr ""
+msgstr "Ур. напомена"
 
 #: scripts/apps/contacts/constants.ts:70
 #: scripts/apps/contacts/views/search-panel.html:47
@@ -6774,7 +6774,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:76
 msgid "Envelope"
-msgstr ""
+msgstr "Коверта"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:243
 msgid "Error"
@@ -7146,7 +7146,7 @@ msgstr "Детаљи догађаја"
 
 #: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:225
 msgid "Event Ends"
-msgstr ""
+msgstr "Догађај се завршава"
 
 #: ../superdesk-planning/client/api/contentProfiles.ts:212
 msgid "Event Fields"
@@ -7176,7 +7176,7 @@ msgstr "Догађај поново заказан са"
 
 #: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:206
 msgid "Event Starts"
-msgstr ""
+msgstr "Догађај почиње"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:60
 msgid "Event cancelled"
@@ -7200,7 +7200,7 @@ msgstr "Догађај је поново заказан"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:77
 msgid "Event has to be created before adding related plannings"
-msgstr ""
+msgstr "Догађај мора бити креиран пре додавања повезаних планирања"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:84
 msgid "Event repetitions modified"
@@ -7232,7 +7232,7 @@ msgstr "Догађај ће бити промењен у вишедневни д
 
 #: ../superdesk-planning/client/components/fields/editor/DatesGroup.tsx:44
 msgid "Event/Planning date"
-msgstr ""
+msgstr "Датум догађаја/планирања"
 
 #: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:75
 #: ../superdesk-planning/client/components/fields/editor/ItemType.tsx:21
@@ -7244,7 +7244,7 @@ msgstr ""
 #: scripts/extensions/auto-tagging-widget/dist/src/groups.js:18
 #: scripts/extensions/auto-tagging-widget/src/groups.ts:26
 msgid "Events"
-msgstr ""
+msgstr "Догађаји"
 
 #: ../superdesk-planning/client/components/Main/FiltersBox.tsx:39
 msgid "Events & Planning"
@@ -7298,7 +7298,7 @@ msgstr "Тачно"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:78
 msgid "Exclamation Sign"
-msgstr ""
+msgstr "Знак узвика"
 
 #: ../superdesk-analytics/client/search/views/preview-source-filter.html:6
 #: ../superdesk-analytics/client/search/views/source-fitlers.html:102
@@ -7319,7 +7319,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/ExcludeRescheduledAndCancelled.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:79
 msgid "Exclude Rescheduled And Cancelled"
-msgstr ""
+msgstr "Изостави поново заказане и отказане"
 
 #: ../superdesk-analytics/client/search/views/source-fitlers.html:304
 msgid "Exclude Rewrites"
@@ -7327,7 +7327,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:173
 msgid "Exclude Spike"
-msgstr ""
+msgstr "Изостави корпу"
 
 #: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:359
 msgid "Exclude all locked items"
@@ -7363,11 +7363,11 @@ msgstr "Прошири"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:80
 msgid "Expand Thin"
-msgstr ""
+msgstr "Прошири танко"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:108
 msgid "Expandable"
-msgstr ""
+msgstr "Проширив"
 
 #: scripts/apps/publish/views/subscribers.html:304
 msgid "Expire in:"
@@ -7376,7 +7376,7 @@ msgstr "Истиче за:"
 #: ../superdesk-planning/client/components/fields/state.tsx:55
 #: ../superdesk-planning/client/utils/index.ts:430
 msgid "Expired"
-msgstr ""
+msgstr "Истекло"
 
 #: scripts/apps/archive/views/metadata-view.html:98
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:277
@@ -7420,7 +7420,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/ExportTemplate.tsx:48
 msgid "Export Template"
-msgstr ""
+msgstr "Шаблон извоза"
 
 #: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:255
 msgid "Export as article"
@@ -7437,7 +7437,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:81
 msgid "External"
-msgstr ""
+msgstr "Спољашњи"
 
 #: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:237
 #: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:116
@@ -7451,7 +7451,7 @@ msgstr "Спољна референца"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:82
 msgid "Eye Open"
-msgstr ""
+msgstr "Отворено око"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:107
 msgid "FR"
@@ -7480,7 +7480,7 @@ msgstr "Facebook"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:84
 msgid "Facebook Circle"
-msgstr ""
+msgstr "Facebook круг"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:923
 msgid "Failed to add Calendar to the Event"
@@ -7912,20 +7912,20 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:208
 #: scripts/extensions/sams/src/containers/FileUploadModal.tsx:240
 msgid "Failed to upload files"
-msgstr ""
+msgstr "Отпремање датотека није успело"
 
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:34
 #: ../superdesk-planning/client/components/fields/preview/base/utils.ts:17
 msgid "False"
-msgstr ""
+msgstr "Нетачно"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:85
 msgid "Fast Forward"
-msgstr ""
+msgstr "Брзо унапред"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:86
 msgid "Fast Rewind"
-msgstr ""
+msgstr "Брзо уназад"
 
 #: scripts/apps/workspace/content/constants.ts:26
 msgid "Feature Image"
@@ -8020,7 +8020,7 @@ msgstr "Преузми"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:87
 msgid "Fetch As"
-msgstr ""
+msgstr "Преузми као"
 
 #: scripts/core/lang/missing-translations-strings.ts:17
 msgid "Fetch Content To a Desk"
@@ -8085,7 +8085,7 @@ msgstr "Поље је обавезно"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:88
 msgid "File"
-msgstr ""
+msgstr "Датотека"
 
 #: scripts/apps/publish/views/file-config.html:11
 #: scripts/apps/publish/views/file-config.html:9
@@ -8175,7 +8175,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:89
 msgid "Filter Large"
-msgstr ""
+msgstr "Велики филтер"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:225
 msgid "Filter Name"
@@ -8279,15 +8279,15 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:35
 msgid "First Day"
-msgstr ""
+msgstr "Први дан"
 
 #: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:224
 msgid "First Event Ends"
-msgstr ""
+msgstr "Први догађај се завршава"
 
 #: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:205
 msgid "First Event Starts"
-msgstr ""
+msgstr "Први догађај почиње"
 
 #: scripts/apps/contacts/constants.ts:68
 #: scripts/apps/contacts/views/search-panel.html:14
@@ -8309,11 +8309,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:90
 msgid "Flip Horizontal"
-msgstr ""
+msgstr "Окрени хоризонтално"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:91
 msgid "Flip Vertical"
-msgstr ""
+msgstr "Окрени вертикално"
 
 #: scripts/apps/authoring/views/change-image.html:208
 msgid "Flip horizontal"
@@ -8329,11 +8329,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:92
 msgid "Folder Close"
-msgstr ""
+msgstr "Затвори фасциклу"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:93
 msgid "Folder Open"
-msgstr ""
+msgstr "Отвори фасциклу"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:94
 #: scripts/apps/authoring-react/toolbar/proofreading-theme-panel.tsx:94
@@ -8384,7 +8384,7 @@ msgstr "Форматери"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:34
 msgid "Formatting Marks"
-msgstr ""
+msgstr "Ознаке форматирања"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:69
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:75
@@ -8400,11 +8400,11 @@ msgstr "Опције форматирања"
 
 #: ../superdesk-planning/client/components/fields/editor/OverrideAutoAssignToWorkflow.tsx:15
 msgid "Forward Planning"
-msgstr ""
+msgstr "Будуће планирање"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:95
 msgid "Forward Thin"
-msgstr ""
+msgstr "Унапред танко"
 
 #: ../superdesk-planning/client/utils/filters.ts:145
 msgid "Fr"
@@ -8412,11 +8412,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:16
 msgid "Frequency"
-msgstr ""
+msgstr "Учесталост"
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:112
 msgid "Fri"
-msgstr ""
+msgstr "Пет"
 
 #: ../superdesk-planning/client/utils/events.tsx:1458
 #: scripts/core/datetime/datetime.ts:294
@@ -8475,7 +8475,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:96
 msgid "Fullscreen"
-msgstr ""
+msgstr "Цео екран"
 
 #: scripts/apps/profiling/views/profiling.html:38
 msgid "Function"
@@ -8614,7 +8614,7 @@ msgstr "Глобалне сачуване претраге"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:97
 msgid "Globe"
-msgstr ""
+msgstr "Глобус"
 
 #: scripts/apps/legal-archive/views/legal_archive.html:94
 #: scripts/apps/search/views/item-globalsearch.html:19
@@ -8669,11 +8669,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:99
 msgid "Grid View"
-msgstr ""
+msgstr "Приказ мреже"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:100
 msgid "Grid View Large"
-msgstr ""
+msgstr "Велики приказ мреже"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:298
 msgid "Group \"{{group}}\" and all its fields will be permanently deleted."
@@ -8766,27 +8766,27 @@ msgstr "Поља заглавља"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:101
 msgid "Heading 1"
-msgstr ""
+msgstr "Наслов 1"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:102
 msgid "Heading 2"
-msgstr ""
+msgstr "Наслов 2"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:103
 msgid "Heading 3"
-msgstr ""
+msgstr "Наслов 3"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:104
 msgid "Heading 4"
-msgstr ""
+msgstr "Наслов 4"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:105
 msgid "Heading 5"
-msgstr ""
+msgstr "Наслов 5"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:106
 msgid "Heading 6"
-msgstr ""
+msgstr "Наслов 6"
 
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:67
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:57
@@ -8827,7 +8827,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:107
 msgid "Heart"
-msgstr ""
+msgstr "Срце"
 
 #: scripts/extensions/helloWorld/dist/src/extension.js:5
 #: scripts/extensions/helloWorld/dist/src/extensions/helloWorld/src/extension.js:5
@@ -8837,7 +8837,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:108
 msgid "Help Large"
-msgstr ""
+msgstr "Велика помоћ"
 
 #: scripts/apps/users/views/edit-form.html:238
 msgid "Help us translate Superdesk"
@@ -8860,16 +8860,16 @@ msgstr "Скривени примаоци (Bcc)"
 #: ../superdesk-planning/client/components/fields/related_events.tsx:40
 msgid "Hide 1 event"
 msgid_plural "Hide {{n}} events"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Сакриј 1 догађај"
+msgstr[1] "Сакриј {{n}} догађаја"
+msgstr[2] "Сакриј {{n}} догађаја"
 
 #: ../superdesk-planning/client/components/fields/related_plannings.tsx:30
 msgid "Hide 1 planning item"
 msgid_plural "Hide {{n}} planning items"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Сакриј 1 ставку планирања"
+msgstr[1] "Сакриј {{n}} ставке планирања"
+msgstr[2] "Сакриј {{n}} ставки планирања"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:250
 msgid "Hide Date"
@@ -8905,7 +8905,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:109
 msgid "Highlight Package"
-msgstr ""
+msgstr "Пакет истицања"
 
 #: scripts/apps/packaging/views/sd-package-items-edit.html:21
 msgid "Highlight Preview"
@@ -8953,7 +8953,7 @@ msgstr "Задржи"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:110
 msgid "Home"
-msgstr ""
+msgstr "Почетна"
 
 #: scripts/apps/publish/views/ftp-config.html:2
 msgid "Host"
@@ -8961,7 +8961,7 @@ msgstr "Хост"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleHour.tsx:41
 msgid "Hour"
-msgstr ""
+msgstr "Сат"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:127
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:213
@@ -8971,7 +8971,7 @@ msgstr ""
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:62
 #: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:20
 msgid "Hourly"
-msgstr ""
+msgstr "Сваког сата"
 
 #: ../superdesk-planning/client/utils/filters.ts:42
 msgid "Hourly to {{ desk }}"
@@ -9203,7 +9203,7 @@ msgstr "Укључи истакнути медиј"
 #: ../superdesk-planning/client/components/fields/editor/IncludeKilled.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:91
 msgid "Include Killed"
-msgstr ""
+msgstr "Укључи уништено"
 
 #: ../superdesk-analytics/client/search/views/source-fitlers.html:303
 msgid "Include Rewrites"
@@ -9212,15 +9212,15 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/IncludeScheduledUpdates.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:95
 msgid "Include Scheduled Updates"
-msgstr ""
+msgstr "Укључи заказана ажурирања"
 
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:175
 msgid "Include Spike"
-msgstr ""
+msgstr "Укључи корпу"
 
 #: ../superdesk-planning/client/components/fields/editor/SpikeState.tsx:31
 msgid "Include Spiked"
-msgstr ""
+msgstr "Укључи у корпи"
 
 #: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:358
 msgid "Include all locked items"
@@ -9267,11 +9267,11 @@ msgstr "Неограничено коришћење"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:111
 msgid "Indent Left"
-msgstr ""
+msgstr "Увлачење лево"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:112
 msgid "Indent Right"
-msgstr ""
+msgstr "Увлачење десно"
 
 #: scripts/apps/authoring/metadata/metadata.ts:1420
 #: scripts/apps/system-messages/components/system-messages-settings.tsx:21
@@ -9280,11 +9280,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:113
 msgid "Info Large"
-msgstr ""
+msgstr "Велика информација"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:114
 msgid "Info Sign"
-msgstr ""
+msgstr "Знак информације"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/ImageTaggingComponent/ImageTaggingComponent.js:199
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:199
@@ -9340,7 +9340,7 @@ msgstr "Скупови правила пријема"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:99
 msgid "Ingest Source"
-msgstr ""
+msgstr "Извор пријема"
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:353
 msgid "Ingest Source deleted."
@@ -9390,7 +9390,7 @@ msgstr "Уметнути коментари"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:119
 msgid "Input Type"
-msgstr ""
+msgstr "Тип уноса"
 
 #: scripts/apps/authoring-react/fields/tag-input/editor.tsx:23
 msgid "Input tags here"
@@ -9456,7 +9456,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/index.tsx:191
 msgid "Invalid Date"
-msgstr ""
+msgstr "Неисправан датум"
 
 #: scripts/apps/archive/controllers/file-upload-error-modal.tsx:73
 msgid "Invalid File : {{name}}"
@@ -9468,7 +9468,7 @@ msgstr "Неисправан формат. Дозвољени су само ал
 
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:315
 msgid "Invalid time"
-msgstr ""
+msgstr "Неисправно време"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:146
 msgid "Invalid value for latitude"
@@ -9515,7 +9515,7 @@ msgstr "Постојећи шаблон ће бити ажуриран."
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:117
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:31
 msgid "Italic"
-msgstr ""
+msgstr "Курзив"
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:76
 msgid "Italic (Ctrl+I)"
@@ -9557,7 +9557,7 @@ msgstr "Ставка преведена"
 #: ../superdesk-planning/client/components/fields/editor/ItemType.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:104
 msgid "Item Type"
-msgstr ""
+msgstr "Тип ставке"
 
 #: ../superdesk-planning/client/actions/main.ts:1466
 #: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:206
@@ -9781,7 +9781,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:118
 msgid "Kanban View"
-msgstr ""
+msgstr "Канбан приказ"
 
 #: scripts/core/keyboard/views/keyboard-modal.html:3
 msgid "Keyboard Shortcuts"
@@ -9820,7 +9820,7 @@ msgstr ""
 #: ../superdesk-planning/client/utils/index.ts:363
 #: scripts/apps/search/components/fields/state.tsx:42
 msgid "Killed"
-msgstr ""
+msgstr "Уништено"
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:184
 msgid "Killed by"
@@ -9872,7 +9872,7 @@ msgstr "Језик:"
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:158
 #: scripts/apps/search/views/search-filters.html:18
 msgid "Languages"
-msgstr ""
+msgstr "Језици"
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-footer.js:32
 #: scripts/extensions/ai-widget/dist/src/translations/translations-footer.js:32
@@ -9949,7 +9949,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/PreviewArticle.tsx:83
 #: scripts/apps/authoring/preview/fullPreview.tsx:77
 msgid "Last modified"
-msgstr ""
+msgstr "Последње измењено"
 
 #: scripts/apps/profiling/views/profiling.html:24
 #: scripts/apps/publish/views/publish-queue.html:78
@@ -10099,11 +10099,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:121
 msgid "LinkedIn"
-msgstr ""
+msgstr "LinkedIn"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:122
 msgid "LinkedIn Circle"
-msgstr ""
+msgstr "LinkedIn круг"
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/link-field.ts:14
 #: ../superdesk-planning/client/components/fields/editor/EventLinks.tsx:62
@@ -10118,11 +10118,11 @@ msgstr "Листа"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:123
 msgid "List Alternate"
-msgstr ""
+msgstr "Алтернативна листа"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:124
 msgid "List Menu"
-msgstr ""
+msgstr "Мени листе"
 
 #: scripts/apps/vocabularies/services/SchemaFactory.ts:9
 msgid "List Name"
@@ -10130,7 +10130,7 @@ msgstr "Назив листе"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:125
 msgid "List Plus"
-msgstr ""
+msgstr "Листа плус"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:126
 #: scripts/apps/desks/directives/DeskConfigModal.ts:34
@@ -10201,7 +10201,7 @@ msgstr "Само локално читање"
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:260
 #: ../superdesk-planning/client/components/fields/resources/locations.ts:56
 msgid "Locality"
-msgstr ""
+msgstr "Место"
 
 #: scripts/core/lang/missing-translations-strings.ts:14
 #: scripts/core/lang/missing-translations-strings.ts:31
@@ -10219,7 +10219,7 @@ msgstr "Локација"
 
 #: ../superdesk-planning/client/components/fields/editor/Location.tsx:62
 msgid "Location Details"
-msgstr ""
+msgstr "Детаљи локације"
 
 #: ../superdesk-planning/client/api/locations.ts:86
 msgid "Location deleted"
@@ -10236,18 +10236,18 @@ msgstr ""
 #: ../superdesk-analytics/client/utils.js:170
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:127
 msgid "Lock"
-msgstr ""
+msgstr "Закључај"
 
 #: ../superdesk-planning/client/components/fields/editor/LockState.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:117
 msgid "Lock State"
-msgstr ""
+msgstr "Статус закључавања"
 
 #: ../superdesk-planning/client/components/fields/editor/LockState.tsx:18
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:147
 #: scripts/apps/authoring/views/article-edit.html:460
 msgid "Locked"
-msgstr ""
+msgstr "Закључано"
 
 #: scripts/apps/archive/views/item-lock.html:7
 #: scripts/apps/authoring-react/subcomponents/lock-info-generic.tsx:47
@@ -10280,7 +10280,7 @@ msgstr "Поруке дневника"
 #: ../superdesk-planning/client/components/fields/preview/index.ts:239
 #: ../superdesk-planning/client/components/fields/resources/events.ts:20
 msgid "Long Description"
-msgstr ""
+msgstr "Дугачак опис"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:310
 msgid "Longitude"
@@ -10288,7 +10288,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:19
 msgid "Lowercase"
-msgstr ""
+msgstr "Мала слова"
 
 #: ../superdesk-planning/client/components/Main/CalendarNavigation.tsx:66
 msgid "M"
@@ -10473,7 +10473,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:128
 msgid "Map Marker"
-msgstr ""
+msgstr "Маркер на мапи"
 
 #: ../superdesk-analytics/client/utils.js:172
 msgid "Mark"
@@ -10604,7 +10604,7 @@ msgstr "Поклапа префикс"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:97
 msgid "Max"
-msgstr ""
+msgstr "Макс"
 
 #: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:147
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:147
@@ -10715,7 +10715,7 @@ msgstr "Управљање метаподацима"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:86
 msgid "Min"
-msgstr ""
+msgstr "Мин"
 
 #: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:485
 #: ../superdesk-planning/client/constants/tooltips.ts:33
@@ -10751,11 +10751,11 @@ msgstr "Минимална дужина"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:129
 msgid "Minus Sign"
-msgstr ""
+msgstr "Знак минус"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:130
 msgid "Minus Small"
-msgstr ""
+msgstr "Мали минус"
 
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:162
 #: scripts/core/ui/views/sd-timepicker-popup.html:15
@@ -10776,7 +10776,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:131
 msgid "Mobile"
-msgstr ""
+msgstr "Мобилни"
 
 #: scripts/apps/archive/views/preview.html:9
 #: scripts/apps/authoring-react/fields/attachments/difference-row.tsx:30
@@ -10806,11 +10806,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/List/CreatedUpdatedColumn.tsx:29
 msgid "Modified: {{ datetime }}"
-msgstr ""
+msgstr "Измењено: {{ datetime }}"
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:108
 msgid "Mon"
-msgstr ""
+msgstr "Пон"
 
 #: ../superdesk-planning/client/utils/events.tsx:1454
 #: scripts/core/datetime/datetime.ts:290
@@ -10847,7 +10847,7 @@ msgstr "Месец(и)"
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:40
 #: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:26
 msgid "Monthly"
-msgstr ""
+msgstr "Месечно"
 
 #: ../superdesk-planning/client/utils/filters.ts:51
 msgid "Monthly on the {{ day }} day @ {{ time }} to {{ desk }}"
@@ -10878,7 +10878,7 @@ msgstr "Више шаблона..."
 #: ../superdesk-analytics/client/utils.js:166
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:132
 msgid "Move"
-msgstr ""
+msgstr "Премести"
 
 #: scripts/core/lang/missing-translations-strings.ts:19
 msgid "Move Content to another desk"
@@ -10928,15 +10928,15 @@ msgstr "Премештено у радну фазу од стране овог �
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:134
 #: scripts/apps/authoring-react/multi-edit-modal.tsx:240
 msgid "Multi Edit"
-msgstr ""
+msgstr "Више уређивања"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:123
 msgid "Multi Line"
-msgstr ""
+msgstr "Више редова"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:133
 msgid "Multi Start"
-msgstr ""
+msgstr "Више почетака"
 
 #: scripts/apps/vocabularies/constants.ts:52
 msgid "Multi selection"
@@ -10964,12 +10964,12 @@ msgstr "Вишеструко уређивање"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:178
 msgid "Multilingual"
-msgstr ""
+msgstr "Вишејезично"
 
 #: ../superdesk-planning/client/components/fields/resources/planning.ts:33
 #: ../superdesk-planning/client/utils/contentProfiles.ts:353
 msgid "Multiple Content"
-msgstr ""
+msgstr "Више садржаја"
 
 #: ../superdesk-planning/client/validators/events.ts:129
 msgid "Must be greater than 1"
@@ -11172,7 +11172,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:135
 msgid "New Document"
-msgstr ""
+msgstr "Нови документ"
 
 #: scripts/apps/users/views/settings-roles.html:30
 msgid "New Role"
@@ -11218,7 +11218,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:29
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:162
 msgid "Next Week"
-msgstr ""
+msgstr "Следећа недеља"
 
 #: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:115
 #: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:114
@@ -11264,15 +11264,15 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:23
 msgid "No Coverage Assigned"
-msgstr ""
+msgstr "Није додељено извештавање"
 
 #: ../superdesk-planning/client/components/UI/Form/InputArray/index.tsx:190
 msgid "No Coverages Yet"
-msgstr ""
+msgstr "Још нема извештавања"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:129
 msgid "No Coverge"
-msgstr ""
+msgstr "Нема извештавања"
 
 #: scripts/apps/templates/constants.ts:11
 msgid "No Desk"
@@ -11305,7 +11305,7 @@ msgstr "Нема пронађених претплатника"
 #: ../superdesk-planning/client/components/fields/editor/ContentTemplate.tsx:70
 #: ../superdesk-planning/client/components/fields/editor/ExportTemplate.tsx:38
 msgid "No Templates Available"
-msgstr ""
+msgstr "Нема доступних шаблона"
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:39
 #: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:39
@@ -11315,7 +11315,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:51
 msgid "No agendas assigned."
-msgstr ""
+msgstr "Нису додељене агенде."
 
 #: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:233
 #: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:227
@@ -11360,11 +11360,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/calendars.tsx:80
 msgid "No calendars assigned"
-msgstr ""
+msgstr "Нису додељени календари"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:59
 msgid "No calendars assigned."
-msgstr ""
+msgstr "Нису додељени календари."
 
 #: scripts/apps/dashboard/world-clock/configuration.html:20
 msgid "No clock here!"
@@ -11422,7 +11422,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:99
 msgid "No events yet, drop some here, or click the plus button"
-msgstr ""
+msgstr "Још нема догађаја, пустите овде, или кликните на дугме плус"
 
 #: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:251
 #: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:129
@@ -11456,7 +11456,7 @@ msgstr "Нема доступних ставки"
 #: ../superdesk-planning/client/components/UI/Form/SelectMetaTermsInput/SelectFieldPopup.tsx:379
 #: ../superdesk-planning/client/components/UI/Form/SelectMetaTermsInput/SelectFieldPopup.tsx:471
 msgid "No items found"
-msgstr ""
+msgstr "Нису пронађене ставке"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:176
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:176
@@ -11520,7 +11520,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:101
 msgid "No planning items have been added"
-msgstr ""
+msgstr "Нису додате ставке планирања"
 
 #: scripts/apps/users/directives/UserPreferencesDirective.ts:442
 msgid ""
@@ -11530,7 +11530,7 @@ msgstr "Нису изабране омиљене категорије. Ако о
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EditorFieldEventRelatedItems.tsx:85
 msgid "No related articles yet"
-msgstr ""
+msgstr "Још нема повезаних чланака"
 
 #: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:149
 msgid "No related planning items."
@@ -11735,7 +11735,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/LockState.tsx:21
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:148
 msgid "Not Locked"
-msgstr ""
+msgstr "Није закључано"
 
 #: scripts/apps/search/constants.ts:38
 msgid "Not Priority"
@@ -11771,7 +11771,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/preview/Flags.tsx:23
 msgid "Not for Publication"
-msgstr ""
+msgstr "Није за објаву"
 
 #: scripts/core/ui/components/List/PubStatus.tsx:22
 msgid "Not for publication"
@@ -11779,7 +11779,7 @@ msgstr "Не за објаву"
 
 #: ../superdesk-planning/client/components/UI/List/PubStatus.tsx:38
 msgid "Not posted"
-msgstr ""
+msgstr "Није објављено"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:134
 msgid "Not scheduled"
@@ -11800,7 +11800,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:319
 #: ../superdesk-planning/client/components/fields/resources/locations.ts:96
 msgid "Notes"
-msgstr ""
+msgstr "Белешке"
 
 #: ../superdesk-planning/client/components/NotificationModal.tsx:44
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:227
@@ -11918,7 +11918,7 @@ msgstr "У реду"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:136
 msgid "Okay"
-msgstr ""
+msgstr "У реду"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:65
 msgid "Old Gold"
@@ -11965,7 +11965,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/OnlyPosted.tsx:15
 msgid "Only Posted"
-msgstr ""
+msgstr "Само објављено"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:293
 msgid ""
@@ -12051,7 +12051,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:215
 #: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:218
 msgid "Open link"
-msgstr ""
+msgstr "Отвори линк"
 
 #: scripts/apps/authoring/views/change-image.html:26
 msgid "Open metadata"
@@ -12143,7 +12143,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:137
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:26
 msgid "Ordered List"
-msgstr ""
+msgstr "Нумерисана листа"
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:87
 msgid "Ordered list"
@@ -12361,11 +12361,11 @@ msgstr "Пакет"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:138
 msgid "Package Create"
-msgstr ""
+msgstr "Креирај пакет"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:139
 msgid "Package Plus"
-msgstr ""
+msgstr "Пакет плус"
 
 #: scripts/apps/publish/views/http-push-config.html:2
 msgid "Package individual items"
@@ -12415,7 +12415,7 @@ msgstr "Страничење"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:140
 msgid "Paragraph"
-msgstr ""
+msgstr "Пасус"
 
 #: scripts/apps/publish/views/subscribers.html:203
 msgid "Parallel publishing"
@@ -12471,11 +12471,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:141
 msgid "Paste"
-msgstr ""
+msgstr "Налепи"
 
 #: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:191
 msgid "Paste link"
-msgstr ""
+msgstr "Налепи линк"
 
 #: scripts/apps/authoring/media/views/media-copy-metadata-directive.html:3
 msgid "Paste metadata"
@@ -12487,15 +12487,15 @@ msgstr "Путања"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:142
 msgid "Pause"
-msgstr ""
+msgstr "Паузирај"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:143
 msgid "Paywall"
-msgstr ""
+msgstr "Платни зид"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:144
 msgid "Pencil"
-msgstr ""
+msgstr "Оловка"
 
 #: scripts/apps/users/controllers/UserListController.ts:157
 msgid "Pending"
@@ -12574,7 +12574,7 @@ msgstr "Телефон"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:146
 msgid "Photo"
-msgstr ""
+msgstr "Фотографија"
 
 #: scripts/apps/desks/directives/DeskConfigModal.ts:40
 #: scripts/apps/monitoring/directives/utils.ts:110
@@ -12592,7 +12592,7 @@ msgstr "Фраза"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:147
 msgid "Pick"
-msgstr ""
+msgstr "Изабери"
 
 #: scripts/apps/dashboard/workspace-tasks/tasks.ts:385
 msgid "Pick task"
@@ -12611,7 +12611,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:149
 #: scripts/apps/authoring-react/widget-header-component.tsx:24
 msgid "Pin"
-msgstr ""
+msgstr "Закачи"
 
 #: scripts/apps/authoring/widgets/WidgetHeaderComponent.tsx:24
 msgid "Pin/Unpin"
@@ -12640,7 +12640,7 @@ msgstr "Места"
 
 #: ../superdesk-planning/client/components/fields/list/Places.tsx:20
 msgid "Places:"
-msgstr ""
+msgstr "Места:"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/rundown-items.js:40
 #: scripts/extensions/broadcasting/dist/src/rundowns/components/rundown-items.js:40
@@ -12776,7 +12776,7 @@ msgstr "Ставка планирања креирана"
 
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:97
 msgid "Planning item has to be created before adding related events"
-msgstr ""
+msgstr "Ставка планирања мора бити креирана пре додавања повезаних догађаја"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:320
 #: ../superdesk-planning/client/actions/planning/ui.ts:364
@@ -12797,7 +12797,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:150
 msgid "Play"
-msgstr ""
+msgstr "Пусти"
 
 #: scripts/apps/vocabularies/components/UploadConfigModal.tsx:58
 msgid ""
@@ -12878,15 +12878,15 @@ msgstr "Користите мање од 80 карактера."
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:151
 msgid "Plus Large"
-msgstr ""
+msgstr "Велики плус"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:152
 msgid "Plus Sign"
-msgstr ""
+msgstr "Знак плус"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:153
 msgid "Plus Small"
-msgstr ""
+msgstr "Мали плус"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:194
 msgid "Point of contact"
@@ -12947,7 +12947,7 @@ msgstr "Постави на 'Enter'"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:64
 msgid "Post planning items with Event"
-msgstr ""
+msgstr "Објави ставке планирања са догађајем"
 
 #: ../superdesk-planning/client/components/AuditInformation/index.tsx:132
 #: ../superdesk-planning/client/components/fields/preview/index.ts:133
@@ -12973,7 +12973,7 @@ msgstr "Одложи {{event}}"
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:208
 #: ../superdesk-planning/client/utils/index.ts:379
 msgid "Postponed"
-msgstr ""
+msgstr "Одложено"
 
 #: scripts/core/menu/views/menu.html:113
 msgid "Powered by Superdesk technology"
@@ -13042,7 +13042,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:156
 msgid "Preview Mode"
-msgstr ""
+msgstr "Режим прегледа"
 
 #: scripts/apps/publish/views/destination.html:17
 msgid "Preview endpoint URL"
@@ -13085,7 +13085,7 @@ msgstr "Претходни корисник"
 #: scripts/apps/authoring/preview/fullPreviewMultiple.tsx:57
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:296
 msgid "Print"
-msgstr ""
+msgstr "Штампај"
 
 #: scripts/apps/authoring-react/toolbar-components/integration-wrapper/print-preview-button.tsx:13
 msgid "Print preview"
@@ -13118,7 +13118,7 @@ msgstr "Приоритет промењен на"
 #: ../superdesk-planning/client/components/fields/preview/index.ts:288
 #: ../superdesk-planning/client/components/fields/priority.tsx:30
 msgid "Priority:"
-msgstr ""
+msgstr "Приоритет:"
 
 #: ../superdesk-planning/client/components/PriorityLabel/index.tsx:51
 msgid "Priority: {{ name }}"
@@ -13498,7 +13498,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:158
 msgid "Question Sign"
-msgstr ""
+msgstr "Знак питања"
 
 #: scripts/apps/publish/views/amazon-sqs-fifo-config.html:67
 msgid "Queue Name"
@@ -13553,7 +13553,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:160
 msgid "Random"
-msgstr ""
+msgstr "Насумично"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:9
 msgid "Range"
@@ -13573,7 +13573,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:42
 msgid "Read Only"
-msgstr ""
+msgstr "Само за читање"
 
 #: scripts/apps/users/config.ts:150
 msgid "Read user roles"
@@ -13664,7 +13664,7 @@ msgstr "Примаоци (видљиви свима)"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:161
 msgid "Recurring"
-msgstr ""
+msgstr "Понављајуће"
 
 #: ../superdesk-planning/client/components/ItemIcon.tsx:26
 msgid "Recurring Event"
@@ -13696,7 +13696,7 @@ msgstr "Понови"
 #: ../superdesk-planning/client/components/fields/resources/events.ts:42
 #: ../superdesk-planning/client/utils/contentProfiles.ts:275
 msgid "Reference"
-msgstr ""
+msgstr "Референца"
 
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:770
 msgid "Refine search"
@@ -13751,7 +13751,7 @@ msgstr "Регион"
 
 #: ../superdesk-planning/client/components/fields/resources/events.ts:75
 msgid "Registration"
-msgstr ""
+msgstr "Регистрација"
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:77
 #: ../superdesk-planning/client/components/fields/preview/index.ts:271
@@ -13786,11 +13786,11 @@ msgstr "Повежи ставку"
 #: ../superdesk-planning/client/components/fields/resources/events.ts:120
 #: ../superdesk-planning/client/utils/contentProfiles.ts:351
 msgid "Related Articles"
-msgstr ""
+msgstr "Повезани чланци"
 
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:109
 msgid "Related Events"
-msgstr ""
+msgstr "Повезани догађаји"
 
 #: scripts/apps/archive/related-item-widget/relatedItem.ts:109
 #: scripts/apps/archive/related-item-widget/relatedItem.ts:13
@@ -13810,7 +13810,7 @@ msgstr "Повезано планирање"
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:111
 #: ../superdesk-planning/client/utils/contentProfiles.ts:301
 msgid "Related Plannings"
-msgstr ""
+msgstr "Повезана планирања"
 
 #: scripts/apps/vocabularies/views/settings.html:31
 msgid "Related content"
@@ -13909,7 +13909,7 @@ msgstr "Уклони"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:36
 msgid "Remove All Format"
-msgstr ""
+msgstr "Уклони сво форматирање"
 
 #: ../superdesk-planning/client/constants/assignments.ts:195
 msgid "Remove Assignment"
@@ -13926,7 +13926,7 @@ msgstr "Уклони филтер садржаја"
 
 #: ../superdesk-planning/client/components/UI/Form/InputArray/index.tsx:84
 msgid "Remove Coverage"
-msgstr ""
+msgstr "Уклони извештавање"
 
 #: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:127
 msgid "Remove Event"
@@ -13942,7 +13942,7 @@ msgstr "Уклони услов филтера"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:35
 msgid "Remove Format"
-msgstr ""
+msgstr "Уклони форматирање"
 
 #: scripts/apps/authoring/multiedit/views/sd-multiedit-article.html:4
 msgid "Remove Item"
@@ -13962,7 +13962,7 @@ msgstr "Уклони провајдера претраге"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:164
 msgid "Remove Sign"
-msgstr ""
+msgstr "Знак уклањања"
 
 #: scripts/apps/templates/views/templates.html:37
 msgid "Remove Template"
@@ -14106,7 +14106,7 @@ msgstr "Прераспореди фазе и сачуване претраге �
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:165
 msgid "Repeat"
-msgstr ""
+msgstr "Понови"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/DaysOfWeekInput.tsx:98
 msgid "Repeat On"
@@ -14240,11 +14240,11 @@ msgstr "Поново закажи {{event}}"
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:206
 #: ../superdesk-planning/client/utils/index.ts:369
 msgid "Rescheduled"
-msgstr ""
+msgstr "Поново заказано"
 
 #: ../superdesk-planning/client/components/fields/state.tsx:30
 msgid "Rescheduled Event"
-msgstr ""
+msgstr "Поново заказан догађај"
 
 #: scripts/apps/archive/views/resend-configuration.html:25
 #: scripts/apps/publish/views/publish-queue.html:147
@@ -14322,12 +14322,12 @@ msgstr "Тип резултата"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:166
 msgid "Retweet"
-msgstr ""
+msgstr "Ретвит"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:167
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:272
 msgid "Revert"
-msgstr ""
+msgstr "Врати"
 
 #: ../superdesk-planning/client/constants/assignments.ts:198
 msgid "Revert Availability"
@@ -14401,11 +14401,11 @@ msgstr "Привилегије улога"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:168
 msgid "Rotate Left"
-msgstr ""
+msgstr "Ротирај лево"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:169
 msgid "Rotate Right"
-msgstr ""
+msgstr "Ротирај десно"
 
 #: scripts/apps/authoring/views/change-image.html:206
 msgid "Rotate left"
@@ -14577,7 +14577,7 @@ msgstr "Пример садржаја"
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:113
 msgid "Sat"
-msgstr ""
+msgstr "Суб"
 
 #: scripts/apps/authoring/views/change-image.html:256
 msgid "Saturation"
@@ -14944,7 +14944,7 @@ msgstr "Закажи фазу"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduledUpdates.tsx:98
 msgid "Schedule an update"
-msgstr ""
+msgstr "Закажи ажурирање"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:84
 msgid "Schedule will be permanently deleted."
@@ -14985,7 +14985,7 @@ msgstr "Заказано(а) време(на)"
 #: ../superdesk-planning/client/components/fields/editor/ScheduledUpdates.tsx:64
 #: ../superdesk-planning/client/utils/contentProfiles.ts:331
 msgid "Scheduled Updates"
-msgstr ""
+msgstr "Заказана ажурирања"
 
 #: scripts/apps/publish/views/publish-queue.html:113
 #: scripts/apps/templates/views/template-editor-modal.html:156
@@ -14998,7 +14998,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/common/PreviewFilterSchedule.tsx:46
 msgid "Scheduled export: {{ description }}"
-msgstr ""
+msgstr "Заказани извоз: {{ description }}"
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:426
 msgid "Scheduled from {{start}} to {{end}}"
@@ -15145,7 +15145,7 @@ msgstr "Провајдери претраге"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:118
 msgid "Search Related Articles"
-msgstr ""
+msgstr "Претражи повезане чланке"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:456
 msgid "Search Source"
@@ -15158,7 +15158,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/FullText.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:87
 msgid "Search Text"
-msgstr ""
+msgstr "Текст за претрагу"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:468
 msgid "Search Urgency"
@@ -15726,7 +15726,7 @@ msgstr "Подешавања"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:172
 msgid "Share Alternate"
-msgstr ""
+msgstr "Алтернативно дељење"
 
 #: scripts/apps/search/views/item-preview.html:3
 msgid "Shift preview"
@@ -15758,16 +15758,16 @@ msgstr "Прикажи"
 #: ../superdesk-planning/client/components/fields/related_events.tsx:46
 msgid "Show 1 event"
 msgid_plural "Show {{n}} events"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Прикажи 1 догађај"
+msgstr[1] "Прикажи {{n}} догађаја"
+msgstr[2] "Прикажи {{n}} догађаја"
 
 #: ../superdesk-planning/client/components/fields/related_plannings.tsx:35
 msgid "Show 1 planning item"
 msgid_plural "Show {{n}} planning items"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Прикажи 1 ставку планирања"
+msgstr[1] "Прикажи {{n}} ставке планирања"
+msgstr[2] "Прикажи {{n}} ставки планирања"
 
 #: scripts/apps/archive/views/provider-menu.html:9
 msgid "Show All"
@@ -15793,11 +15793,11 @@ msgstr "Прикажи наслов слике"
 #: scripts/apps/master-desk/components/HeaderComponent.tsx:226
 #: scripts/apps/master-desk/components/HeaderComponent.tsx:229
 msgid "Show all"
-msgstr ""
+msgstr "Прикажи све"
 
 #: ../superdesk-planning/client/components/fields/editor/Language.tsx:96
 msgid "Show all language fields"
-msgstr ""
+msgstr "Прикажи сва језичка поља"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:93
 msgid "Show all messages"
@@ -15825,7 +15825,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:30
 msgid "Show in embedded form"
-msgstr ""
+msgstr "Прикажи у уграђеном облику"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:263
 msgid "Show in preview"
@@ -15845,14 +15845,14 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEventItem.tsx:94
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx:109
 msgid "Show less"
-msgstr ""
+msgstr "Прикажи мање"
 
 #: ../superdesk-planning/client/components/Archive/ArchivePreview/index.tsx:42
 #: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:93
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEventItem.tsx:94
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx:109
 msgid "Show more"
-msgstr ""
+msgstr "Прикажи више"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show.js:66
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:13
@@ -15928,7 +15928,7 @@ msgstr ""
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:303
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:124
 msgid "Signal"
-msgstr ""
+msgstr "Сигнал"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:10
 msgid "Single Day"
@@ -15936,7 +15936,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:122
 msgid "Single Line"
-msgstr ""
+msgstr "Један ред"
 
 #: scripts/core/editor3/components/media/MediaBlock.tsx:13
 msgid "Single Usage"
@@ -15996,11 +15996,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:174
 msgid "Skip Next"
-msgstr ""
+msgstr "Прескочи следеће"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:175
 msgid "Skip Previous"
-msgstr ""
+msgstr "Прескочи претходно"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:203
 msgid "Skip config test"
@@ -16012,7 +16012,7 @@ msgstr "Назив Slack канала"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:176
 msgid "Slideshow"
-msgstr ""
+msgstr "Слајдшоу"
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:18
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:66
@@ -16072,7 +16072,7 @@ msgstr "СМС"
 
 #: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:24
 msgid "Some Coverages Assigned"
-msgstr ""
+msgstr "Нека извештавања додељена"
 
 #: scripts/apps/authoring/multiedit/multiedit.ts:85
 msgid "Some articles failed to unlock"
@@ -16272,7 +16272,7 @@ msgstr "Премести ставку планирања у корпу"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:146
 msgid "Spike State"
-msgstr ""
+msgstr "Статус корпе"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:104
 msgid "Spike all recurring events or just this one?"
@@ -16311,7 +16311,7 @@ msgstr "Ставке у корпи"
 
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:177
 msgid "Spiked Only"
-msgstr ""
+msgstr "Само у корпи"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:221
 #: scripts/apps/authoring/versioning/history/views/history.html:63
@@ -16373,11 +16373,11 @@ msgstr "Фазе"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:177
 msgid "Star"
-msgstr ""
+msgstr "Звезда"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:178
 msgid "Star Empty"
-msgstr ""
+msgstr "Празна звезда"
 
 #: scripts/apps/publish/views/subscribers.html:87
 msgid "Start Date"
@@ -16445,7 +16445,7 @@ msgstr "Држава/Покрајина или регион"
 #: ../superdesk-planning/client/components/Locations/LocationsList.tsx:124
 #: ../superdesk-planning/client/components/fields/resources/locations.ts:64
 msgid "State/Province/Region"
-msgstr ""
+msgstr "Држава/Покрајина/Регион"
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:145
 msgid "States"
@@ -16489,7 +16489,7 @@ msgstr "Статус: {{filter}}"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:179
 msgid "Stop"
-msgstr ""
+msgstr "Заустави"
 
 #: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:37
 msgid "Stop routing"
@@ -16554,7 +16554,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:180
 msgid "Stream"
-msgstr ""
+msgstr "Ток"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:534
 msgid "Street Address"
@@ -16637,7 +16637,7 @@ msgstr "Теме"
 
 #: ../superdesk-planning/client/components/fields/list/Subject.tsx:20
 msgid "Subjects:"
-msgstr ""
+msgstr "Теме:"
 
 #: scripts/core/editor3/components/annotations/AnnotationInput.tsx:287
 #: scripts/core/editor3/components/comments/CommentInput.tsx:97
@@ -16715,7 +16715,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:244
 #: ../superdesk-planning/client/components/fields/resources/locations.ts:40
 msgid "Suburb"
-msgstr ""
+msgstr "Предграђе"
 
 #: scripts/apps/system-messages/components/system-messages-settings.tsx:27
 msgid "Success"
@@ -16723,7 +16723,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:183
 msgid "Suggestion"
-msgstr ""
+msgstr "Сугестија"
 
 #: scripts/apps/authoring/track-changes/suggestions.ts:91
 #: scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx:84
@@ -16751,7 +16751,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:106
 msgid "Sun"
-msgstr ""
+msgstr "Нед"
 
 #: ../superdesk-planning/client/utils/events.tsx:1460
 #: scripts/core/datetime/datetime.ts:296
@@ -16784,7 +16784,7 @@ msgstr "Канбан приказ"
 
 #: ../superdesk-planning/client/components/fields/editor/Language.tsx:111
 msgid "Switch Metadata Language"
-msgstr ""
+msgstr "Промени језик метаподатака"
 
 #: scripts/apps/authoring-react/multi-edit-modal.tsx:115
 msgid "Switch article"
@@ -16830,7 +16830,7 @@ msgstr "Пребаци на приказ листе"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:185
 msgid "Switches"
-msgstr ""
+msgstr "Прекидачи"
 
 #: scripts/apps/system-messages/components/system-messages-settings.tsx:148
 #: scripts/apps/system-messages/index.ts:34
@@ -16869,11 +16869,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:41
 msgid "Tab"
-msgstr ""
+msgstr "Таб"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:42
 msgid "Tab As Spaces"
-msgstr ""
+msgstr "Таб као размаци"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:93
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:186
@@ -16884,15 +16884,15 @@ msgstr "Табела"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:191
 msgid "Table Header"
-msgstr ""
+msgstr "Заглавље табеле"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:192
 msgid "Table Header Large"
-msgstr ""
+msgstr "Велико заглавље табеле"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:193
 msgid "Table Header List"
-msgstr ""
+msgstr "Листа заглавља табеле"
 
 #: scripts/apps/authoring-react/fields/tag-input/index.tsx:26
 msgid "Tag-input (authoring-react)"
@@ -16973,7 +16973,7 @@ msgstr "Наставци"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:187
 msgid "Takes Package"
-msgstr ""
+msgstr "Пакет наставака"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:540
 msgid "Tansa is not responding. You can continue editing or publish the story."
@@ -17131,7 +17131,7 @@ msgstr "Текст"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:190
 msgid "Text Format"
-msgstr ""
+msgstr "Формат текста"
 
 #: ../superdesk-planning/client/utils/filters.ts:142
 msgid "Th"
@@ -17266,7 +17266,7 @@ msgstr "Коментар ће бити обрисан. Да ли сте сигу
 
 #: ../superdesk-planning/client/components/UI/Form/InputArray/index.tsx:94
 msgid "The coverage has been removed"
-msgstr ""
+msgstr "Извештавање је уклоњено"
 
 #: ../superdesk-planning/client/constants/tooltips.ts:29
 msgid "The event has been killed"
@@ -17749,7 +17749,7 @@ msgstr "Овај URL није могуће уградити."
 #: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:26
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:160
 msgid "This Week"
-msgstr ""
+msgstr "Ове недеље"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:32
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:27
@@ -17956,7 +17956,7 @@ msgstr "Ово ће уклонити везу текстуалне ставке 
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:111
 msgid "Thu"
-msgstr ""
+msgstr "Чет"
 
 #: scripts/apps/authoring/authoring/components/video-thumbnail-editor.tsx:117
 msgid "Thumbnail"
@@ -18040,7 +18040,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:344
 msgid "Time picker"
-msgstr ""
+msgstr "Бирач времена"
 
 #: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:315
 msgid "Time spent producing content"
@@ -18114,7 +18114,7 @@ msgstr "До"
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:65
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:87
 msgid "To Be Confirmed"
-msgstr ""
+msgstr "Биће потврђено"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/to-desk.tsx:13
 #: scripts/apps/authoring/views/authoring-topbar.html:55
@@ -18133,11 +18133,11 @@ msgstr "За урадити"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:195
 msgid "To Lowercase"
-msgstr ""
+msgstr "У мала слова"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:196
 msgid "To Uppercase"
-msgstr ""
+msgstr "У велика слова"
 
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:70
 msgid ""
@@ -18385,12 +18385,12 @@ msgstr "Пренето у"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:197
 msgid "Trash"
-msgstr ""
+msgstr "Корпа"
 
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:33
 #: ../superdesk-planning/client/components/fields/preview/base/utils.ts:16
 msgid "True"
-msgstr ""
+msgstr "Тачно"
 
 #: scripts/core/auth/login-modal.html:48
 #: scripts/core/auth/reset-password.html:38
@@ -18405,7 +18405,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:109
 msgid "Tue"
-msgstr ""
+msgstr "Уто"
 
 #: ../superdesk-planning/client/utils/events.tsx:1455
 #: scripts/core/datetime/datetime.ts:291
@@ -18423,7 +18423,7 @@ msgstr "Twitter"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:199
 msgid "Twitter Circle"
-msgstr ""
+msgstr "Twitter круг"
 
 #: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:36
 #: scripts/apps/archive/views/metadata-view.html:207
@@ -18466,7 +18466,7 @@ msgstr "Унесите свој коментар..."
 #: scripts/extensions/sams/src/components/assets/assetGridItem.tsx:147
 #: scripts/extensions/sams/src/components/assets/assetListItem.tsx:131
 msgid "Type:"
-msgstr ""
+msgstr "Тип:"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:139
 msgid "Type: {{ type }}"
@@ -18548,7 +18548,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:200
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:30
 msgid "Underline"
-msgstr ""
+msgstr "Подвучено"
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:77
 msgid "Underline (Ctrl+U)"
@@ -18631,11 +18631,11 @@ msgstr "Уклони везу као извештавање"
 
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEventItem.tsx:75
 msgid "Unlink related event"
-msgstr ""
+msgstr "Уклони везу повезаног догађаја"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx:90
 msgid "Unlink related planning"
-msgstr ""
+msgstr "Уклони везу повезаног планирања"
 
 #: scripts/apps/archive/index.tsx:310
 msgid "Unlink update"
@@ -18671,7 +18671,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:202
 #: scripts/apps/authoring/views/article-edit.html:461
 msgid "Unlocked"
-msgstr ""
+msgstr "Откључано"
 
 #: ../superdesk-analytics/client/utils.js:173
 #: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:22
@@ -18701,7 +18701,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:203
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:27
 msgid "Unordered List"
-msgstr ""
+msgstr "Ненумерисана листа"
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:86
 msgid "Unordered list"
@@ -18991,7 +18991,7 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:233
 #: scripts/extensions/sams/src/containers/FileUploadModal.tsx:295
 msgid "Upload"
-msgstr ""
+msgstr "Отпреми"
 
 #: scripts/apps/vocabularies/views/settings.html:9
 msgid "Upload Config"
@@ -19062,7 +19062,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:18
 msgid "Uppercase"
-msgstr ""
+msgstr "Велика слова"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:560
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:139
@@ -19097,7 +19097,7 @@ msgstr "Статистика хитности"
 
 #: ../superdesk-planning/client/components/fields/urgency.tsx:21
 msgid "Urgency:"
-msgstr ""
+msgstr "Хитност:"
 
 #: scripts/apps/authoring-react/fields/urls/index.tsx:20
 msgid "Urls (authoring-react)"
@@ -19532,7 +19532,7 @@ msgstr "Упозорење"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:208
 msgid "Warning Sign"
-msgstr ""
+msgstr "Знак упозорења"
 
 #: ../superdesk-planning/client/utils/filters.ts:139
 msgid "We"
@@ -19552,7 +19552,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:110
 msgid "Wed"
-msgstr ""
+msgstr "Сре"
 
 #: ../superdesk-planning/client/utils/events.tsx:1456
 #: scripts/core/datetime/datetime.ts:292
@@ -19569,7 +19569,7 @@ msgstr "Недеља"
 
 #: ../superdesk-planning/client/components/fields/editor/Days.tsx:32
 msgid "Week Days"
-msgstr ""
+msgstr "Дани у недељи"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:31
 msgid "Week(s)"
@@ -19578,7 +19578,7 @@ msgstr "Недеља(е)"
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:37
 #: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:23
 msgid "Weekly"
-msgstr ""
+msgstr "Недељно"
 
 #: ../superdesk-planning/client/utils/filters.ts:48
 msgid "Weekly @ {{ time }} to {{ desk }}"
@@ -19641,7 +19641,7 @@ msgstr "Агенција/Штампа"
 
 #: ../superdesk-planning/client/components/fields/editor/NoCoverage.tsx:15
 msgid "Without Coverage"
-msgstr ""
+msgstr "Без извештавања"
 
 #: scripts/apps/archive/views/metadata-view.html:17
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:288
@@ -19669,11 +19669,11 @@ msgstr "Радни ток"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:171
 msgid "Workflow State"
-msgstr ""
+msgstr "Стање радног тока"
 
 #: ../superdesk-planning/client/components/fields/index.tsx:229
 msgid "Workflow States"
-msgstr ""
+msgstr "Стања радног тока"
 
 #: scripts/apps/desks/views/desk-config-modal.html:305
 #: scripts/apps/desks/views/desk-config-modal.html:358
@@ -19808,7 +19808,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:35
 msgid "You cannot change workflow status"
-msgstr ""
+msgstr "Не можете променити статус радног тока"
 
 #: scripts/core/menu/notifications/views/notifications.html:13
 msgid "You don't have any notifications"
@@ -19882,11 +19882,11 @@ msgstr "Ваше отпремање је успешно"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:209
 msgid "Zoom In"
-msgstr ""
+msgstr "Увеличај"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:210
 msgid "Zoom Out"
-msgstr ""
+msgstr "Умањи"
 
 #: scripts/apps/search/views/saved-searches.html:11
 msgid "[Global]"
@@ -21571,11 +21571,11 @@ msgstr[2] ""
 
 #: ../superdesk-planning/client/components/fields/calendars.tsx:45
 msgid "{{ name }} (disabled)"
-msgstr ""
+msgstr "{{ name }} (онемогућено)"
 
 #: ../superdesk-planning/client/components/fields/editor/base/multilingualText.tsx:150
 msgid "{{ name }} ({{ language }})"
-msgstr ""
+msgstr "{{ name }} ({{ language }})"
 
 #: ../superdesk-planning/client/validators/assignments.tsx:9
 #: ../superdesk-planning/client/validators/profile.ts:108

--- a/po/sr.po
+++ b/po/sr.po
@@ -527,11 +527,11 @@ msgstr "9. ажурирање"
 
 #: scripts/apps/desks/views/desk-config-modal.html:249
 msgid ": OFF"
-msgstr ""
+msgstr ": ИСКЉУЧЕНО"
 
 #: scripts/apps/desks/views/desk-config-modal.html:252
 msgid ": ON"
-msgstr ""
+msgstr ": УКЉУЧЕНО"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:206
 msgid ":00am"
@@ -935,7 +935,7 @@ msgstr ""
 
 #: scripts/apps/desks/views/desk-config-modal.html:4
 msgid "Add New Desk"
-msgstr ""
+msgstr "Додај нови деск"
 
 #: scripts/apps/publish/views/subscribers.html:227
 msgid "Add New Destination"
@@ -1277,7 +1277,7 @@ msgstr "Алати администратора"
 #: scripts/apps/users/views/edit-form.html:169
 #: scripts/apps/users/views/edit-form.html:67
 msgid "Administrator"
-msgstr ""
+msgstr "Администратор"
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:14
 #: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:14
@@ -1597,7 +1597,7 @@ msgstr ""
 
 #: scripts/apps/users/views/list.html:14
 msgid "All user types"
-msgstr ""
+msgstr "Сви типови корисника"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:267
 msgid "Allow Multiple Items"
@@ -1856,7 +1856,7 @@ msgstr ""
 #: scripts/apps/users/views/user-preferences.html:21
 #: scripts/apps/users/views/user-preferences.html:255
 msgid "Appearance"
-msgstr ""
+msgstr "Изглед"
 
 #: scripts/apps/publish/views/subscribers.html:244
 msgid "Applied Global Block Filters"
@@ -2025,7 +2025,7 @@ msgstr ""
 
 #: scripts/apps/users/directives/UserRolesDirective.ts:89
 msgid "Are you sure you want to delete user role?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете корисничку улогу?"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:1028
 #: ../superdesk-planning/client/actions/events/ui.ts:995
@@ -2068,7 +2068,7 @@ msgstr ""
 
 #: scripts/apps/users/views/user-preferences.html:103
 msgid "Article Defaults"
-msgstr ""
+msgstr "Подразумеване вредности чланка"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:215
 #: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:297
@@ -2112,7 +2112,7 @@ msgstr ""
 
 #: scripts/apps/users/views/user-preferences.html:16
 msgid "Article defaults"
-msgstr ""
+msgstr "Подразумеване вредности чланка"
 
 #: scripts/apps/authoring-react/packages.tsx:116
 msgid "Article is not linked to any packages"
@@ -2590,16 +2590,16 @@ msgstr "Токен за аутентификацију"
 #: scripts/apps/users/views/edit-form.html:170
 #: scripts/apps/users/views/edit-form.html:66
 msgid "Author"
-msgstr ""
+msgstr "Аутор"
 
 #: scripts/apps/users/views/edit-form.html:20
 #: scripts/apps/users/views/edit-form.html:249
 msgid "Author info"
-msgstr ""
+msgstr "Информације о аутору"
 
 #: scripts/apps/users/views/settings-roles.html:61
 msgid "Author roles controlled vocabullary is missing."
-msgstr ""
+msgstr "Недостаје контролисани вокабулар улога аутора."
 
 #: scripts/apps/authoring-react/toolbar/version-header.tsx:43
 msgid "Author:"
@@ -2617,7 +2617,7 @@ msgid ""
 "Authoring desks are for content creation, and items within it are protected "
 "from accidental publication. Publishing is only permitted  from production "
 "desks."
-msgstr ""
+msgstr "Дескови за уређивање служе за креирање садржаја, а ставке у њима су заштићене од случајног објављивања. Објављивање је дозвољено само са продукцијских дескова."
 
 #: scripts/apps/authoring-react/field-adapters/authors.tsx:80
 #: scripts/apps/search/components/fields/authors.tsx:113
@@ -2627,7 +2627,7 @@ msgstr ""
 
 #: scripts/apps/users/views/list.html:15
 msgid "Authors only"
-msgstr ""
+msgstr "Само аутори"
 
 #: scripts/apps/templates/views/templates.html:61
 msgid "Automated item creation"
@@ -2737,7 +2737,7 @@ msgstr ""
 
 #: scripts/apps/users/views/edit.html:3
 msgid "Back to users list"
-msgstr ""
+msgstr "Назад на листу корисника"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:46
 msgid "Backward Thin"
@@ -2781,7 +2781,7 @@ msgstr ""
 
 #: scripts/apps/users/views/edit-form.html:286
 msgid "Biography"
-msgstr ""
+msgstr "Биографија"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:46
 msgid "Black"
@@ -2903,13 +2903,13 @@ msgid ""
 "By selecting the categories you are interested in, the system will only "
 "display these in a menu for setting the content item's categories (along "
 "with any of its existing categories)."
-msgstr ""
+msgstr "Бирањем категорија које вас занимају, систем ће приказивати само њих у менију за подешавање категорија ставке садржаја (заједно са постојећим категоријама)."
 
 #: scripts/apps/users/views/user-preferences.html:185
 msgid ""
 "By selecting the desks as your preferred desks, they appear first in the "
 "order when sending or publishing items."
-msgstr ""
+msgstr "Бирањем дескова као омиљених, они се појављују први у редоследу приликом слања или објављивања ставки."
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:362
 #: scripts/apps/authoring-react/field-adapters/byline.ts:20
@@ -2919,7 +2919,7 @@ msgstr ""
 #: scripts/apps/users/views/edit-form.html:268
 #: scripts/apps/workspace/content/constants.ts:16
 msgid "Byline"
-msgstr ""
+msgstr "Потпис"
 
 #: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:244
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:244
@@ -3326,7 +3326,7 @@ msgstr ""
 
 #: scripts/apps/users/config.ts:122 scripts/apps/users/views/edit-form.html:52
 msgid "Change avatar"
-msgstr ""
+msgstr "Промени аватар"
 
 #: scripts/apps/authoring/views/change-image.html:203
 msgid "Change image settings"
@@ -3338,7 +3338,7 @@ msgstr "Промени лозинку"
 
 #: scripts/apps/users/views/user-preferences.html:258
 msgid "Change the appearance of Superdesk across the whole application."
-msgstr ""
+msgstr "Промените изглед Superdesk-а кроз целу апликацију."
 
 #: ../superdesk-analytics/client/charts/views/table.html:23
 msgid "Change the search filters and try again!"
@@ -3369,7 +3369,7 @@ msgstr ""
 
 #: scripts/apps/desks/views/desk-config-modal.html:205
 msgid "Character limit exceeded, desk can not be created/updated."
-msgstr ""
+msgstr "Прекорачен је лимит карактера, деск није могуће креирати/ажурирати."
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:49
 msgid "Character limit exceeded, dictionary can not be created/updated."
@@ -3381,7 +3381,7 @@ msgstr ""
 
 #: scripts/apps/desks/views/desk-config-modal.html:290
 msgid "Character limit exceeded, stage can not be created/updated."
-msgstr ""
+msgstr "Прекорачен је лимит карактера, фазу није могуће креирати/ажурирати."
 
 #: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:124
 msgid "Character limit settings"
@@ -3543,7 +3543,7 @@ msgstr ""
 
 #: scripts/apps/users/views/user-preferences.html:155
 msgid "Clear all selected"
-msgstr ""
+msgstr "Очисти све изабрано"
 
 #: ../superdesk-planning/client/components/UI/Form/DateTimeInput/index.tsx:155
 #: scripts/core/ui/components/Form/DateTimeInput/index.tsx:85
@@ -3575,7 +3575,7 @@ msgstr "Очисти претрагу"
 
 #: scripts/apps/users/config.ts:93
 msgid "Clear sessions"
-msgstr ""
+msgstr "Очисти сесије"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:365
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:365
@@ -3598,7 +3598,7 @@ msgstr ""
 #: scripts/apps/users/views/change-avatar.html:38
 msgid ""
 "Click to capture using camera. Be sure that you allow camera accessibility."
-msgstr ""
+msgstr "Кликните да снимите камером. Уверите се да сте дозволили приступ камери."
 
 #: scripts/apps/authoring/authoring/components/video-thumbnail-editor.tsx:108
 msgid "Click to replace thumbnail"
@@ -4107,15 +4107,15 @@ msgstr "Подешавање садржаја"
 
 #: scripts/apps/users/views/settings-roles.html:65
 msgid "Content creation"
-msgstr ""
+msgstr "Креирање садржаја"
 
 #: scripts/apps/users/views/settings-roles.html:75
 msgid "Content editing"
-msgstr ""
+msgstr "Уређивање садржаја"
 
 #: scripts/apps/desks/views/desk-config-modal.html:324
 msgid "Content expiry:"
-msgstr ""
+msgstr "Истек садржаја:"
 
 #: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:103
 msgid "Content fields"
@@ -4630,7 +4630,7 @@ msgstr ""
 
 #: scripts/apps/desks/views/desk-config-modal.html:292
 msgid "Create new Stage"
-msgstr ""
+msgstr "Креирај нову фазу"
 
 #: scripts/apps/workspace/views/edit-workspace-modal.html:3
 msgid "Create new Workspace"
@@ -4719,7 +4719,7 @@ msgstr ""
 
 #: scripts/apps/users/views/list.html:3
 msgid "Create user"
-msgstr ""
+msgstr "Креирај корисника"
 
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:129
 #: ../superdesk-planning/client/components/AuditInformation/index.tsx:110
@@ -5117,7 +5117,7 @@ msgstr ""
 #: scripts/apps/users/views/user-preferences.html:106
 #: scripts/apps/workspace/content/constants.ts:21
 msgid "Dateline"
-msgstr ""
+msgstr "Датумска линија"
 
 #: scripts/apps/authoring-react/fields/dateline/index.tsx:27
 msgid "Dateline (authoring-react)"
@@ -5174,23 +5174,23 @@ msgstr "Подразумевано"
 
 #: scripts/apps/users/views/user-preferences.html:219
 msgid "Default Agenda"
-msgstr ""
+msgstr "Подразумевана агенда"
 
 #: scripts/apps/users/views/user-preferences.html:206
 msgid "Default Calendar"
-msgstr ""
+msgstr "Подразумевани календар"
 
 #: scripts/apps/desks/views/desk-config-modal.html:176
 msgid "Default Content Profile"
-msgstr ""
+msgstr "Подразумевани профил садржаја"
 
 #: scripts/apps/desks/views/desk-config-modal.html:153
 msgid "Default Content Template"
-msgstr ""
+msgstr "Подразумевани шаблон садржаја"
 
 #: scripts/apps/users/views/edit-form.html:220
 msgid "Default Desk"
-msgstr ""
+msgstr "Подразумевани деск"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:147
 msgid "Default Duration"
@@ -5198,7 +5198,7 @@ msgstr ""
 
 #: scripts/apps/users/views/user-preferences.html:232
 msgid "Default Events & Planning Filter"
-msgstr ""
+msgstr "Подразумевани филтер догађаја и планирања"
 
 #: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:72
 msgid "Default Template"
@@ -5216,12 +5216,12 @@ msgstr ""
 
 #: scripts/apps/users/views/settings-roles.html:54
 msgid "Default author roles"
-msgstr ""
+msgstr "Подразумеване улоге аутора"
 
 #: scripts/apps/users/views/edit-form.html:18
 #: scripts/apps/users/views/edit-form.html:215
 msgid "Default desk"
-msgstr ""
+msgstr "Подразумевани деск"
 
 #: scripts/core/ui/components/content-create-dropdown/initial-view.tsx:131
 msgid "Default desk template"
@@ -5237,7 +5237,7 @@ msgstr ""
 
 #: scripts/apps/desks/views/desk-config-modal.html:131
 msgid "Default monitoring view"
-msgstr ""
+msgstr "Подразумевани приказ мониторинга"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/manage-schedule.js:128
 #: scripts/extensions/availability-manager/dist/src/settings/manage-schedule.js:128
@@ -5502,7 +5502,7 @@ msgstr ""
 #: scripts/apps/templates/views/template-editor-modal.html:80
 #: scripts/apps/workspace/content/constants.ts:23
 msgid "Desk"
-msgstr ""
+msgstr "Деск"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:231
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:383
@@ -5517,7 +5517,7 @@ msgstr ""
 
 #: scripts/apps/desks/views/desk-config-modal.html:68
 msgid "Desk Email"
-msgstr ""
+msgstr "Имејл деска"
 
 #: scripts/core/lang/missing-translations-strings.ts:16
 msgid "Desk Management"
@@ -5552,35 +5552,35 @@ msgstr ""
 #: scripts/apps/desks/views/desk-config-modal.html:93
 #: scripts/apps/desks/views/settings.html:82
 msgid "Desk Type"
-msgstr ""
+msgstr "Тип деска"
 
 #: scripts/apps/desks/controllers/DeskConfigController.ts:63
 msgid "Desk deleted."
-msgstr ""
+msgstr "Деск обрисан."
 
 #: scripts/apps/desks/views/desk-config-modal.html:32
 msgid "Desk description"
-msgstr ""
+msgstr "Опис деска"
 
 #: scripts/apps/desks/views/desk-config-modal.html:70
 msgid "Desk email address."
-msgstr ""
+msgstr "Имејл адреса деска."
 
 #: scripts/apps/desks/services/DesksFactory.ts:425
 msgid "Desk has been modified elsewhere. Please reload the desks."
-msgstr ""
+msgstr "Деск је измењен на другом месту. Поново учитајте дескове."
 
 #: scripts/apps/desks/views/desk-config-modal.html:114
 msgid "Desk language"
-msgstr ""
+msgstr "Језик деска"
 
 #: scripts/apps/desks/views/settings.html:4
 msgid "Desk management"
-msgstr ""
+msgstr "Управљање десковима"
 
 #: scripts/apps/desks/views/desk-config-modal.html:16
 msgid "Desk name"
-msgstr ""
+msgstr "Назив деска"
 
 #: scripts/apps/dashboard/closed-desk/index.ts:26
 msgid "Desk status is outdated, please refresh."
@@ -5597,7 +5597,7 @@ msgstr "Шаблон деска"
 
 #: scripts/apps/desks/directives/DeskeditBasic.ts:65
 msgid "Desk with name {{name}} already exists."
-msgstr ""
+msgstr "Деск са називом {{name}} већ постоји."
 
 #: scripts/apps/templates/views/templates.html:52
 msgid "Desk(s)"
@@ -5735,13 +5735,13 @@ msgstr ""
 
 #: scripts/apps/users/config.ts:76
 msgid "Disable user"
-msgstr ""
+msgstr "Онемогући корисника"
 
 #: ../superdesk-planning/client/components/Agendas/AgendaListItem.tsx:41
 #: ../superdesk-planning/client/utils/planning.tsx:1368
 #: scripts/apps/users/controllers/UserListController.ts:159
 msgid "Disabled"
-msgstr ""
+msgstr "Онемогућено"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:216
 msgid "Disabled Agendas"
@@ -5759,7 +5759,7 @@ msgstr ""
 
 #: scripts/apps/desks/views/desk-config-modal.html:197
 msgid "Disallow sending items to this desk"
-msgstr ""
+msgstr "Забрани слање ставки на овај деск"
 
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:76
 msgid "Disallowed characters"
@@ -5852,7 +5852,7 @@ msgstr ""
 
 #: scripts/apps/users/views/edit-form.html:360
 msgid "Do you want to reset the password for user {{user.full_name}} ?"
-msgstr ""
+msgstr "Да ли желите да ресетујете лозинку за корисника {{user.full_name}}?"
 
 #: ../superdesk-planning/client/actions/multiSelect.ts:128
 msgid "Do you want to spike  item(s) ?"
@@ -6010,7 +6010,7 @@ msgstr ""
 
 #: scripts/apps/users/views/change-avatar.html:29
 msgid "Drop it here"
-msgstr ""
+msgstr "Пустите овде"
 
 #: scripts/apps/relations/views/related-items.html:11
 #: scripts/core/ui/components/drop-zone-3.tsx:128
@@ -6300,7 +6300,7 @@ msgstr ""
 
 #: scripts/apps/desks/views/desk-config-modal.html:5
 msgid "Edit \"{{name}}\" Desk"
-msgstr ""
+msgstr "Уреди деск \"{{name}}\""
 
 #: scripts/apps/products/views/products-config-modal.html:4
 msgid "Edit \"{{name}}\" Product"
@@ -6391,7 +6391,7 @@ msgstr ""
 
 #: scripts/apps/users/views/settings-roles.html:29
 msgid "Edit Role"
-msgstr ""
+msgstr "Уреди улогу"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:67
 msgid "Edit Rule"
@@ -6473,7 +6473,7 @@ msgstr "Уреди исечке"
 
 #: scripts/apps/desks/views/settings.html:34
 msgid "Edit desk"
-msgstr ""
+msgstr "Уреди деск"
 
 #: scripts/apps/dictionaries/views/settings.html:54
 msgid "Edit dictionary"
@@ -6545,7 +6545,7 @@ msgstr ""
 
 #: scripts/apps/users/views/settings-roles.html:17
 msgid "Edit role"
-msgstr ""
+msgstr "Уреди улогу"
 
 #: scripts/apps/ingest/views/settings/ingest-rules-content.html:19
 msgid "Edit rule set"
@@ -6677,7 +6677,7 @@ msgstr ""
 
 #: scripts/apps/users/config.ts:108
 msgid "Enable user"
-msgstr ""
+msgstr "Омогући корисника"
 
 #: ../superdesk-planning/client/components/Agendas/ManageAgendasModal.tsx:31
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/availability-settings.js:129
@@ -6752,7 +6752,7 @@ msgstr "Унесите нову лозинку"
 
 #: scripts/apps/users/views/change-avatar.html:44
 msgid "Enter web url"
-msgstr ""
+msgstr "Унесите веб URL"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:36
 #: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:36
@@ -6819,7 +6819,7 @@ msgstr ""
 
 #: scripts/apps/users/controllers/SessionsDeleteCommand.ts:15
 msgid "Error. Sessions could not be cleared."
-msgstr ""
+msgstr "Грешка. Сесије нису могле бити очишћене."
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:315
 #: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:270
@@ -6847,11 +6847,11 @@ msgstr ""
 
 #: scripts/apps/users/controllers/UserDeleteCommand.ts:24
 msgid "Error. User Profile cannot be disabled."
-msgstr ""
+msgstr "Грешка. Кориснички профил не може бити онемогућен."
 
 #: scripts/apps/users/controllers/UserEnableCommand.ts:21
 msgid "Error. User Profile cannot be enabled."
-msgstr ""
+msgstr "Грешка. Кориснички профил не може бити омогућен."
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:120
 msgid "Error. Vocabulary not saved."
@@ -6979,7 +6979,7 @@ msgstr ""
 
 #: scripts/apps/users/directives/UserEditDirective.ts:272
 msgid "Error: {{error}}"
-msgstr ""
+msgstr "Грешка: {{error}}"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:316
 #: scripts/apps/authoring/authoring/services/LockService.ts:20
@@ -7476,7 +7476,7 @@ msgstr "URL FTP сервера"
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:83
 #: scripts/apps/users/views/edit-form.html:295
 msgid "Facebook"
-msgstr ""
+msgstr "Facebook"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:84
 msgid "Facebook Circle"
@@ -7947,7 +7947,7 @@ msgstr ""
 #: scripts/apps/users/views/user-preferences.html:13
 #: scripts/apps/users/views/user-preferences.html:27
 msgid "Feature preview"
-msgstr ""
+msgstr "Преглед нових функција"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeatureLabel.tsx:9
 #: ../superdesk-planning/client/components/fields/editor/Featured.tsx:15
@@ -8267,7 +8267,7 @@ msgstr ""
 
 #: scripts/apps/users/config.ts:39
 msgid "Find your colleagues"
-msgstr ""
+msgstr "Пронађите своје колеге"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:67
 msgid "Fire Brick"
@@ -8461,7 +8461,7 @@ msgstr ""
 
 #: scripts/apps/users/views/list.html:33
 msgid "Full name"
-msgstr ""
+msgstr "Пуно име"
 
 #: scripts/apps/authoring/authoring/components/toggleFullWithEditor.tsx:20
 msgid "Full width mode"
@@ -8594,11 +8594,11 @@ msgstr ""
 #: scripts/apps/desks/views/desk-config-modal.html:249
 #: scripts/apps/desks/views/desk-config-modal.html:350
 msgid "Global Read"
-msgstr ""
+msgstr "Глобално читање"
 
 #: scripts/apps/desks/views/desk-config-modal.html:310
 msgid "Global Read:"
-msgstr ""
+msgstr "Глобално читање:"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-list.html:28
 msgid "Global Saved Reports"
@@ -8841,7 +8841,7 @@ msgstr ""
 
 #: scripts/apps/users/views/edit-form.html:238
 msgid "Help us translate Superdesk"
-msgstr ""
+msgstr "Помозите нам да преведемо Superdesk"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:115
 msgid ""
@@ -8984,11 +8984,11 @@ msgstr "Сати"
 
 #: scripts/apps/users/directives/UserRolesDirective.ts:46
 msgid "I'm sorry but a role with that name already exists."
-msgstr ""
+msgstr "Извините, али улога са тим називом већ постоји."
 
 #: scripts/apps/users/directives/UserRolesDirective.ts:50
 msgid "I'm sorry but there was an error when saving the role."
-msgstr ""
+msgstr "Извините, али дошло је до грешке приликом чувања улоге."
 
 #: scripts/apps/ingest/directives/IngestRoutingContent.ts:188
 msgid "I'm sorry but there was an error when saving the routing scheme."
@@ -9056,7 +9056,7 @@ msgstr "Ако није подешено, претпоставља се врем
 
 #: scripts/apps/desks/views/desk-config-modal.html:84
 msgid "If selected, content published from this desk will be not be expired"
-msgstr ""
+msgstr "Ако је изабрано, садржај објављен са овог деска неће истицати"
 
 #: scripts/core/editor3/components/embeds/EmbedInput.tsx:153
 msgid "If you paste an embed code, it will be used \"as is\"."
@@ -9069,7 +9069,7 @@ msgid ""
 "name and the role.\n"
 "                        The roles are managed in <b>Author roles</b> "
 "controlled vocabulary in the Metadata section."
-msgstr ""
+msgstr "Ако изаберете подразумевану улогу за креирање или уређивање садржаја,\n                        Superdesk ће унапред попунити поље Аутори корисниковим именом и улогом.\n                        Улоге се управљају у контролисаном вокабулару <b>Улоге аутора</b> у одељку Метаподаци."
 
 #: ../superdesk-planning/client/components/ConfirmationModal.tsx:137
 #: ../superdesk-planning/client/components/FulFilAssignmentModal/index.tsx:104
@@ -9140,11 +9140,11 @@ msgstr ""
 
 #: scripts/apps/users/import/views/import-user.html:44
 msgid "Import"
-msgstr ""
+msgstr "Увоз"
 
 #: scripts/apps/users/import/import.ts:50
 msgid "Import user"
-msgstr ""
+msgstr "Увези корисника"
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/field-components/time-header-common.tsx:35
 msgid "In 1 hr"
@@ -9249,17 +9249,17 @@ msgstr ""
 
 #: scripts/apps/desks/views/desk-config-modal.html:386
 msgid "Incoming Rule"
-msgstr ""
+msgstr "Долазно правило"
 
 #: scripts/apps/desks/views/desk-config-modal.html:334
 msgid "Incoming Rule:"
-msgstr ""
+msgstr "Долазно правило:"
 
 #: scripts/apps/desks/views/desk-config-modal.html:307
 #: scripts/apps/desks/views/desk-config-modal.html:362
 #: scripts/apps/workspace/content/constants.ts:57
 msgid "Incoming Stage"
-msgstr ""
+msgstr "Долазна фаза"
 
 #: scripts/core/editor3/components/media/MediaBlock.tsx:17
 msgid "Indefinite Usage"
@@ -9404,7 +9404,7 @@ msgstr "Уметни"
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:116
 #: scripts/apps/users/views/edit-form.html:312
 msgid "Instagram"
-msgstr ""
+msgstr "Instagram"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:87
 msgid "Installed Version:"
@@ -9464,7 +9464,7 @@ msgstr ""
 
 #: scripts/apps/users/views/edit-form.html:258
 msgid "Invalid format. Only Alphanumerics are allowed."
-msgstr ""
+msgstr "Неисправан формат. Дозвољени су само алфанумерички знакови."
 
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:315
 msgid "Invalid time"
@@ -9755,13 +9755,13 @@ msgstr ""
 
 #: scripts/apps/users/views/edit-form.html:186
 msgid "Jabber Identifier (JID)"
-msgstr ""
+msgstr "Jabber идентификатор (JID)"
 
 #: scripts/apps/contacts/constants.ts:73
 #: scripts/apps/contacts/views/search-panel.html:39
 #: scripts/apps/users/views/edit-form.html:277
 msgid "Job Title"
-msgstr ""
+msgstr "Назив посла"
 
 #: ../superdesk-planning/client/components/Main/JumpToDropdown.tsx:61
 #: ../superdesk-planning/client/components/Main/JumpToDropdown.tsx:67
@@ -9858,7 +9858,7 @@ msgstr ""
 #: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/GetFields.js:14
 #: scripts/extensions/annotationsLibrary/src/GetFields.ts:15
 msgid "Language"
-msgstr ""
+msgstr "Језик"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:31
 msgid "Language code"
@@ -10140,7 +10140,7 @@ msgstr ""
 #: scripts/apps/users/directives/UserPreferencesDirective.ts:28
 #: scripts/apps/users/directives/UserPreferencesDirective.ts:30
 msgid "List View"
-msgstr ""
+msgstr "Приказ листе"
 
 #: scripts/apps/monitoring/directives/utils.ts:88
 msgid "List view"
@@ -10188,15 +10188,15 @@ msgstr "Учитавање..."
 
 #: scripts/apps/desks/views/desk-config-modal.html:354
 msgid "Local Read Only"
-msgstr ""
+msgstr "Само локално читање"
 
 #: scripts/apps/desks/views/desk-config-modal.html:315
 msgid "Local Read Only:"
-msgstr ""
+msgstr "Само локално читање:"
 
 #: scripts/apps/desks/views/desk-config-modal.html:252
 msgid "Local Readonly"
-msgstr ""
+msgstr "Само локално читање"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:260
 #: ../superdesk-planning/client/components/fields/resources/locations.ts:56
@@ -10315,12 +10315,12 @@ msgstr ""
 #: scripts/apps/desks/views/actionpicker.html:26
 #: scripts/apps/internal-destinations/InternalDestinations.tsx:59
 msgid "Macro"
-msgstr ""
+msgstr "Макро"
 
 #: scripts/apps/authoring/macros/macros.ts:399
 #: scripts/apps/desks/views/desk-config-modal.html:465
 msgid "Macros"
-msgstr ""
+msgstr "Макрои"
 
 #: scripts/apps/authoring-react/macros/macros.tsx:37
 msgid "Macros widget"
@@ -10344,7 +10344,7 @@ msgstr ""
 
 #: scripts/apps/users/views/change-avatar.html:53
 msgid "Make sure you're looking the best"
-msgstr ""
+msgstr "Уверите се да изгледате најбоље"
 
 #: scripts/apps/production-api-keys/utils.tsx:45
 msgid ""
@@ -10457,11 +10457,11 @@ msgstr ""
 
 #: scripts/apps/users/config.ts:145
 msgid "Manage user roles"
-msgstr ""
+msgstr "Управљај корисничким улогама"
 
 #: scripts/apps/users/config.ts:135
 msgid "Manage users"
-msgstr ""
+msgstr "Управљај корисницима"
 
 #: scripts/apps/search/views/saved-search-manage-subscribers.html:5
 msgid "Manage:"
@@ -10679,7 +10679,7 @@ msgstr ""
 
 #: scripts/apps/users/views/edit-form.html:61
 msgid "Member since"
-msgstr ""
+msgstr "Члан од"
 
 #: scripts/core/editor3/highlightsConfig.ts:92
 msgid "Merge paragraphs"
@@ -10915,11 +10915,11 @@ msgstr ""
 
 #: scripts/apps/desks/views/desk-config-modal.html:397
 msgid "Moved onto stage Rule"
-msgstr ""
+msgstr "Премештено у фазу - правило"
 
 #: scripts/apps/desks/views/desk-config-modal.html:338
 msgid "Moved onto stage Rule:"
-msgstr ""
+msgstr "Премештено у фазу - правило:"
 
 #: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:154
 msgid "Moved to a working stage by this user"
@@ -11019,7 +11019,7 @@ msgstr ""
 
 #: scripts/apps/users/index.ts:89
 msgid "My Profile"
-msgstr ""
+msgstr "Мој профил"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-list.html:12
 msgid "My Saved Reports"
@@ -11176,7 +11176,7 @@ msgstr ""
 
 #: scripts/apps/users/views/settings-roles.html:30
 msgid "New Role"
-msgstr ""
+msgstr "Нова улога"
 
 #: scripts/core/editor3/components/annotations/AnnotationInput.tsx:310
 msgid "New annotation"
@@ -11184,7 +11184,7 @@ msgstr "Нова анотација"
 
 #: scripts/apps/desks/views/desk-config-modal.html:237
 msgid "New stage"
-msgstr ""
+msgstr "Нова фаза"
 
 #: scripts/apps/search/views/saved-search-subscribe.html:6
 msgid "New subscription"
@@ -11227,7 +11227,7 @@ msgstr ""
 
 #: scripts/apps/users/config.ts:158
 msgid "Next user"
-msgstr ""
+msgstr "Следећи корисник"
 
 #: scripts/core/ui/components/generic-form/input-types/checkbox.tsx:10
 #: scripts/core/ui/components/generic-form/input-types/yes-no.tsx:7
@@ -11327,7 +11327,7 @@ msgstr ""
 #: scripts/apps/desks/views/mark_desks_dropdown_directive.html:8
 #: scripts/apps/search/components/actions-menu/Item.tsx:168
 msgid "No available desks"
-msgstr ""
+msgstr "Нема доступних дескова"
 
 #: scripts/apps/desks/directives/MarkDesksDropdown.ts:24
 #: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:113
@@ -11335,7 +11335,7 @@ msgstr ""
 #: scripts/apps/highlights/views/package_highlights_dropdown_directive.html:26
 #: scripts/apps/search/components/actions-menu/Item.tsx:167
 msgid "No available highlights"
-msgstr ""
+msgstr "Нема доступних истицања"
 
 #: scripts/apps/archive/views/package_item_labels_dropdown_directive.html:13
 msgid "No available labels"
@@ -11352,7 +11352,7 @@ msgstr ""
 #: scripts/apps/desks/directives/MarkDesksDropdown.ts:26
 #: scripts/apps/search/components/actions-menu/Item.tsx:169
 msgid "No available translations"
-msgstr ""
+msgstr "Нема доступних превода"
 
 #: ../superdesk-planning/client/components/PlanningTemplatesModal/TemplatesListView.tsx:38
 msgid "No calendar"
@@ -11397,7 +11397,7 @@ msgstr ""
 
 #: scripts/apps/users/views/edit-form.html:222
 msgid "No desk selected"
-msgstr ""
+msgstr "Није изабран деск"
 
 #: scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx:174
 #: scripts/core/interactive-article-actions-panel/actions/send-to-tab.tsx:40
@@ -11444,7 +11444,7 @@ msgstr ""
 
 #: scripts/apps/users/views/change-avatar.html:15
 msgid "No image"
-msgstr ""
+msgstr "Нема слике"
 
 #: scripts/core/ui/components/generic-form/input-types/select_single_value.tsx:88
 #: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/editor.js:34
@@ -11483,7 +11483,7 @@ msgstr "Нема ставки за додавање!"
 
 #: scripts/apps/desks/views/task-status-items.html:3
 msgid "No items with this status"
-msgstr ""
+msgstr "Нема ставки са овим статусом"
 
 #: scripts/core/ui/components/virtual-lists/select.tsx:149
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:146
@@ -11526,7 +11526,7 @@ msgstr ""
 msgid ""
 "No preferred categories selected. Should you choose to proceed with your "
 "choice. A default set of categories will be selected for you."
-msgstr ""
+msgstr "Нису изабране омиљене категорије. Ако одлучите да наставите са својим избором, биће вам изабран подразумевани скуп категорија."
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EditorFieldEventRelatedItems.tsx:85
 msgid "No related articles yet"
@@ -11559,7 +11559,7 @@ msgstr ""
 
 #: scripts/apps/users/views/settings-roles.html:22
 msgid "No roles created yet."
-msgstr ""
+msgstr "Још нису креиране улоге."
 
 #: scripts/apps/ingest/views/settings/ingest-rules-content.html:63
 msgid "No rules defined in a set."
@@ -11641,7 +11641,7 @@ msgstr ""
 
 #: scripts/apps/users/views/list.html:28
 msgid "No user roles defined!"
-msgstr ""
+msgstr "Нису дефинисане корисничке улоге!"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/assignCalendarForm.tsx:87
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:136
@@ -11701,7 +11701,7 @@ msgstr ""
 
 #: scripts/apps/desks/views/settings.html:87
 msgid "Not Expired"
-msgstr ""
+msgstr "Није истекло"
 
 #: ../superdesk-planning/client/components/fields/editor/NotForPublication.tsx:15
 #: ../superdesk-planning/client/constants/tooltips.ts:31
@@ -11838,7 +11838,7 @@ msgstr ""
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:71
 #: scripts/apps/users/activity-widget/configuration.html:7
 msgid "Number of items"
-msgstr ""
+msgstr "Број ставки"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:27
 msgid "OEM"
@@ -11847,7 +11847,7 @@ msgstr ""
 #: scripts/apps/desks/views/desk-config-modal.html:312
 #: scripts/apps/desks/views/desk-config-modal.html:317
 msgid "OFF"
-msgstr ""
+msgstr "ИСКЉУЧЕНО"
 
 #: ../superdesk-planning/client/components/Assignments/EditCoverageAssignmentModal.tsx:106
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:106
@@ -11863,7 +11863,7 @@ msgstr "У реду"
 #: scripts/apps/desks/views/desk-config-modal.html:311
 #: scripts/apps/desks/views/desk-config-modal.html:316
 msgid "ON"
-msgstr ""
+msgstr "УКЉУЧЕНО"
 
 #: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:87
 msgid "OR"
@@ -11903,7 +11903,7 @@ msgstr ""
 
 #: scripts/apps/users/components/UserAvatar.tsx:100
 msgid "Offline"
-msgstr ""
+msgstr "Ван мреже"
 
 #: ../superdesk-planning/client/components/ConfirmationModal.tsx:127
 #: scripts/apps/archive/controllers/file-upload-error-modal.tsx:38
@@ -11950,7 +11950,7 @@ msgstr[2] ""
 #: scripts/apps/users/components/UserAvatar.tsx:99
 #: scripts/apps/users/controllers/UserListController.ts:156
 msgid "Online"
-msgstr ""
+msgstr "На мрежи"
 
 #: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:86
 msgid "Only 1 image is allowed in this field"
@@ -12264,11 +12264,11 @@ msgstr ""
 
 #: scripts/apps/desks/views/desk-config-modal.html:408
 msgid "Outgoing Rule"
-msgstr ""
+msgstr "Одлазно правило"
 
 #: scripts/apps/desks/views/desk-config-modal.html:342
 msgid "Outgoing Rule:"
-msgstr ""
+msgstr "Одлазно правило:"
 
 #: scripts/apps/publish/views/file-config.html:2
 #: scripts/apps/publish/views/file-config.html:4
@@ -12294,7 +12294,7 @@ msgstr ""
 #: scripts/apps/master-desk/MasterDesk.tsx:36
 #: scripts/apps/users/controllers/UserEditController.ts:14
 msgid "Overview"
-msgstr ""
+msgstr "Преглед"
 
 #: scripts/apps/templates/views/templates.html:48
 msgid "Owner"
@@ -12499,7 +12499,7 @@ msgstr ""
 
 #: scripts/apps/users/controllers/UserListController.ts:157
 msgid "Pending"
-msgstr ""
+msgstr "На чекању"
 
 #: scripts/apps/desks/views/desk-config-modal.html:426
 #: scripts/apps/desks/views/settings.html:71
@@ -12507,7 +12507,7 @@ msgstr ""
 #: scripts/extensions/auto-tagging-widget/dist/src/groups.js:14
 #: scripts/extensions/auto-tagging-widget/src/groups.ts:21
 msgid "People"
-msgstr ""
+msgstr "Људи"
 
 #: scripts/apps/products/views/products-config-modal.html:70
 msgid "Permitting"
@@ -12560,7 +12560,7 @@ msgstr ""
 
 #: scripts/apps/users/controllers/UserEditController.ts:23
 msgid "Personal preferences"
-msgstr ""
+msgstr "Личне поставке"
 
 #: scripts/apps/monitoring/config.ts:64
 #: scripts/core/interactive-article-actions-panel/subcomponents/destination-select.tsx:28
@@ -12686,7 +12686,7 @@ msgstr ""
 #: scripts/apps/users/views/user-preferences.html:19
 #: scripts/apps/users/views/user-preferences.html:203
 msgid "Planning"
-msgstr ""
+msgstr "Планирање"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:61
 msgid "Planning Cancelled"
@@ -12815,15 +12815,15 @@ msgstr "Проверите да ли је следећи ИД исти као н
 
 #: scripts/apps/users/config.ts:95
 msgid "Please confirm that you want to delete all the sessions for this user."
-msgstr ""
+msgstr "Потврдите да желите да обришете све сесије за овог корисника."
 
 #: scripts/apps/users/config.ts:78
 msgid "Please confirm that you want to disable a user."
-msgstr ""
+msgstr "Потврдите да желите да онемогућите корисника."
 
 #: scripts/apps/desks/controllers/DeskConfigController.ts:57
 msgid "Please confirm you want to delete desk."
-msgstr ""
+msgstr "Потврдите да желите да обришете деск."
 
 #: scripts/apps/dictionaries/controllers/DictionaryConfigController.ts:89
 msgid "Please confirm you want to delete dictionary."
@@ -12844,7 +12844,7 @@ msgstr ""
 #: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:94
 #: scripts/apps/users/views/edit-form.html:340
 msgid "Please provide a valid twitter account"
-msgstr ""
+msgstr "Унесите исправан Twitter налог"
 
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:129
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:130
@@ -12991,7 +12991,7 @@ msgstr "Преферисане категорије"
 
 #: scripts/apps/desks/views/desk-config-modal.html:200
 msgid "Preferred values for vocabularies"
-msgstr ""
+msgstr "Омиљене вредности за вокабуларе"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:374
 msgid "Prefill the field with text from:"
@@ -13013,7 +13013,7 @@ msgstr ""
 
 #: scripts/apps/desks/views/desk-config-modal.html:86
 msgid "Preserve Published Content"
-msgstr ""
+msgstr "Сачувај објављен садржај"
 
 #: ../superdesk-planning/client/constants/events.ts:171
 #: ../superdesk-planning/client/constants/planning.ts:148
@@ -13078,7 +13078,7 @@ msgstr ""
 
 #: scripts/apps/users/config.ts:157
 msgid "Previous user"
-msgstr ""
+msgstr "Претходни корисник"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:157
 #: scripts/apps/authoring-react/preview-article-modal.tsx:24
@@ -13141,16 +13141,16 @@ msgstr "Приватне сачуване претраге"
 
 #: scripts/apps/users/controllers/UserEditController.ts:32
 msgid "Privileges"
-msgstr ""
+msgstr "Привилегије"
 
 #: scripts/apps/users/directives/UserPrivilegesDirective.ts:43
 msgid "Privileges not found."
-msgstr ""
+msgstr "Привилегије нису пронађене."
 
 #: scripts/apps/users/directives/RolesPrivilegesDirective.ts:34
 #: scripts/apps/users/directives/UserPrivilegesDirective.ts:77
 msgid "Privileges updated."
-msgstr ""
+msgstr "Привилегије ажуриране."
 
 #: scripts/apps/packaging/views/sd-package-item-preview.html:37
 #: scripts/apps/packaging/views/sd-package-item-preview.html:8
@@ -13258,7 +13258,7 @@ msgstr ""
 
 #: scripts/apps/users/views/change-avatar.html:47
 msgid "Provided image URL is not valid."
-msgstr ""
+msgstr "Унет URL слике није исправан."
 
 #: scripts/apps/search/constants.ts:18
 #: scripts/apps/search/views/search-parameters.html:161
@@ -13384,7 +13384,7 @@ msgstr "Објављено"
 
 #: scripts/apps/desks/views/settings.html:86
 msgid "Published Content"
-msgstr ""
+msgstr "Објављен садржај"
 
 #: ../superdesk-analytics/client/publishing_performance_report/controllers/PublishingPerformanceReportController.ts:383
 msgid "Published Content for {{group}}: {{data}}"
@@ -13577,11 +13577,11 @@ msgstr ""
 
 #: scripts/apps/users/config.ts:150
 msgid "Read user roles"
-msgstr ""
+msgstr "Читај корисничке улоге"
 
 #: scripts/apps/users/config.ts:140
 msgid "Read users"
-msgstr ""
+msgstr "Читај кориснике"
 
 #: scripts/apps/authoring-react/fields/common-field-configuration.tsx:29
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/read-only-label.tsx:7
@@ -13647,7 +13647,7 @@ msgstr "Недавни шаблони"
 
 #: scripts/apps/users/views/list.html:42
 msgid "Recently added"
-msgstr ""
+msgstr "Недавно додато"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:62
 #: scripts/apps/publish/views/email-config.html:2
@@ -13986,7 +13986,7 @@ msgstr ""
 
 #: scripts/apps/desks/views/settings.html:53
 msgid "Remove desk"
-msgstr ""
+msgstr "Уклони деск"
 
 #: scripts/apps/dictionaries/views/settings.html:55
 msgid "Remove dictionary"
@@ -14049,7 +14049,7 @@ msgstr ""
 
 #: scripts/apps/users/views/settings-roles.html:18
 msgid "Remove role"
-msgstr ""
+msgstr "Уклони улогу"
 
 #: scripts/apps/ingest/views/settings/ingest-rules-content.html:20
 msgid "Remove rule set"
@@ -14377,19 +14377,19 @@ msgstr ""
 #: scripts/apps/users/views/list.html:35
 #: scripts/apps/users/views/user-privileges.html:19
 msgid "Role"
-msgstr ""
+msgstr "Улога"
 
 #: scripts/apps/users/views/settings-roles.html:45
 msgid "Role Description"
-msgstr ""
+msgstr "Опис улоге"
 
 #: scripts/apps/users/views/settings-roles.html:38
 msgid "Role Name"
-msgstr ""
+msgstr "Назив улоге"
 
 #: scripts/apps/users/views/settings.html:9
 msgid "Roles"
-msgstr ""
+msgstr "Улоге"
 
 #: scripts/core/lang/missing-translations-strings.ts:20
 msgid "Roles Management"
@@ -14397,7 +14397,7 @@ msgstr "Управљање улогама"
 
 #: scripts/apps/users/views/settings.html:12
 msgid "Roles privileges"
-msgstr ""
+msgstr "Привилегије улога"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:168
 msgid "Rotate Left"
@@ -14682,7 +14682,7 @@ msgstr ""
 #: scripts/apps/desks/views/desk-config-modal.html:214
 #: scripts/apps/desks/views/desk-config-modal.html:451
 msgid "Save & Continue"
-msgstr ""
+msgstr "Сачувај и настави"
 
 #: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:137
 #: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:372
@@ -14847,7 +14847,7 @@ msgstr ""
 
 #: scripts/apps/users/views/edit-form.html:401
 msgid "Save password"
-msgstr ""
+msgstr "Сачувај лозинку"
 
 #: scripts/apps/search/views/save-search.html:23
 msgid "Save search"
@@ -14864,7 +14864,7 @@ msgstr ""
 #: scripts/apps/search/views/search-panel.html:9
 #: scripts/apps/users/directives/UserEditDirective.ts:240
 msgid "Saved"
-msgstr ""
+msgstr "Сачувано"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:348
 msgid "Saved Featured Stories record"
@@ -15295,14 +15295,14 @@ msgid ""
 "ingest. If you don't see any, create one\n"
 "                                   <a href=\"#/settings/content-"
 "profiles\">here</a>"
-msgstr ""
+msgstr "Изаберите подразумевани профил садржаја који се користи за чланке преузете из доласка. Ако ниједан не видите, креирајте га\n                                   <a href=\"#/settings/content-profiles\">овде</a>"
 
 #: scripts/apps/desks/views/desk-config-modal.html:156
 msgid ""
 "Select a default template for new articles. If you don't see any, first make "
 "sure that there is at least one content profile. Each time a profile is "
 "created, Superdesk creates a template with the same name."
-msgstr ""
+msgstr "Изаберите подразумевани шаблон за нове чланке. Ако ниједан не видите, прво се уверите да постоји барем један профил садржаја. Сваки пут када се креира профил, Superdesk креира шаблон са истим називом."
 
 #: scripts/core/ui/components/generic-form/input-types/desk_single_value.tsx:40
 msgid "Select a desk"
@@ -15344,7 +15344,7 @@ msgstr ""
 
 #: scripts/apps/users/views/user-preferences.html:149
 msgid "Select all categories"
-msgstr ""
+msgstr "Изабери све категорије"
 
 #: ../superdesk-planning/client/components/FulFilAssignmentModal/index.tsx:76
 msgid "Select an Assignment"
@@ -15377,7 +15377,7 @@ msgstr ""
 
 #: scripts/apps/users/views/user-preferences.html:161
 msgid "Select default categories only"
-msgstr ""
+msgstr "Изабери само подразумеване категорије"
 
 #: scripts/apps/authoring-react/toolbar/mark-for-desks/mark-for-desks-modal.tsx:43
 #: scripts/apps/master-desk/components/HeaderComponent.tsx:224
@@ -15568,7 +15568,7 @@ msgstr ""
 
 #: scripts/apps/users/components/EmailNotificationPreferences.tsx:24
 msgid "Send {{name}} notifications"
-msgstr ""
+msgstr "Шаљи {{name}} обавештења"
 
 #: scripts/core/lang/missing-translations-strings.ts:22
 msgid "Sending"
@@ -15621,7 +15621,7 @@ msgstr ""
 
 #: scripts/apps/users/controllers/SessionsDeleteCommand.ts:13
 msgid "Sessions cleared"
-msgstr ""
+msgstr "Сесије очишћене"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:192
 #: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:136
@@ -15656,7 +15656,7 @@ msgstr "Постављено и потом скривено"
 
 #: scripts/apps/users/views/settings-roles.html:50
 msgid "Set as default"
-msgstr ""
+msgstr "Постави као подразумевано"
 
 #: scripts/extensions/sams/dist/src/api/sets.js:34
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:34
@@ -15897,7 +15897,7 @@ msgstr ""
 
 #: scripts/apps/users/views/change-avatar.html:17
 msgid "Shows your initials instead"
-msgstr ""
+msgstr "Уместо тога приказује ваше иницијале"
 
 #: scripts/apps/authoring-react/field-adapters/sign_off.tsx:118
 #: scripts/apps/workspace/content/constants.ts:40
@@ -15916,7 +15916,7 @@ msgstr "Одјави се"
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:159
 #: scripts/apps/users/views/edit-form.html:254
 msgid "Sign-Off"
-msgstr ""
+msgstr "Потпис"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:364
 #: scripts/apps/search/views/search-parameters.html:22
@@ -16008,7 +16008,7 @@ msgstr ""
 
 #: scripts/apps/desks/views/desk-config-modal.html:59
 msgid "Slack Channel Name"
-msgstr ""
+msgstr "Назив Slack канала"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:176
 msgid "Slideshow"
@@ -16141,7 +16141,7 @@ msgstr "Извините, дати назив радног простора се
 
 #: scripts/apps/users/views/settings-roles.html:40
 msgid "Sorry, this role name already exists."
-msgstr ""
+msgstr "Извините, овај назив улоге већ постоји."
 
 #: scripts/core/auth/login-modal.html:38
 msgid "Sorry, user not found."
@@ -16225,7 +16225,7 @@ msgstr ""
 
 #: scripts/apps/desks/views/desk-config-modal.html:44
 msgid "Source for User Created Articles"
-msgstr ""
+msgstr "Извор за чланке које су креирали корисници"
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:9
 msgid "Source stats"
@@ -16339,27 +16339,27 @@ msgstr "Подели пасус"
 #: scripts/apps/workspace/content/constants.ts:45
 #: scripts/core/interactive-article-actions-panel/subcomponents/destination-select.tsx:87
 msgid "Stage"
-msgstr ""
+msgstr "Фаза"
 
 #: scripts/apps/desks/views/desk-config-modal.html:299
 msgid "Stage Details"
-msgstr ""
+msgstr "Детаљи фазе"
 
 #: scripts/apps/desks/views/desk-config-modal.html:369
 msgid "Stage description"
-msgstr ""
+msgstr "Опис фазе"
 
 #: scripts/apps/desks/views/desk-config-modal.html:320
 msgid "Stage description:"
-msgstr ""
+msgstr "Опис фазе:"
 
 #: scripts/apps/desks/directives/DeskeditStages.ts:190
 msgid "Stage has been modified elsewhere. Please reload the desks"
-msgstr ""
+msgstr "Фаза је измењена на другом месту. Поново учитајте дескове"
 
 #: scripts/apps/desks/views/desk-config-modal.html:289
 msgid "Stage with name"
-msgstr ""
+msgstr "Фаза са називом"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:624
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:157
@@ -16922,7 +16922,7 @@ msgstr ""
 
 #: scripts/apps/users/controllers/ChangeAvatarController.ts:7
 msgid "Take a picture"
-msgstr ""
+msgstr "Сними слику"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:132
 msgid "Take created by"
@@ -17341,12 +17341,12 @@ msgstr ""
 
 #: scripts/apps/users/views/change-avatar.html:33
 msgid "The minimum image resolution is 200x200 pixels."
-msgstr ""
+msgstr "Минимална резолуција слике је 200x200 пиксела."
 
 #: scripts/apps/desks/views/desk-config-modal.html:61
 msgid ""
 "The name of a Slack channel associated with this desk, the # is not required"
-msgstr ""
+msgstr "Назив Slack канала повезаног са овим деском, # није потребан"
 
 #: scripts/api/article-send.tsx:113
 msgid ""
@@ -17365,7 +17365,7 @@ msgstr "Лозинка је промењена."
 
 #: scripts/apps/users/directives/ResetPasswordDirective.ts:18
 msgid "The password has been reset."
-msgstr ""
+msgstr "Лозинка је ресетована."
 
 #: scripts/apps/publish/views/email-config.html:35
 msgid "The rendition to attach to the email"
@@ -17444,7 +17444,7 @@ msgstr ""
 
 #: scripts/apps/users/views/user-preferences.html:257
 msgid "Themes"
-msgstr ""
+msgstr "Теме"
 
 #: scripts/apps/contacts/components/ItemList.tsx:180
 #: scripts/apps/master-desk/components/ListItemsComponent.tsx:45
@@ -17608,7 +17608,7 @@ msgstr ""
 #: scripts/apps/users/controllers/ChangeAvatarController.ts:51
 #: scripts/apps/users/controllers/ChangeAvatarController.ts:63
 msgid "There was a problem with your upload"
-msgstr ""
+msgstr "Дошло је до проблема са вашим отпремањем"
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:42
 msgid "There was a problem, Planning item not spiked!"
@@ -17620,11 +17620,11 @@ msgstr ""
 
 #: scripts/apps/desks/directives/DeskeditBasic.ts:61
 msgid "There was a problem, desk not created/updated."
-msgstr ""
+msgstr "Дошло је до проблема, деск није креиран/ажуриран."
 
 #: scripts/apps/desks/controllers/DeskConfigController.ts:106
 msgid "There was a problem, desk not saved. Refresh Desks."
-msgstr ""
+msgstr "Дошло је до проблема, деск није сачуван. Освежите дескове."
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:50
 msgid "There was a problem, dictionary not created/updated."
@@ -17637,15 +17637,15 @@ msgstr ""
 
 #: scripts/apps/desks/directives/DeskeditPeople.ts:66
 msgid "There was a problem, members not saved. Refresh Desks."
-msgstr ""
+msgstr "Дошло је до проблема, чланови нису сачувани. Освежите дескове."
 
 #: scripts/apps/desks/views/desk-config-modal.html:291
 msgid "There was a problem, stage not created/updated."
-msgstr ""
+msgstr "Дошло је до проблема, фаза није креирана/ажурирана."
 
 #: scripts/apps/desks/directives/DeskeditStages.ts:241
 msgid "There was a problem, stage was not deleted."
-msgstr ""
+msgstr "Дошло је до проблема, фаза није обрисана."
 
 #: scripts/apps/search/components/ErrorBox.tsx:7
 msgid "There was an error archiving this item"
@@ -17661,7 +17661,7 @@ msgstr ""
 
 #: scripts/apps/users/directives/UserEditDirective.ts:268
 msgid "There was an error when saving the user account."
-msgstr ""
+msgstr "Дошло је до грешке приликом чувања корисничког налога."
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary.js:22
 #: scripts/extensions/ai-widget/dist/src/summary/summary.js:22
@@ -17708,7 +17708,7 @@ msgstr ""
 
 #: scripts/apps/users/directives/UserRolesDirective.ts:68
 msgid "There was an error. Role cannot be deleted."
-msgstr ""
+msgstr "Дошло је до грешке. Улога не може бити обрисана."
 
 #: scripts/apps/ingest/directives/IngestRoutingContent.ts:55
 msgid "There was an error. Routing scheme cannot be deleted."
@@ -17821,7 +17821,7 @@ msgstr ""
 #: scripts/apps/users/views/edit-form.html:85
 #: scripts/apps/users/views/edit-form.html:97
 msgid "This field is required."
-msgstr ""
+msgstr "Ово поље је обавезно."
 
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:92
 msgid ""
@@ -18419,7 +18419,7 @@ msgstr "Искључи преглед нових функција"
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:198
 #: scripts/apps/users/views/edit-form.html:329
 msgid "Twitter"
-msgstr ""
+msgstr "Twitter"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:199
 msgid "Twitter Circle"
@@ -18600,7 +18600,7 @@ msgstr ""
 
 #: scripts/apps/desks/controllers/DeskConfigController.ts:69
 msgid "Unknown Error: There was a problem, desk was not deleted."
-msgstr ""
+msgstr "Непозната грешка: дошло је до проблема, деск није обрисан."
 
 #: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:73
 msgid "Unknown Type ({{qcode}})"
@@ -19016,7 +19016,7 @@ msgstr ""
 
 #: scripts/apps/users/controllers/ChangeAvatarController.ts:6
 msgid "Upload from computer"
-msgstr ""
+msgstr "Отпреми са рачунара"
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:243
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:243
@@ -19139,7 +19139,7 @@ msgstr "Користи безбедност транспортног слоја 
 
 #: scripts/apps/users/controllers/ChangeAvatarController.ts:8
 msgid "Use a Web URL"
-msgstr ""
+msgstr "Користи веб URL"
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:238
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:238
@@ -19180,7 +19180,7 @@ msgstr ""
 #: scripts/apps/authoring/metadata/views/metadata-terms.html:52
 #: scripts/apps/users/views/user-privileges.html:18
 msgid "User"
-msgstr ""
+msgstr "Корисник"
 
 #: ../superdesk-analytics/client/user_activity_report/index.js:46
 #: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:340
@@ -19199,43 +19199,43 @@ msgstr "Управљање корисницима"
 
 #: scripts/apps/users/import/views/import-user.html:28
 msgid "User Profile to Import"
-msgstr ""
+msgstr "Кориснички профил за увоз"
 
 #: scripts/apps/users/config.ts:66 scripts/apps/users/views/settings.html:4
 msgid "User Roles"
-msgstr ""
+msgstr "Корисничке улоге"
 
 #: scripts/apps/users/directives/UserPrivilegesDirective.ts:32
 msgid "User not found."
-msgstr ""
+msgstr "Корисник није пронађен."
 
 #: scripts/apps/users/directives/UserPreferencesDirective.ts:163
 msgid "User preferences could not be saved..."
-msgstr ""
+msgstr "Корисничке поставке нису могле бити сачуване..."
 
 #: scripts/apps/users/directives/UserPreferencesDirective.ts:159
 msgid "User preferences saved"
-msgstr ""
+msgstr "Корисничке поставке сачуване"
 
 #: scripts/apps/users/directives/UserRolesDirective.ts:35
 msgid "User role created."
-msgstr ""
+msgstr "Корисничка улога креирана."
 
 #: scripts/apps/users/directives/UserPrivilegesDirective.ts:55
 msgid "User role not found."
-msgstr ""
+msgstr "Корисничка улога није пронађена."
 
 #: scripts/apps/users/directives/UserRolesDirective.ts:37
 msgid "User role updated."
-msgstr ""
+msgstr "Корисничка улога ажурирана."
 
 #: scripts/apps/users/controllers/UserResolver.ts:12
 msgid "User was not found, sorry."
-msgstr ""
+msgstr "Корисник није пронађен, извините."
 
 #: scripts/apps/users/directives/UserEditDirective.ts:266
 msgid "User was not found. The account might have been deleted."
-msgstr ""
+msgstr "Корисник није пронађен. Налог је можда обрисан."
 
 #: ../superdesk-analytics/client/user_activity_report/views/item-timeline-tooltip.html:2
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:102
@@ -19257,15 +19257,15 @@ msgstr "Корисничко име"
 #: scripts/apps/production-api-keys/config.ts:25
 #: scripts/apps/users/views/list.html:2
 msgid "Users"
-msgstr ""
+msgstr "Корисници"
 
 #: scripts/apps/users/config.ts:56
 msgid "Users Profile"
-msgstr ""
+msgstr "Кориснички профил"
 
 #: scripts/apps/users/views/edit.html:9
 msgid "Users Profile:"
-msgstr ""
+msgstr "Кориснички профил:"
 
 #: scripts/core/lang/missing-translations-strings.ts:13
 msgid "Users archive view format"
@@ -19406,11 +19406,11 @@ msgstr ""
 #: scripts/apps/users/views/user-preferences.html:14
 #: scripts/apps/users/views/user-preferences.html:43
 msgid "View formats"
-msgstr ""
+msgstr "Формати приказа"
 
 #: scripts/apps/users/views/list.html:67
 msgid "View full profile"
-msgstr ""
+msgstr "Прикажи цео профил"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:516
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:106
@@ -19491,7 +19491,7 @@ msgstr ""
 #: scripts/apps/users/views/user-preferences.html:20
 #: scripts/apps/users/views/user-preferences.html:248
 msgid "Vocabulary values"
-msgstr ""
+msgstr "Вредности вокабулара"
 
 #: scripts/apps/vocabularies/controllers/VocabularyConfigController.ts:243
 msgid "Vocabulary was deleted."
@@ -19653,7 +19653,7 @@ msgstr ""
 
 #: scripts/apps/desks/views/desk-config-modal.html:232
 msgid "Work stages"
-msgstr ""
+msgstr "Радне фазе"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:100
 msgid "Work started"
@@ -19679,7 +19679,7 @@ msgstr ""
 #: scripts/apps/desks/views/desk-config-modal.html:358
 #: scripts/apps/workspace/content/constants.ts:55
 msgid "Working Stage"
-msgstr ""
+msgstr "Радна фаза"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/working-hours-grid-labels.js:16
 #: scripts/extensions/availability-manager/dist/src/settings/working-hours-grid-labels.js:16
@@ -19794,7 +19794,7 @@ msgid ""
 "You can choose the default content view of your desk. Use only if you want "
 "to override individual users' monitoring view preferences. Select \"none\" "
 "if you want to let users decide."
-msgstr ""
+msgstr "Можете изабрати подразумевани приказ садржаја вашег деска. Користите само ако желите да заобиђете поставке приказа мониторинга појединачних корисника. Изаберите \"ништа\" ако желите да оставите корисницима да одлуче."
 
 #: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:148
 msgid ""
@@ -19828,7 +19828,7 @@ msgstr "Имате несачуване измене, желите ли да н�
 
 #: scripts/apps/desks/controllers/DeskConfigController.ts:93
 msgid "You have unsaved changes. Do you want to save them now?"
-msgstr ""
+msgstr "Имате несачуване измене. Желите ли сада да их сачувате?"
 
 #: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:76
 msgid "You have unsaved changes. What would you like to do?"
@@ -19848,11 +19848,11 @@ msgstr ""
 
 #: scripts/apps/users/import/views/import-user.html:11
 msgid "Your Credentials"
-msgstr ""
+msgstr "Ваши акредитиви"
 
 #: scripts/apps/users/views/edit-form.html:198
 msgid "Your Slack user name without the leading @"
-msgstr ""
+msgstr "Ваше Slack корисничко име без водећег @"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:500
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:124
@@ -19930,7 +19930,7 @@ msgstr ""
 
 #: scripts/apps/users/views/edit-form.html:36
 msgid "active"
-msgstr ""
+msgstr "активно"
 
 #: scripts/core/lang/missing-translations-strings.ts:38
 msgid "added new task {{subject}} of type {{type}}"
@@ -19957,7 +19957,7 @@ msgstr "све"
 #: scripts/apps/desks/views/desk-config-modal.html:289
 #: scripts/apps/highlights/views/highlights_config_modal.html:15
 msgid "already exists"
-msgstr ""
+msgstr "већ постоји"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:103
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:120
@@ -20075,7 +20075,7 @@ msgstr "категорије"
 
 #: scripts/apps/users/views/edit-form.html:211
 msgid "change password"
-msgstr ""
+msgstr "промени лозинку"
 
 #: scripts/core/menu/notifications/views/notifications.html:42
 msgid ""
@@ -20135,7 +20135,7 @@ msgstr "композитни"
 
 #: scripts/apps/users/views/edit-form.html:390
 msgid "confirm"
-msgstr ""
+msgstr "потврди"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:69
 msgid "confirmed"
@@ -20192,7 +20192,7 @@ msgstr "креирао корисника {{user}}"
 
 #: scripts/apps/users/views/edit-form.html:379
 msgid "current"
-msgstr ""
+msgstr "тренутно"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:86
 msgid "custom blocks"
@@ -20209,20 +20209,20 @@ msgstr "датум"
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:41
 #: scripts/apps/desks/views/content-expiry.html:3
 msgid "day"
-msgstr ""
+msgstr "дан"
 
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:11
 #: scripts/apps/authoring-react/fields/date/config.tsx:83
 #: scripts/apps/desks/views/content-expiry.html:32
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:153
 msgid "days"
-msgstr ""
+msgstr "дана"
 
 #: scripts/apps/users/views/settings-privileges.html:16
 #: scripts/apps/users/views/settings-roles.html:15
 #: scripts/apps/users/views/user-preferences.html:159
 msgid "default"
-msgstr ""
+msgstr "подразумевано"
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:21
 msgid "default template"
@@ -20248,7 +20248,7 @@ msgstr ""
 #: scripts/apps/users/views/edit-form.html:34
 #: scripts/apps/users/views/user-list-item.html:15
 msgid "disabled"
-msgstr ""
+msgstr "онемогућено"
 
 #: scripts/core/lang/missing-translations-strings.ts:36
 msgid "disabled user {{user}}"
@@ -20276,7 +20276,7 @@ msgstr ""
 
 #: scripts/apps/users/views/edit-form.html:338
 msgid "e.g. @superdeskman"
-msgstr ""
+msgstr "нпр. @superdeskman"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:559
 msgid "e.g. Rhodes, CBD"
@@ -20300,16 +20300,16 @@ msgstr ""
 
 #: scripts/apps/users/views/edit-form.html:303
 msgid "e.g. superdeskman from https://www.facebook.com/superdeskman"
-msgstr ""
+msgstr "нпр. superdeskman из https://www.facebook.com/superdeskman"
 
 #: scripts/apps/users/views/edit-form.html:320
 msgid "e.g. superdeskman from https://www.instagram.com/superdeskman"
-msgstr ""
+msgstr "нпр. superdeskman из https://www.instagram.com/superdeskman"
 
 #: scripts/apps/contacts/constants.ts:49
 #: scripts/apps/users/views/edit-form.html:131
 msgid "email"
-msgstr ""
+msgstr "имејл"
 
 #: scripts/apps/archive/views/item-state.html:6
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:225
@@ -20406,7 +20406,7 @@ msgstr ""
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:275
 #: scripts/apps/users/views/edit-form.html:82
 msgid "first name"
-msgstr ""
+msgstr "име"
 
 #: ../superdesk-planning/client/utils/tests/index_test.ts:208
 msgid "foo"
@@ -20479,7 +20479,7 @@ msgstr ""
 
 #: scripts/apps/users/views/edit-form.html:73
 msgid "full name"
-msgstr ""
+msgstr "пуно име"
 
 #: scripts/core/itemList/views/relatedItem-list-widget.html:42
 msgid "genre:"
@@ -20545,7 +20545,7 @@ msgstr ""
 #: scripts/apps/desks/views/content-expiry.html:4
 #: scripts/apps/desks/views/content-expiry.html:40
 msgid "hr"
-msgstr ""
+msgstr "ч"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:162
 msgid "hrs"
@@ -20635,7 +20635,7 @@ msgstr "у_току"
 #: scripts/apps/users/views/edit-form.html:35
 #: scripts/apps/users/views/user-list-item.html:16
 msgid "inactive"
-msgstr ""
+msgstr "неактивно"
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "ingested"
@@ -20690,7 +20690,7 @@ msgstr ""
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:296
 #: scripts/apps/users/views/edit-form.html:94
 msgid "last name"
-msgstr ""
+msgstr "презиме"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:80
 msgid "last update and last item arrived."
@@ -20786,7 +20786,7 @@ msgstr ""
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:133
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:174
 msgid "min"
-msgstr ""
+msgstr "мин"
 
 #: scripts/extensions/datetimeField/dist/src/config.js:31
 #: scripts/extensions/datetimeField/dist/src/config.js:52
@@ -20821,7 +20821,7 @@ msgstr ""
 
 #: scripts/apps/users/views/edit-form.html:385
 msgid "new"
-msgstr ""
+msgstr "ново"
 
 #: scripts/core/ui/components/content-create-dropdown/content-create-dropdown.tsx:17
 msgid "new item"
@@ -20913,7 +20913,7 @@ msgstr "или"
 
 #: scripts/apps/users/views/change-avatar.html:31
 msgid "or Select from computer"
-msgstr ""
+msgstr "или изаберите са рачунара"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:73
 #: scripts/core/editor3/helpers/highlights.ts:67
@@ -20953,7 +20953,7 @@ msgstr "лозинке морају бити исте"
 
 #: scripts/apps/users/views/user-list-item.html:17
 msgid "pending"
-msgstr ""
+msgstr "на чекању"
 
 #: scripts/apps/contacts/constants.ts:48
 msgid "phone"
@@ -20961,7 +20961,7 @@ msgstr ""
 
 #: scripts/apps/users/views/edit-form.html:177
 msgid "phone number"
-msgstr ""
+msgstr "број телефона"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:399
 #: scripts/core/lang/missing-translations-strings.ts:9
@@ -20979,13 +20979,13 @@ msgstr ""
 
 #: scripts/apps/users/views/edit-form.html:141
 msgid "please provide a valid email address"
-msgstr ""
+msgstr "унесите исправну имејл адресу"
 
 #: scripts/apps/users/views/edit-form.html:121
 msgid ""
 "please use only letters (a-z), numbers (0-9), dashes (&mdash;), underscores "
 "(_), apostrophes (') and periods (.)"
-msgstr ""
+msgstr "користите само слова (a-z), бројеве (0-9), цртице (&mdash;), доње црте (_), апострофе (') и тачке (.)"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:121
 msgid "post"
@@ -21023,7 +21023,7 @@ msgstr "продукција"
 
 #: scripts/apps/users/import/views/import-user.html:31
 msgid "profile"
-msgstr ""
+msgstr "профил"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:233
 msgid "public"
@@ -21096,7 +21096,7 @@ msgstr "обавезно"
 
 #: scripts/apps/users/views/edit-form.html:208
 msgid "reset password"
-msgstr ""
+msgstr "ресетуј лозинку"
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "retrying"
@@ -21180,11 +21180,11 @@ msgstr "слаглајни"
 
 #: scripts/apps/users/views/edit-form.html:146
 msgid "sorry, a user with this email already exists"
-msgstr ""
+msgstr "извините, корисник са овим имејлом већ постоји"
 
 #: scripts/apps/users/views/edit-form.html:119
 msgid "sorry, this username is already taken."
-msgstr ""
+msgstr "извините, ово корисничко име је већ заузето."
 
 #: scripts/apps/search/components/MediaInfo.tsx:26
 msgid "source"
@@ -21480,7 +21480,7 @@ msgstr "видео"
 
 #: scripts/apps/desks/views/settings.html:77
 msgid "view all"
-msgstr ""
+msgstr "прикажи све"
 
 #: scripts/core/notification/notification.ts:231
 msgid ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -35,7 +35,7 @@ msgstr "Поље \"{{x}}\" је обавезно"
 msgid ""
 "'' is currently managing featured stories. This feature can only be accessed "
 "by one user at a time."
-msgstr ""
+msgstr "'' тренутно управља истакнутим причама. Овој функцији може приступити само један корисник истовремено."
 
 #: scripts/core/lang/missing-translations-strings.ts:23
 msgid "'ABSTRACT is a required field'"
@@ -707,14 +707,14 @@ msgstr "ИД приступног кључа"
 #: ../superdesk-planning/client/components/fields/resources/events.ts:108
 #: ../superdesk-planning/client/utils/contentProfiles.ts:347
 msgid "Accreditation Deadline"
-msgstr ""
+msgstr "Рок за акредитацију"
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:73
 #: ../superdesk-planning/client/components/fields/preview/index.ts:284
 #: ../superdesk-planning/client/components/fields/resources/events.ts:97
 #: ../superdesk-planning/client/utils/contentProfiles.ts:345
 msgid "Accreditation Info"
-msgstr ""
+msgstr "Подаци о акредитацији"
 
 #: scripts/apps/monitoring/views/desk-notifications.html:28
 msgid "Acknowledge"
@@ -1032,7 +1032,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Planning/PlanningItem.tsx:317
 #: ../superdesk-planning/client/components/Planning/PlanningItem.tsx:322
 msgid "Add as coverage"
-msgstr ""
+msgstr "Додај као извештавање"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:278
 #: ../superdesk-planning/client/utils/events.tsx:717
@@ -1158,11 +1158,11 @@ msgstr "Додај опис задатка"
 
 #: ../superdesk-planning/client/actions/agenda.ts:166
 msgid "Add these  events to the planning list?"
-msgstr ""
+msgstr "Додати ове догађаје на листу планирања?"
 
 #: ../superdesk-planning/client/actions/agenda.ts:165
 msgid "Add this event to the planning list?"
-msgstr ""
+msgstr "Додати овај догађај на листу планирања?"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:251
 msgid "Add this item to all recurring events or just this one?"
@@ -1179,13 +1179,13 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningItem.tsx:111
 msgid "Add to Feature Stories"
-msgstr ""
+msgstr "Додај у истакнуте приче"
 
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:129
 #: ../superdesk-planning/client/planning-extension/src/extension.ts:175
 #: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:165
 msgid "Add to Planning"
-msgstr ""
+msgstr "Додај у планирање"
 
 #: scripts/apps/packaging/index.ts:74
 msgid "Add to current"
@@ -1224,7 +1224,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:90
 msgid "Added to featured stories"
-msgstr ""
+msgstr "Додато у истакнуте приче"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:236
 msgid "Added to workflow"
@@ -1302,7 +1302,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Main/ToggleFiltersButton.tsx:14
 #: ../superdesk-planning/client/components/Main/ToggleFiltersButton.tsx:15
 msgid "Advanced filters"
-msgstr ""
+msgstr "Напредни филтери"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageAddButton/CoveragesMenuPopup.tsx:66
 msgid "Advanced mode"
@@ -1370,7 +1370,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:240
 msgid "Agenda assigned to the planning item."
-msgstr ""
+msgstr "Агенда додељена ставци планирања."
 
 #: ../superdesk-planning/client/components/fields/agendas.tsx:29
 msgid "Agenda:"
@@ -1386,7 +1386,7 @@ msgstr ""
 #: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx:88
 #: ../superdesk-planning/client/utils/contentProfiles.ts:307
 msgid "Agendas"
-msgstr ""
+msgstr "Агенде"
 
 #: scripts/extensions/ai-widget/dist/src/ai-assistant.js:21
 #: scripts/extensions/ai-widget/dist/src/ai-assistant.js:90
@@ -1503,7 +1503,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:303
 msgid "All Coverage has been cancelled"
-msgstr ""
+msgstr "Сва извештавања су отказана"
 
 #: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:25
 msgid "All Coverages Assigned"
@@ -1528,17 +1528,17 @@ msgstr ""
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:253
 #: ../superdesk-planning/client/constants/events.ts:175
 msgid "All Events"
-msgstr ""
+msgstr "Сви догађаји"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:241
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:97
 msgid "All Events & Planning"
-msgstr ""
+msgstr "Сви догађаји и планирање"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:173
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:270
 msgid "All Planning Items"
-msgstr ""
+msgstr "Све ставке планирања"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:180
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:215
@@ -1563,7 +1563,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:122
 msgid "All featured planning items are currently selected"
-msgstr ""
+msgstr "Све истакнуте ставке планирања су тренутно изабране"
 
 #: scripts/core/menu/notifications/views/notifications.html:12
 msgid "All good so far"
@@ -1771,7 +1771,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/agenda.ts:47
 msgid "An agenda with this name already exists"
-msgstr ""
+msgstr "Агенда са овим називом већ постоји"
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:84
 msgid "An error occured when testing config."
@@ -2030,7 +2030,7 @@ msgstr "Да ли сте сигурни да желите да обришете 
 #: ../superdesk-planning/client/actions/events/ui.ts:1028
 #: ../superdesk-planning/client/actions/events/ui.ts:995
 msgid "Are you sure you want to mark this event as complete?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да означите овај догађај као завршен?"
 
 #: scripts/apps/archive/index.tsx:498
 msgid "Are you sure you want to spike the item?"
@@ -2128,7 +2128,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/multiSelect.ts:236
 msgid "Article was created."
-msgstr ""
+msgstr "Чланак је креиран."
 
 #: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:49
 msgid "Article {{slug}} is already marked for this highlight"
@@ -2348,7 +2348,7 @@ msgstr "Додељени дескови"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:74
 msgid "Assigned to agenda '{{ agenda }}'"
-msgstr ""
+msgstr "Додељено агенди '{{ agenda }}'"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:25
 msgid "Assigned to provider"
@@ -2356,7 +2356,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:195
 msgid "Assigned to:"
-msgstr ""
+msgstr "Додељено:"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:114
 msgid "Assigned:"
@@ -2384,7 +2384,7 @@ msgstr ""
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:8
 #: scripts/apps/search/views/item-preview.html:24
 msgid "Assignment"
-msgstr ""
+msgstr "Задатак"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:243
 #: ../superdesk-planning/client/components/fields/editor/AssignmentPriority.tsx:28
@@ -2393,7 +2393,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:192
 msgid "Assignment does not exist"
-msgstr ""
+msgstr "Задатак не постоји"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:50
 msgid "Assignment for"
@@ -2429,7 +2429,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:464
 msgid "Assignment priority has been updated."
-msgstr ""
+msgstr "Приоритет задатка је ажуриран."
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:97
 msgid "Assignment removed"
@@ -2437,7 +2437,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/assignments/api.ts:362
 msgid "Assignment reverted."
-msgstr ""
+msgstr "Задатак враћен."
 
 #: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:78
 #: ../superdesk-planning/client/components/Assignments/SubNavBar.tsx:62
@@ -2448,7 +2448,7 @@ msgstr ""
 #: ../superdesk-planning/index.ts:21 scripts/apps/master-desk/MasterDesk.tsx:40
 #: scripts/apps/production-api-keys/config.ts:29
 msgid "Assignments"
-msgstr ""
+msgstr "Задаци"
 
 #: ../superdesk-planning/client/apps/Assignments/AssignmentsUi.tsx:14
 #: ../superdesk-planning/client/apps/Assignments/FulfilAssignmentUi.tsx:14
@@ -2470,7 +2470,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/index.tsx:210
 #: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:233
 msgid "Associated Events"
-msgstr ""
+msgstr "Повезани догађаји"
 
 #: scripts/apps/search/constants.ts:19
 msgid "Associated Feature Media"
@@ -2482,7 +2482,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:94
 msgid "Associated an event"
-msgstr ""
+msgstr "Повезан догађај"
 
 #: scripts/apps/publish/views/ftp-config.html:38
 msgid "Associated/featuremedia path"
@@ -2518,12 +2518,12 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/EventAttachments.tsx:100
 #: ../superdesk-planning/client/components/fields/resources/common.tsx:60
 msgid "Attached Files"
-msgstr ""
+msgstr "Приложене датотеке"
 
 #: ../superdesk-planning/client/components/Coverages/CoveragePreview/index.tsx:165
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:104
 msgid "Attached files"
-msgstr ""
+msgstr "Приложене датотеке"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:43
 #: scripts/core/editor3/components/links/LinkInput.tsx:72
@@ -2700,7 +2700,7 @@ msgstr "Доступни језици"
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningList.tsx:92
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:167
 msgid "Available selections"
-msgstr ""
+msgstr "Доступни избори"
 
 #: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:279
 #: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:30
@@ -2975,7 +2975,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/events/ui.ts:922
 msgid "Calendar assigned to the event"
-msgstr ""
+msgstr "Календар додељен догађају"
 
 #: ../superdesk-planning/client/components/fields/calendars.tsx:52
 msgid "Calendar:"
@@ -2995,7 +2995,7 @@ msgstr ""
 #: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx:96
 #: ../superdesk-planning/client/utils/contentProfiles.ts:277
 msgid "Calendars"
-msgstr ""
+msgstr "Календари"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:89
 #: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:89
@@ -3268,15 +3268,15 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/main.ts:905
 msgid "Cannot load more data as filter type is not selected."
-msgstr ""
+msgstr "Није могуће учитати више података јер тип филтера није изабран."
 
 #: ../superdesk-planning/client/actions/main.ts:926
 msgid "Cannot load more data. Failed to run the query."
-msgstr ""
+msgstr "Није могуће учитати више података. Извршавање упита није успело."
 
 #: ../superdesk-planning/client/actions/main.ts:947
 msgid "Cannot search as filter type is not selected."
-msgstr ""
+msgstr "Није могуће претраживати јер тип филтера није изабран."
 
 #: scripts/apps/archive/views/metadata-associateditem-view.html:7
 #: scripts/core/editor3/components/media/MediaBlock.tsx:317
@@ -3346,7 +3346,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:167
 msgid "Change view"
-msgstr ""
+msgstr "Промени приказ"
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/controllers/FeaturemediaUpdatesReportController.js:143
 #: ../superdesk-analytics/client/featuremedia_updates_report/directives/FeaturemediaUpdatesReportPreview.js:21
@@ -3835,7 +3835,7 @@ msgstr "Компактан приказ"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:102
 msgid "Compact list"
-msgstr ""
+msgstr "Компактна листа"
 
 #: scripts/apps/search/constants.ts:16
 #: scripts/apps/workspace/content/constants.ts:18
@@ -3981,7 +3981,7 @@ msgstr "Стринг везе"
 
 #: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/contact/index.tsx:23
 msgid "Contact"
-msgstr ""
+msgstr "Контакт"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:220
 #: scripts/apps/contacts/constants.ts:72
@@ -4001,7 +4001,7 @@ msgstr "Тип контакта \"{{ contact_type }}\" МОРА имати им�
 #: ../superdesk-planning/client/utils/contentProfiles.ts:333
 #: scripts/apps/production-api-keys/config.ts:26
 msgid "Contacts"
-msgstr ""
+msgstr "Контакти"
 
 #: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:52
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:91
@@ -4135,7 +4135,7 @@ msgstr "Ток садржаја"
 
 #: ../superdesk-planning/client/actions/assignments/api.ts:265
 msgid "Content items not found!"
-msgstr ""
+msgstr "Ставке садржаја нису пронађене!"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:75
 msgid "Content linked"
@@ -4341,27 +4341,27 @@ msgstr "Није могуће учитати наслов"
 #: ../superdesk-planning/client/actions/events/ui.ts:1039
 #: ../superdesk-planning/client/actions/events/ui.ts:895
 msgid "Could not obtain lock on the event."
-msgstr ""
+msgstr "Није могуће закључати догађај."
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:245
 msgid "Could not obtain lock on the planning item."
-msgstr ""
+msgstr "Није могуће закључати ставку планирања."
 
 #: ../superdesk-planning/client/components/editor-standalone/authoring-storage-event-http.ts:51
 msgid "Could not save event"
-msgstr ""
+msgstr "Догађај није могао бити сачуван"
 
 #: ../superdesk-planning/client/actions/main.ts:1654
 msgid "Could not save the item."
-msgstr ""
+msgstr "Ставка није могла бити сачувана."
 
 #: ../superdesk-planning/client/actions/assignments/api.ts:364
 msgid "Could not unlock the assignment."
-msgstr ""
+msgstr "Задатак није могао бити откључан."
 
 #: ../superdesk-planning/client/actions/main.ts:1650
 msgid "Could not unlock the item."
-msgstr ""
+msgstr "Ставка није могла бити откључана."
 
 #: scripts/apps/highlights/services/HighlightsService.ts:126
 msgid "Couldn't mark item"
@@ -4504,7 +4504,7 @@ msgstr ""
 #: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/coverages/index.tsx:27
 #: ../superdesk-planning/client/utils/contentProfiles.ts:317
 msgid "Coverages"
-msgstr ""
+msgstr "Извештавања"
 
 #: ../superdesk-planning/client/api/planning.ts:299
 msgid "Coverages added to workflow."
@@ -4538,7 +4538,7 @@ msgstr "Креирај"
 
 #: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:420
 msgid "Create & Post"
-msgstr ""
+msgstr "Креирај и објави"
 
 #: scripts/apps/archive/index.tsx:246
 msgid "Create Broadcast"
@@ -4645,12 +4645,12 @@ msgstr "Креирај нову ставку"
 
 #: ../superdesk-planning/client/components/Main/ListPanel.tsx:344
 msgid "Create new items or change your search filters"
-msgstr ""
+msgstr "Креирајте нове ставке или промените филтере претраге"
 
 #: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:109
 #: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:113
 msgid "Create new planning item"
-msgstr ""
+msgstr "Креирај нову ставку планирања"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:18
 #: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:18
@@ -4799,11 +4799,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:37
 msgid "Created from content"
-msgstr ""
+msgstr "Креирано из садржаја"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:32
 msgid "Created from event"
-msgstr ""
+msgstr "Креирано из догађаја"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:127
 msgid "Created from highlight"
@@ -4911,7 +4911,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:181
 msgid "Currently Selected"
-msgstr ""
+msgstr "Тренутно изабрано"
 
 #: scripts/apps/search/views/multi-image-edit.html:93
 msgid "Currently editing: {{getSelectedItemsLength()}} items"
@@ -4919,7 +4919,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningSelectedList.tsx:23
 msgid "Currently selected"
-msgstr ""
+msgstr "Тренутно изабрано"
 
 #: scripts/core/upload/image-crop-directive.ts:254
 msgid "Currently the image size is {{width}}x{{height}})."
@@ -4968,7 +4968,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Main/CalendarNavigation.tsx:46
 msgid "D"
-msgstr ""
+msgstr "D"
 
 #: scripts/apps/workspace/views/workspace-dropdown.html:11
 msgid "DESKS"
@@ -5047,7 +5047,7 @@ msgstr ""
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:177
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:91
 msgid "Date Created"
-msgstr ""
+msgstr "Датум креирања"
 
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:2
 #: ../superdesk-planning/client/components/fields/preview/index.ts:142
@@ -5066,7 +5066,7 @@ msgstr ""
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:180
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:94
 msgid "Date Updated"
-msgstr ""
+msgstr "Датум ажурирања"
 
 #: scripts/apps/search/directives/DateFilters.ts:76
 msgid "Date created"
@@ -5087,7 +5087,7 @@ msgstr ""
 #: ../superdesk-planning/client/apps/Planning/SubNavDatePicker.tsx:71
 #: ../superdesk-planning/client/components/UI/Form/DateInput/index.tsx:209
 msgid "Date picker"
-msgstr ""
+msgstr "Бирач датума"
 
 #: scripts/apps/search/constants.ts:21
 #: scripts/apps/search/directives/DateFilters.ts:92
@@ -5148,7 +5148,7 @@ msgstr ""
 #: scripts/extensions/availability-manager/src/constants.ts:42
 #: scripts/extensions/availability-manager/src/correspondent-availability/filters.tsx:128
 msgid "Day"
-msgstr ""
+msgstr "Дан"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:29
 msgid "Day of the Month"
@@ -5745,11 +5745,11 @@ msgstr "Онемогућено"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:216
 msgid "Disabled Agendas"
-msgstr ""
+msgstr "Онемогућене агенде"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:158
 msgid "Disabled Calendars"
-msgstr ""
+msgstr "Онемогућени календари"
 
 #: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:77
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:77
@@ -5829,7 +5829,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/locations.ts:66
 msgid "Do you want to delete the location \"{{ name }}\"?"
-msgstr ""
+msgstr "Желите ли да обришете локацију \"{{ name }}\"?"
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:391
 msgid "Do you want to deschedule articles?"
@@ -5856,11 +5856,11 @@ msgstr "Да ли желите да ресетујете лозинку за к�
 
 #: ../superdesk-planning/client/actions/multiSelect.ts:128
 msgid "Do you want to spike  item(s) ?"
-msgstr ""
+msgstr "Желите ли да преместите ставку(е) у корпу?"
 
 #: ../superdesk-planning/client/actions/multiSelect.ts:148
 msgid "Do you want to unspike  item(s) ?"
-msgstr ""
+msgstr "Желите ли да вратите ставку(е) из корпе?"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:122
 #: scripts/extensions/sams/dist/src/utils/assets.js:122
@@ -6113,7 +6113,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:96
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:78
 msgid "Duplicate created"
-msgstr ""
+msgstr "Дупликат креиран"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:171
 #: scripts/apps/authoring/versioning/history/views/history.html:52
@@ -6135,7 +6135,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:100
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:82
 msgid "Duplicated"
-msgstr ""
+msgstr "Дуплирано"
 
 #: ../superdesk-analytics/client/utils.js:152
 msgid "Duplicated From"
@@ -6216,7 +6216,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/resources/common.tsx:16
 #: scripts/apps/archive/views/metadata-associateditem-view.html:19
 msgid "Ed Note"
-msgstr ""
+msgstr "Уредничка напомена"
 
 #: scripts/apps/authoring-react/field-adapters/ednote.ts:20
 #: scripts/apps/workspace/content/constants.ts:24
@@ -6383,7 +6383,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:148
 msgid "Edit Planning"
-msgstr ""
+msgstr "Уреди планирање"
 
 #: ../superdesk-planning/client/constants/assignments.ts:194
 msgid "Edit Priority"
@@ -6507,7 +6507,7 @@ msgstr ""
 #: ../superdesk-planning/client/constants/planning.ts:142
 #: ../superdesk-planning/client/constants/tooltips.ts:32
 msgid "Edit in popup"
-msgstr ""
+msgstr "Уреди у искачућем прозору"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:374
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:374
@@ -6577,7 +6577,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:27
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:41
 msgid "Edited"
-msgstr ""
+msgstr "Уређено"
 
 #: scripts/apps/workspace/content/views/profile-settings.html:138
 msgid "Editing"
@@ -7109,7 +7109,7 @@ msgstr ""
 #: scripts/extensions/auto-tagging-widget/dist/src/groups.js:17
 #: scripts/extensions/auto-tagging-widget/src/groups.ts:25
 msgid "Event"
-msgstr ""
+msgstr "Догађај"
 
 #: ../superdesk-planning/client/utils/events.tsx:479
 msgid "Event \"{{name}}\" is already added as related"
@@ -7118,7 +7118,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:43
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:57
 msgid "Event Cancelled"
-msgstr ""
+msgstr "Догађај отказан"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:59
 msgid "Event Cancelled:"
@@ -7129,20 +7129,20 @@ msgstr ""
 #: ../superdesk-planning/client/components/StateLabel/index.tsx:61
 #: ../superdesk-planning/client/components/fields/state.tsx:45
 msgid "Event Completed"
-msgstr ""
+msgstr "Догађај завршен"
 
 #: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/event-dates/index.tsx:23
 msgid "Event Date"
-msgstr ""
+msgstr "Датум догађаја"
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/event-dates.ts:18
 msgid "Event Dates"
-msgstr ""
+msgstr "Датуми догађаја"
 
 #: ../superdesk-planning/client/components/Main/ItemEditor/Editor.tsx:187
 #: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:126
 msgid "Event Details"
-msgstr ""
+msgstr "Детаљи догађаја"
 
 #: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:225
 msgid "Event Ends"
@@ -7159,7 +7159,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:47
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:65
 msgid "Event Postponed"
-msgstr ""
+msgstr "Догађај одложен"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:41
 msgid "Event Postponed:"
@@ -7168,7 +7168,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:39
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:53
 msgid "Event Rescheduled"
-msgstr ""
+msgstr "Догађај поново заказан"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:51
 msgid "Event Rescheduled from"
@@ -7188,15 +7188,15 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/events/ui.ts:136
 msgid "Event has been cancelled"
-msgstr ""
+msgstr "Догађај је отказан"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:151
 msgid "Event has been postponed"
-msgstr ""
+msgstr "Догађај је одложен"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:324
 msgid "Event has been rescheduled"
-msgstr ""
+msgstr "Догађај је поново заказан"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:77
 msgid "Event has to be created before adding related plannings"
@@ -7208,7 +7208,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/events/ui.ts:522
 msgid "Event repetitions updated"
-msgstr ""
+msgstr "Понављања догађаја ажурирана"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:31
 msgid "Event spiked"
@@ -7216,7 +7216,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/events/ui.ts:507
 msgid "Event time has been updated"
-msgstr ""
+msgstr "Време догађаја је ажурирано"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:76
 msgid "Event time modified"
@@ -7248,16 +7248,16 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Main/FiltersBox.tsx:39
 msgid "Events & Planning"
-msgstr ""
+msgstr "Догађаји и планирање"
 
 #: ../superdesk-planning/client/apps/Planning/AddToPlanningUi.tsx:34
 #: ../superdesk-planning/client/apps/Planning/PlanningUi.tsx:21
 msgid "Events and Planning content"
-msgstr ""
+msgstr "Садржај догађаја и планирања"
 
 #: ../superdesk-planning/client/components/Main/FiltersBox.tsx:45
 msgid "Events only"
-msgstr ""
+msgstr "Само догађаји"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:101
 msgid "Every"
@@ -7447,7 +7447,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Events/EventEditor/index.tsx:172
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:61
 msgid "External Reference"
-msgstr ""
+msgstr "Спољна референца"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:82
 msgid "Eye Open"
@@ -7484,7 +7484,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/events/ui.ts:923
 msgid "Failed to add Calendar to the Event"
-msgstr ""
+msgstr "Додавање календара у догађај није успело"
 
 #: ../superdesk-planning/client/api/planning.ts:306
 msgid "Failed to add coverages to workflow"
@@ -7493,7 +7493,7 @@ msgstr ""
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:328
 #: ../superdesk-planning/client/actions/planning/ui.ts:369
 msgid "Failed to add planning item added as featured story"
-msgstr ""
+msgstr "Додавање ставке планирања као истакнуте приче није успело"
 
 #: scripts/apps/archive/directives/ArchivedItemKill.ts:33
 #: scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.ts:97
@@ -7506,15 +7506,15 @@ msgstr "Повезивање ажурирања није успело: {{message
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:307
 msgid "Failed to cancel all coverage!"
-msgstr ""
+msgstr "Отказивање свих извештавања није успело!"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:140
 msgid "Failed to cancel the Event!"
-msgstr ""
+msgstr "Отказивање догађаја није успело!"
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:289
 msgid "Failed to cancel the Planning Item!"
-msgstr ""
+msgstr "Отказивање ставке планирања није успело!"
 
 #: scripts/core/auth/login-modal-directive.ts:80
 msgid "Failed to change the password."
@@ -7526,7 +7526,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:710
 msgid "Failed to create an archive item."
-msgstr ""
+msgstr "Креирање архивске ставке није успело."
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsModal.js:102
 msgid "Failed to create the Report Schedule!"
@@ -7544,7 +7544,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:197
 msgid "Failed to create/update Events and Planning view filter"
-msgstr ""
+msgstr "Креирање/ажурирање филтера приказа догађаја и планирања није успело"
 
 #: scripts/extensions/sams/dist/src/api/assets.js:449
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:449
@@ -7581,7 +7581,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:239
 msgid "Failed to fetch all filters"
-msgstr ""
+msgstr "Преузимање свих филтера није успело"
 
 #: ../superdesk-planning/client/controllers/AssignmentPreviewController.tsx:107
 #: ../superdesk-planning/client/controllers/AssignmentPreviewController.tsx:73
@@ -7590,7 +7590,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:242
 msgid "Failed to fetch featured stories!"
-msgstr ""
+msgstr "Преузимање истакнутих прича није успело!"
 
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:72
 msgid "Failed to fetch item from archive"
@@ -7598,7 +7598,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:633
 msgid "Failed to fetch planning item."
-msgstr ""
+msgstr "Преузимање ставке планирања није успело."
 
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:115
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:65
@@ -7658,11 +7658,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/autosave.ts:76
 msgid "Failed to get the autosave entry"
-msgstr ""
+msgstr "Преузимање ставке аутоматског чувања није успело"
 
 #: ../superdesk-planning/client/actions/main.ts:1528
 msgid "Failed to get the queue item"
-msgstr ""
+msgstr "Преузимање ставке из реда није успело"
 
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:254
 msgid "Failed to link to requested assignment!"
@@ -7682,7 +7682,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/events/ui.ts:352
 msgid "Failed to load duplicated Event."
-msgstr ""
+msgstr "Учитавање дуплираног догађаја није успело."
 
 #: ../superdesk-planning/client/api/locks.ts:80
 msgid "Failed to load item locks"
@@ -7703,12 +7703,12 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/autosave.ts:32
 msgid "Failed to load {{ itemType }} autosaves."
-msgstr ""
+msgstr "Учитавање аутоматских чувања {{ itemType }} није успело."
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:277
 #: ../superdesk-planning/client/actions/planning/ui.ts:330
 msgid "Failed to lock featured story action!"
-msgstr ""
+msgstr "Закључавање радње истакнуте приче није успело!"
 
 #: ../superdesk-planning/client/api/locks.ts:226
 msgid "Failed to lock item"
@@ -7726,15 +7726,15 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/main.ts:485
 msgid "Failed to post the {{ itemType }}"
-msgstr ""
+msgstr "Објављивање {{ itemType }} није успело"
 
 #: ../superdesk-planning/client/actions/main.ts:447
 msgid "Failed to post, could not find the item type!"
-msgstr ""
+msgstr "Објављивање није успело, тип ставке није пронађен!"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:155
 msgid "Failed to postpone the Event!"
-msgstr ""
+msgstr "Одлагање догађаја није успело!"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/publish-and-continue.tsx:25
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:671
@@ -7749,7 +7749,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/autosave.ts:199
 msgid "Failed to remove autosave. Not found"
-msgstr ""
+msgstr "Уклањање аутоматског чувања није успело. Није пронађено"
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:279
 msgid "Failed to remove link: {{message}}"
@@ -7758,27 +7758,27 @@ msgstr ""
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:327
 #: ../superdesk-planning/client/actions/planning/ui.ts:368
 msgid "Failed to remove planning item as featured story"
-msgstr ""
+msgstr "Уклањање ставке планирања као истакнуте приче није успело"
 
 #: ../superdesk-planning/client/actions/events/api.ts:762
 msgid "Failed to remove the file from event."
-msgstr ""
+msgstr "Уклањање датотеке из догађаја није успело."
 
 #: ../superdesk-planning/client/actions/planning/api.ts:728
 msgid "Failed to remove the file from planning."
-msgstr ""
+msgstr "Уклањање датотеке из планирања није успело."
 
 #: ../superdesk-planning/client/actions/events/ui.ts:365
 msgid "Failed to reschedule the Event!"
-msgstr ""
+msgstr "Поновно заказивање догађаја није успело!"
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:544
 msgid "Failed to revert the assignment."
-msgstr ""
+msgstr "Враћање задатка није успело."
 
 #: ../superdesk-planning/client/actions/main.ts:896
 msgid "Failed to run the query"
-msgstr ""
+msgstr "Извршавање упита није успело"
 
 #: scripts/apps/contacts/directives/ContactsSearchResultsDirective.ts:80
 #: scripts/apps/content-api/directives/ContentAPISearchResultsDirective.ts:77
@@ -7788,15 +7788,15 @@ msgstr "Извршавање упита није успело!"
 
 #: ../superdesk-planning/client/actions/main.ts:986
 msgid "Failed to run the query.."
-msgstr ""
+msgstr "Извршавање упита није успело.."
 
 #: ../superdesk-planning/client/actions/autosave.ts:141
 msgid "Failed to save autosave item."
-msgstr ""
+msgstr "Чување ставке аутоматског чувања није успело."
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:357
 msgid "Failed to save featured story record!"
-msgstr ""
+msgstr "Чување записа истакнуте приче није успело!"
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:169
 msgid "Failed to save report"
@@ -7824,11 +7824,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:469
 msgid "Failed to save the assignment."
-msgstr ""
+msgstr "Чување задатка није успело."
 
 #: ../superdesk-planning/client/actions/events/api.ts:833
 msgid "Failed to save the event template"
-msgstr ""
+msgstr "Чување шаблона догађаја није успело"
 
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:190
 #: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:135
@@ -7837,11 +7837,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/main.ts:351
 msgid "Failed to save the {{itemType}}!"
-msgstr ""
+msgstr "Чување {{itemType}} није успело!"
 
 #: ../superdesk-planning/client/actions/main.ts:293
 msgid "Failed to save, could not find the item {{itemType}}!"
-msgstr ""
+msgstr "Чување није успело, ставка типа {{itemType}} није пронађена!"
 
 #: ../superdesk-analytics/client/email_report/services/EmailReportService.js:69
 msgid "Failed to send report email!"
@@ -7850,7 +7850,7 @@ msgstr ""
 #: ../superdesk-planning/client/actions/events/ui.ts:69
 #: ../superdesk-planning/client/actions/events/ui.ts:86
 msgid "Failed to spike the event(s)"
-msgstr ""
+msgstr "Премештање догађаја у корпу није успело"
 
 #: ../superdesk-planning/client/api/locks.ts:354
 #: ../superdesk-planning/client/api/locks.ts:396
@@ -7865,15 +7865,15 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/main.ts:408
 msgid "Failed to unpost the {{ itemType }}"
-msgstr ""
+msgstr "Поништавање објаве {{ itemType }} није успело"
 
 #: ../superdesk-planning/client/actions/main.ts:385
 msgid "Failed to unpost, could not find the item type!"
-msgstr ""
+msgstr "Поништавање објаве није успело, тип ставке није пронађен!"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:526
 msgid "Failed to update Event repetitions"
-msgstr ""
+msgstr "Ажурирање понављања догађаја није успело"
 
 #: scripts/extensions/sams/dist/src/api/assets.js:365
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:365
@@ -7893,7 +7893,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/events/ui.ts:511
 msgid "Failed to update the Event time!"
-msgstr ""
+msgstr "Ажурирање времена догађаја није успело!"
 
 #: scripts/extensions/sams/dist/src/api/sets.js:66
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:66
@@ -7953,7 +7953,7 @@ msgstr "Преглед нових функција"
 #: ../superdesk-planning/client/components/fields/editor/Featured.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:83
 msgid "Featured"
-msgstr ""
+msgstr "Истакнуто"
 
 #: scripts/apps/authoring/views/confirm-media-associated.html:8
 msgid "Featured Media"
@@ -7961,23 +7961,23 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:75
 msgid "Featured Stories"
-msgstr ""
+msgstr "Истакнуте приче"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:66
 msgid "Featured Stories Locked"
-msgstr ""
+msgstr "Истакнуте приче закључане"
 
 #: ../superdesk-planning/client/actions/planning/notifications.ts:383
 msgid "Featured Stories Unlocked"
-msgstr ""
+msgstr "Истакнуте приче откључане"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:133
 msgid "Featured Stories based on timezone: {{tz}}"
-msgstr ""
+msgstr "Истакнуте приче засноване на временској зони: {{tz}}"
 
 #: ../superdesk-planning/client/actions/planning/notifications.ts:384
 msgid "Featured stories you were managing was unlocked by"
-msgstr ""
+msgstr "Истакнуте приче којима сте управљали откључане су од стране"
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:20
 msgid "Featuremedia History"
@@ -8441,7 +8441,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:73
 #: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:84
 msgid "From template"
-msgstr ""
+msgstr "Из шаблона"
 
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:30
 msgid "From:"
@@ -8453,7 +8453,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:152
 msgid "Fulfil assignment"
-msgstr ""
+msgstr "Изврши задатак"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:160
 msgid "Full"
@@ -8700,7 +8700,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:155
 msgid "Group by day"
-msgstr ""
+msgstr "Групиши по дану"
 
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:326
 msgid "Groups"
@@ -8945,7 +8945,7 @@ msgstr "Управљање листом истицања/прегледа"
 #: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:92
 #: scripts/apps/authoring/versioning/versioning.ts:8
 msgid "History"
-msgstr ""
+msgstr "Историја"
 
 #: scripts/core/lang/missing-translations-strings.ts:18
 msgid "Hold"
@@ -9148,7 +9148,7 @@ msgstr "Увези корисника"
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/field-components/time-header-common.tsx:35
 msgid "In 1 hr"
-msgstr ""
+msgstr "За 1 ч"
 
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:104
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DateInputPopup.tsx:217
@@ -9158,7 +9158,7 @@ msgstr "За 2 дана"
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/field-components/time-header-common.tsx:46
 msgid "In 2 hr"
-msgstr ""
+msgstr "За 2 ч"
 
 #: scripts/apps/vocabularies/services/VocabularyService.ts:136
 msgid "In 3 days"
@@ -9166,7 +9166,7 @@ msgstr "За 3 дана"
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/field-components/time-header-common.tsx:24
 msgid "In 30 min"
-msgstr ""
+msgstr "За 30 мин"
 
 #: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:32
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/State.tsx:36
@@ -9374,7 +9374,7 @@ msgstr ""
 #: ../superdesk-planning/client/utils/index.ts:351
 #: scripts/apps/search/components/fields/state.tsx:31
 msgid "Ingested"
-msgstr ""
+msgstr "Примљено"
 
 #: scripts/extensions/datetimeField/dist/src/config.js:24
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:24
@@ -9416,7 +9416,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:181
 msgid "Insufficient privileges to view the assignment"
-msgstr ""
+msgstr "Недовољне привилегије за приказ задатка"
 
 #: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:166
 #: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:188
@@ -9443,7 +9443,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/resources/common.tsx:27
 #: ../superdesk-planning/client/utils/contentProfiles.ts:293
 msgid "Internal Note"
-msgstr ""
+msgstr "Интерна напомена"
 
 #: ../superdesk-planning/client/components/InternalNoteLabel/index.tsx:83
 msgid "Internal Note:"
@@ -9483,7 +9483,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/resources/events.ts:86
 #: ../superdesk-planning/client/utils/contentProfiles.ts:343
 msgid "Invitation Details"
-msgstr ""
+msgstr "Детаљи позивнице"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:41
 msgid "Is Default"
@@ -9564,7 +9564,7 @@ msgstr ""
 #: ../superdesk-planning/client/controllers/FulfilAssignmentController.tsx:172
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:106
 msgid "Item Unlocked"
-msgstr ""
+msgstr "Ставка откључана"
 
 #: scripts/apps/search/components/Item.tsx:44
 #: scripts/core/ui/components/article-item-concise.tsx:78
@@ -9660,7 +9660,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:205
 #: scripts/apps/search/views/item-preview.html:2
 msgid "Item preview"
-msgstr ""
+msgstr "Преглед ставке"
 
 #: scripts/api/article.ts:380
 msgid "Item published."
@@ -9766,7 +9766,7 @@ msgstr "Назив посла"
 #: ../superdesk-planning/client/components/Main/JumpToDropdown.tsx:61
 #: ../superdesk-planning/client/components/Main/JumpToDropdown.tsx:67
 msgid "Jump to specific date"
-msgstr ""
+msgstr "Скочи на одређени датум"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/kill-action.tsx:9
 #: scripts/apps/authoring/views/authoring-topbar.html:158
@@ -10083,7 +10083,7 @@ msgstr "Линк је послат. Проверите своје сандуче
 #: ../superdesk-planning/client/planning-extension/src/extension.ts:204
 #: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:172
 msgid "Link to Assignment"
-msgstr ""
+msgstr "Линк до задатка"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:131
 msgid "Linked by"
@@ -10110,11 +10110,11 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/resources/events.ts:53
 #: ../superdesk-planning/client/utils/contentProfiles.ts:299
 msgid "Links"
-msgstr ""
+msgstr "Линкови"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:78
 msgid "List"
-msgstr ""
+msgstr "Листа"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:123
 msgid "List Alternate"
@@ -10215,7 +10215,7 @@ msgstr "Лоцирано"
 #: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/location/index.tsx:25
 #: ../superdesk-planning/client/utils/contentProfiles.ts:283
 msgid "Location"
-msgstr ""
+msgstr "Локација"
 
 #: ../superdesk-planning/client/components/fields/editor/Location.tsx:62
 msgid "Location Details"
@@ -10292,7 +10292,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Main/CalendarNavigation.tsx:66
 msgid "M"
-msgstr ""
+msgstr "M"
 
 #: scripts/apps/authoring/views/authoring-header.html:72
 msgid "MASTER"
@@ -10362,31 +10362,31 @@ msgstr ""
 #: ../superdesk-planning/client/components/Agendas/ManageAgendasModal.tsx:67
 #: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:22
 msgid "Manage Agendas"
-msgstr ""
+msgstr "Управљај агендама"
 
 #: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:211
 #: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:34
 msgid "Manage Coverage Profiles"
-msgstr ""
+msgstr "Управљај профилима извештавања"
 
 #: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:96
 #: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:66
 msgid "Manage Custom Layouts"
-msgstr ""
+msgstr "Управљај прилагођеним распоредима"
 
 #: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:59
 msgid "Manage Event & Planning Filters"
-msgstr ""
+msgstr "Управљај филтерима догађаја и планирања"
 
 #: ../superdesk-planning/client/api/contentProfiles.ts:210
 #: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:43
 msgid "Manage Event Profile"
-msgstr ""
+msgstr "Управљај профилом догађаја"
 
 #: ../superdesk-planning/client/components/Events/ManageEventTemplatesModal.tsx:96
 #: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:50
 msgid "Manage Event Templates"
-msgstr ""
+msgstr "Управљај шаблонима догађаја"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:202
 msgid "Manage Events & Planning Filters"
@@ -10403,7 +10403,7 @@ msgstr ""
 #: ../superdesk-planning/client/api/contentProfiles.ts:183
 #: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:29
 msgid "Manage Planning Profile"
-msgstr ""
+msgstr "Управљај профилом планирања"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:144
 #: scripts/extensions/broadcasting/dist/src/page.js:148
@@ -10720,7 +10720,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:485
 #: ../superdesk-planning/client/constants/tooltips.ts:33
 msgid "Minimise"
-msgstr ""
+msgstr "Умањи"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/minimize-button.tsx:12
 #: scripts/apps/authoring/views/authoring-topbar.html:248
@@ -10838,7 +10838,7 @@ msgstr "Подешавања мониторинга"
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:163
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:83
 msgid "Month"
-msgstr ""
+msgstr "Месец"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:32
 msgid "Month(s)"
@@ -11005,17 +11005,17 @@ msgstr ""
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:115
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:254
 msgid "My Events"
-msgstr ""
+msgstr "Моји догађаји"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:242
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:98
 msgid "My Events & Planning"
-msgstr ""
+msgstr "Моји догађаји и планирање"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:174
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:271
 msgid "My Planning"
-msgstr ""
+msgstr "Моје планирање"
 
 #: scripts/apps/users/index.ts:89
 msgid "My Profile"
@@ -11239,7 +11239,7 @@ msgstr "Не"
 #: ../superdesk-planning/client/components/fields/editor/NoAgendaAssigned.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:121
 msgid "No Agenda Assigned"
-msgstr ""
+msgstr "Није додељена агенда"
 
 #: ../superdesk-planning/client/components/Agendas/AgendaNameList.tsx:14
 msgid "No Agenda Assigned."
@@ -11256,7 +11256,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/NoCalendarAssigned.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:125
 msgid "No Calendar Assigned"
-msgstr ""
+msgstr "Није додељен календар"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:337
 msgid "No Content Linking"
@@ -11280,7 +11280,7 @@ msgstr "Нема деска"
 
 #: ../superdesk-planning/client/components/Main/ListPanel.tsx:343
 msgid "No Event or Planning items found"
-msgstr ""
+msgstr "Нису пронађене ставке догађаја ни планирања"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:7
 msgid "No Fetch actions defined"
@@ -11321,7 +11321,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:227
 #: ../superdesk-planning/client/components/UI/FileReadOnlyList.tsx:65
 msgid "No attached files added."
-msgstr ""
+msgstr "Нису додате приложене датотеке."
 
 #: scripts/apps/desks/directives/MarkDesksDropdown.ts:25
 #: scripts/apps/desks/views/mark_desks_dropdown_directive.html:8
@@ -11347,7 +11347,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:123
 msgid "No available selections"
-msgstr ""
+msgstr "Нема доступних избора"
 
 #: scripts/apps/desks/directives/MarkDesksDropdown.ts:26
 #: scripts/apps/search/components/actions-menu/Item.tsx:169
@@ -11474,7 +11474,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/multiSelect.ts:208
 msgid "No items selected."
-msgstr ""
+msgstr "Нема изабраних ставки."
 
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:11
 #: scripts/apps/authoring/multiedit/views/sd-multiedit-inner-dropdown.html:10
@@ -11572,7 +11572,7 @@ msgstr "Још нису дефинисана правила"
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:180
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningSelectedList.tsx:25
 msgid "No selected featured stories"
-msgstr ""
+msgstr "Нема изабраних истакнутих прича"
 
 #: scripts/core/auth/login-modal.html:43
 #: scripts/core/auth/reset-password.html:33
@@ -11893,7 +11893,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/EventOccurenceStatus.tsx:30
 #: ../superdesk-planning/client/components/fields/preview/index.ts:175
 msgid "Occurrence Status"
-msgstr ""
+msgstr "Статус појаве"
 
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.js:74
 #: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx:82
@@ -12247,7 +12247,7 @@ msgstr "Остало"
 
 #: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:264
 msgid "Other Coverages"
-msgstr ""
+msgstr "Остала извештавања"
 
 #: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:100
 msgid "Other Names"
@@ -12436,7 +12436,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:642
 msgid "Parent coverage not linked to a news item yet."
-msgstr ""
+msgstr "Родитељско извештавање још није повезано са вешћу."
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:58
 #: scripts/extensions/availability-manager/dist/src/utils.js:58
@@ -12690,7 +12690,7 @@ msgstr "Планирање"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:61
 msgid "Planning Cancelled"
-msgstr ""
+msgstr "Планирање отказано"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikePlanningForm.tsx:49
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikePlanningForm.tsx:48
@@ -12699,14 +12699,14 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/preview/index.ts:180
 #: ../superdesk-planning/client/utils/contentProfiles.ts:303
 msgid "Planning Date"
-msgstr ""
+msgstr "Датум планирања"
 
 #: ../superdesk-planning/client/components/Main/ItemEditor/Editor.tsx:188
 #: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:127
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/planning-details-widget.js:25
 #: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:11
 msgid "Planning Details"
-msgstr ""
+msgstr "Детаљи планирања"
 
 #: ../superdesk-planning/client/api/contentProfiles.ts:185
 msgid "Planning Fields"
@@ -12715,11 +12715,11 @@ msgstr ""
 #: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:43
 #: ../superdesk-planning/client/utils/index.ts:583
 msgid "Planning Item"
-msgstr ""
+msgstr "Ставка планирања"
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:283
 msgid "Planning Item has been cancelled"
-msgstr ""
+msgstr "Ставка планирања је отказана"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:143
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:111
@@ -12747,7 +12747,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:56
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:69
 msgid "Planning cancelled"
-msgstr ""
+msgstr "Планирање отказано"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelPlanningCoveragesForm.tsx:142
 msgid "Planning cancelled:"
@@ -12759,12 +12759,12 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:256
 msgid "Planning duplicated"
-msgstr ""
+msgstr "Планирање дуплирано"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:321
 #: ../superdesk-planning/client/actions/planning/ui.ts:365
 msgid "Planning item added as featured story"
-msgstr ""
+msgstr "Ставка планирања додата као истакнута прича"
 
 #: ../superdesk-planning/client/utils/events.tsx:501
 msgid "Planning item already has one related event. Can not add more."
@@ -12781,11 +12781,11 @@ msgstr ""
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:320
 #: ../superdesk-planning/client/actions/planning/ui.ts:364
 msgid "Planning item removed as featured story"
-msgstr ""
+msgstr "Ставка планирања уклоњена као истакнута прича"
 
 #: ../superdesk-planning/client/components/Main/FiltersBox.tsx:51
 msgid "Planning only"
-msgstr ""
+msgstr "Само планирање"
 
 #: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:66
 msgid "Planning templates"
@@ -12935,7 +12935,7 @@ msgstr ""
 #: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.tsx:86
 #: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx:77
 msgid "Post Items"
-msgstr ""
+msgstr "Објави ставке"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:77
 msgid "Post all recurring events or just this one?"
@@ -12959,7 +12959,7 @@ msgstr "Послато"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:346
 msgid "Posted Featured Stories record"
-msgstr ""
+msgstr "Запис истакнутих прича објављен"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:104
 msgid "Postpone"
@@ -13074,7 +13074,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:661
 msgid "Previous scheduled update is not linked to a news item yet."
-msgstr ""
+msgstr "Претходно заказано ажурирање још није повезано са вешћу."
 
 #: scripts/apps/users/config.ts:157
 msgid "Previous user"
@@ -13758,7 +13758,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/resources/events.ts:64
 #: ../superdesk-planning/client/utils/contentProfiles.ts:341
 msgid "Registration Details"
-msgstr ""
+msgstr "Детаљи регистрације"
 
 #: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:163
 msgid "Reject"
@@ -14010,7 +14010,7 @@ msgstr "Уклони форматирање"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningItem.tsx:83
 msgid "Remove from Feature Stories"
-msgstr ""
+msgstr "Уклони из истакнутих прича"
 
 #: ../superdesk-planning/client/constants/planning.ts:146
 msgid "Remove from featured stories"
@@ -14069,7 +14069,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:86
 msgid "Removed from featured stories"
-msgstr ""
+msgstr "Уклоњено из истакнутих прича"
 
 #: scripts/apps/workspace/views/edit-workspace-modal.html:4
 msgid "Rename Workspace"
@@ -14127,7 +14127,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/EventRecurringRules.tsx:60
 #: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/recurring-rules/index.tsx:23
 msgid "Repeats"
-msgstr ""
+msgstr "Понавља се"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:88
 msgid "Repetitions updated"
@@ -14687,7 +14687,7 @@ msgstr "Сачувај и настави"
 #: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:137
 #: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:372
 msgid "Save & Post"
-msgstr ""
+msgstr "Сачувај и објави"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:64
 msgid "Save & Post Event"
@@ -14695,7 +14695,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:382
 msgid "Save & Unpost"
-msgstr ""
+msgstr "Сачувај и поништи објаву"
 
 #: scripts/apps/workspace/content/views/profile-settings.html:131
 msgid "Save &amp; Continue"
@@ -14773,51 +14773,51 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:340
 msgid "Save changes before adding to top stories ?"
-msgstr ""
+msgstr "Сачувати измене пре додавања у истакнуте приче?"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:289
 msgid "Save changes before adding to top stories?"
-msgstr ""
+msgstr "Сачувати измене пре додавања у истакнуте приче?"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:225
 msgid "Save changes before cancelling the Event?"
-msgstr ""
+msgstr "Сачувати измене пре отказивања догађаја?"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:956
 msgid "Save changes before creating a planning item ?"
-msgstr ""
+msgstr "Сачувати измене пре креирања ставке планирања?"
 
 #: ../superdesk-planning/client/components/Main/ItemEditor/EditorItemActions.tsx:106
 msgid "Save changes before creating a template?"
-msgstr ""
+msgstr "Сачувати измене пре креирања шаблона?"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:988
 msgid "Save changes before marking event as complete ?"
-msgstr ""
+msgstr "Сачувати измене пре означавања догађаја као завршеног?"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:249
 msgid "Save changes before postponing the Event?"
-msgstr ""
+msgstr "Сачувати измене пре одлагања догађаја?"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:272
 msgid "Save changes before rescheduling the Event?"
-msgstr ""
+msgstr "Сачувати измене пре поновног заказивања догађаја?"
 
 #: ../superdesk-planning/client/actions/main.ts:1578
 msgid "Save changes before spiking ?"
-msgstr ""
+msgstr "Сачувати измене пре премештања у корпу?"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:307
 msgid "Save changes before updating Event Repetitions?"
-msgstr ""
+msgstr "Сачувати измене пре ажурирања понављања догађаја?"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:202
 msgid "Save changes before updating the Event's time?"
-msgstr ""
+msgstr "Сачувати измене пре ажурирања времена догађаја?"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:402
 msgid "Save changes without re-posting?"
-msgstr ""
+msgstr "Сачувати измене без поновног објављивања?"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:112
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:169
@@ -14868,7 +14868,7 @@ msgstr "Сачувано"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:348
 msgid "Saved Featured Stories record"
-msgstr ""
+msgstr "Запис истакнутих прича сачуван"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:71
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:83
@@ -14964,7 +14964,7 @@ msgstr ""
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:174
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:88
 msgid "Scheduled Date"
-msgstr ""
+msgstr "Заказани датум"
 
 #: scripts/apps/workspace/content/constants.ts:70
 msgid "Scheduled Desk Output"
@@ -15116,7 +15116,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:86
 msgid "Search Filters"
-msgstr ""
+msgstr "Филтери претраге"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:444
 msgid "Search Genre"
@@ -15196,7 +15196,7 @@ msgstr ""
 #: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:116
 #: ../superdesk-planning/client/components/Main/SubNavBar.tsx:29
 msgid "Search planning"
-msgstr ""
+msgstr "Претражи планирање"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:217
 msgid "Search provider contacts"
@@ -15256,7 +15256,7 @@ msgstr "Изабери"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:277
 msgid "Select Agenda"
-msgstr ""
+msgstr "Изабери агенду"
 
 #: scripts/apps/search/views/multi-image-edit.html:25
 msgid "Select All"
@@ -15274,7 +15274,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:260
 msgid "Select Calendar"
-msgstr ""
+msgstr "Изабери календар"
 
 #: scripts/apps/vocabularies/components/drop-zone.tsx:76
 msgid "Select Files"
@@ -15479,7 +15479,7 @@ msgstr "Изабрани текст:"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:200
 msgid "Selections automatically removed"
-msgstr ""
+msgstr "Избори аутоматски уклоњени"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:39
 #: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:170
@@ -16081,7 +16081,7 @@ msgstr "Неки чланци нису успели да се откључају
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:42
 #: ../superdesk-planning/client/planning-extension/src/extension.ts:57
 msgid "Some items are linked to in-progress planning coverage."
-msgstr ""
+msgstr "Неке ставке су повезане са извештавањем планирања у току."
 
 #: scripts/api/article-send.tsx:135
 msgid ""
@@ -16090,13 +16090,13 @@ msgstr "Неки пакети садрже следеће објављене с�
 
 #: ../superdesk-planning/client/actions/main.ts:477
 msgid "Some related planning item post validation failed"
-msgstr ""
+msgstr "Провера објаве неких повезаних ставки планирања није успела"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:458
 msgid ""
 "Some selected items have not yet been posted. All selections must be visible "
 "to subscribers."
-msgstr ""
+msgstr "Неке изабране ставке још нису објављене. Сви избори морају бити видљиви претплатницима."
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:53
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:53
@@ -16169,7 +16169,7 @@ msgstr "Сортирај по"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:239
 msgid "Sort by:"
-msgstr ""
+msgstr "Сортирај по:"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:262
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:262
@@ -17067,7 +17067,7 @@ msgstr "Тип шаблона"
 
 #: ../superdesk-planning/client/actions/events/api.ts:842
 msgid "Template already exists. Do you want to overwrite it?"
-msgstr ""
+msgstr "Шаблон већ постоји. Желите ли да га замените?"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:93
 #: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:93
@@ -17139,79 +17139,79 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/agenda.ts:407
 msgid "The Agenda you were viewing was deleted!"
-msgstr ""
+msgstr "Агенда коју сте прегледали је обрисана!"
 
 #: ../superdesk-planning/client/actions/assignments/notifications.ts:22
 msgid "The Assignment you were viewing was removed."
-msgstr ""
+msgstr "Задатак који сте прегледали је уклоњен."
 
 #: ../superdesk-planning/client/actions/eventsPlanning/notifications.ts:39
 msgid "The Event and Planning filter you were viewing is deleted!"
-msgstr ""
+msgstr "Филтер догађаја и планирања који сте прегледали је обрисан!"
 
 #: ../superdesk-planning/client/actions/eventsPlanning/notifications.ts:16
 msgid "The Event and Planning filter you were viewing is modified!"
-msgstr ""
+msgstr "Филтер догађаја и планирања који сте прегледали је измењен!"
 
 #: ../superdesk-planning/client/actions/events/notifications.ts:123
 msgid "The Event was spiked"
-msgstr ""
+msgstr "Догађај је премештен у корпу"
 
 #: ../superdesk-planning/client/actions/events/notifications.ts:152
 msgid "The Event was unspiked"
-msgstr ""
+msgstr "Догађај је враћен из корпе"
 
 #: ../superdesk-planning/client/actions/main.ts:1410
 msgid "The Event you were editing was unlocked"
-msgstr ""
+msgstr "Догађај који сте уређивали је откључан"
 
 #: ../superdesk-planning/client/actions/main.ts:1405
 msgid "The Event you were editing was unlocked by \"{{ userName }}\""
-msgstr ""
+msgstr "Догађај који сте уређивали откључао је \"{{ userName }}\""
 
 #: ../superdesk-planning/client/actions/main.ts:1399
 msgid "The Event you were editing was updated via ingest"
-msgstr ""
+msgstr "Догађај који сте уређивали ажуриран је преко пријема"
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:214
 msgid "The Events and Planning view filter is deleted."
-msgstr ""
+msgstr "Филтер приказа догађаја и планирања је обрисан."
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:187
 msgid "The Events and Planning view filter is {{action}}."
-msgstr ""
+msgstr "Филтер приказа догађаја и планирања је {{action}}."
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:196
 msgid "The Events and Planning view filter with this name already exists"
-msgstr ""
+msgstr "Филтер приказа догађаја и планирања са овим називом већ постоји"
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:37
 msgid "The Planning Item(s) has been spiked."
-msgstr ""
+msgstr "Ставка(е) планирања је(су) премештена(е) у корпу."
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:59
 msgid "The Planning Item(s) has been unspiked."
-msgstr ""
+msgstr "Ставка(е) планирања је(су) враћена(е) из корпе."
 
 #: ../superdesk-planning/client/actions/planning/notifications.ts:218
 msgid "The Planning item was spiked"
-msgstr ""
+msgstr "Ставка планирања је премештена у корпу"
 
 #: ../superdesk-planning/client/actions/planning/notifications.ts:251
 msgid "The Planning item was unspiked"
-msgstr ""
+msgstr "Ставка планирања је враћена из корпе"
 
 #: ../superdesk-planning/client/actions/main.ts:1411
 msgid "The Planning item you were editing was unlocked"
-msgstr ""
+msgstr "Ставка планирања коју сте уређивали је откључана"
 
 #: ../superdesk-planning/client/actions/main.ts:1406
 msgid "The Planning item you were editing was unlocked by \"{{ userName }}\""
-msgstr ""
+msgstr "Ставку планирања коју сте уређивали откључао је \"{{ userName }}\""
 
 #: ../superdesk-planning/client/actions/main.ts:1400
 msgid "The Planning item you were editing was updated via ingest"
-msgstr ""
+msgstr "Ставка планирања коју сте уређивали ажурирана је преко пријема"
 
 #: scripts/apps/products/views/products-config-modal.html:31
 msgid ""
@@ -17254,11 +17254,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:541
 msgid "The assignment has been reverted."
-msgstr ""
+msgstr "Задатак је враћен."
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:463
 msgid "The assignment was reassigned."
-msgstr ""
+msgstr "Задатак је поново додељен."
 
 #: scripts/core/editor3/components/comments/CommentPopup.tsx:151
 msgid "The comment will be deleted. Are you sure?"
@@ -17274,11 +17274,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/events/ui.ts:64
 msgid "The event(s) have been spiked"
-msgstr ""
+msgstr "Догађај(и) је(су) премештен(и) у корпу"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:81
 msgid "The event(s) have been unspiked"
-msgstr ""
+msgstr "Догађај(и) је(су) враћен(и) из корпе"
 
 #: scripts/apps/archive/controllers/file-upload-error-modal.tsx:31
 msgid "The file was not uploaded"
@@ -17432,15 +17432,15 @@ msgstr[2] "Вокабулар {{name}} не може бити обрисан ј�
 
 #: ../superdesk-planning/client/actions/main.ts:468
 msgid "The {{ itemType }} has been posted"
-msgstr ""
+msgstr "{{ itemType }} је објављен"
 
 #: ../superdesk-planning/client/actions/main.ts:318
 msgid "The {{ itemType }} has been saved"
-msgstr ""
+msgstr "{{ itemType }} је сачуван"
 
 #: ../superdesk-planning/client/actions/main.ts:396
 msgid "The {{ itemType }} has been unposted"
-msgstr ""
+msgstr "Објава {{ itemType }} је поништена"
 
 #: scripts/apps/users/views/user-preferences.html:257
 msgid "Themes"
@@ -17578,7 +17578,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/assignments/notifications.ts:350
 msgid "There is a {{ type }} assignment '{{ slugline }}' {{ state }}"
-msgstr ""
+msgstr "Постоји {{ type }} задатак '{{ slugline }}' {{ state }}"
 
 #: scripts/apps/archive/related-item-widget/relatedItem.ts:194
 msgid "There is an error. Failed to associate update."
@@ -17612,11 +17612,11 @@ msgstr "Дошло је до проблема са вашим отпремање
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:42
 msgid "There was a problem, Planning item not spiked!"
-msgstr ""
+msgstr "Дошло је до проблема, ставка планирања није премештена у корпу!"
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:63
 msgid "There was a problem, Planning item not unspiked!"
-msgstr ""
+msgstr "Дошло је до проблема, ставка планирања није враћена из корпе!"
 
 #: scripts/apps/desks/directives/DeskeditBasic.ts:61
 msgid "There was a problem, desk not created/updated."
@@ -17653,7 +17653,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/multiSelect.ts:255
 msgid "There was an error when exporting."
-msgstr ""
+msgstr "Дошло је до грешке приликом извоза."
 
 #: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:195
 msgid "There was an error when saving the contact."
@@ -17683,7 +17683,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:219
 msgid "There was an error, could not delete Events and Planning view filter."
-msgstr ""
+msgstr "Дошло је до грешке, филтер приказа догађаја и планирања није могао бити обрисан."
 
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:92
 msgid "There was an error. Content filter cannot be deleted."
@@ -17728,7 +17728,7 @@ msgstr "Трећина"
 
 #: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:259
 msgid "This Coverage"
-msgstr ""
+msgstr "Ово извештавање"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:261
 msgid ""
@@ -17858,7 +17858,7 @@ msgstr ""
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:26
 #: ../superdesk-planning/client/planning-extension/src/extension.ts:40
 msgid "This item is linked to in-progress planning coverage."
-msgstr ""
+msgstr "Ова ставка је повезана са извештавањем планирања у току."
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:118
 msgid "This item was locked by {{username}}."
@@ -17878,7 +17878,7 @@ msgstr "Овај линк није могуће уградити."
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModalSubnav.tsx:66
 msgid "This list contains unposted changes!"
-msgstr ""
+msgstr "Ова листа садржи необјављене измене!"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:270
 msgid "This planning only"
@@ -17921,7 +17921,7 @@ msgstr ""
 msgid ""
 "This will also remove other linked assignments (if any, for story updates). "
 "Are you sure?"
-msgstr ""
+msgstr "Ово ће такође уклонити друге повезане задатке (ако постоје, за ажурирања приче). Да ли сте сигурни?"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:51
 msgid "This will also {{action}} the following events"
@@ -17952,7 +17952,7 @@ msgstr ""
 #: ../superdesk-planning/client/actions/assignments/ui.ts:553
 msgid ""
 "This will unlink the text item associated with the assignment. Are you sure ?"
-msgstr ""
+msgstr "Ово ће уклонити везу текстуалне ставке повезане са задатком. Да ли сте сигурни?"
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:111
 msgid "Thu"
@@ -18213,7 +18213,7 @@ msgstr "Укључи/искључи режим сугестија"
 #: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:142
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:54
 msgid "Toggle advanced Filters"
-msgstr ""
+msgstr "Прикажи/сакриј напредне филтере"
 
 #: scripts/core/editor3/highlightsConfig.ts:43
 msgid "Toggle bold"
@@ -18627,7 +18627,7 @@ msgstr ""
 #: ../superdesk-planning/client/planning-extension/src/extension.ts:188
 #: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:155
 msgid "Unlink as Coverage"
-msgstr ""
+msgstr "Уклони везу као извештавање"
 
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEventItem.tsx:75
 msgid "Unlink related event"
@@ -18658,7 +18658,7 @@ msgstr ""
 #: scripts/apps/authoring-react/subcomponents/lock-info.tsx:58
 #: scripts/apps/authoring/views/authoring-topbar.html:22
 msgid "Unlock"
-msgstr ""
+msgstr "Откључај"
 
 #: scripts/core/lang/missing-translations-strings.ts:21
 msgid "Unlock content"
@@ -18711,7 +18711,7 @@ msgstr "Ненумерисана листа"
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:122
 #: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:382
 msgid "Unpost"
-msgstr ""
+msgstr "Поништи објаву"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:78
 msgid "Unpost all recurring events or just this one?"
@@ -18788,7 +18788,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:49
 msgid "Unspiked"
-msgstr ""
+msgstr "Враћено из корпе"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:237
 #: scripts/apps/authoring/versioning/history/views/history.html:74
@@ -19393,7 +19393,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:168
 msgid "View associated event"
-msgstr ""
+msgstr "Прикажи повезан догађај"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:155
 msgid "View duplicate event"
@@ -19401,7 +19401,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:140
 msgid "View duplicate planning item"
-msgstr ""
+msgstr "Прикажи дупликат ставке планирања"
 
 #: scripts/apps/users/views/user-preferences.html:14
 #: scripts/apps/users/views/user-preferences.html:43
@@ -19437,7 +19437,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:152
 msgid "View original planning item"
-msgstr ""
+msgstr "Прикажи оригиналну ставку планирања"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:143
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:204
@@ -19482,7 +19482,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/planning-extension/src/extension.ts:283
 msgid "Vocabulary `locators` is not configured!"
-msgstr ""
+msgstr "Вокабулар `locators` није конфигурисан!"
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:101
 msgid "Vocabulary saved successfully"
@@ -19503,7 +19503,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Main/CalendarNavigation.tsx:56
 msgid "W"
-msgstr ""
+msgstr "W"
 
 #: scripts/apps/content-filters/controllers/FilterConditionsController.ts:44
 msgid "WARNING unknown filter condition value: {{ value }}"
@@ -19565,7 +19565,7 @@ msgstr "Среда"
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/constants.js:35
 #: scripts/extensions/availability-manager/src/constants.ts:43
 msgid "Week"
-msgstr ""
+msgstr "Недеља"
 
 #: ../superdesk-planning/client/components/fields/editor/Days.tsx:32
 msgid "Week Days"
@@ -19765,7 +19765,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:73
 msgid "You are currently managing featured story in another session"
-msgstr ""
+msgstr "Тренутно управљате истакнутом причом у другој сесији"
 
 #: scripts/validate-instance-configuration.tsx:38
 msgid "You are likely running an outdated version of auto tagging extension."
@@ -19858,7 +19858,7 @@ msgstr "Ваше Slack корисничко име без водећег @"
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:124
 #: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:84
 msgid "Your changes will be lost if you close now. What would you like to do?"
-msgstr ""
+msgstr "Ваше измене ће бити изгубљене ако сада затворите. Шта желите да урадите?"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:285
 msgid "Your changes will be lost if you switch now. What would you like to do?"
@@ -20167,15 +20167,15 @@ msgstr "креирање"
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:189
 msgid "created"
-msgstr ""
+msgstr "креирано"
 
 #: ../superdesk-planning/client/actions/agenda.ts:240
 msgid "created  planning item."
-msgstr ""
+msgstr "креирана ставка планирања."
 
 #: ../superdesk-planning/client/actions/agenda.ts:229
 msgid "created / planning item(s)"
-msgstr ""
+msgstr "креирана / ставка(е) планирања"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:42
 #: ../superdesk-planning/client/components/RelatedPlannings/index.tsx:102
@@ -20731,7 +20731,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Main/ListPanel.tsx:435
 msgid "loading more items..."
-msgstr ""
+msgstr "учитавање још ставки..."
 
 #: scripts/apps/desks/directives/DeskeditPeople.ts:13
 #: scripts/apps/desks/directives/DeskeditStages.ts:92
@@ -21373,7 +21373,7 @@ msgstr "ажурирање"
 #: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:140
 #: scripts/apps/search/components/MediaInfo.tsx:32
 msgid "updated"
-msgstr ""
+msgstr "ажурирано"
 
 #: scripts/core/lang/missing-translations-strings.ts:40
 msgid "updated Ingest Channel {{name}}"
@@ -21547,7 +21547,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/main.ts:325
 msgid "{{ itemType }} created"
-msgstr ""
+msgstr "{{ itemType }} креиран"
 
 #: ../superdesk-planning/client/validators/index.ts:119
 #: ../superdesk-planning/client/validators/planning.ts:170
@@ -21600,7 +21600,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/actions/assignments/notifications.ts:371
 msgid "{{ type }} assignment '{{ slugline }}' is deleted"
-msgstr ""
+msgstr "{{ type }} задатак '{{ slugline }}' је обрисан"
 
 #: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:4
 msgid "{{ widget.configuration.label || widget.label }}"

--- a/po/sr.po
+++ b/po/sr.po
@@ -1,13 +1,13 @@
 msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: \n"
 "PO-Revision-Date: 2026-05-06 00:00+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: sr\n"
 "MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
@@ -35,7 +35,9 @@ msgstr "Поље \"{{x}}\" је обавезно"
 msgid ""
 "'' is currently managing featured stories. This feature can only be accessed "
 "by one user at a time."
-msgstr "'' тренутно управља истакнутим причама. Овој функцији може приступити само један корисник истовремено."
+msgstr ""
+"'' тренутно управља истакнутим причама. Овој функцији може приступити само "
+"један корисник истовремено."
 
 #: scripts/core/lang/missing-translations-strings.ts:23
 msgid "'ABSTRACT is a required field'"
@@ -556,7 +558,10 @@ msgid ""
 "<p>Generate a report showing usage of the Planning module.<br></p>\n"
 "    <p>This provides a statistics on who is and who isn't creating items in "
 "the Planning module</p>"
-msgstr "<p>Генериши извештај који приказује коришћење модула планирања.<br></p>\n    <p>Ово пружа статистику о томе ко креира, а ко не креира ставке у модулу планирања</p>"
+msgstr ""
+"<p>Генериши извештај који приказује коришћење модула планирања.<br></p>\n"
+"    <p>Ово пружа статистику о томе ко креира, а ко не креира ставке у модулу "
+"планирања</p>"
 
 #: scripts/apps/users/views/edit-form.html:6
 msgid ""
@@ -584,7 +589,9 @@ msgstr "Деск је обавезан"
 msgid ""
 "A link was sent to the specified email address. Please use it to reset your "
 "password. It is valid a limited amount of time."
-msgstr "Линк је послат на наведену имејл адресу. Користите га да ресетујете лозинку. Важи ограничено време."
+msgstr ""
+"Линк је послат на наведену имејл адресу. Користите га да ресетујете лозинку. "
+"Важи ограничено време."
 
 #: ../superdesk-planning/client/api/locations.ts:30
 msgid "A location matching this one already exists"
@@ -1027,7 +1034,9 @@ msgstr "Додај чланак"
 msgid ""
 "Add article to Planning - select an existing Planning Item or create a new "
 "one"
-msgstr "Додај чланак у планирање - изаберите постојећу ставку планирања или креирајте нову"
+msgstr ""
+"Додај чланак у планирање - изаберите постојећу ставку планирања или "
+"креирајте нову"
 
 #: ../superdesk-planning/client/components/Planning/PlanningItem.tsx:317
 #: ../superdesk-planning/client/components/Planning/PlanningItem.tsx:322
@@ -1233,18 +1242,21 @@ msgstr "Додато у радни ток"
 #: scripts/apps/relations/services/RelationsService.ts:46
 msgid ""
 "Adding ingested items as related is not allowed due to configuration options"
-msgstr "Додавање ставки из пријема као повезаних није дозвољено због подешавања"
+msgstr ""
+"Додавање ставки из пријема као повезаних није дозвољено због подешавања"
 
 #: scripts/apps/relations/services/RelationsService.ts:29
 msgid ""
 "Adding published items as related is not allowed due to configuration options"
-msgstr "Додавање објављених ставки као повезаних није дозвољено због подешавања"
+msgstr ""
+"Додавање објављених ставки као повезаних није дозвољено због подешавања"
 
 #: scripts/apps/relations/services/RelationsService.ts:36
 msgid ""
 "Adding related items that are not published is not allowed due to "
 "configuration options"
-msgstr "Додавање повезаних ставки које нису објављене није дозвољено због подешавања"
+msgstr ""
+"Додавање повезаних ставки које нису објављене није дозвољено због подешавања"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:227
 #: ../superdesk-planning/client/components/Locations/LocationsList.tsx:112
@@ -1797,7 +1809,9 @@ msgstr "Ажурирање не може бити креирано за став
 msgid ""
 "An update for this version of the item already exists. To create another "
 "update, find the latest version of the item."
-msgstr "Ажурирање за ову верзију ставке већ постоји. Да бисте креирали ново ажурирање, пронађите најновију верзију ставке."
+msgstr ""
+"Ажурирање за ову верзију ставке већ постоји. Да бисте креирали ново "
+"ажурирање, пронађите најновију верзију ставке."
 
 #: ../superdesk-analytics/client/index.js:94
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:36
@@ -1822,7 +1836,9 @@ msgstr "Тип анотације"
 msgid ""
 "Annotation Types information is not available. Please check your metadata "
 "configuration."
-msgstr "Информације о типовима анотација нису доступне. Проверите подешавање метаподатака."
+msgstr ""
+"Информације о типовима анотација нису доступне. Проверите подешавање "
+"метаподатака."
 
 #: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:124
 msgid "Annotation type"
@@ -2042,7 +2058,8 @@ msgstr "Да ли сте сигурни да желите да премести�
 
 #: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:64
 msgid "Are you sure you want to unpublish item \"{{headline}}\"?"
-msgstr "Да ли сте сигурни да желите да повучете објаву ставке \"{{headline}}\"?"
+msgstr ""
+"Да ли сте сигурни да желите да повучете објаву ставке \"{{headline}}\"?"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:53
 msgid "Are you sure you want to unpublish item \"{{label}}\"?"
@@ -2108,7 +2125,8 @@ msgstr "Тип чланка: {{type}}"
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:577
 msgid ""
 "Article cannot be published. Please accept or reject all suggestions first."
-msgstr "Чланак не може бити објављен. Прво прихватите или одбијте све сугестије."
+msgstr ""
+"Чланак не може бити објављен. Прво прихватите или одбијте све сугестије."
 
 #: scripts/apps/users/views/user-preferences.html:16
 msgid "Article defaults"
@@ -2499,7 +2517,8 @@ msgstr "Потребно је најмање једно од [{{list}}]."
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:146
 msgid ""
 "At least two versions are needed for comparison. This article has only one."
-msgstr "За поређење су потребне најмање две верзије. Овај чланак има само једну."
+msgstr ""
+"За поређење су потребне најмање две верзије. Овај чланак има само једну."
 
 #: scripts/extensions/sams/dist/src/components/assets/selectAssetModal.js:153
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/selectAssetModal.js:153
@@ -2617,7 +2636,10 @@ msgid ""
 "Authoring desks are for content creation, and items within it are protected "
 "from accidental publication. Publishing is only permitted  from production "
 "desks."
-msgstr "Дескови за уређивање служе за креирање садржаја, а ставке у њима су заштићене од случајног објављивања. Објављивање је дозвољено само са продукцијских дескова."
+msgstr ""
+"Дескови за уређивање служе за креирање садржаја, а ставке у њима су "
+"заштићене од случајног објављивања. Објављивање је дозвољено само са "
+"продукцијских дескова."
 
 #: scripts/apps/authoring-react/field-adapters/authors.tsx:80
 #: scripts/apps/search/components/fields/authors.tsx:113
@@ -2662,7 +2684,9 @@ msgstr "Управљање доступношћу"
 msgid ""
 "Availability manager extension could not start because vocabulary \"{{id}}\" "
 "is missing"
-msgstr "Екстензија управљача доступношћу није могла да се покрене јер недостаје вокабулар \"{{id}}\""
+msgstr ""
+"Екстензија управљача доступношћу није могла да се покрене јер недостаје "
+"вокабулар \"{{id}}\""
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/availability-settings.js:189
 #: scripts/extensions/availability-manager/dist/src/settings/availability-settings.js:189
@@ -2765,7 +2789,8 @@ msgstr "Пре емитовања"
 msgid ""
 "Before you start using your new newsroom, please tell us a little about "
 "yourself:"
-msgstr "Пре него што почнете са коришћењем нове редакције, реците нам нешто о себи:"
+msgstr ""
+"Пре него што почнете са коришћењем нове редакције, реците нам нешто о себи:"
 
 #: scripts/apps/search/components/fields/state.tsx:41
 msgid "Being Corrected"
@@ -2860,7 +2885,9 @@ msgstr "Обоје"
 msgid ""
 "Both start and end date need to be filled in (or cleared) to save the "
 "subscriber."
-msgstr "Морате попунити (или обрисати) и почетни и крајњи датум да бисте сачували претплатника."
+msgstr ""
+"Морате попунити (или обрисати) и почетни и крајњи датум да бисте сачували "
+"претплатника."
 
 #: scripts/apps/authoring/views/change-image.html:242
 msgid "Brightness"
@@ -2903,13 +2930,18 @@ msgid ""
 "By selecting the categories you are interested in, the system will only "
 "display these in a menu for setting the content item's categories (along "
 "with any of its existing categories)."
-msgstr "Бирањем категорија које вас занимају, систем ће приказивати само њих у менију за подешавање категорија ставке садржаја (заједно са постојећим категоријама)."
+msgstr ""
+"Бирањем категорија које вас занимају, систем ће приказивати само њих у "
+"менију за подешавање категорија ставке садржаја (заједно са постојећим "
+"категоријама)."
 
 #: scripts/apps/users/views/user-preferences.html:185
 msgid ""
 "By selecting the desks as your preferred desks, they appear first in the "
 "order when sending or publishing items."
-msgstr "Бирањем дескова као омиљених, они се појављују први у редоследу приликом слања или објављивања ставки."
+msgstr ""
+"Бирањем дескова као омиљених, они се појављују први у редоследу приликом "
+"слања или објављивања ставки."
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:362
 #: scripts/apps/authoring-react/field-adapters/byline.ts:20
@@ -3256,7 +3288,9 @@ msgstr "Не можете додати саму ставку као повеза
 msgid ""
 "Cannot change workflow status if the coverage is part of an expired planning "
 "item"
-msgstr "Није могуће променити статус радног тока ако је извештавање део истекле ставке планирања"
+msgstr ""
+"Није могуће променити статус радног тока ако је извештавање део истекле "
+"ставке планирања"
 
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:35
 msgid "Cannot delete vocabulary"
@@ -3361,7 +3395,8 @@ msgstr "Измене ће бити изгубљене ако не буду са�
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorTools.js:32
 #: scripts/extensions/videoEditor/src/VideoEditorTools.tsx:76
 msgid "Changing quality is only supported for 480p and higher quality videos."
-msgstr "Промена квалитета подржана је само за видео записе квалитета 480p и већег."
+msgstr ""
+"Промена квалитета подржана је само за видео записе квалитета 480p и већег."
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:38
 msgid "Channel has gone strangely quiet."
@@ -3377,7 +3412,8 @@ msgstr "Прекорачен је лимит карактера, речник н
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:14
 msgid "Character limit exceeded, highlight can not be created/updated."
-msgstr "Прекорачен је лимит карактера, истицање није могуће креирати/ажурирати."
+msgstr ""
+"Прекорачен је лимит карактера, истицање није могуће креирати/ажурирати."
 
 #: scripts/apps/desks/views/desk-config-modal.html:290
 msgid "Character limit exceeded, stage can not be created/updated."
@@ -3462,7 +3498,13 @@ msgid ""
 "                                    in the list. The CVs are grouped under "
 "each label. You can choose only one\n"
 "                                    label."
-msgstr "Изаберите постојеће ознаке или креирајте нове\n                                    куцањем. Ознаке се користе само за организовање контролисаних вокабулара\n                                    у листи. КВ су груписани под сваком ознаком. Можете изабрати само једну\n                                    ознаку."
+msgstr ""
+"Изаберите постојеће ознаке или креирајте нове\n"
+"                                    куцањем. Ознаке се користе само за "
+"организовање контролисаних вокабулара\n"
+"                                    у листи. КВ су груписани под сваком "
+"ознаком. Можете изабрати само једну\n"
+"                                    ознаку."
 
 #: scripts/apps/highlights/views/package_highlights_dropdown_directive.html:20
 msgid "Choose highlight list"
@@ -3598,7 +3640,8 @@ msgstr "Кликните на дугме плус да бисте додали �
 #: scripts/apps/users/views/change-avatar.html:38
 msgid ""
 "Click to capture using camera. Be sure that you allow camera accessibility."
-msgstr "Кликните да снимите камером. Уверите се да сте дозволили приступ камери."
+msgstr ""
+"Кликните да снимите камером. Уверите се да сте дозволили приступ камери."
 
 #: scripts/apps/authoring/authoring/components/video-thumbnail-editor.tsx:108
 msgid "Click to replace thumbnail"
@@ -3898,7 +3941,9 @@ msgstr "Конфигурација обрисана."
 msgid ""
 "Configuration has changed. {{message}} Would you like to save the story to "
 "your workspace?"
-msgstr "Конфигурација је измењена. {{message}} Желите ли да сачувате причу у свој радни простор?"
+msgstr ""
+"Конфигурација је измењена. {{message}} Желите ли да сачувате причу у свој "
+"радни простор?"
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:11
 #: scripts/apps/highlights/views/highlights_config_modal.html:12
@@ -4026,7 +4071,9 @@ msgstr "Садржај"
 msgid ""
 "Content\n"
 "                                Type"
-msgstr "Тип\n                                садржаја"
+msgstr ""
+"Тип\n"
+"                                садржаја"
 
 #: scripts/apps/publish/views/subscribers.html:254
 msgid "Content API"
@@ -5254,7 +5301,10 @@ msgid ""
 "Defines the width of the pop-up in the\n"
 "                                    article header. A minimal value of 200 "
 "is required."
-msgstr "Дефинише ширину искачућег прозора у\n                                    заглављу чланка. Потребна је минимална вредност 200."
+msgstr ""
+"Дефинише ширину искачућег прозора у\n"
+"                                    заглављу чланка. Потребна је минимална "
+"вредност 200."
 
 #: scripts/extensions/annotationsLibrary/dist/src/GetFields.js:23
 #: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/GetFields.js:23
@@ -5706,7 +5756,9 @@ msgstr "Речник са називом {{dictionary.name}} већ постој
 msgid ""
 "Difference view for \"{{type}}\" fields is not implemented. Latter version "
 "is being displayed."
-msgstr "Приказ разлика за \"{{type}}\" поља није имплементиран. Приказана је новија верзија."
+msgstr ""
+"Приказ разлика за \"{{type}}\" поља није имплементиран. Приказана је новија "
+"верзија."
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:72
 msgid "Digital/Internet"
@@ -5790,7 +5842,9 @@ msgstr "Прекинута веза са сервером обавештења!"
 msgid ""
 "Displaying news ingest statistics. You can switch color themes or graph "
 "sources."
-msgstr "Приказује статистике пријема вести. Можете променити теме боја или изворе графикона."
+msgstr ""
+"Приказује статистике пријема вести. Можете променити теме боја или изворе "
+"графикона."
 
 #: scripts/core/keyboard/keyboard.ts:401 scripts/core/keyboard/keyboard.ts:410
 msgid "Displays active keyboard shortcuts"
@@ -5989,16 +6043,22 @@ msgstr "Превуците датотеке овде или"
 msgid ""
 "Drag one or more files here to upload them,\n"
 "                or select files by clicking the button below"
-msgstr "Превуците једну или више датотека овде да их отпремите,\n                или изаберите датотеке кликом на дугме испод"
+msgstr ""
+"Превуците једну или више датотека овде да их отпремите,\n"
+"                или изаберите датотеке кликом на дугме испод"
 
 #: scripts/apps/authoring/attachments/AttachmentsWidgetComponent.tsx:126
 msgid "Drag one or more files here to upload them, or just click here."
-msgstr "Превуците једну или више датотека овде да их отпремите, или само кликните овде."
+msgstr ""
+"Превуците једну или више датотека овде да их отпремите, или само кликните "
+"овде."
 
 #: scripts/apps/authoring/attachments/AttachmentsWidgetComponent.tsx:104
 msgid ""
 "Drag one or more files here to upload them, or just click the button below."
-msgstr "Превуците једну или више датотека овде да их отпремите, или само кликните на дугме испод."
+msgstr ""
+"Превуците једну или више датотека овде да их отпремите, или само кликните на "
+"дугме испод."
 
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:101
 msgid "Drop events here"
@@ -6210,7 +6270,9 @@ msgstr "СПОЉАШЊИ ЛИНК {{ index }} не може се завршит�
 msgid ""
 "EXTERNAL LINK {{ index }} must start with \"http://\", \"https://\" or \"www."
 "\""
-msgstr "СПОЉАШЊИ ЛИНК {{ index }} мора почињати са \"http://\", \"https://\" или \"www.\""
+msgstr ""
+"СПОЉАШЊИ ЛИНК {{ index }} мора почињати са \"http://\", \"https://\" или "
+"\"www.\""
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:35
 #: ../superdesk-planning/client/components/fields/resources/common.tsx:16
@@ -6734,7 +6796,9 @@ msgstr "Завршава се"
 msgid ""
 "Ensure correct preview endpoint is configured or contact endpoint "
 "maintainers."
-msgstr "Уверите се да је исправна крајња тачка прегледа подешена или контактирајте њене одржаваоце."
+msgstr ""
+"Уверите се да је исправна крајња тачка прегледа подешена или контактирајте "
+"њене одржаваоце."
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:163
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:535
@@ -7816,11 +7880,14 @@ msgstr "Чување области од интереса није успело:
 
 #: scripts/apps/authoring/tests/changeImage.spec.ts:94
 msgid "Failed to save the area of interest: Failed to call picture_crop."
-msgstr "Чување области од интереса није успело: позивање picture_crop није успело."
+msgstr ""
+"Чување области од интереса није успело: позивање picture_crop није успело."
 
 #: scripts/apps/authoring/tests/changeImage.spec.ts:128
 msgid "Failed to save the area of interest: Failed to call picture_renditions."
-msgstr "Чување области од интереса није успело: позивање picture_renditions није успело."
+msgstr ""
+"Чување области од интереса није успело: позивање picture_renditions није "
+"успело."
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:469
 msgid "Failed to save the assignment."
@@ -8066,7 +8133,9 @@ msgstr "Поље"
 msgid ""
 "Field\n"
 "                                    type"
-msgstr "Тип\n                                    поља"
+msgstr ""
+"Тип\n"
+"                                    поља"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:200
 msgid "Field \"{{field}}\" will be permanently deleted."
@@ -8518,7 +8587,9 @@ msgstr "Генериши извештај који приказује актив
 msgid ""
 "Generate a report showing average and maximum time it took to produce "
 "content per desk."
-msgstr "Генериши извештај који приказује просечно и максимално време потребно за продукцију садржаја по деску."
+msgstr ""
+"Генериши извештај који приказује просечно и максимално време потребно за "
+"продукцију садржаја по деску."
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-parameters.html:1
 #: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-parameters.html:1
@@ -8529,13 +8600,17 @@ msgstr "Генериши извештај који приказује стати
 msgid ""
 "Generate a report showing the time between original publish and update "
 "publish."
-msgstr "Генериши извештај који приказује време између оригиналне објаве и објаве ажурирања."
+msgstr ""
+"Генериши извештај који приказује време између оригиналне објаве и објаве "
+"ажурирања."
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-parameters.html:1
 msgid ""
 "Generate a report showing updates to featuremedia items after initial "
 "publish."
-msgstr "Генериши извештај који приказује ажурирања ставки истакнутог медија након првобитне објаве."
+msgstr ""
+"Генериши извештај који приказује ажурирања ставки истакнутог медија након "
+"првобитне објаве."
 
 #: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-parameters.html:1
 msgid "Generate a report showing user activity."
@@ -8847,7 +8922,9 @@ msgstr "Помозите нам да преведемо Superdesk"
 msgid ""
 "Helper\n"
 "                                    text"
-msgstr "Помоћни\n                                    текст"
+msgstr ""
+"Помоћни\n"
+"                                    текст"
 
 #: scripts/apps/authoring/views/article-edit.html:395
 msgid "Helplines/Contact Information"
@@ -9009,13 +9086,18 @@ msgid ""
 "ID\n"
 "                                must contain only letters, digits and "
 "characters -, _."
-msgstr "ИД\n                                мора садржати само слова, цифре и знакове -, _."
+msgstr ""
+"ИД\n"
+"                                мора садржати само слова, цифре и знакове -, "
+"_."
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:43
 msgid ""
 "ID conflicts\n"
 "                                with system field."
-msgstr "ИД је у конфликту\n                                са системским пољем."
+msgstr ""
+"ИД је у конфликту\n"
+"                                са системским пољем."
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:41
 msgid "ID must be unique."
@@ -9046,7 +9128,10 @@ msgid ""
 "If enabled, it will be possible to embed articles using this content profile "
 "into other articles that accept embeds (configurable in content profile "
 "field settings)"
-msgstr "Ако је омогућено, биће могуће уградити чланке користећи овај профил садржаја у друге чланке који прихватају уграђени садржај (подесиво у поставкама поља профила садржаја)"
+msgstr ""
+"Ако је омогућено, биће могуће уградити чланке користећи овај профил садржаја "
+"у друге чланке који прихватају уграђени садржај (подесиво у поставкама поља "
+"профила садржаја)"
 
 #: scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx:134
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx:194
@@ -9069,7 +9154,12 @@ msgid ""
 "name and the role.\n"
 "                        The roles are managed in <b>Author roles</b> "
 "controlled vocabulary in the Metadata section."
-msgstr "Ако изаберете подразумевану улогу за креирање или уређивање садржаја,\n                        Superdesk ће унапред попунити поље Аутори корисниковим именом и улогом.\n                        Улоге се управљају у контролисаном вокабулару <b>Улоге аутора</b> у одељку Метаподаци."
+msgstr ""
+"Ако изаберете подразумевану улогу за креирање или уређивање садржаја,\n"
+"                        Superdesk ће унапред попунити поље Аутори "
+"корисниковим именом и улогом.\n"
+"                        Улоге се управљају у контролисаном вокабулару "
+"<b>Улоге аутора</b> у одељку Метаподаци."
 
 #: ../superdesk-planning/client/components/ConfirmationModal.tsx:137
 #: ../superdesk-planning/client/components/FulFilAssignmentModal/index.tsx:104
@@ -9114,7 +9204,9 @@ msgstr "Ширина слике"
 #: scripts/core/upload/crop-directive.ts:41
 msgid ""
 "Image is bigger than {{maxFileSize}}MB, upload file size may be limited!"
-msgstr "Слика је већа од {{maxFileSize}}MB, величина отпремљене датотеке може бити ограничена!"
+msgstr ""
+"Слика је већа од {{maxFileSize}}MB, величина отпремљене датотеке може бити "
+"ограничена!"
 
 #: scripts/apps/authoring/views/change-image.html:217
 msgid "Image size"
@@ -9130,7 +9222,9 @@ msgstr "Провера величине слике није успела"
 msgid ""
 "Image suggestions are based on generated tags and can be added to article "
 "content by dragging."
-msgstr "Сугестије слика заснивају се на генерисаним ознакама и могу се додати у садржај чланка превлачењем."
+msgstr ""
+"Сугестије слика заснивају се на генерисаним ознакама и могу се додати у "
+"садржај чланка превлачењем."
 
 #: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:73
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:73
@@ -9184,7 +9278,9 @@ msgstr "У току"
 msgid ""
 "In the story {{slugline}} sent at: {{date}}.{{lineBreak}}This is a corrected "
 "repeat."
-msgstr "У причи {{slugline}} послато: {{date}}.{{lineBreak}}Ово је исправљено понављање."
+msgstr ""
+"У причи {{slugline}} послато: {{date}}.{{lineBreak}}Ово је исправљено "
+"понављање."
 
 #: ../superdesk-planning/client/utils/index.ts:335
 #: scripts/apps/contacts/components/ContactInfo.tsx:64
@@ -9606,7 +9702,9 @@ msgstr "Ставка је поново послата."
 msgid ""
 "Item has changed since it was opened. Please close and reopen the item to "
 "continue. Regrettably, your changes cannot be saved."
-msgstr "Ставка је измењена откад је отворена. Затворите и поново је отворите да бисте наставили. Нажалост, ваше измене не могу бити сачуване."
+msgstr ""
+"Ставка је измењена откад је отворена. Затворите и поново је отворите да "
+"бисте наставили. Нажалост, ваше измене не могу бити сачуване."
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:60
 msgid "Item has not been transmitted to any subscriber"
@@ -9694,8 +9792,10 @@ msgid "Item was not added. Only 1 item is allowed for this field."
 msgid_plural ""
 "Item was not added. Only {{number}} items are allowed in this field."
 msgstr[0] "Ставка није додата. У овом пољу је дозвољена само 1 ставка."
-msgstr[1] "Ставка није додата. У овом пољу су дозвољене само {{number}} ставке."
-msgstr[2] "Ставка није додата. У овом пољу је дозвољено само {{number}} ставки."
+msgstr[1] ""
+"Ставка није додата. У овом пољу су дозвољене само {{number}} ставке."
+msgstr[2] ""
+"Ставка није додата. У овом пољу је дозвољено само {{number}} ставки."
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:490
 msgid "Item was unpublished successfully."
@@ -9996,7 +10096,12 @@ msgid ""
 "support, join the discussion on <a href=\"https://forum.sourcefabric.org/"
 "categories/superdesk-dev\" title=\"Superdesk forum\" "
 "target=\"_blank\">Superdesk forums</a>."
-msgstr "Сазнајте више о Superdesk-у на <a href=\"https://www.superdesk.org/\" title=\"Superdesk\" target=\"_blank\">www.superdesk.org</a>. За помоћ и подршку, придружите се дискусији на <a href=\"https://forum.sourcefabric.org/categories/superdesk-dev\" title=\"Superdesk forum\" target=\"_blank\">Superdesk форумима</a>."
+msgstr ""
+"Сазнајте више о Superdesk-у на <a href=\"https://www.superdesk.org/\" "
+"title=\"Superdesk\" target=\"_blank\">www.superdesk.org</a>. За помоћ и "
+"подршку, придружите се дискусији на <a href=\"https://forum.sourcefabric.org/"
+"categories/superdesk-dev\" title=\"Superdesk forum\" "
+"target=\"_blank\">Superdesk форумима</a>."
 
 #: scripts/apps/authoring/authoring/components/toggleFullWithEditor.tsx:20
 msgid "Leave full width mode"
@@ -10350,7 +10455,9 @@ msgstr "Уверите се да изгледате најбоље"
 msgid ""
 "Make sure you've saved your Client Secret.You won't be able to access it "
 "again after closing"
-msgstr "Уверите се да сте сачували тајни кључ клијента. Након затварања нећете моћи поново да приступите."
+msgstr ""
+"Уверите се да сте сачували тајни кључ клијента. Након затварања нећете моћи "
+"поново да приступите."
 
 #: scripts/apps/search/views/search-panel.html:45
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/availability-settings.js:190
@@ -10987,7 +11094,9 @@ msgstr "Мора бити мање од {{ maximum }}"
 msgid ""
 "Must be {{MIN_LENGTH}} characters long and contain {{MIN_STRENGTH}} out of 4 "
 "of the following:"
-msgstr "Мора бити дуго {{MIN_LENGTH}} карактера и садржати {{MIN_STRENGTH}} од 4 следећа елемента:"
+msgstr ""
+"Мора бити дуго {{MIN_LENGTH}} карактера и садржати {{MIN_STRENGTH}} од 4 "
+"следећа елемента:"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:165
 msgid "Must select at least one day"
@@ -11120,7 +11229,8 @@ msgstr "Преводи назива"
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:218
 msgid ""
 "Name field should only have alphanumeric characters, dashes and underscores"
-msgstr "Поље назива треба да садржи само алфанумеричке знакове, цртице и доње црте"
+msgstr ""
+"Поље назива треба да садржи само алфанумеричке знакове, цртице и доње црте"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:79
 msgid "Name is not unique."
@@ -11436,7 +11546,9 @@ msgstr "Нису дефинисане радње преузимања ни об�
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:1080
 msgid ""
 "No formatters found for {{formats}} while publishing item having unique name."
-msgstr "Форматери за {{formats}} нису пронађени приликом објављивања ставке са јединственим називом."
+msgstr ""
+"Форматери за {{formats}} нису пронађени приликом објављивања ставке са "
+"јединственим називом."
 
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:206
 msgid "No highlights have been created yet."
@@ -11526,7 +11638,9 @@ msgstr "Нису додате ставке планирања"
 msgid ""
 "No preferred categories selected. Should you choose to proceed with your "
 "choice. A default set of categories will be selected for you."
-msgstr "Нису изабране омиљене категорије. Ако одлучите да наставите са својим избором, биће вам изабран подразумевани скуп категорија."
+msgstr ""
+"Нису изабране омиљене категорије. Ако одлучите да наставите са својим "
+"избором, биће вам изабран подразумевани скуп категорија."
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EditorFieldEventRelatedItems.tsx:85
 msgid "No related articles yet"
@@ -11943,9 +12057,15 @@ msgid ""
 msgid_plural ""
 "{{ count }} items that were selected are locked. By default locked items are "
 "not included in the export."
-msgstr[0] "Једна од изабраних ставки је закључана. Подразумевано, закључане ставке нису укључене у извоз."
-msgstr[1] "{{ count }} изабраних ставки је закључано. Подразумевано, закључане ставке нису укључене у извоз."
-msgstr[2] "{{ count }} изабраних ставки је закључано. Подразумевано, закључане ставке нису укључене у извоз."
+msgstr[0] ""
+"Једна од изабраних ставки је закључана. Подразумевано, закључане ставке нису "
+"укључене у извоз."
+msgstr[1] ""
+"{{ count }} изабраних ставки је закључано. Подразумевано, закључане ставке "
+"нису укључене у извоз."
+msgstr[2] ""
+"{{ count }} изабраних ставки је закључано. Подразумевано, закључане ставке "
+"нису укључене у извоз."
 
 #: scripts/apps/users/components/UserAvatar.tsx:99
 #: scripts/apps/users/controllers/UserListController.ts:156
@@ -11971,7 +12091,9 @@ msgstr "Само објављено"
 msgid ""
 "Only allow content with the\n"
 "                                following status:"
-msgstr "Дозволи само садржај са\n                                следећим статусом:"
+msgstr ""
+"Дозволи само садржај са\n"
+"                                следећим статусом:"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageForm.tsx:247
 msgid "Only one XMP files are accepted"
@@ -12185,13 +12307,17 @@ msgstr "Оригинал"
 msgid ""
 "Original ({{item.renditions.original.width}} x "
 "{{item.renditions.original.height}} px)"
-msgstr "Оригинал ({{item.renditions.original.width}} x {{item.renditions.original.height}} px)"
+msgstr ""
+"Оригинал ({{item.renditions.original.width}} x "
+"{{item.renditions.original.height}} px)"
 
 #: ../superdesk-analytics/client/views/renditions-preview.html:33
 msgid ""
 "Original ({{preview.item.update.update.renditions.original.width}} x "
 "{{preview.item.update.update.renditions.original.height}} px)"
-msgstr "Оригинал ({{preview.item.update.update.renditions.original.width}} x {{preview.item.update.update.renditions.original.height}} px)"
+msgstr ""
+"Оригинал ({{preview.item.update.update.renditions.original.width}} x "
+"{{preview.item.update.update.renditions.original.height}} px)"
 
 #: scripts/apps/search/components/fields/translations.tsx:26
 msgid "Original Article"
@@ -12768,7 +12894,8 @@ msgstr "Ставка планирања додата као истакнута �
 
 #: ../superdesk-planning/client/utils/events.tsx:501
 msgid "Planning item already has one related event. Can not add more."
-msgstr "Ставка планирања већ има један повезан догађај. Више није могуће додати."
+msgstr ""
+"Ставка планирања већ има један повезан догађај. Више није могуће додати."
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:72
 msgid "Planning item created"
@@ -12803,7 +12930,9 @@ msgstr "Пусти"
 msgid ""
 "Please be aware that uploading external config files\n"
 "                will overwrite your existing configuration."
-msgstr "Имајте на уму да отпремање спољних конфигурационих датотека\n                ће заменити вашу постојећу конфигурацију."
+msgstr ""
+"Имајте на уму да отпремање спољних конфигурационих датотека\n"
+"                ће заменити вашу постојећу конфигурацију."
 
 #: scripts/apps/templates/directives/TemplatesDirective.ts:359
 msgid "Please change the default templates first."
@@ -12859,7 +12988,9 @@ msgstr "Унесите ИД чланка"
 msgid ""
 "Please specify 'first name, last name' or  'organisation' or both, and at "
 "least one of [{{list}}] fields."
-msgstr "Наведите 'име, презиме' или 'организацију' или оба, и најмање једно од [{{list}}] поља."
+msgstr ""
+"Наведите 'име, презиме' или 'организацију' или оба, и најмање једно од "
+"[{{list}}] поља."
 
 #: scripts/apps/templates/views/create-template.html:27
 #: scripts/apps/templates/views/template-editor-modal.html:22
@@ -13254,7 +13385,9 @@ msgstr "Тема за лектуру"
 msgid ""
 "Provide your email in order to get 'Reset Token'. Once you get it, use it to "
 "reset your password."
-msgstr "Унесите свој имејл да бисте добили 'Токен за ресет'. Када га добијете, искористите га за ресет лозинке."
+msgstr ""
+"Унесите свој имејл да бисте добили 'Токен за ресет'. Када га добијете, "
+"искористите га за ресет лозинке."
 
 #: scripts/apps/users/views/change-avatar.html:47
 msgid "Provided image URL is not valid."
@@ -13284,7 +13417,8 @@ msgstr "Секвенца провајдера"
 #: scripts/core/lang/missing-translations-strings.ts:39
 msgid ""
 "Provider {{name}} has gone strangely quiet. Last activity was on {{last}}"
-msgstr "Провајдер {{name}} је неуобичајено тих. Последња активност је била {{last}}"
+msgstr ""
+"Провајдер {{name}} је неуобичајено тих. Последња активност је била {{last}}"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:279
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:110
@@ -13824,7 +13958,9 @@ msgstr "Повезана ставка није доступна."
 msgid ""
 "Related item was not added, because the field reached the limit of related "
 "items allowed."
-msgstr "Повезана ставка није додата јер је поље достигло ограничење дозвољених повезаних ставки."
+msgstr ""
+"Повезана ставка није додата јер је поље достигло ограничење дозвољених "
+"повезаних ставки."
 
 #: scripts/apps/vocabularies/constants.ts:22
 msgid "Related items"
@@ -14879,7 +15015,9 @@ msgstr "Сачуван извештај"
 msgid ""
 "Saved Report has changed since it was opened. Please re-select the Saved "
 "Report to continue. Regrettably, your changes cannot be saved."
-msgstr "Сачувани извештај је измењен откад је отворен. Поново изаберите сачувани извештај да наставите. Нажалост, ваше измене не могу бити сачуване."
+msgstr ""
+"Сачувани извештај је измењен откад је отворен. Поново изаберите сачувани "
+"извештај да наставите. Нажалост, ваше измене не могу бити сачуване."
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:62
 msgid "Saved Searches"
@@ -15295,14 +15433,21 @@ msgid ""
 "ingest. If you don't see any, create one\n"
 "                                   <a href=\"#/settings/content-"
 "profiles\">here</a>"
-msgstr "Изаберите подразумевани профил садржаја који се користи за чланке преузете из пријема. Ако ниједан не видите, креирајте га\n                                   <a href=\"#/settings/content-profiles\">овде</a>"
+msgstr ""
+"Изаберите подразумевани профил садржаја који се користи за чланке преузете "
+"из пријема. Ако ниједан не видите, креирајте га\n"
+"                                   <a href=\"#/settings/content-"
+"profiles\">овде</a>"
 
 #: scripts/apps/desks/views/desk-config-modal.html:156
 msgid ""
 "Select a default template for new articles. If you don't see any, first make "
 "sure that there is at least one content profile. Each time a profile is "
 "created, Superdesk creates a template with the same name."
-msgstr "Изаберите подразумевани шаблон за нове чланке. Ако ниједан не видите, прво се уверите да постоји барем један профил садржаја. Сваки пут када се креира профил, Superdesk креира шаблон са истим називом."
+msgstr ""
+"Изаберите подразумевани шаблон за нове чланке. Ако ниједан не видите, прво "
+"се уверите да постоји барем један профил садржаја. Сваки пут када се креира "
+"профил, Superdesk креира шаблон са истим називом."
 
 #: scripts/core/ui/components/generic-form/input-types/desk_single_value.tsx:40
 msgid "Select a desk"
@@ -15680,7 +15825,8 @@ msgstr "Постави ознаку у тренутном пакету"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:131
 msgid "Set maximum items per stages and saved searches for view"
-msgstr "Подеси максималан број ставки по фазама и сачуваним претрагама за приказ"
+msgstr ""
+"Подеси максималан број ставки по фазама и сачуваним претрагама за приказ"
 
 #: scripts/apps/monitoring/aggregate-widget/aggregate.ts:17
 msgid ""
@@ -15689,7 +15835,12 @@ msgid ""
 "sensible name, select a saved search or desk or its workflow stages. Monitor "
 "anything, anywhere, anytime. You can have as many Monitor widgets as you "
 "wish."
-msgstr "Подесите различите мониторе да бисте пратили било које теме из пријема или продукције, излаза дескова или било ког дела радног тока. Све што вам треба је да им дате смислен назив, изаберете сачувану претрагу или деск или његове радне фазе. Пратите било шта, било где, било када. Можете имати онолико виџета Монитора колико желите."
+msgstr ""
+"Подесите различите мониторе да бисте пратили било које теме из пријема или "
+"продукције, излаза дескова или било ког дела радног тока. Све што вам треба "
+"је да им дате смислен назив, изаберете сачувану претрагу или деск или његове "
+"радне фазе. Пратите било шта, било где, било када. Можете имати онолико "
+"виџета Монитора колико желите."
 
 #: scripts/extensions/sams/dist/src/api/sets.js:57
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:57
@@ -15888,7 +16039,9 @@ msgstr "Прикажи послате/ставке у реду"
 msgid ""
 "Show to users\n"
 "                                as"
-msgstr "Прикажи корисницима\n                                као"
+msgstr ""
+"Прикажи корисницима\n"
+"                                као"
 
 #: scripts/apps/archive/views/item-crops.html:1
 #: scripts/apps/authoring-react/fields/media/media-carousel/image-crops.tsx:22
@@ -16096,7 +16249,9 @@ msgstr "Провера објаве неких повезаних ставки �
 msgid ""
 "Some selected items have not yet been posted. All selections must be visible "
 "to subscribers."
-msgstr "Неке изабране ставке још нису објављене. Сви избори морају бити видљиви претплатницима."
+msgstr ""
+"Неке изабране ставке још нису објављене. Сви избори морају бити видљиви "
+"претплатницима."
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:53
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:53
@@ -16122,7 +16277,8 @@ msgstr "Слика мора бити најмање {{width}}x{{height}}."
 #: scripts/apps/authoring/attachments/AttachmentsWidget.tsx:38
 msgid ""
 "Sorry, but some files \"{{filenames}}\" are bigger than limit ({{limit}})"
-msgstr "Извините, али неке датотеке \"{{filenames}}\" су веће од лимита ({{limit}})"
+msgstr ""
+"Извините, али неке датотеке \"{{filenames}}\" су веће од лимита ({{limit}})"
 
 #: scripts/apps/templates/views/create-template.html:23
 msgid "Sorry, but template name must be unique."
@@ -17216,7 +17372,9 @@ msgstr "Ставка планирања коју сте уређивали аж�
 #: scripts/apps/products/views/products-config-modal.html:31
 msgid ""
 "The Product ID can be copied and used as Superdesk Newshub product query."
-msgstr "ИД производа се може копирати и користити као упит за производе у Superdesk Newshub-у."
+msgstr ""
+"ИД производа се може копирати и користити као упит за производе у Superdesk "
+"Newshub-у."
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:278
 msgid "The Saved Report you are using was deleted!"
@@ -17225,7 +17383,9 @@ msgstr "Сачувани извештај који користите је об�
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:270
 msgid ""
 "The Saved Report you are using was updated! Please re-select the Saved Report"
-msgstr "Сачувани извештај који користите је ажуриран! Поново изаберите сачувани извештај"
+msgstr ""
+"Сачувани извештај који користите је ажуриран! Поново изаберите сачувани "
+"извештај"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:52
 msgid ""
@@ -17233,7 +17393,11 @@ msgid ""
 "github.com/superdesk\" title=\"Superdesk GitHub\" target=\"_blank\">GitHub</"
 "a> by <a href=\"https://www.sourcefabric.org/\" title=\"Sourcefabric\" "
 "target=\"_blank\">Sourcefabric</a>."
-msgstr "Superdesk пројекат развија и одржава <a href=\"https://github.com/superdesk\" title=\"Superdesk GitHub\" target=\"_blank\">GitHub</a> заједница и <a href=\"https://www.sourcefabric.org/\" title=\"Sourcefabric\" target=\"_blank\">Sourcefabric</a>."
+msgstr ""
+"Superdesk пројекат развија и одржава <a href=\"https://github.com/"
+"superdesk\" title=\"Superdesk GitHub\" target=\"_blank\">GitHub</a> "
+"заједница и <a href=\"https://www.sourcefabric.org/\" title=\"Sourcefabric\" "
+"target=\"_blank\">Sourcefabric</a>."
 
 #: scripts/core/auth/reset-password.html:74
 msgid "The activation token is not valid."
@@ -17352,7 +17516,8 @@ msgstr "Назив Slack канала повезаног са овим деск�
 msgid ""
 "The package \"{{name}}\" contains the following published items that can not "
 "be sent:"
-msgstr "Пакет \"{{name}}\" садржи следеће објављене ставке које не могу бити послате:"
+msgstr ""
+"Пакет \"{{name}}\" садржи следеће објављене ставке које не могу бити послате:"
 
 #: scripts/apps/authoring-react/authoring-swtich.tsx:19
 msgid "The page needs to be reloaded in order to do that."
@@ -17389,19 +17554,25 @@ msgstr "Величина {{filename}} је {{width}}x{{height}}"
 msgid ""
 "The subscriber is currently inactive, but the schedule from {{start}} to "
 "{{end}} is valid. The subscriber will be activated on save."
-msgstr "Претплатник је тренутно неактиван, али распоред од {{start}} до {{end}} је важећи. Претплатник ће бити активиран приликом чувања."
+msgstr ""
+"Претплатник је тренутно неактиван, али распоред од {{start}} до {{end}} је "
+"важећи. Претплатник ће бити активиран приликом чувања."
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:383
 msgid ""
 "The subscriber is set to start on {{date}}, but the Active switch will "
 "override this and activate the subscriber on save."
-msgstr "Претплатник је подешен да почне {{date}}, али ће га прекидач Активно заменити и активирати приликом чувања."
+msgstr ""
+"Претплатник је подешен да почне {{date}}, али ће га прекидач Активно "
+"заменити и активирати приликом чувања."
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:391
 msgid ""
 "The subscriber schedule ended on {{date}}, but the Active switch will keep "
 "the subscriber active on save."
-msgstr "Распоред претплатника је завршен {{date}}, али ће га прекидач Активно одржати активним приликом чувања."
+msgstr ""
+"Распоред претплатника је завршен {{date}}, али ће га прекидач Активно "
+"одржати активним приликом чувања."
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:39
 msgid ""
@@ -17413,7 +17584,10 @@ msgid ""
 "The user activity widget provides information about user activity. Using the "
 "widget, editors can search and select a user. Upon selection a list of "
 "content items is shown categorized as follows:"
-msgstr "Виџет активности корисника пружа информације о активности корисника. Користећи виџет, уредници могу претраживати и изабрати корисника. Након избора приказује се листа ставки садржаја категоризована на следећи начин:"
+msgstr ""
+"Виџет активности корисника пружа информације о активности корисника. "
+"Користећи виџет, уредници могу претраживати и изабрати корисника. Након "
+"избора приказује се листа ставки садржаја категоризована на следећи начин:"
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:226
 msgid "The values should be unique for {{uniqueField}}"
@@ -17426,9 +17600,15 @@ msgid ""
 msgid_plural ""
 "The vocabulary {{name}} can't be deleted because it is currently used in the "
 "following Content Profiles:"
-msgstr[0] "Вокабулар {{name}} не може бити обрисан јер се тренутно користи у следећем профилу садржаја:"
-msgstr[1] "Вокабулар {{name}} не може бити обрисан јер се тренутно користи у следећим профилима садржаја:"
-msgstr[2] "Вокабулар {{name}} не може бити обрисан јер се тренутно користи у следећим профилима садржаја:"
+msgstr[0] ""
+"Вокабулар {{name}} не може бити обрисан јер се тренутно користи у следећем "
+"профилу садржаја:"
+msgstr[1] ""
+"Вокабулар {{name}} не може бити обрисан јер се тренутно користи у следећим "
+"профилима садржаја:"
+msgstr[2] ""
+"Вокабулар {{name}} не може бити обрисан јер се тренутно користи у следећим "
+"профилима садржаја:"
 
 #: ../superdesk-planning/client/actions/main.ts:468
 msgid "The {{ itemType }} has been posted"
@@ -17459,7 +17639,8 @@ msgstr "Постоје проблеми са конфигурацијом инс
 
 #: scripts/api/highlights.ts:37
 msgid "There are items locked or not published. Do you want to continue?"
-msgstr "Постоје ставке које су закључане или нису објављене. Желите ли да наставите?"
+msgstr ""
+"Постоје ставке које су закључане или нису објављене. Желите ли да наставите?"
 
 #: ../superdesk-planning/client/components/ItemActionsMenu/ActionsMenuPopup.tsx:91
 msgid "There are no actions available."
@@ -17574,7 +17755,8 @@ msgstr "Постоје несачуване измене."
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:28
 msgid ""
 "There are unsaved changes. If you navigate away, your changes will be lost."
-msgstr "Постоје несачуване измене. Ако напустите страницу, измене ће бити изгубљене."
+msgstr ""
+"Постоје несачуване измене. Ако напустите страницу, измене ће бити изгубљене."
 
 #: ../superdesk-planning/client/actions/assignments/notifications.ts:350
 msgid "There is a {{ type }} assignment '{{ slugline }}' {{ state }}"
@@ -17683,7 +17865,9 @@ msgstr "Дошло је до грешке приликом покушаја ге
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:219
 msgid "There was an error, could not delete Events and Planning view filter."
-msgstr "Дошло је до грешке, филтер приказа догађаја и планирања није могао бити обрисан."
+msgstr ""
+"Дошло је до грешке, филтер приказа догађаја и планирања није могао бити "
+"обрисан."
 
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:92
 msgid "There was an error. Content filter cannot be deleted."
@@ -17770,7 +17954,10 @@ msgstr "Ово и све будуће планирање"
 msgid ""
 "This article contains unresolved comments.Click on Cancel to go back to "
 "editing toresolve those comments or OK to ignore and proceed with publishing"
-msgstr "Овај чланак садржи неразрешене коментаре. Кликните на Откажи да се вратите на уређивање и разрешите коментаре или У реду да их игноришете и наставите са објавом"
+msgstr ""
+"Овај чланак садржи неразрешене коментаре. Кликните на Откажи да се вратите "
+"на уређивање и разрешите коментаре или У реду да их игноришете и наставите "
+"са објавом"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:25
 msgid "This event is a recurring event!"
@@ -17828,7 +18015,10 @@ msgid ""
 "This field will initialize with the value of specified field when toggled "
 "from \"off\" to \"on\". Only plain-text gets copied. Formatting options or "
 "links are not preserved."
-msgstr "Ово поље ће се иницијализовати вредношћу наведеног поља при пребацивању са \"off\" на \"on\". Копира се само обичан текст. Опције форматирања и линкови се не задржавају."
+msgstr ""
+"Ово поље ће се иницијализовати вредношћу наведеног поља при пребацивању са "
+"\"off\" на \"on\". Копира се само обичан текст. Опције форматирања и линкови "
+"се не задржавају."
 
 #: scripts/apps/templates/directives/TemplatesDirective.ts:358
 msgid "This is a default template of the following desk(s): {{deskNames}}."
@@ -17892,7 +18082,9 @@ msgstr "Ову причу је прерадио:"
 msgid ""
 "This vocabulary is not currently used in any Content Profile and can be "
 "safely removed."
-msgstr "Овај вокабулар се тренутно не користи ни у једном профилу садржаја и може се безбедно уклонити."
+msgstr ""
+"Овај вокабулар се тренутно не користи ни у једном профилу садржаја и може се "
+"безбедно уклонити."
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:42
 msgid "This week"
@@ -17903,7 +18095,11 @@ msgid ""
 "This widget allows you to create literally any content view you may need in "
 "Superdesk, be it production or ingest. All you need is to select a desk, its "
 "stages or a saved search. Name your view once you are done. Enjoy!"
-msgstr "Овај виџет вам омогућава да креирате буквално било који приказ садржаја који вам је потребан у Superdesk-у, било да се ради о продукцији или пријему. Све што треба је да изаберете деск, његове фазе или сачувану претрагу. Именујте свој приказ када завршите. Уживајте!"
+msgstr ""
+"Овај виџет вам омогућава да креирате буквално било који приказ садржаја који "
+"вам је потребан у Superdesk-у, било да се ради о продукцији или пријему. Све "
+"што треба је да изаберете деск, његове фазе или сачувану претрагу. Именујте "
+"свој приказ када завршите. Уживајте!"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:83
 msgid "This will also post the related event's entire recurring series"
@@ -17921,7 +18117,9 @@ msgstr "Ово ће такође уклонити повезане задатк�
 msgid ""
 "This will also remove other linked assignments (if any, for story updates). "
 "Are you sure?"
-msgstr "Ово ће такође уклонити друге повезане задатке (ако постоје, за ажурирања приче). Да ли сте сигурни?"
+msgstr ""
+"Ово ће такође уклонити друге повезане задатке (ако постоје, за ажурирања "
+"приче). Да ли сте сигурни?"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:51
 msgid "This will also {{action}} the following events"
@@ -17935,11 +18133,14 @@ msgstr "Ово ће такође {{action}} следеће ставке план
 msgid ""
 "This will appear below the field in the\n"
 "                                    Editor."
-msgstr "Ово ће се појавити испод поља у\n                                    уређивачу."
+msgstr ""
+"Ово ће се појавити испод поља у\n"
+"                                    уређивачу."
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/convertToRecurringEventForm.tsx:152
 msgid "This will create new events in the remote ({{timeZone}}) timezone"
-msgstr "Ово ће креирати нове догађаје у удаљеној ({{timeZone}}) временској зони"
+msgstr ""
+"Ово ће креирати нове догађаје у удаљеној ({{timeZone}}) временској зони"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:269
 msgid "This will create the new event in the remote ({{timeZone}}) timezone"
@@ -17952,7 +18153,9 @@ msgstr "Ово ће означити следеће ставке планира�
 #: ../superdesk-planning/client/actions/assignments/ui.ts:553
 msgid ""
 "This will unlink the text item associated with the assignment. Are you sure ?"
-msgstr "Ово ће уклонити везу текстуалне ставке повезане са задатком. Да ли сте сигурни?"
+msgstr ""
+"Ово ће уклонити везу текстуалне ставке повезане са задатком. Да ли сте "
+"сигурни?"
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:111
 msgid "Thu"
@@ -18032,7 +18235,11 @@ msgid ""
 "article is created\n"
 "            based on this template, it's value will initialize to creation "
 "time + {{x}} minutes"
-msgstr "Временски померај је подешен на {{x}} минута за ово поље. Када се чланак креира\n            на основу овог шаблона, његова вредност ће се иницијализовати на време креирања + {{x}} минута"
+msgstr ""
+"Временски померај је подешен на {{x}} минута за ово поље. Када се чланак "
+"креира\n"
+"            на основу овог шаблона, његова вредност ће се иницијализовати на "
+"време креирања + {{x}} минута"
 
 #: scripts/apps/profiling/views/profiling.html:34
 msgid "Time per call"
@@ -18143,7 +18350,9 @@ msgstr "У велика слова"
 msgid ""
 "To delete this vocabulary, you must first remove it from all Content "
 "Profiles listed above."
-msgstr "Да бисте обрисали овај вокабулар, прво га уклоните из свих профила садржаја наведених изнад."
+msgstr ""
+"Да бисте обрисали овај вокабулар, прво га уклоните из свих профила садржаја "
+"наведених изнад."
 
 #: scripts/core/editor3/components/embeds/EmbedInput.tsx:152
 msgid "To get a responsive embed code, paste a URL."
@@ -18152,7 +18361,9 @@ msgstr "За добијање прилагодљивог кода за угра�
 #: scripts/apps/authoring-react/fields/media/difference.tsx:72
 msgid ""
 "To see detailed differences, compare primary and secondary items visually"
-msgstr "Да бисте видели детаљне разлике, упоредите примарну и секундарну ставку визуелно"
+msgstr ""
+"Да бисте видели детаљне разлике, упоредите примарну и секундарну ставку "
+"визуелно"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:18
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:129
@@ -18613,7 +18824,9 @@ msgstr "Дошло је до непознате грешке, покушајте
 #: scripts/apps/search/controllers/get-multi-actions.tsx:302
 msgid ""
 "Unknown error occured. Try publishing the item from the article edit view."
-msgstr "Дошло је до непознате грешке. Покушајте да објавите ставку из приказа за уређивање чланка."
+msgstr ""
+"Дошло је до непознате грешке. Покушајте да објавите ставку из приказа за "
+"уређивање чланка."
 
 #: scripts/api/article-send.tsx:248
 msgid "Unknown error occurred"
@@ -18811,7 +19024,9 @@ msgstr "Откажи претплату корисника"
 msgid ""
 "Unsupported extension point is being used: "
 "`contributions.authoringHeaderComponents`"
-msgstr "Користи се неподржана тачка проширења: `contributions.authoringHeaderComponents`"
+msgstr ""
+"Користи се неподржана тачка проширења: "
+"`contributions.authoringHeaderComponents`"
 
 #: ../superdesk-planning/client/components/WorkqueueContainer/WorkqueueItem.tsx:41
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:6
@@ -18982,7 +19197,9 @@ msgstr "Ажурирања"
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:34
 msgid ""
 "Updates can only be created for text items. The type of this item is {{type}}"
-msgstr "Ажурирања могу бити креирана само за текстуалне ставке. Тип ове ставке је {{type}}"
+msgstr ""
+"Ажурирања могу бити креирана само за текстуалне ставке. Тип ове ставке је "
+"{{type}}"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:205
 #: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:136
@@ -19544,7 +19761,10 @@ msgid ""
 "address you have provided. Your data will be kept secure and it won't be "
 "used for any other purpose. You may opt-out of receiving further email "
 "communications at any time."
-msgstr "Слаћемо повремена ажурирања о Superdesk развоју на имејл адресу коју сте навели. Ваши подаци ће бити безбедни и неће се користити у друге сврхе. Можете отказати даља имејл обавештења у било ком тренутку."
+msgstr ""
+"Слаћемо повремена ажурирања о Superdesk развоју на имејл адресу коју сте "
+"навели. Ваши подаци ће бити безбедни и неће се користити у друге сврхе. "
+"Можете отказати даља имејл обавештења у било ком тренутку."
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:38
 msgid "Weak"
@@ -19618,7 +19838,8 @@ msgstr "Подешавања виџета"
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:8
 msgid ""
 "Widget settings <span translate>for \"{{currentDesk.name}}\" Desk</span>"
-msgstr "Подешавања виџета <span translate>за деск \"{{currentDesk.name}}\"</span>"
+msgstr ""
+"Подешавања виџета <span translate>за деск \"{{currentDesk.name}}\"</span>"
 
 #: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:95
 msgid "Widgets"
@@ -19633,7 +19854,9 @@ msgstr "Ширина"
 msgid ""
 "Width of the\n"
 "                                    popup window (in pixels)"
-msgstr "Ширина\n                                    искачућег прозора (у пикселима)"
+msgstr ""
+"Ширина\n"
+"                                    искачућег прозора (у пикселима)"
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:73
 msgid "Wire/Paper"
@@ -19751,13 +19974,16 @@ msgstr "Јуче"
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:106
 msgid ""
 "You are about to delete the vocabulary {{name}}. This action can't be undone."
-msgstr "Управо ћете обрисати вокабулар {{name}}. Ова радња не може бити поништена."
+msgstr ""
+"Управо ћете обрисати вокабулар {{name}}. Ова радња не може бити поништена."
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:109
 msgid ""
 "You are changing you personal preferences. If you would like to set the "
 "default order for the desk, you can do so from the settings page."
-msgstr "Мењате своје личне поставке. Ако желите да поставите подразумевани редослед за деск, то можете учинити на страници подешавања."
+msgstr ""
+"Мењате своје личне поставке. Ако желите да поставите подразумевани редослед "
+"за деск, то можете учинити на страници подешавања."
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:249
 msgid "You are creating a new planning item."
@@ -19769,7 +19995,8 @@ msgstr "Тренутно управљате истакнутом причом у
 
 #: scripts/validate-instance-configuration.tsx:38
 msgid "You are likely running an outdated version of auto tagging extension."
-msgstr "Вероватно користите застарелу верзију екстензије за аутоматско означавање."
+msgstr ""
+"Вероватно користите застарелу верзију екстензије за аутоматско означавање."
 
 #: scripts/apps/workspace/content/services/ContentService.ts:71
 msgid "You are not allowed to create an article there."
@@ -19783,7 +20010,9 @@ msgstr "Није вам дозвољено да креирате чланак у
 msgid ""
 "You are trying to add multiple related events when only one is allowed. Only "
 "the first event({{name}}) will be added."
-msgstr "Покушавате да додате више повезаних догађаја када је дозвољен само један. Биће додат само први догађај ({{name}})."
+msgstr ""
+"Покушавате да додате више повезаних догађаја када је дозвољен само један. "
+"Биће додат само први догађај ({{name}})."
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageForm.tsx:233
 msgid "You can associate only one XMP file"
@@ -19794,13 +20023,18 @@ msgid ""
 "You can choose the default content view of your desk. Use only if you want "
 "to override individual users' monitoring view preferences. Select \"none\" "
 "if you want to let users decide."
-msgstr "Можете изабрати подразумевани приказ садржаја вашег деска. Користите само ако желите да заобиђете поставке приказа мониторинга појединачних корисника. Изаберите \"ништа\" ако желите да оставите корисницима да одлуче."
+msgstr ""
+"Можете изабрати подразумевани приказ садржаја вашег деска. Користите само "
+"ако желите да заобиђете поставке приказа мониторинга појединачних корисника. "
+"Изаберите \"ништа\" ако желите да оставите корисницима да одлуче."
 
 #: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:148
 msgid ""
 "You can either completely block further writing after the characterlimit is "
 "reached or highlight exceeding characters in red."
-msgstr "Можете потпуно блокирати даље писање након што се достигне лимит карактера или истаћи карактере преко лимита црвеном бојом."
+msgstr ""
+"Можете потпуно блокирати даље писање након што се достигне лимит карактера "
+"или истаћи карактере преко лимита црвеном бојом."
 
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:154
 msgid "You can't multi-edit, because these articles can't be edited"
@@ -19837,14 +20071,19 @@ msgstr "Имате несачуване измене. Шта желите да �
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:242
 msgid ""
 "You made changes to this planning item that is part of a recurring event."
-msgstr "Направили сте измене на овој ставци планирања која је део понављајућег догађаја."
+msgstr ""
+"Направили сте измене на овој ставци планирања која је део понављајућег "
+"догађаја."
 
 #: scripts/apps/production-api-keys/config.ts:40
 msgid ""
 "Your Client ID and Client Secret will be generated when you save. Make sure "
 "to copy the Client Secret immediately. It will only be shown once and it "
 "cannot be retrieved later."
-msgstr "ИД клијента и тајни кључ клијента биће генерисани приликом чувања. Обавезно одмах копирајте тајни кључ клијента. Биће приказан само једном и не може се касније преузети."
+msgstr ""
+"ИД клијента и тајни кључ клијента биће генерисани приликом чувања. Обавезно "
+"одмах копирајте тајни кључ клијента. Биће приказан само једном и не може се "
+"касније преузети."
 
 #: scripts/apps/users/import/views/import-user.html:11
 msgid "Your Credentials"
@@ -19858,11 +20097,13 @@ msgstr "Ваше Slack корисничко име без водећег @"
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:124
 #: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:84
 msgid "Your changes will be lost if you close now. What would you like to do?"
-msgstr "Ваше измене ће бити изгубљене ако сада затворите. Шта желите да урадите?"
+msgstr ""
+"Ваше измене ће бити изгубљене ако сада затворите. Шта желите да урадите?"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:285
 msgid "Your changes will be lost if you switch now. What would you like to do?"
-msgstr "Ваше измене ће бити изгубљене ако сада промените. Шта желите да урадите?"
+msgstr ""
+"Ваше измене ће бити изгубљене ако сада промените. Шта желите да урадите?"
 
 #: scripts/apps/dashboard/world-clock/configuration.html:12
 msgid "Your clock"
@@ -20081,7 +20322,9 @@ msgstr "промени лозинку"
 msgid ""
 "changed the following original item. Please make sure to update the "
 "corresponding translated item accordingly"
-msgstr "изменио је следећу оригиналну ставку. Обавезно ажурирајте одговарајућу преведену ставку у складу са тим"
+msgstr ""
+"изменио је следећу оригиналну ставку. Обавезно ажурирајте одговарајућу "
+"преведену ставку у складу са тим"
 
 #: scripts/apps/authoring/authoring/components/CharacterCount.tsx:30
 #: scripts/apps/authoring/authoring/components/CharacterCount.tsx:64
@@ -20184,7 +20427,8 @@ msgstr "креирао"
 
 #: scripts/core/lang/missing-translations-strings.ts:36
 msgid "created new version {{version}} for item {{type}} about \"{{subject}}\""
-msgstr "креирао нову верзију {{version}} за ставку типа {{type}} о \"{{subject}}\""
+msgstr ""
+"креирао нову верзију {{version}} за ставку типа {{type}} о \"{{subject}}\""
 
 #: scripts/core/lang/missing-translations-strings.ts:42
 msgid "created user {{user}}"
@@ -20572,7 +20816,9 @@ msgstr "iMatrics грешка сервиса"
 msgid ""
 "iMatrics service has returned tags referencing parents that do not exist in "
 "the response."
-msgstr "iMatrics сервис је вратио ознаке које реферишу родитеље који не постоје у одговору."
+msgstr ""
+"iMatrics сервис је вратио ознаке које реферишу родитеље који не постоје у "
+"одговору."
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extension.js:10
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/extension.js:10
@@ -20985,7 +21231,9 @@ msgstr "унесите исправну имејл адресу"
 msgid ""
 "please use only letters (a-z), numbers (0-9), dashes (&mdash;), underscores "
 "(_), apostrophes (') and periods (.)"
-msgstr "користите само слова (a-z), бројеве (0-9), цртице (&mdash;), доње црте (_), апострофе (') и тачке (.)"
+msgstr ""
+"користите само слова (a-z), бројеве (0-9), цртице (&mdash;), доње црте (_), "
+"апострофе (') и тачке (.)"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:121
 msgid "post"
@@ -21223,7 +21471,9 @@ msgstr "почетно време"
 #: scripts/extensions/availability-manager/src/utils.ts:102
 msgid ""
 "start time cannot be greater than end time ({{start_time}} - {{end_time}})"
-msgstr "почетно време не може бити веће од крајњег времена ({{start_time}} - {{end_time}})"
+msgstr ""
+"почетно време не може бити веће од крајњег времена ({{start_time}} - "
+"{{end_time}})"
 
 #: scripts/apps/authoring/metadata/views/meta-place-directive.html:19
 msgid "state, region, ..."
@@ -21485,7 +21735,9 @@ msgstr "прикажи све"
 #: scripts/core/notification/notification.ts:231
 msgid ""
 "vocabulary has been updated. Please re-login to see updated vocabulary values"
-msgstr "вокабулар је ажуриран. Поново се пријавите да бисте видели ажуриране вредности вокабулара"
+msgstr ""
+"вокабулар је ажуриран. Поново се пријавите да бисте видели ажуриране "
+"вредности вокабулара"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:448
 msgid "website"

--- a/po/sr.po
+++ b/po/sr.po
@@ -13,7 +13,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:32
 msgid "\"GENRE 'null value not allowed'"
-msgstr ""
+msgstr "\"ЖАНР 'није дозвољена нул вредност'"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:199
 msgid "\"Name\" is a required field"
@@ -39,59 +39,59 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:23
 msgid "'ABSTRACT is a required field'"
-msgstr ""
+msgstr "'САЖЕТАК је обавезно поље'"
 
 #: scripts/core/lang/missing-translations-strings.ts:24
 msgid "'ANPA_CATEGORY is a required field'"
-msgstr ""
+msgstr "'ANPA_CATEGORY је обавезно поље'"
 
 #: scripts/core/lang/missing-translations-strings.ts:23
 msgid "'BYLINE is a required field'"
-msgstr ""
+msgstr "'ПОТПИС је обавезно поље'"
 
 #: scripts/core/lang/missing-translations-strings.ts:33
 msgid "'CATEGORY is a required field'"
-msgstr ""
+msgstr "'КАТЕГОРИЈА је обавезно поље'"
 
 #: scripts/core/lang/missing-translations-strings.ts:32
 msgid "'DATELINE is a required field'"
-msgstr ""
+msgstr "'ДАТУМСКА ЛИНИЈА је обавезно поље'"
 
 #: scripts/core/lang/missing-translations-strings.ts:22
 msgid "'GENRE is a required field'"
-msgstr ""
+msgstr "'ЖАНР је обавезно поље'"
 
 #: scripts/core/lang/missing-translations-strings.ts:25
 msgid "'GENRE null value not allowed'"
-msgstr ""
+msgstr "'ЖАНР није дозвољена нул вредност'"
 
 #: scripts/core/lang/missing-translations-strings.ts:24
 msgid "'HEADLINE is a required field'"
-msgstr ""
+msgstr "'НАСЛОВ је обавезно поље'"
 
 #: scripts/core/lang/missing-translations-strings.ts:30
 msgid "'PLACE is a required field'"
-msgstr ""
+msgstr "'МЕСТО је обавезно поље'"
 
 #: scripts/core/lang/missing-translations-strings.ts:43
 msgid "'PRIORITY is a required field'"
-msgstr ""
+msgstr "'ПРИОРИТЕТ је обавезно поље'"
 
 #: scripts/core/lang/missing-translations-strings.ts:24
 msgid "'SLUGLINE is a required field'"
-msgstr ""
+msgstr "'СЛАГЛАЈН је обавезно поље'"
 
 #: scripts/core/lang/missing-translations-strings.ts:23
 msgid "'SUBJECT is a required field'"
-msgstr ""
+msgstr "'ТЕМА је обавезно поље'"
 
 #: scripts/core/lang/missing-translations-strings.ts:43
 msgid "'URGENCY is a required field'"
-msgstr ""
+msgstr "'ХИТНОСТ је обавезно поље'"
 
 #: scripts/core/lang/missing-translations-strings.ts:34
 msgid "'must be of list type'\""
-msgstr ""
+msgstr "'мора бити типа листе'\""
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:37
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:146
@@ -233,7 +233,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:28
 msgid "10th update"
-msgstr ""
+msgstr "10. ажурирање"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:45
 #: ../superdesk-planning/client/utils/filters.ts:83
@@ -242,7 +242,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:28
 msgid "11th update"
-msgstr ""
+msgstr "11. ажурирање"
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:17
 msgid "12 Hours"
@@ -259,7 +259,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:29
 msgid "12th update"
-msgstr ""
+msgstr "12. ажурирање"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:47
 #: ../superdesk-planning/client/utils/filters.ts:87
@@ -268,7 +268,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:29
 msgid "13th update"
-msgstr ""
+msgstr "13. ажурирање"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:48
 #: ../superdesk-planning/client/utils/filters.ts:89
@@ -277,7 +277,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:29
 msgid "14th update"
-msgstr ""
+msgstr "14. ажурирање"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:49
 #: ../superdesk-planning/client/utils/filters.ts:91
@@ -286,7 +286,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:29
 msgid "15th update"
-msgstr ""
+msgstr "15. ажурирање"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:50
 #: ../superdesk-planning/client/utils/filters.ts:93
@@ -295,7 +295,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:29
 msgid "16th update"
-msgstr ""
+msgstr "16. ажурирање"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:51
 msgid "17th"
@@ -303,7 +303,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:29
 msgid "17th update"
-msgstr ""
+msgstr "17. ажурирање"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:52
 msgid "18th"
@@ -311,7 +311,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:30
 msgid "18th update"
-msgstr ""
+msgstr "18. ажурирање"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:53
 #: ../superdesk-planning/client/utils/filters.ts:99
@@ -320,7 +320,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:30
 msgid "19th update"
-msgstr ""
+msgstr "19. ажурирање"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:189
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:189
@@ -353,7 +353,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:30
 msgid "20th update"
-msgstr ""
+msgstr "20. ажурирање"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:55
 #: ../superdesk-planning/client/utils/filters.ts:103
@@ -418,7 +418,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:27
 msgid "2nd update"
-msgstr ""
+msgstr "2. ажурирање"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:37
 #: ../superdesk-planning/client/utils/filters.ts:67
@@ -427,11 +427,11 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:27
 msgid "3rd update"
-msgstr ""
+msgstr "3. ажурирање"
 
 #: scripts/core/lang/missing-translations-strings.ts:25
 msgid "412: Can't publish as item state is draft"
-msgstr ""
+msgstr "412: Није могуће објавити јер је стање ставке нацрт"
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:20
 msgid "48 Hours"
@@ -444,7 +444,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:27
 msgid "4th update"
-msgstr ""
+msgstr "4. ажурирање"
 
 #: scripts/apps/publish/controllers/SubscriberTokenController.ts:26
 msgid "5 years"
@@ -475,7 +475,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:27
 msgid "5th update"
-msgstr ""
+msgstr "5. ажурирање"
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:16
 msgid "6 Hours"
@@ -492,7 +492,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:28
 msgid "6th update"
-msgstr ""
+msgstr "6. ажурирање"
 
 #: ../superdesk-planning/client/utils/filters.ts:95
 msgid "70th"
@@ -505,7 +505,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:28
 msgid "7th update"
-msgstr ""
+msgstr "7. ажурирање"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:42
 #: ../superdesk-planning/client/utils/filters.ts:77
@@ -514,7 +514,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:28
 msgid "8th update"
-msgstr ""
+msgstr "8. ажурирање"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:43
 #: ../superdesk-planning/client/utils/filters.ts:79
@@ -523,7 +523,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:28
 msgid "9th update"
-msgstr ""
+msgstr "9. ажурирање"
 
 #: scripts/apps/desks/views/desk-config-modal.html:249
 msgid ": OFF"
@@ -604,7 +604,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:47
 msgid "ABSTRACT is too long"
-msgstr ""
+msgstr "САЖЕТАК је предугачак"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:66
 msgid "ADD WORD"
@@ -633,7 +633,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:31
 msgid "ANPA Take Key"
-msgstr ""
+msgstr "ANPA кључ наставка"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx:109
 msgid "ASSOCIATED XMP FILE"
@@ -796,11 +796,11 @@ msgstr "Активно до {{end}}"
 #: scripts/apps/users/views/activity-feed.html:4
 #: scripts/core/lang/missing-translations-strings.ts:44
 msgid "Activity Stream"
-msgstr ""
+msgstr "Ток активности"
 
 #: scripts/core/lang/missing-translations-strings.ts:44
 msgid "Activity stream widget"
-msgstr ""
+msgstr "Виџет тока активности"
 
 #: ../superdesk-planning/client/components/fields/editor/AdHocPlanning.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:41
@@ -1900,7 +1900,7 @@ msgstr "Примени водени жиг"
 #: scripts/apps/production-api-keys/config.ts:23
 #: scripts/core/lang/missing-translations-strings.ts:15
 msgid "Archive"
-msgstr ""
+msgstr "Архива"
 
 #: scripts/apps/workspace/content/constants.ts:11
 msgid "Archive description"
@@ -1916,7 +1916,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:15
 msgid "Archived Management"
-msgstr ""
+msgstr "Управљање архивираним"
 
 #: scripts/apps/archive/views/preview.html:46
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/archived-from.tsx:8
@@ -2820,7 +2820,7 @@ msgstr "Тело"
 #: scripts/apps/workspace/content/constants.ts:15
 #: scripts/core/lang/missing-translations-strings.ts:31
 msgid "Body HTML"
-msgstr ""
+msgstr "Тело HTML"
 
 #: scripts/apps/authoring-react/field-adapters/body_footer.ts:37
 #: scripts/apps/workspace/content/constants.ts:14
@@ -2869,7 +2869,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:50
 #: scripts/core/lang/missing-translations-strings.ts:15
 msgid "Broadcast"
-msgstr ""
+msgstr "Емисија"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:51
 msgid "Broadcast Create"
@@ -2896,7 +2896,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:31
 msgid "By"
-msgstr ""
+msgstr "Од"
 
 #: scripts/apps/users/views/user-preferences.html:143
 msgid ""
@@ -4039,7 +4039,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:26
 msgid "Content Expiry"
-msgstr ""
+msgstr "Истек садржаја"
 
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:332
 msgid "Content Fields"
@@ -4072,7 +4072,7 @@ msgstr "Профил садржаја"
 #: scripts/apps/workspace/content/views/profile-settings.html:4
 #: scripts/core/lang/missing-translations-strings.ts:31
 msgid "Content Profiles"
-msgstr ""
+msgstr "Профили садржаја"
 
 #: ../superdesk-analytics/client/content_publishing_report/index.js:44
 msgid "Content Publishing"
@@ -4099,7 +4099,7 @@ msgstr "Тип садржаја:"
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:395
 #: scripts/core/lang/missing-translations-strings.ts:15
 msgid "Content Types"
-msgstr ""
+msgstr "Типови садржаја"
 
 #: scripts/core/activity/activity.ts:27
 msgid "Content config"
@@ -4305,7 +4305,7 @@ msgstr ""
 #: scripts/apps/search/components/fields/state.tsx:40
 #: scripts/core/lang/missing-translations-strings.ts:16
 msgid "Correction"
-msgstr ""
+msgstr "Исправка"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:165
 msgid "Correction Cancel by"
@@ -4758,7 +4758,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:39
 msgid "Created Ingest Channel {{name}}"
-msgstr ""
+msgstr "Креиран канал доласка {{name}}"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:158
 msgid "Created To"
@@ -5038,7 +5038,7 @@ msgstr "Контролна табла је празна"
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:41
 #: scripts/extensions/datetimeField/src/editor.tsx:64
 msgid "Date"
-msgstr ""
+msgstr "Датум"
 
 #: scripts/apps/authoring-react/fields/date/index.tsx:17
 msgid "Date (authoring-react)"
@@ -5376,7 +5376,7 @@ msgstr "Обриши радни простор"
 
 #: scripts/core/lang/missing-translations-strings.ts:40
 msgid "Deleted Ingest Channel {{name}}"
-msgstr ""
+msgstr "Обрисан канал доласка {{name}}"
 
 #: scripts/apps/publish/views/destination.html:22
 msgid "Delivery type"
@@ -5521,7 +5521,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:16
 msgid "Desk Management"
-msgstr ""
+msgstr "Управљање десковима"
 
 #: scripts/apps/monitoring/directives/AggregateSettings.ts:56
 #: scripts/apps/workspace/content/constants.ts:66
@@ -5672,7 +5672,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:16
 msgid "Dictionaries List Management"
-msgstr ""
+msgstr "Управљање листом речника"
 
 #: scripts/apps/dictionaries/views/settings.html:23
 msgid "Dictionary"
@@ -5790,7 +5790,7 @@ msgstr "Прекинута веза са сервером обавештења!"
 msgid ""
 "Displaying news ingest statistics. You can switch color themes or graph "
 "sources."
-msgstr ""
+msgstr "Приказује статистике доласка вести. Можете променити теме боја или изворе графикона."
 
 #: scripts/core/keyboard/keyboard.ts:401 scripts/core/keyboard/keyboard.ts:410
 msgid "Displays active keyboard shortcuts"
@@ -6087,7 +6087,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:16
 msgid "Duplicate Content within a Desk"
-msgstr ""
+msgstr "Дуплирај садржај унутар деска"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:55
 msgid "Duplicate ID: {{x}}"
@@ -6436,7 +6436,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:17
 msgid "Edit Unique Name"
-msgstr ""
+msgstr "Уреди јединствени назив"
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditor.js:486
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditor.js:486
@@ -6665,7 +6665,7 @@ msgstr "Уграђивање није дозвољено за овај уређ�
 
 #: scripts/core/lang/missing-translations-strings.ts:14
 msgid "Enable Feature Preview"
-msgstr ""
+msgstr "Омогући преглед нових функција"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:204
 msgid "Enable if config can't be tested on REST server."
@@ -7938,7 +7938,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:17
 msgid "Feature Preview"
-msgstr ""
+msgstr "Преглед нових функција"
 
 #: scripts/apps/authoring-react/field-adapters/feature_media.ts:21
 msgid "Feature media"
@@ -8024,7 +8024,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:17
 msgid "Fetch Content To a Desk"
-msgstr ""
+msgstr "Преузми садржај на деск"
 
 #: scripts/apps/ingest/index.ts:115 scripts/apps/ingest/index.ts:146
 msgid "Fetch To"
@@ -8708,7 +8708,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:22
 msgid "Groups Management"
-msgstr ""
+msgstr "Управљање групама"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:402
 msgid "Guid"
@@ -8746,7 +8746,7 @@ msgstr "H6"
 
 #: scripts/core/lang/missing-translations-strings.ts:47
 msgid "HEADLINE is too long"
-msgstr ""
+msgstr "НАСЛОВ је предугачак"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/TimeInputs.tsx:45
 msgid "HOUR"
@@ -8939,7 +8939,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:17
 msgid "Highlights/Summary List Management"
-msgstr ""
+msgstr "Управљање листом истицања/прегледа"
 
 #: ../superdesk-planning/client/components/Main/ItemEditor/Editor.tsx:63
 #: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:92
@@ -8949,7 +8949,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:18
 msgid "Hold"
-msgstr ""
+msgstr "Задржи"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:110
 msgid "Home"
@@ -9301,7 +9301,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:18
 msgid "Ingest Channels"
-msgstr ""
+msgstr "Канали доласка"
 
 #: scripts/apps/ingest/index.ts:92
 #: scripts/apps/ingest/views/dashboard/dashboard.html:2
@@ -9353,7 +9353,7 @@ msgstr ""
 #: scripts/apps/ingest/ingest-stats-widget/stats.ts:9
 #: scripts/core/lang/missing-translations-strings.ts:44
 msgid "Ingest Stats"
-msgstr ""
+msgstr "Статистика доласка"
 
 #: scripts/apps/archive/views/metadata-view.html:128
 msgid "Ingest provider sequence"
@@ -9909,7 +9909,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:63
 #: scripts/core/lang/missing-translations-strings.ts:20
 msgid "Last Day"
-msgstr ""
+msgstr "Последњи дан"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:34
 msgid "Last Item Arrived"
@@ -9919,7 +9919,7 @@ msgstr ""
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:20
 #: scripts/core/lang/missing-translations-strings.ts:21
 msgid "Last Month"
-msgstr ""
+msgstr "Последњи месец"
 
 #: scripts/apps/contacts/constants.ts:69
 #: scripts/apps/contacts/views/search-panel.html:22
@@ -9939,7 +9939,7 @@ msgstr "Последње ажурирано"
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:14
 #: scripts/core/lang/missing-translations-strings.ts:26
 msgid "Last Week"
-msgstr ""
+msgstr "Последња недеља"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:31
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:26
@@ -10206,7 +10206,7 @@ msgstr ""
 #: scripts/core/lang/missing-translations-strings.ts:14
 #: scripts/core/lang/missing-translations-strings.ts:31
 msgid "Located"
-msgstr ""
+msgstr "Лоцирано"
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/locations-field.ts:19
 #: ../superdesk-planning/client/components/fields/editor/Location.tsx:49
@@ -10394,7 +10394,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:18
 msgid "Manage Global Saved Searches"
-msgstr ""
+msgstr "Управљај глобалним сачуваним претрагама"
 
 #: ../superdesk-planning/index.ts:28 ../superdesk-planning/index.ts:29
 msgid "Manage Locations"
@@ -10419,7 +10419,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:18
 msgid "Manage Search Providers"
-msgstr ""
+msgstr "Управљај провајдерима претраге"
 
 #: scripts/extensions/sams/dist/src/components/sets/manageSetsModal.js:99
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:118
@@ -10531,7 +10531,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:19
 msgid "Mark items for Highlights/Summary Lists"
-msgstr ""
+msgstr "Означи ставке за листе истицања/прегледа"
 
 #: scripts/apps/search/constants.ts:17
 #: scripts/apps/search/views/search-parameters.html:71
@@ -10882,7 +10882,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:19
 msgid "Move Content to another desk"
-msgstr ""
+msgstr "Премести садржај на други деск"
 
 #: ../superdesk-analytics/client/utils.js:167
 msgid "Move From"
@@ -11040,7 +11040,7 @@ msgstr "НЕМА СУГЕСТИЈА."
 
 #: scripts/core/lang/missing-translations-strings.ts:33
 msgid "NTB Currency Macro"
-msgstr ""
+msgstr "NTB макро за валуту"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:31
 #: ../superdesk-planning/client/components/Agendas/ManageAgendasModal.tsx:15
@@ -12636,7 +12636,7 @@ msgstr ""
 #: scripts/extensions/auto-tagging-widget/dist/src/groups.js:22
 #: scripts/extensions/auto-tagging-widget/src/groups.ts:31
 msgid "Places"
-msgstr ""
+msgstr "Места"
 
 #: ../superdesk-planning/client/components/fields/list/Places.tsx:20
 msgid "Places:"
@@ -12729,7 +12729,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:19
 msgid "Planning Management"
-msgstr ""
+msgstr "Управљање планирањем"
 
 #: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:150
 msgid "Planning Module (Items created per user)"
@@ -12902,7 +12902,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:33
 msgid "Populate Abstract"
-msgstr ""
+msgstr "Попуни сажетак"
 
 #: scripts/core/editor3/components/toolbar/FloatingCharacterCount.tsx:45
 msgid "Position"
@@ -12987,7 +12987,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:15
 msgid "Preferred Categories"
-msgstr ""
+msgstr "Преферисане категорије"
 
 #: scripts/apps/desks/views/desk-config-modal.html:200
 msgid "Preferred values for vocabularies"
@@ -13284,7 +13284,7 @@ msgstr ""
 #: scripts/core/lang/missing-translations-strings.ts:39
 msgid ""
 "Provider {{name}} has gone strangely quiet. Last activity was on {{last}}"
-msgstr ""
+msgstr "Провајдер {{name}} је неуобичајено тих. Последња активност је била {{last}}"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:279
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:110
@@ -14314,7 +14314,7 @@ msgstr "URL ресурса"
 
 #: scripts/core/lang/missing-translations-strings.ts:20
 msgid "Restore"
-msgstr ""
+msgstr "Врати"
 
 #: scripts/apps/products/views/product-test.html:15
 msgid "Result Type"
@@ -14393,7 +14393,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:20
 msgid "Roles Management"
-msgstr ""
+msgstr "Управљање улогама"
 
 #: scripts/apps/users/views/settings.html:12
 msgid "Roles privileges"
@@ -14441,7 +14441,7 @@ msgstr "Усмерено са:"
 
 #: scripts/core/lang/missing-translations-strings.ts:20
 msgid "Routing Rules Management"
-msgstr ""
+msgstr "Управљање правилима усмеравања"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:219
 msgid "Routing Scheme"
@@ -14532,7 +14532,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:47
 msgid "SLUGLINE is too long"
-msgstr ""
+msgstr "СЛАГЛАЈН је предугачак"
 
 #: scripts/apps/workspace/content/constants.ts:42
 msgid "SMS"
@@ -15532,7 +15532,7 @@ msgstr "Пошаљи уништење"
 
 #: scripts/core/lang/missing-translations-strings.ts:14
 msgid "Send notifications via email"
-msgstr ""
+msgstr "Шаљи обавештења путем имејла"
 
 #: scripts/apps/internal-destinations/InternalDestinations.tsx:70
 msgid "Send only after publish schedule"
@@ -15572,7 +15572,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:22
 msgid "Sending"
-msgstr ""
+msgstr "Слање"
 
 #: scripts/apps/workspace/content/constants.ts:68
 msgid "Sent Desk Output"
@@ -15903,7 +15903,7 @@ msgstr ""
 #: scripts/apps/workspace/content/constants.ts:40
 #: scripts/core/lang/missing-translations-strings.ts:18
 msgid "Sign Off"
-msgstr ""
+msgstr "Потпис"
 
 #: scripts/core/auth/login-modal.html:31
 msgid "Sign in as a different user."
@@ -16633,7 +16633,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/preview/index.ts:162
 #: scripts/core/lang/missing-translations-strings.ts:12
 msgid "Subjects"
-msgstr ""
+msgstr "Теме"
 
 #: ../superdesk-planning/client/components/fields/list/Subject.tsx:20
 msgid "Subjects:"
@@ -17033,7 +17033,7 @@ msgstr "Задаци"
 
 #: scripts/core/lang/missing-translations-strings.ts:20
 msgid "Tasks Management"
-msgstr ""
+msgstr "Управљање задацима"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:58
 #: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:58
@@ -17903,7 +17903,7 @@ msgid ""
 "This widget allows you to create literally any content view you may need in "
 "Superdesk, be it production or ingest. All you need is to select a desk, its "
 "stages or a saved search. Name your view once you are done. Enjoy!"
-msgstr ""
+msgstr "Овај виџет вам омогућава да креирате буквално било који приказ садржаја који вам је потребан у Superdesk-у, било да се ради о продукцији или доласку. Све што треба је да изаберете деск, његове фазе или сачувану претрагу. Именујте свој приказ када завршите. Уживајте!"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:83
 msgid "This will also post the related event's entire recurring series"
@@ -18068,7 +18068,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:249
 #: scripts/core/lang/missing-translations-strings.ts:34
 msgid "Timezone"
-msgstr ""
+msgstr "Временска зона"
 
 #: ../superdesk-analytics/client/charts/views/chart-form-options.html:3
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:11
@@ -18333,7 +18333,7 @@ msgstr "Укупно:"
 
 #: scripts/core/lang/missing-translations-strings.ts:21
 msgid "Transformation Rules Management"
-msgstr ""
+msgstr "Управљање правилима трансформације"
 
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:244
 #: scripts/apps/authoring-react/toolbar/translate-modal.tsx:100
@@ -18516,7 +18516,7 @@ msgstr "Непозната грешка валидације"
 
 #: scripts/core/lang/missing-translations-strings.ts:21
 msgid "Un Spike"
-msgstr ""
+msgstr "Врати из корпе"
 
 #: scripts/extensions/sams/dist/src/components/assets/uploadAssetModal.js:148
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/uploadAssetModal.js:148
@@ -18662,7 +18662,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:21
 msgid "Unlock content"
-msgstr ""
+msgstr "Откључај садржај"
 
 #: scripts/apps/authoring/authoring/index.ts:468
 msgid "Unlock current item"
@@ -19195,7 +19195,7 @@ msgstr ""
 #: scripts/apps/users/config.ts:38
 #: scripts/core/lang/missing-translations-strings.ts:21
 msgid "User Management"
-msgstr ""
+msgstr "Управљање корисницима"
 
 #: scripts/apps/users/import/views/import-user.html:28
 msgid "User Profile to Import"
@@ -19269,7 +19269,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:13
 msgid "Users archive view format"
-msgstr ""
+msgstr "Формат приказа архиве за кориснике"
 
 #: scripts/apps/archive/views/export.html:17
 #: scripts/apps/archive/views/export.html:18
@@ -19474,7 +19474,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:22
 msgid "Vocabularies Management"
-msgstr ""
+msgstr "Управљање вокабуларима"
 
 #: scripts/apps/authoring-react/fields/dropdown/config-main.tsx:82
 msgid "Vocabulary"
@@ -19705,7 +19705,7 @@ msgstr "Радни простор:"
 #: scripts/apps/dashboard/world-clock/world-clock.ts:209
 #: scripts/core/lang/missing-translations-strings.ts:44
 msgid "World Clock"
-msgstr ""
+msgstr "Светски сат"
 
 #: scripts/apps/dashboard/world-clock/world-clock.ts:42
 msgid "World clock added: {{zone}}"
@@ -19718,7 +19718,7 @@ msgstr ""
 #: scripts/apps/dashboard/world-clock/world-clock.ts:221
 #: scripts/core/lang/missing-translations-strings.ts:45
 msgid "World clock widget"
-msgstr ""
+msgstr "Виџет светског сата"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:339
 msgid "XMP File"
@@ -19934,15 +19934,15 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:38
 msgid "added new task {{subject}} of type {{type}}"
-msgstr ""
+msgstr "додао нови задатак {{subject}} типа {{type}}"
 
 #: scripts/core/lang/missing-translations-strings.ts:35
 msgid "added new {{type}} item about \"{{subject}}\""
-msgstr ""
+msgstr "додао нову ставку типа {{type}} о \"{{subject}}\""
 
 #: scripts/core/lang/missing-translations-strings.ts:35
 msgid "added new {{type}} item with empty header/title"
-msgstr ""
+msgstr "додао нову ставку типа {{type}} са празним заглављем/насловом"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:78
 msgid "added to workflow"
@@ -19987,7 +19987,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:13
 msgid "archive"
-msgstr ""
+msgstr "архива"
 
 #: scripts/apps/search/components/ItemContainer.tsx:20
 msgid "archived"
@@ -20010,7 +20010,7 @@ msgstr ""
 #: scripts/core/lang/missing-translations-strings.ts:9
 #: scripts/core/utils.tsx:281 scripts/core/utils.tsx:349
 msgid "audio"
-msgstr ""
+msgstr "аудио"
 
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-article.html:7
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:7
@@ -20019,7 +20019,7 @@ msgstr "аутор"
 
 #: scripts/core/lang/missing-translations-strings.ts:27
 msgid "authoring"
-msgstr ""
+msgstr "уређивање"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:83
 msgid "bold"
@@ -20071,7 +20071,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:14
 msgid "categories"
-msgstr ""
+msgstr "категорије"
 
 #: scripts/apps/users/views/edit-form.html:211
 msgid "change password"
@@ -20126,12 +20126,12 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:13
 msgid "compact"
-msgstr ""
+msgstr "компактно"
 
 #: scripts/core/lang/missing-translations-strings.ts:9
 #: scripts/core/utils.tsx:283
 msgid "composite"
-msgstr ""
+msgstr "композитни"
 
 #: scripts/apps/users/views/edit-form.html:390
 msgid "confirm"
@@ -20147,11 +20147,11 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "content"
-msgstr ""
+msgstr "садржај"
 
 #: scripts/core/lang/missing-translations-strings.ts:12
 msgid "corrected"
-msgstr ""
+msgstr "исправљено"
 
 #: scripts/apps/search/components/fields/update.tsx:15
 msgid "correction sequence"
@@ -20163,7 +20163,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:34
 msgid "create"
-msgstr ""
+msgstr "креирање"
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:189
 msgid "created"
@@ -20184,11 +20184,11 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:36
 msgid "created new version {{version}} for item {{type}} about \"{{subject}}\""
-msgstr ""
+msgstr "креирао нову верзију {{version}} за ставку типа {{type}} о \"{{subject}}\""
 
 #: scripts/core/lang/missing-translations-strings.ts:42
 msgid "created user {{user}}"
-msgstr ""
+msgstr "креирао корисника {{user}}"
 
 #: scripts/apps/users/views/edit-form.html:379
 msgid "current"
@@ -20230,7 +20230,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:26
 msgid "desk Output"
-msgstr ""
+msgstr "излаз деска"
 
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:9
 #: scripts/apps/authoring/versioning/versions/views/versions.html:13
@@ -20252,7 +20252,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:36
 msgid "disabled user {{user}}"
-msgstr ""
+msgstr "онемогућио корисника {{user}}"
 
 #: scripts/apps/authoring/macros/views/macros-replace.html:9
 msgid "done"
@@ -20260,7 +20260,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "draft"
-msgstr ""
+msgstr "нацрт"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:42
 msgid "due"
@@ -20333,7 +20333,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "error"
-msgstr ""
+msgstr "грешка"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:71
 msgid "event"
@@ -20364,7 +20364,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "failed"
-msgstr ""
+msgstr "неуспешно"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:435
 msgid "fax"
@@ -20372,11 +20372,11 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:14
 msgid "feature"
-msgstr ""
+msgstr "функција"
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "fetched"
-msgstr ""
+msgstr "преузето"
 
 #: scripts/apps/archive/views/fetched-desks.html:2
 #: scripts/apps/search/components/FetchedDesksInfo.tsx:75
@@ -20527,7 +20527,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:34
 msgid "highlights"
-msgstr ""
+msgstr "истицања"
 
 #: scripts/core/utils.tsx:347
 msgid "highlights package"
@@ -20626,11 +20626,11 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "in-progress"
-msgstr ""
+msgstr "у току"
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "in_progress"
-msgstr ""
+msgstr "у_току"
 
 #: scripts/apps/users/views/edit-form.html:35
 #: scripts/apps/users/views/user-list-item.html:16
@@ -20639,7 +20639,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "ingested"
-msgstr ""
+msgstr "примљено"
 
 #: scripts/apps/contacts/constants.ts:52
 msgid "instagram"
@@ -20673,7 +20673,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:12
 msgid "killed"
-msgstr ""
+msgstr "уништено"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:111
 msgid "label"
@@ -20856,7 +20856,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:13
 msgid "notifications"
-msgstr ""
+msgstr "обавештења"
 
 #: scripts/core/list/views/sdPagination.html:15
 #: scripts/core/list/views/sdPaginationAlt.html:2
@@ -20967,7 +20967,7 @@ msgstr ""
 #: scripts/core/lang/missing-translations-strings.ts:9
 #: scripts/core/utils.tsx:287 scripts/core/utils.tsx:344
 msgid "picture"
-msgstr ""
+msgstr "слика"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:75
 msgid "planning item"
@@ -21019,7 +21019,7 @@ msgstr "преглед"
 
 #: scripts/core/lang/missing-translations-strings.ts:25
 msgid "production"
-msgstr ""
+msgstr "продукција"
 
 #: scripts/apps/users/import/views/import-user.html:31
 msgid "profile"
@@ -21031,11 +21031,11 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:9
 msgid "publish"
-msgstr ""
+msgstr "објављивање"
 
 #: scripts/core/lang/missing-translations-strings.ts:12
 msgid "published"
-msgstr ""
+msgstr "објављено"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:59
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:59
@@ -21079,7 +21079,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:37
 msgid "removed item {{type}} about {{subject}}"
-msgstr ""
+msgstr "уклонио ставку типа {{type}} о {{subject}}"
 
 #: scripts/apps/authoring/macros/views/macros-replace.html:6
 msgid "replace"
@@ -21087,7 +21087,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:43
 msgid "replaced item {{type}} about {{subject}}"
-msgstr ""
+msgstr "заменио ставку типа {{type}} о {{subject}}"
 
 #: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:181
 #: scripts/core/editor3/directive.tsx:452
@@ -21100,7 +21100,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "retrying"
-msgstr ""
+msgstr "поновни покушај"
 
 #: scripts/apps/authoring/versioning/versions/views/versions.html:20
 msgid "revert"
@@ -21116,11 +21116,11 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:41
 msgid "role {{role}} is granted new privileges: Please re-login."
-msgstr ""
+msgstr "улози {{role}} су додељене нове привилегије: пријавите се поново."
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "routed"
-msgstr ""
+msgstr "усмерено"
 
 #: scripts/core/editor3/components/toolbar/TableControls.tsx:90
 msgid "row"
@@ -21128,15 +21128,15 @@ msgstr "ред"
 
 #: scripts/core/lang/missing-translations-strings.ts:12
 msgid "scheduled"
-msgstr ""
+msgstr "заказано"
 
 #: scripts/core/lang/missing-translations-strings.ts:26
 msgid "scheduled Desk Output"
-msgstr ""
+msgstr "заказани излаз деска"
 
 #: scripts/core/lang/missing-translations-strings.ts:25
 msgid "search"
-msgstr ""
+msgstr "претрага"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:118
 msgid "search provider password"
@@ -21160,7 +21160,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:9
 msgid "send"
-msgstr ""
+msgstr "слање"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:20
 msgid "since"
@@ -21172,11 +21172,11 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:32
 msgid "slugline"
-msgstr ""
+msgstr "слаглајн"
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "sluglines"
-msgstr ""
+msgstr "слаглајни"
 
 #: scripts/apps/users/views/edit-form.html:146
 msgid "sorry, a user with this email already exists"
@@ -21196,7 +21196,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:12
 msgid "spiked"
-msgstr ""
+msgstr "у корпи"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:91
 msgid "spiked and unlinked"
@@ -21204,7 +21204,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:26
 msgid "stage"
-msgstr ""
+msgstr "фаза"
 
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:10
 #: scripts/apps/authoring/versioning/versions/views/versions.html:14
@@ -21242,7 +21242,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:83
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "submitted"
-msgstr ""
+msgstr "поднето"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:79
 msgid "subscript"
@@ -21250,7 +21250,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:32
 msgid "subscription"
-msgstr ""
+msgstr "претплата"
 
 #: scripts/apps/search/views/saved-search-manage-subscribers.html:16
 #: scripts/apps/search/views/search-panel.html:43
@@ -21259,7 +21259,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "success"
-msgstr ""
+msgstr "успех"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:92
 msgid "suggestions"
@@ -21366,7 +21366,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:27
 msgid "update"
-msgstr ""
+msgstr "ажурирање"
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:189
 #: ../superdesk-planning/client/components/Agendas/AgendaListItem.tsx:47
@@ -21377,7 +21377,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:40
 msgid "updated Ingest Channel {{name}}"
-msgstr ""
+msgstr "ажуриран канал доласка {{name}}"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:25
 msgid "updated fields"
@@ -21385,11 +21385,11 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:38
 msgid "updated task {{subject}} for item {{type}}"
-msgstr ""
+msgstr "ажурирао задатак {{subject}} за ставку типа {{type}}"
 
 #: scripts/core/lang/missing-translations-strings.ts:34
 msgid "uploaded media {{name}}"
-msgstr ""
+msgstr "отпремио медиј {{name}}"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:30
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:99
@@ -21402,15 +21402,15 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:37
 msgid "user {{user}} has been added to desk {{desk}}: Please re-login."
-msgstr ""
+msgstr "корисник {{user}} је додат на деск {{desk}}: пријавите се поново."
 
 #: scripts/core/lang/missing-translations-strings.ts:41
 msgid "user {{user}} is granted new privileges: Please re-login."
-msgstr ""
+msgstr "кориснику {{user}} су додељене нове привилегије: пријавите се поново."
 
 #: scripts/core/lang/missing-translations-strings.ts:42
 msgid "user {{user}} is updated to administrator: Please re-login."
-msgstr ""
+msgstr "корисник {{user}} је ажуриран у администратора: пријавите се поново."
 
 #: scripts/apps/ingest/views/settings/searchConfig.html:3
 #: scripts/apps/users/import/views/import-user.html:14
@@ -21421,7 +21421,7 @@ msgstr "корисничко име"
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "users"
-msgstr ""
+msgstr "корисници"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/form-validation.js:27
 #: scripts/extensions/broadcasting/dist/src/form-validation.js:27
@@ -21476,7 +21476,7 @@ msgstr ""
 #: scripts/core/lang/missing-translations-strings.ts:9
 #: scripts/core/utils.tsx:293 scripts/core/utils.tsx:348
 msgid "video"
-msgstr ""
+msgstr "видео"
 
 #: scripts/apps/desks/views/settings.html:77
 msgid "view all"
@@ -21780,7 +21780,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:40
 msgid "{{status}} Ingest Channel {{name}}"
-msgstr ""
+msgstr "{{status}} канал доласка {{name}}"
 
 #: scripts/apps/archive/views/metadata-associateditem-view.html:1
 msgid "{{title}}"

--- a/po/sr.po
+++ b/po/sr.po
@@ -100,11 +100,11 @@ msgstr ""
 
 #: scripts/apps/highlights/services/HighlightsService.ts:16
 msgid "(Global)"
-msgstr ""
+msgstr "(Глобално)"
 
 #: scripts/apps/contacts/components/ListTypeIcon.tsx:13
 msgid "(Private)"
-msgstr ""
+msgstr "(Приватно)"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:269
 msgid "(advanced mode)"
@@ -1255,11 +1255,11 @@ msgstr ""
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:541
 msgid "Address line 1"
-msgstr ""
+msgstr "Адреса 1"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:553
 msgid "Address line 2"
-msgstr ""
+msgstr "Адреса 2"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:30
 msgid "Adjust"
@@ -1947,7 +1947,7 @@ msgstr "Да ли сте сигурни да желите да обришете 
 
 #: scripts/apps/highlights/controllers/HighlightsConfig.ts:66
 msgid "Are you sure you want to delete configuration?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете конфигурацију?"
 
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:84
 msgid "Are you sure you want to delete content filter?"
@@ -2132,7 +2132,7 @@ msgstr ""
 
 #: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:49
 msgid "Article {{slug}} is already marked for this highlight"
-msgstr ""
+msgstr "Чланак {{slug}} је већ означен за ово истицање"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:168
 #: ../superdesk-planning/client/components/OrderBar/OrderDirectionIcon.tsx:16
@@ -2344,7 +2344,7 @@ msgstr ""
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:27
 msgid "Assigned desks"
-msgstr ""
+msgstr "Додељени дескови"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:74
 msgid "Assigned to agenda '{{ agenda }}'"
@@ -2494,7 +2494,7 @@ msgstr ""
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:198
 msgid "At least one of [{{list}}] is required."
-msgstr ""
+msgstr "Потребно је најмање једно од [{{list}}]."
 
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:146
 msgid ""
@@ -2639,7 +2639,7 @@ msgstr "Аутоматски креирај ставку"
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:39
 msgid "Automatically insert items from"
-msgstr ""
+msgstr "Аутоматски убаци ставке из"
 
 #: scripts/extensions/availability-manager/dist/src/extension.js:36
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/extension.js:37
@@ -2888,7 +2888,7 @@ msgstr ""
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:546
 msgid "Building, Suite, Unit, Apartment, Floor, etc."
-msgstr ""
+msgstr "Зграда, апартман, стан, спрат, итд."
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:52
 msgid "Business"
@@ -3377,7 +3377,7 @@ msgstr "Прекорачен је лимит карактера, речник н
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:14
 msgid "Character limit exceeded, highlight can not be created/updated."
-msgstr ""
+msgstr "Прекорачен је лимит карактера, истицање није могуће креирати/ажурирати."
 
 #: scripts/apps/desks/views/desk-config-modal.html:290
 msgid "Character limit exceeded, stage can not be created/updated."
@@ -3466,7 +3466,7 @@ msgstr "Изаберите постојеће ознаке или креирај
 
 #: scripts/apps/highlights/views/package_highlights_dropdown_directive.html:20
 msgid "Choose highlight list"
-msgstr ""
+msgstr "Изабери листу истицања"
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:40
 #: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:40
@@ -3477,7 +3477,7 @@ msgstr ""
 #: scripts/apps/contacts/constants.ts:75
 #: scripts/apps/contacts/views/search-panel.html:61
 msgid "City"
-msgstr ""
+msgstr "Град"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:252
 #: ../superdesk-planning/client/components/Locations/LocationsList.tsx:118
@@ -3892,7 +3892,7 @@ msgstr "Поверљиви подаци"
 
 #: scripts/apps/highlights/controllers/HighlightsConfig.ts:70
 msgid "Configuration deleted."
-msgstr ""
+msgstr "Конфигурација обрисана."
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:79
 msgid ""
@@ -3903,7 +3903,7 @@ msgstr ""
 #: scripts/apps/highlights/views/highlights_config_modal.html:11
 #: scripts/apps/highlights/views/highlights_config_modal.html:12
 msgid "Configuration name"
-msgstr ""
+msgstr "Назив конфигурације"
 
 #: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:89
 #: scripts/apps/authoring/views/theme-select.html:9
@@ -3987,11 +3987,11 @@ msgstr ""
 #: scripts/apps/contacts/constants.ts:72
 #: scripts/apps/contacts/views/search-panel.html:31
 msgid "Contact Type"
-msgstr ""
+msgstr "Тип контакта"
 
 #: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:108
 msgid "Contact type \"{{ contact_type }}\" MUST have an email"
-msgstr ""
+msgstr "Тип контакта \"{{ contact_type }}\" МОРА имати имејл"
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/contacts.ts:10
 #: ../superdesk-planning/client/components/fields/editor/Contacts.tsx:19
@@ -4365,11 +4365,11 @@ msgstr ""
 
 #: scripts/apps/highlights/services/HighlightsService.ts:126
 msgid "Couldn't mark item"
-msgstr ""
+msgstr "Није могуће означити ставку"
 
 #: scripts/apps/highlights/services/HighlightsService.ts:126
 msgid "Couldn't unmark item"
-msgstr ""
+msgstr "Није могуће поништити ознаку ставке"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:288
 #: ../superdesk-planning/client/components/Locations/LocationsList.tsx:136
@@ -4378,7 +4378,7 @@ msgstr ""
 #: scripts/apps/contacts/constants.ts:77
 #: scripts/apps/contacts/views/search-panel.html:75
 msgid "Country"
-msgstr ""
+msgstr "Држава"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:88
 #: scripts/apps/archive/views/assignment-icon.html:1
@@ -4602,15 +4602,15 @@ msgstr ""
 
 #: scripts/apps/highlights/views/settings.html:11
 msgid "Create configuration"
-msgstr ""
+msgstr "Креирај конфигурацију"
 
 #: scripts/apps/contacts/views/list.html:10
 msgid "Create contact"
-msgstr ""
+msgstr "Креирај контакт"
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:3
 msgid "Create highlight configuration"
-msgstr ""
+msgstr "Креирај конфигурацију истицања"
 
 #: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:45
 #: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:55
@@ -6308,7 +6308,7 @@ msgstr "Уреди производ \"{{name}}\""
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:4
 msgid "Edit \"{{name}}\" highlight"
-msgstr ""
+msgstr "Уреди истицање \"{{name}}\""
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:7
 msgid "Edit Abbreviations Dictionary"
@@ -6460,7 +6460,7 @@ msgstr ""
 
 #: scripts/apps/highlights/views/settings.html:19
 msgid "Edit configuration"
-msgstr ""
+msgstr "Уреди конфигурацију"
 
 #: scripts/apps/authoring-react/fields/media/media-carousel/image.tsx:104
 #: scripts/apps/authoring/views/article-edit.html:301
@@ -7784,7 +7784,7 @@ msgstr ""
 #: scripts/apps/content-api/directives/ContentAPISearchResultsDirective.ts:77
 #: scripts/apps/search/directives/SearchResults.ts:293
 msgid "Failed to run the query!"
-msgstr ""
+msgstr "Извршавање упита није успело!"
 
 #: ../superdesk-planning/client/actions/main.ts:986
 msgid "Failed to run the query.."
@@ -8211,7 +8211,7 @@ msgstr "Услов филтера сачуван."
 
 #: scripts/apps/contacts/views/search-panel.html:3
 msgid "Filter contacts"
-msgstr ""
+msgstr "Филтрирај контакте"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:158
 msgid "Filter file types"
@@ -8293,7 +8293,7 @@ msgstr ""
 #: scripts/apps/contacts/views/search-panel.html:14
 #: scripts/core/directives/views/phone-home-modal-directive.html:19
 msgid "First Name"
-msgstr ""
+msgstr "Име"
 
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:1058
 msgid "First created"
@@ -8917,7 +8917,7 @@ msgstr ""
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:15
 msgid "Highlight with name"
-msgstr ""
+msgstr "Истицање са називом"
 
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:219
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/manage-highlights.tsx:21
@@ -8931,11 +8931,11 @@ msgstr "Истицања"
 
 #: scripts/apps/highlights/index.ts:70
 msgid "Highlights View"
-msgstr ""
+msgstr "Приказ истицања"
 
 #: scripts/apps/highlights/views/settings.html:4
 msgid "Highlights configurations"
-msgstr ""
+msgstr "Конфигурације истицања"
 
 #: scripts/core/lang/missing-translations-strings.ts:17
 msgid "Highlights/Summary List Management"
@@ -9639,7 +9639,7 @@ msgstr ""
 
 #: scripts/apps/highlights/services/HighlightsService.ts:125
 msgid "Item marked"
-msgstr ""
+msgstr "Ставка означена"
 
 #: scripts/apps/authoring-react/fields/media/editor.tsx:134
 msgid "Item not added. Maximum limit of {{n}} items exceeded."
@@ -9682,7 +9682,7 @@ msgstr "Статистика типа ставке"
 
 #: scripts/apps/highlights/services/HighlightsService.ts:125
 msgid "Item unmarked"
-msgstr ""
+msgstr "Ознака ставке поништена"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:299
 #: scripts/apps/authoring/multiedit/multiedit.ts:375
@@ -9888,7 +9888,7 @@ msgstr ""
 #: ../superdesk-planning/client/utils/filters.ts:119
 #: scripts/apps/highlights/views/highlights_config_modal.html:45
 msgid "Last"
-msgstr ""
+msgstr "Последње"
 
 #: scripts/apps/search/directives/DateFilters.ts:47
 msgid "Last 24 Hours"
@@ -9925,7 +9925,7 @@ msgstr "Последњи месец"
 #: scripts/apps/contacts/views/search-panel.html:22
 #: scripts/core/directives/views/phone-home-modal-directive.html:24
 msgid "Last Name"
-msgstr ""
+msgstr "Презиме"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:30
 msgid "Last Time Updated"
@@ -10310,7 +10310,7 @@ msgstr ""
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:411
 msgid "MORE"
-msgstr ""
+msgstr "ВИШЕ"
 
 #: scripts/apps/desks/views/actionpicker.html:26
 #: scripts/apps/internal-destinations/InternalDestinations.tsx:59
@@ -10659,7 +10659,7 @@ msgstr ""
 
 #: scripts/apps/contacts/index.ts:22
 msgid "Media Contacts"
-msgstr ""
+msgstr "Медијски контакти"
 
 #: scripts/apps/publish/views/subscribers.html:143
 msgid "Media Type"
@@ -11288,7 +11288,7 @@ msgstr "Нису дефинисане радње преузимања"
 
 #: scripts/apps/highlights/views/search_highlights_dropdown_directive.html:6
 msgid "No Filter"
-msgstr ""
+msgstr "Без филтера"
 
 #: scripts/apps/products/views/products.html:39
 msgid "No Products Found"
@@ -11825,7 +11825,7 @@ msgstr "Обавести када је неактиван дуже од"
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:84
 #: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:67
 msgid "Number"
-msgstr ""
+msgstr "Број"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentGroupList.tsx:306
 msgid "Number of Assignments:"
@@ -12156,12 +12156,12 @@ msgstr "Нумерисана листа"
 #: scripts/extensions/auto-tagging-widget/dist/src/groups.js:9
 #: scripts/extensions/auto-tagging-widget/src/groups.ts:15
 msgid "Organisation"
-msgstr ""
+msgstr "Организација"
 
 #: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:249
 #: scripts/apps/contacts/components/ListTypeIcon.tsx:7
 msgid "Organisation Contact"
-msgstr ""
+msgstr "Контакт организације"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:10
 #: scripts/extensions/auto-tagging-widget/dist/src/groups.js:10
@@ -12521,11 +12521,11 @@ msgstr ""
 
 #: scripts/apps/contacts/services/ContactsService.ts:38
 msgid "Person (Last Name)"
-msgstr ""
+msgstr "Особа (презиме)"
 
 #: scripts/apps/contacts/components/ListTypeIcon.tsx:7
 msgid "Person Contact"
-msgstr ""
+msgstr "Контакт особе"
 
 #: scripts/apps/dictionaries/views/settings.html:48
 #: scripts/apps/monitoring/controllers/AggregateCtrl.ts:568
@@ -12570,7 +12570,7 @@ msgstr "Лични простор"
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:145
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:394
 msgid "Phone"
-msgstr ""
+msgstr "Телефон"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:146
 msgid "Photo"
@@ -12839,7 +12839,7 @@ msgstr "Пријавите се поново."
 
 #: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:86
 msgid "Please provide a valid email address"
-msgstr ""
+msgstr "Унесите исправну имејл адресу"
 
 #: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:94
 #: scripts/apps/users/views/edit-form.html:340
@@ -12859,7 +12859,7 @@ msgstr "Унесите ИД чланка"
 msgid ""
 "Please specify 'first name, last name' or  'organisation' or both, and at "
 "least one of [{{list}}] fields."
-msgstr ""
+msgstr "Наведите 'име, презиме' или 'организацију' или оба, и најмање једно од [{{list}}] поља."
 
 #: scripts/apps/templates/views/create-template.html:27
 #: scripts/apps/templates/views/template-editor-modal.html:22
@@ -12890,7 +12890,7 @@ msgstr ""
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:194
 msgid "Point of contact"
-msgstr ""
+msgstr "Тачка контакта"
 
 #: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:171
 msgid "Point of interest is not defined."
@@ -12924,7 +12924,7 @@ msgstr "Постави"
 #: scripts/apps/contacts/constants.ts:74
 #: scripts/apps/contacts/views/search-panel.html:54
 msgid "Post Code"
-msgstr ""
+msgstr "Поштански број"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:66
 msgid "Post Event"
@@ -13126,7 +13126,7 @@ msgstr ""
 
 #: scripts/apps/contacts/views/list.html:27
 msgid "Privacy Level:"
-msgstr ""
+msgstr "Ниво приватности:"
 
 #: scripts/apps/contacts/services/ContactsService.ts:57
 #: scripts/apps/templates/constants.ts:9
@@ -13311,7 +13311,7 @@ msgstr ""
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:312
 #: scripts/extensions/sams/src/utils/ui.tsx:84
 msgid "Public"
-msgstr ""
+msgstr "Јавно"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:441
 #: ../superdesk-analytics/client/utils.js:154
@@ -13978,7 +13978,7 @@ msgstr ""
 
 #: scripts/apps/highlights/views/settings.html:20
 msgid "Remove configuration"
-msgstr ""
+msgstr "Уклони конфигурацију"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/index.tsx:277
 msgid "Remove coverage"
@@ -15672,7 +15672,7 @@ msgstr ""
 
 #: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:90
 msgid "Set highlights"
-msgstr ""
+msgstr "Постави истицања"
 
 #: scripts/apps/archive/index.tsx:219
 msgid "Set label in current package"
@@ -16439,7 +16439,7 @@ msgstr "Стање"
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:598
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:611
 msgid "State/Province or Region"
-msgstr ""
+msgstr "Држава/Покрајина или регион"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:268
 #: ../superdesk-planning/client/components/Locations/LocationsList.tsx:124
@@ -16558,11 +16558,11 @@ msgstr ""
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:534
 msgid "Street Address"
-msgstr ""
+msgstr "Адреса улице"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:533
 msgid "Street Address, PO Box, Company Name"
-msgstr ""
+msgstr "Адреса улице, поштански фах, назив компаније"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:65
 msgid "Strength"
@@ -16760,7 +16760,7 @@ msgstr "Недеља"
 
 #: scripts/apps/contacts/controllers/ContactsController.ts:33
 msgid "Superdesk Contacts Management"
-msgstr ""
+msgstr "Superdesk управљање контактима"
 
 #: scripts/core/menu/views/superdesk-view.html:50
 msgid "Superdesk is experiencing network connection issues:/"
@@ -16817,7 +16817,7 @@ msgstr "Пређи на преглед нових функција"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:270
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:439
 msgid "Switch to grid view"
-msgstr ""
+msgstr "Пребаци на приказ мреже"
 
 #: scripts/apps/archive/views/list.html:21
 #: scripts/apps/contacts/views/list.html:7
@@ -16826,7 +16826,7 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:271
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:440
 msgid "Switch to list view"
-msgstr ""
+msgstr "Пребаци на приказ листе"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:185
 msgid "Switches"
@@ -17055,7 +17055,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:136
 #: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:210
 msgid "Template"
-msgstr ""
+msgstr "Шаблон"
 
 #: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:49
 msgid "Template Content"
@@ -17603,7 +17603,7 @@ msgstr "Нема токена за претплатника."
 
 #: scripts/apps/highlights/controllers/HighlightsConfig.ts:60
 msgid "There was a problem while saving highlights configuration"
-msgstr ""
+msgstr "Дошло је до проблема приликом чувања конфигурације истицања"
 
 #: scripts/apps/users/controllers/ChangeAvatarController.ts:51
 #: scripts/apps/users/controllers/ChangeAvatarController.ts:63
@@ -17657,7 +17657,7 @@ msgstr ""
 
 #: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:195
 msgid "There was an error when saving the contact."
-msgstr ""
+msgstr "Дошло је до грешке приликом чувања контакта."
 
 #: scripts/apps/users/directives/UserEditDirective.ts:268
 msgid "There was an error when saving the user account."
@@ -17896,7 +17896,7 @@ msgstr "Овај вокабулар се тренутно не користи н
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:42
 msgid "This week"
-msgstr ""
+msgstr "Ове недеље"
 
 #: scripts/core/lang/missing-translations-strings.ts:46
 msgid ""
@@ -18973,7 +18973,7 @@ msgstr ""
 
 #: scripts/apps/contacts/components/ContactFooter.tsx:18
 msgid "Updated:"
-msgstr ""
+msgstr "Ажурирано:"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:576
 msgid "Updates"
@@ -19111,7 +19111,7 @@ msgstr ""
 
 #: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:85
 msgid "Usage"
-msgstr ""
+msgstr "Употреба"
 
 #: scripts/apps/workspace/content/constants.ts:49
 msgid "Usage Terms"
@@ -19464,7 +19464,7 @@ msgstr ""
 
 #: scripts/apps/contacts/index.ts:23
 msgid "View/Manage media contacts"
-msgstr ""
+msgstr "Прикажи/Управљај медијским контактима"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectCustomVocabulariesList.tsx:27
 #: ../superdesk-planning/client/components/fields/index.tsx:226
@@ -19600,7 +19600,7 @@ msgstr ""
 #: scripts/apps/highlights/views/highlights_config_modal.html:38
 #: scripts/apps/highlights/views/highlights_config_modal.html:47
 msgid "When creating a highlights package"
-msgstr ""
+msgstr "Када се креира пакет истицања"
 
 #: scripts/apps/publish/views/subscribers.html:204
 msgid "When enabled it can send multiple items at the same time."
@@ -20092,7 +20092,7 @@ msgstr "знакови"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:583
 msgid "city"
-msgstr ""
+msgstr "град"
 
 #: scripts/core/ui/components/virtual-lists/select.tsx:176
 msgid "clear"
@@ -20143,7 +20143,7 @@ msgstr ""
 
 #: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:181
 msgid "contact saved."
-msgstr ""
+msgstr "контакт сачуван."
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "content"
@@ -20226,7 +20226,7 @@ msgstr "подразумевано"
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:21
 msgid "default template"
-msgstr ""
+msgstr "подразумевани шаблон"
 
 #: scripts/core/lang/missing-translations-strings.ts:26
 msgid "desk Output"
@@ -20272,7 +20272,7 @@ msgstr ""
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:463
 msgid "e.g. @cityofsydney"
-msgstr ""
+msgstr "нпр. @cityofsydney"
 
 #: scripts/apps/users/views/edit-form.html:338
 msgid "e.g. @superdeskman"
@@ -20280,23 +20280,23 @@ msgstr "нпр. @superdeskman"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:559
 msgid "e.g. Rhodes, CBD"
-msgstr ""
+msgstr "нпр. Rhodes, CBD"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:489
 msgid "e.g. cityofsydney from https://www.facebook.com/cityofsydney"
-msgstr ""
+msgstr "нпр. cityofsydney из https://www.facebook.com/cityofsydney"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:513
 msgid "e.g. cityofsydney from https://www.instagram.com/cityofsydney"
-msgstr ""
+msgstr "нпр. cityofsydney из https://www.instagram.com/cityofsydney"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:447
 msgid "e.g. http://www.website.com"
-msgstr ""
+msgstr "нпр. http://www.website.com"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:254
 msgid "e.g. professor, commissioner"
-msgstr ""
+msgstr "нпр. професор, комесар"
 
 #: scripts/apps/users/views/edit-form.html:303
 msgid "e.g. superdeskman from https://www.facebook.com/superdeskman"
@@ -20360,7 +20360,7 @@ msgstr "истиче:"
 
 #: scripts/apps/contacts/constants.ts:51
 msgid "facebook"
-msgstr ""
+msgstr "facebook"
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "failed"
@@ -20368,7 +20368,7 @@ msgstr "неуспешно"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:435
 msgid "fax"
-msgstr ""
+msgstr "факс"
 
 #: scripts/core/lang/missing-translations-strings.ts:14
 msgid "feature"
@@ -20535,12 +20535,12 @@ msgstr ""
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:255
 msgid "honorific"
-msgstr ""
+msgstr "почасна титула"
 
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:5
 #: scripts/apps/highlights/views/highlights_config_modal.html:45
 msgid "hours"
-msgstr ""
+msgstr "сати"
 
 #: scripts/apps/desks/views/content-expiry.html:4
 #: scripts/apps/desks/views/content-expiry.html:40
@@ -20643,7 +20643,7 @@ msgstr "примљено"
 
 #: scripts/apps/contacts/constants.ts:52
 msgid "instagram"
-msgstr ""
+msgstr "instagram"
 
 #: scripts/extensions/sams/dist/src/components/attachments/samsAttachmentsList.js:114
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/samsAttachmentsList.js:114
@@ -20741,7 +20741,7 @@ msgstr "учитавање..."
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:560
 msgid "locality"
-msgstr ""
+msgstr "место"
 
 #: scripts/apps/search/components/ItemContainer.tsx:16
 msgid "location:"
@@ -20803,7 +20803,7 @@ msgstr ""
 
 #: scripts/apps/contacts/constants.ts:47
 msgid "mobile"
-msgstr ""
+msgstr "мобилни"
 
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:23
 #: scripts/apps/authoring-react/fields/date/config.tsx:85
@@ -20852,7 +20852,7 @@ msgstr ""
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:650
 msgid "notes"
-msgstr ""
+msgstr "белешке"
 
 #: scripts/core/lang/missing-translations-strings.ts:13
 msgid "notifications"
@@ -20923,11 +20923,11 @@ msgstr "нумерисана листа"
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:320
 #: scripts/apps/contacts/constants.ts:71
 msgid "organisation"
-msgstr ""
+msgstr "организација"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:624
 msgid "other"
-msgstr ""
+msgstr "остало"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:400
 #: scripts/core/utils.tsx:346
@@ -20957,7 +20957,7 @@ msgstr "на чекању"
 
 #: scripts/apps/contacts/constants.ts:48
 msgid "phone"
-msgstr ""
+msgstr "телефон"
 
 #: scripts/apps/users/views/edit-form.html:177
 msgid "phone number"
@@ -20993,7 +20993,7 @@ msgstr ""
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:570
 msgid "postcode"
-msgstr ""
+msgstr "поштански број"
 
 #: ../superdesk-planning/client/utils/history.tsx:84
 msgid "posted"
@@ -21027,7 +21027,7 @@ msgstr "профил"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:233
 msgid "public"
-msgstr ""
+msgstr "јавно"
 
 #: scripts/core/lang/missing-translations-strings.ts:9
 msgid "publish"
@@ -21337,7 +21337,7 @@ msgstr ""
 
 #: scripts/apps/contacts/constants.ts:50
 msgid "twitter"
-msgstr ""
+msgstr "twitter"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:81
 msgid "underline"
@@ -21489,7 +21489,7 @@ msgstr ""
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:448
 msgid "website"
-msgstr ""
+msgstr "веб сајт"
 
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:17
 #: scripts/apps/authoring-react/fields/date/config.tsx:84

--- a/po/sr.po
+++ b/po/sr.po
@@ -145,7 +145,7 @@ msgstr "(нема поклапања)"
 
 #: scripts/apps/authoring/compare-versions/views/compare-versions.html:17
 msgid "* choose article version from dropdown menu"
-msgstr ""
+msgstr "* изаберите верзију чланка из падајућег менија"
 
 #: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:127
 msgid "* fields are required"
@@ -592,7 +592,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar/template-modal.tsx:107
 msgid "A new template will be created"
-msgstr ""
+msgstr "Биће креиран нови шаблон"
 
 #: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:226
 msgid "A user is required"
@@ -671,7 +671,7 @@ msgstr "О Superdesk-у"
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:378
 #: scripts/apps/workspace/content/constants.ts:8
 msgid "Abstract"
-msgstr ""
+msgstr "Сажетак"
 
 #: scripts/apps/authoring/views/theme-select.html:47
 #: scripts/apps/authoring/views/theme-select.html:98
@@ -681,18 +681,18 @@ msgstr ""
 #: scripts/apps/dashboard/views/workspace.html:9
 #: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:160
 msgid "Accept"
-msgstr ""
+msgstr "Прихвати"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Accepted.tsx:15
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:173
 #: scripts/apps/authoring-react/article-widgets/suggestions.tsx:73
 #: scripts/apps/authoring/track-changes/views/suggestions-widget.html:8
 msgid "Accepted"
-msgstr ""
+msgstr "Прихваћено"
 
 #: scripts/apps/authoring/track-changes/views/suggestions-widget.html:37
 msgid "Accepted by"
-msgstr ""
+msgstr "Прихватио"
 
 #: scripts/apps/authoring-react/article-widgets/suggestions.tsx:126
 msgid "Accepted by {{user}}"
@@ -762,7 +762,7 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:127
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:150
 msgid "Actions"
-msgstr ""
+msgstr "Радње"
 
 #: scripts/apps/authoring-react/subcomponents/authoring-actions-menu.tsx:42
 #: scripts/apps/authoring-react/subcomponents/authoring-actions-menu.tsx:71
@@ -830,7 +830,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/editor.js:35
 #: scripts/extensions/broadcasting/src/authoring-fields/subitems/editor.tsx:79
 msgid "Add"
-msgstr ""
+msgstr "Додај"
 
 #: ../superdesk-planning/client/utils/confirmAddingRelatedItems.tsx:56
 msgid "Add 1 item"
@@ -1119,7 +1119,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/EventLinks.tsx:77
 #: scripts/core/editor3/highlightsConfig.ts:112
 msgid "Add link"
-msgstr ""
+msgstr "Додај линк"
 
 #: scripts/apps/authoring/metadata/views/meta-place-directive.html:2
 #: scripts/apps/authoring/metadata/views/metadata-tags.html:3
@@ -1193,7 +1193,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx:67
 msgid "Add to dictionary"
-msgstr ""
+msgstr "Додај у речник"
 
 #: ../superdesk-planning/client/constants/planning.ts:145
 msgid "Add to featured stories"
@@ -1663,7 +1663,7 @@ msgstr ""
 #: scripts/apps/authoring/views/item-carousel.html:104
 #: scripts/core/editor3/components/media/MediaBlock.tsx:204
 msgid "Alt text:"
-msgstr ""
+msgstr "Алтернативни текст:"
 
 #: scripts/apps/authoring-react/article-widgets/demo-widget.tsx:27
 msgid "Alter slugline"
@@ -1779,7 +1779,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:46
 msgid "An error occured, please try again."
-msgstr ""
+msgstr "Дошло је до грешке, покушајте поново."
 
 #: scripts/apps/publish-preview/previewModal.tsx:66
 msgid "An error occurred while trying to preview the item."
@@ -1808,25 +1808,25 @@ msgstr ""
 #: scripts/core/editor3/components/toolbar/index.tsx:410
 #: scripts/core/editor3/highlightsConfig.ts:19
 msgid "Annotation"
-msgstr ""
+msgstr "Анотација"
 
 #: scripts/core/editor3/components/annotations/AnnotationInput.tsx:265
 msgid "Annotation Body"
-msgstr ""
+msgstr "Тело анотације"
 
 #: scripts/core/editor3/components/annotations/AnnotationInput.tsx:250
 msgid "Annotation Type"
-msgstr ""
+msgstr "Тип анотације"
 
 #: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:66
 msgid ""
 "Annotation Types information is not available. Please check your metadata "
 "configuration."
-msgstr ""
+msgstr "Информације о типовима анотација нису доступне. Проверите подешавање метаподатака."
 
 #: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:124
 msgid "Annotation type"
-msgstr ""
+msgstr "Тип анотације"
 
 #: scripts/apps/archive/views/html-preview.html:2
 #: scripts/apps/authoring-react/article-widgets/metadata/AnnotationsPreview.tsx:20
@@ -1922,7 +1922,7 @@ msgstr ""
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/archived-from.tsx:8
 #: scripts/apps/authoring/views/authoring-topbar.html:35
 msgid "Archived from"
-msgstr ""
+msgstr "Архивирано из"
 
 #: scripts/apps/search/components/ItemContainer.tsx:14
 msgid "Archived from {{desk}}"
@@ -2046,7 +2046,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:53
 msgid "Are you sure you want to unpublish item \"{{label}}\"?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да повучете објаву ставке \"{{label}}\"?"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:96
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:236
@@ -2317,7 +2317,7 @@ msgstr ""
 #: scripts/core/editor3/components/media/MediaBlock.tsx:258
 #: scripts/core/editor3/components/media/MediaBlock.tsx:298
 msgid "Assign rights:"
-msgstr ""
+msgstr "Додели права:"
 
 #: ../superdesk-planning/client/constants/planning.ts:143
 msgid "Assign to agenda"
@@ -2528,7 +2528,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:43
 #: scripts/core/editor3/components/links/LinkInput.tsx:72
 msgid "Attachment"
-msgstr ""
+msgstr "Прилог"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:44
 msgid "Attachment Large"
@@ -2603,14 +2603,14 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar/version-header.tsx:43
 msgid "Author:"
-msgstr ""
+msgstr "Аутор:"
 
 #: scripts/apps/authoring/authoring/index.ts:205
 #: scripts/apps/authoring/compare-versions/index.ts:27
 #: scripts/apps/authoring/multiedit/multiedit.ts:465
 #: scripts/apps/authoring/views/authoring.html:2
 msgid "Authoring"
-msgstr ""
+msgstr "Уређивање"
 
 #: scripts/apps/desks/views/desk-config-modal.html:106
 msgid ""
@@ -2695,7 +2695,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar/translate-modal.tsx:108
 msgid "Available languages"
-msgstr ""
+msgstr "Доступни језици"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningList.tsx:92
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:167
@@ -2753,7 +2753,7 @@ msgstr ""
 
 #: scripts/apps/authoring/comments/views/comments-widget.html:24
 msgid "Be the first one..."
-msgstr ""
+msgstr "Будите први..."
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:178
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:181
@@ -2814,7 +2814,7 @@ msgstr ""
 #: scripts/apps/authoring/views/theme-select.html:105
 #: scripts/apps/authoring/views/theme-select.html:54
 msgid "Body"
-msgstr ""
+msgstr "Тело"
 
 #: scripts/apps/authoring-react/field-adapters/body_html.ts:22
 #: scripts/apps/workspace/content/constants.ts:15
@@ -2843,7 +2843,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:75
 msgid "Bold (Ctrl+B)"
-msgstr ""
+msgstr "Подебљано (Ctrl+B)"
 
 #: scripts/apps/authoring-react/fields/boolean/index.ts:23
 msgid "Boolean"
@@ -2939,7 +2939,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/cancel-authoring.tsx:12
 msgid "CANCEL"
-msgstr ""
+msgstr "ОТКАЖИ"
 
 #: scripts/apps/publish/views/email-config.html:20
 msgid "CID"
@@ -3017,7 +3017,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/article-embed/can-add-article-embed.ts:35
 msgid "Can not embed to item which itself can be embedded."
-msgstr ""
+msgstr "Није могуће уградити у ставку која се сама може уградити."
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:48
 msgid "Can not update a broadcast version of the story."
@@ -3281,7 +3281,7 @@ msgstr ""
 #: scripts/apps/archive/views/metadata-associateditem-view.html:7
 #: scripts/core/editor3/components/media/MediaBlock.tsx:317
 msgid "Caption"
-msgstr ""
+msgstr "Натпис"
 
 #: scripts/apps/authoring/editor/views/find-replace.html:18
 msgid "Case Sensitive"
@@ -3774,7 +3774,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:64
 #: scripts/core/editor3/components/Editor3Component.tsx:901
 msgid "Collapse"
-msgstr ""
+msgstr "Скупи"
 
 #: scripts/apps/authoring-react/multi-edit-modal.tsx:158
 msgid "Collapse widgets"
@@ -3814,14 +3814,14 @@ msgstr ""
 #: scripts/core/editor3/components/toolbar/index.tsx:398
 #: scripts/core/editor3/highlightsConfig.ts:12
 msgid "Comment"
-msgstr ""
+msgstr "Коментар"
 
 #: scripts/apps/authoring-react/article-widgets/comments/index.tsx:9
 #: scripts/apps/authoring-react/generic-widgets/comments/CommentsWidget.tsx:25
 #: scripts/apps/authoring-react/generic-widgets/comments/index.tsx:38
 #: scripts/apps/authoring/comments/comments.ts:146
 msgid "Comments"
-msgstr ""
+msgstr "Коментари"
 
 #: ../superdesk-planning/client/components/fields/index.tsx:223
 msgid "Common"
@@ -3852,11 +3852,11 @@ msgstr ""
 
 #: scripts/apps/authoring/compare-versions/views/compare-versions.html:2
 msgid "Compare Versions"
-msgstr ""
+msgstr "Упореди верзије"
 
 #: scripts/apps/authoring-react/toolbar/compare-article-versions.tsx:129
 msgid "Compare article versions"
-msgstr ""
+msgstr "Упореди верзије чланка"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:148
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:132
@@ -3908,7 +3908,7 @@ msgstr ""
 #: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:89
 #: scripts/apps/authoring/views/theme-select.html:9
 msgid "Configure Editor themes"
-msgstr ""
+msgstr "Подеси теме уређивача"
 
 #: scripts/extensions/predefinedTextField/dist/src/config.js:64
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:64
@@ -3918,7 +3918,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar-components/integration-wrapper/configure-theme-button.tsx:13
 msgid "Configure themes"
-msgstr ""
+msgstr "Подеси теме"
 
 #: ../superdesk-planning/client/api/coverages.ts:34
 #: ../superdesk-planning/client/api/coverages.ts:55
@@ -3951,7 +3951,7 @@ msgstr ""
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:28
 #: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:41
 msgid "Confirm Unpublishing"
-msgstr ""
+msgstr "Потврди повлачење објаве"
 
 #: scripts/apps/authoring/views/change-image.html:194
 msgid "Confirm crop"
@@ -4181,11 +4181,11 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/index.tsx:452
 msgid "Convert text to lowercase"
-msgstr ""
+msgstr "Претвори текст у мала слова"
 
 #: scripts/core/editor3/components/toolbar/index.tsx:441
 msgid "Convert text to uppercase"
-msgstr ""
+msgstr "Претвори текст у велика слова"
 
 #: ../superdesk-planning/client/constants/events.ts:163
 msgid "Convert to Recurring Event"
@@ -4251,7 +4251,7 @@ msgstr ""
 #: scripts/core/editor3/components/media/MediaBlock.tsx:254
 #: scripts/core/editor3/components/media/MediaBlock.tsx:294
 msgid "Copyright holder:"
-msgstr ""
+msgstr "Носилац ауторских права:"
 
 #: scripts/apps/archive/views/metadata-associateditem-view.html:36
 #: scripts/apps/archive/views/metadata-view.html:177
@@ -4270,7 +4270,7 @@ msgstr ""
 #: scripts/core/editor3/components/media/MediaBlock.tsx:265
 #: scripts/core/editor3/components/media/MediaBlock.tsx:305
 msgid "Copyright notice:"
-msgstr ""
+msgstr "Обавештење о ауторским правима:"
 
 #: scripts/apps/search/views/multi-image-edit.html:69
 msgid "Copyright:"
@@ -4282,7 +4282,7 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-topbar.html:129
 #: scripts/apps/authoring/views/authoring-topbar.html:130
 msgid "Correct"
-msgstr ""
+msgstr "Исправи"
 
 #: scripts/apps/authoring/authoring/index.ts:357
 msgid "Correct item"
@@ -4746,7 +4746,7 @@ msgstr ""
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:171
 #: scripts/extensions/sams/src/utils/ui.tsx:105
 msgid "Created"
-msgstr ""
+msgstr "Креирано"
 
 #: ../superdesk-planning/client/components/UI/List/CreatedUpdatedColumn.tsx:28
 msgid "Created : {{ datetime }}"
@@ -4865,7 +4865,7 @@ msgstr ""
 #: scripts/core/editor3/components/media/MediaBlock.tsx:250
 #: scripts/core/editor3/components/media/MediaBlock.tsx:290
 msgid "Credit:"
-msgstr ""
+msgstr "Заслуге:"
 
 #: scripts/apps/search/views/search-filters.html:57
 msgid "Credits"
@@ -4936,7 +4936,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/index.tsx:358
 msgid "Custom block"
-msgstr ""
+msgstr "Прилагођени блок"
 
 #: scripts/apps/vocabularies/views/settings.html:22
 msgid "Custom blocks"
@@ -5207,7 +5207,7 @@ msgstr ""
 #: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:96
 #: scripts/apps/authoring/views/theme-select.html:15
 msgid "Default Theme"
-msgstr ""
+msgstr "Подразумевана тема"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:236
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:208
@@ -5341,7 +5341,7 @@ msgstr ""
 
 #: scripts/core/editor3/highlightsConfig.ts:102
 msgid "Delete empty paragraphs"
-msgstr ""
+msgstr "Обриши празне пасусе"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:101
 msgid "Delete failed! Field is required by the system"
@@ -5404,7 +5404,7 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-topbar.html:110
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:316
 msgid "Deschedule"
-msgstr ""
+msgstr "Откажи заказивање"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:113
 #: scripts/apps/authoring/versioning/history/views/history.html:17
@@ -5464,7 +5464,7 @@ msgstr ""
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:291
 #: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:144
 msgid "Description"
-msgstr ""
+msgstr "Опис"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:291
 msgid "Description Long"
@@ -5593,7 +5593,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar/template-modal.tsx:126
 msgid "Desk template"
-msgstr ""
+msgstr "Шаблон деска"
 
 #: scripts/apps/desks/directives/DeskeditBasic.ts:65
 msgid "Desk with name {{name}} already exists."
@@ -5631,7 +5631,7 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/DesksSelectInput.js:130
 #: scripts/extensions/sams/src/components/common/DesksSelectInput.tsx:109
 msgid "Desks"
-msgstr ""
+msgstr "Дескови"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:196
 #: scripts/apps/publish/views/publish-queue.html:111
@@ -6292,7 +6292,7 @@ msgstr ""
 #: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:102
 #: scripts/extensions/sams/src/utils/assets.ts:69
 msgid "Edit"
-msgstr ""
+msgstr "Уреди"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:8
 msgid "Edit \"' + schedule.name + '\" Schedule"
@@ -6469,7 +6469,7 @@ msgstr ""
 #: scripts/apps/authoring/views/item-carousel.html:100
 #: scripts/core/editor3/components/media/MediaBlock.tsx:192
 msgid "Edit crops"
-msgstr ""
+msgstr "Уреди исечке"
 
 #: scripts/apps/desks/views/settings.html:34
 msgid "Edit desk"
@@ -6481,7 +6481,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/embeds/EmbedBlock.tsx:83
 msgid "Edit embed"
-msgstr ""
+msgstr "Уреди уграђени садржај"
 
 #: scripts/apps/authoring-react/fields/media/media-carousel/image.tsx:94
 #: scripts/apps/authoring/views/article-edit.html:300
@@ -6491,7 +6491,7 @@ msgstr ""
 #: scripts/apps/authoring/views/item-carousel.html:99
 #: scripts/core/editor3/components/media/MediaBlock.tsx:182
 msgid "Edit image"
-msgstr ""
+msgstr "Уреди слику"
 
 #: scripts/apps/authoring/authoring/index.ts:241
 msgid "Edit in new Window"
@@ -6517,7 +6517,7 @@ msgstr ""
 
 #: scripts/core/editor3/highlightsConfig.ts:124
 msgid "Edit link"
-msgstr ""
+msgstr "Уреди линк"
 
 #: scripts/apps/authoring-react/fields/media/media-carousel/audio.tsx:85
 #: scripts/apps/authoring-react/fields/media/media-carousel/image.tsx:84
@@ -6536,7 +6536,7 @@ msgstr ""
 #: scripts/core/editor3/components/media/MediaBlock.tsx:172
 #: scripts/core/editor3/components/media/MediaBlock.tsx:332
 msgid "Edit metadata"
-msgstr ""
+msgstr "Уреди метаподатке"
 
 #: scripts/apps/products/views/product-test.html:35
 #: scripts/apps/products/views/products.html:31
@@ -6653,15 +6653,15 @@ msgstr ""
 
 #: scripts/core/editor3/components/BaseUnstyledComponent.tsx:103
 msgid "Embedding articles is not configured for this content profile field"
-msgstr ""
+msgstr "Уграђивање чланака није подешено за ово поље профила садржаја"
 
 #: scripts/core/editor3/components/article-embed/article-embed.tsx:24
 msgid "Embedding from:"
-msgstr ""
+msgstr "Уграђено са:"
 
 #: scripts/core/editor3/actions/editor3.tsx:75
 msgid "Embedding is not allowed for this editor"
-msgstr ""
+msgstr "Уграђивање није дозвољено за овај уређивач"
 
 #: scripts/core/lang/missing-translations-strings.ts:14
 msgid "Enable Feature Preview"
@@ -6743,7 +6743,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/embeds/EmbedInput.tsx:164
 msgid "Enter URL or code to embed"
-msgstr ""
+msgstr "Унесите URL или код за уграђивање"
 
 #: scripts/core/auth/login-modal.html:75
 #: scripts/core/auth/reset-password.html:48
@@ -7349,7 +7349,7 @@ msgstr ""
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:87
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:39
 msgid "Exit"
-msgstr ""
+msgstr "Излаз"
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:173
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:556
@@ -7359,7 +7359,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:79
 #: scripts/core/editor3/components/Editor3Component.tsx:901
 msgid "Expand"
-msgstr ""
+msgstr "Прошири"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:80
 msgid "Expand Thin"
@@ -7390,7 +7390,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx:64
 msgid "Explanation"
-msgstr ""
+msgstr "Објашњење"
 
 #: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:266
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:142
@@ -7408,7 +7408,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:287
 #: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:452
 msgid "Export"
-msgstr ""
+msgstr "Извоз"
 
 #: ../superdesk-analytics/client/charts/views/chart.html:23
 msgid "Export Chart As..."
@@ -7739,7 +7739,7 @@ msgstr ""
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/publish-and-continue.tsx:25
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:671
 msgid "Failed to publish and continue."
-msgstr ""
+msgstr "Објављивање и наставак нису успели."
 
 #: scripts/extensions/sams/dist/src/api/assets.js:249
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:249
@@ -8340,7 +8340,7 @@ msgstr ""
 #: scripts/apps/authoring/views/theme-select.html:18
 #: scripts/apps/authoring/views/theme-select.html:69
 msgid "Font"
-msgstr ""
+msgstr "Фонт"
 
 #: scripts/apps/workspace/content/constants.ts:28
 msgid "Footer"
@@ -8380,7 +8380,7 @@ msgstr ""
 #: scripts/apps/authoring-react/toolbar/export-modal.tsx:88
 #: scripts/apps/authoring/views/preview-formatted.html:13
 msgid "Formatters"
-msgstr ""
+msgstr "Форматери"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:34
 msgid "Formatting Marks"
@@ -8717,32 +8717,32 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:20
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:79
 msgid "H1"
-msgstr ""
+msgstr "H1"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:21
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:80
 msgid "H2"
-msgstr ""
+msgstr "H2"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:22
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:81
 msgid "H3"
-msgstr ""
+msgstr "H3"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:23
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:82
 msgid "H4"
-msgstr ""
+msgstr "H4"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:24
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:83
 msgid "H5"
-msgstr ""
+msgstr "H5"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:25
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:84
 msgid "H6"
-msgstr ""
+msgstr "H6"
 
 #: scripts/core/lang/missing-translations-strings.ts:47
 msgid "HEADLINE is too long"
@@ -8810,7 +8810,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:311
 #: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:501
 msgid "Headline"
-msgstr ""
+msgstr "Наслов"
 
 #: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-tooltip.html:3
 msgid "Headline:"
@@ -8927,7 +8927,7 @@ msgstr ""
 #: scripts/apps/highlights/views/package_highlights_dropdown_directive.html:2
 #: scripts/apps/templates/services/TemplatesService.ts:71
 msgid "Highlights"
-msgstr ""
+msgstr "Истицања"
 
 #: scripts/apps/highlights/index.ts:70
 msgid "Highlights View"
@@ -9060,7 +9060,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/embeds/EmbedInput.tsx:153
 msgid "If you paste an embed code, it will be used \"as is\"."
-msgstr ""
+msgstr "Ако налепите код за уграђивање, биће коришћен \"какав јесте\"."
 
 #: scripts/apps/users/views/settings-roles.html:55
 msgid ""
@@ -9090,7 +9090,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx:74
 msgid "Ignore word"
-msgstr ""
+msgstr "Игнориши реч"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:233
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:235
@@ -9263,7 +9263,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/media/MediaBlock.tsx:17
 msgid "Indefinite Usage"
-msgstr ""
+msgstr "Неограничено коришћење"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:111
 msgid "Indent Left"
@@ -9386,7 +9386,7 @@ msgstr ""
 #: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:19
 #: scripts/apps/authoring/track-changes/inline-comments.ts:137
 msgid "Inline comments"
-msgstr ""
+msgstr "Уметнути коментари"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:119
 msgid "Input Type"
@@ -9399,7 +9399,7 @@ msgstr ""
 #: scripts/core/editor3/components/links/LinkInput.tsx:221
 #: scripts/core/editor3/components/links/LinkInput.tsx:253
 msgid "Insert"
-msgstr ""
+msgstr "Уметни"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:116
 #: scripts/apps/users/views/edit-form.html:312
@@ -9519,7 +9519,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:76
 msgid "Italic (Ctrl+I)"
-msgstr ""
+msgstr "Курзив (Ctrl+I)"
 
 #: ../superdesk-planning/client/utils/index.ts:599
 msgid "Item"
@@ -9551,7 +9551,7 @@ msgstr ""
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/extension.js:32
 #: scripts/extensions/ai-widget/src/extension.ts:35
 msgid "Item Translated"
-msgstr ""
+msgstr "Ставка преведена"
 
 #: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:73
 #: ../superdesk-planning/client/components/fields/editor/ItemType.tsx:15
@@ -9584,7 +9584,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/article-embed/can-add-article-embed.ts:30
 msgid "Item content profile is not configured to allow embedding."
-msgstr ""
+msgstr "Профил садржаја ставке није подешен да дозвољава уграђивање."
 
 #: scripts/api/article-duplicate.tsx:42
 msgid "Item duplicated"
@@ -9687,7 +9687,7 @@ msgstr ""
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:299
 #: scripts/apps/authoring/multiedit/multiedit.ts:375
 msgid "Item updated."
-msgstr ""
+msgstr "Ставка ажурирана."
 
 #: scripts/apps/authoring/authoring/controllers/AssociationController.ts:200
 msgid "Item was not added. Only 1 item is allowed for this field."
@@ -9807,7 +9807,7 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-topbar.html:157
 #: scripts/apps/templates/services/TemplatesService.ts:69
 msgid "Kill"
-msgstr ""
+msgstr "Уништи"
 
 #: scripts/apps/authoring/authoring/index.ts:309
 msgid "Kill item"
@@ -10061,15 +10061,15 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:29
 #: scripts/core/editor3/components/toolbar/TableControls.tsx:118
 msgid "Link"
-msgstr ""
+msgstr "Линк"
 
 #: scripts/core/editor3/components/toolbar/index.tsx:287
 msgid "Link (Ctrl+K)"
-msgstr ""
+msgstr "Линк (Ctrl+K)"
 
 #: scripts/core/editor3/components/links/LinkToolbar.tsx:52
 msgid "Link controls:"
-msgstr ""
+msgstr "Контроле линка:"
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:276
 msgid "Link has been removed"
@@ -10148,7 +10148,7 @@ msgstr ""
 
 #: scripts/apps/authoring/suggest/SuggestView.html:4
 msgid "Live Suggestions"
-msgstr ""
+msgstr "Сугестије уживо"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:278
 msgid "Live suggestions"
@@ -10555,7 +10555,7 @@ msgstr ""
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/marked-desks.tsx:11
 #: scripts/apps/authoring-react/toolbar/highlights-management.tsx:74
 msgid "Marked for"
-msgstr ""
+msgstr "Означено за"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:319
 msgid "Marked for desk {{x}} by {{user}}"
@@ -10565,7 +10565,7 @@ msgstr ""
 #: scripts/apps/authoring-react/toolbar/mark-for-desks/mark-for-desks-modal.tsx:37
 #: scripts/apps/authoring/views/authoring-topbar.html:337
 msgid "Marked for desks"
-msgstr ""
+msgstr "Означено за дескове"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:285
 msgid "Marked for highlight {{x}} by {{user}}"
@@ -10651,7 +10651,7 @@ msgstr ""
 #: scripts/apps/workspace/content/constants.ts:35
 #: scripts/core/editor3/components/toolbar/index.tsx:302
 msgid "Media"
-msgstr ""
+msgstr "Медиј"
 
 #: scripts/apps/authoring-react/fields/media/index.tsx:21
 msgid "Media (authoring-react)"
@@ -10683,7 +10683,7 @@ msgstr ""
 
 #: scripts/core/editor3/highlightsConfig.ts:92
 msgid "Merge paragraphs"
-msgstr ""
+msgstr "Споји пасусе"
 
 #: scripts/apps/publish/views/publish-queue.html:116
 #: scripts/apps/system-messages/components/system-messages-settings.tsx:69
@@ -10726,7 +10726,7 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-topbar.html:248
 #: scripts/apps/authoring/views/authoring-topbar.html:249
 msgid "Minimize"
-msgstr ""
+msgstr "Умањи"
 
 #: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:277
 #: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:28
@@ -10950,7 +10950,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/index.tsx:320
 msgid "Multi-line quote"
-msgstr ""
+msgstr "Цитат у више редова"
 
 #: scripts/apps/workspace/index.ts:39
 msgid "Multi-select (or deselect) an item"
@@ -10960,7 +10960,7 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-topbar.html:296
 #: scripts/apps/authoring/views/opened-articles.html:22
 msgid "Multiedit"
-msgstr ""
+msgstr "Вишеструко уређивање"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:178
 msgid "Multilingual"
@@ -11036,7 +11036,7 @@ msgstr ""
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:17
 #: scripts/apps/authoring/multiedit/views/sd-multiedit-dropdown.html:10
 msgid "NO SUGGESTIONS."
-msgstr ""
+msgstr "НЕМА СУГЕСТИЈА."
 
 #: scripts/core/lang/missing-translations-strings.ts:33
 msgid "NTB Currency Macro"
@@ -11180,7 +11180,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/annotations/AnnotationInput.tsx:310
 msgid "New annotation"
-msgstr ""
+msgstr "Нова анотација"
 
 #: scripts/apps/desks/views/desk-config-modal.html:237
 msgid "New stage"
@@ -11374,11 +11374,11 @@ msgstr ""
 #: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:216
 #: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:48
 msgid "No comments have been posted"
-msgstr ""
+msgstr "Нема постављених коментара"
 
 #: scripts/apps/authoring/comments/views/comments-widget.html:23
 msgid "No comments so far."
-msgstr ""
+msgstr "За сада нема коментара."
 
 #: scripts/apps/ingest/views/settings/ingest-routing-filter.html:5
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:11
@@ -11479,7 +11479,7 @@ msgstr ""
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:11
 #: scripts/apps/authoring/multiedit/views/sd-multiedit-inner-dropdown.html:10
 msgid "No items to add!"
-msgstr ""
+msgstr "Нема ставки за додавање!"
 
 #: scripts/apps/desks/views/task-status-items.html:3
 msgid "No items with this status"
@@ -11595,11 +11595,11 @@ msgstr ""
 
 #: scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx:91
 msgid "No suggestions available"
-msgstr ""
+msgstr "Нема доступних сугестија"
 
 #: scripts/apps/authoring/track-changes/views/suggestions-widget.html:46
 msgid "No suggestions have been resolved"
-msgstr ""
+msgstr "Ниједна сугестија није разрешена"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:363
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:363
@@ -12020,7 +12020,7 @@ msgstr ""
 #: scripts/apps/search-providers/directive.ts:117
 #: scripts/core/editor3/components/links/LinkToolbar.tsx:55
 msgid "Open"
-msgstr ""
+msgstr "Отвори"
 
 #: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:43
 #: ../superdesk-planning/client/constants/assignments.ts:196
@@ -12063,7 +12063,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar/multi-edit-toolbar-action.tsx:58
 msgid "Open multi edit"
-msgstr ""
+msgstr "Отвори вишеструко уређивање"
 
 #: scripts/apps/authoring-react/packages.tsx:106
 msgid "Open package"
@@ -12147,7 +12147,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:87
 msgid "Ordered list"
-msgstr ""
+msgstr "Нумерисана листа"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:337
 #: scripts/apps/contacts/directives/ContactsSearchPanelDirective.tsx:87
@@ -12337,7 +12337,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/publish-correction.tsx:13
 msgid "PUBLISH"
-msgstr ""
+msgstr "ОБЈАВИ"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:98
 msgid "Pacific/Auckland"
@@ -12906,7 +12906,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/FloatingCharacterCount.tsx:45
 msgid "Position"
-msgstr ""
+msgstr "Позиција"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:119
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:122
@@ -12916,7 +12916,7 @@ msgstr ""
 #: ../superdesk-planning/client/constants/events.ts:165
 #: scripts/apps/authoring/comments/views/comments-widget.html:46
 msgid "Post"
-msgstr ""
+msgstr "Постави"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:280
 #: ../superdesk-planning/client/components/Locations/LocationsList.tsx:130
@@ -12943,7 +12943,7 @@ msgstr ""
 
 #: scripts/apps/authoring/comments/views/comments-widget.html:45
 msgid "Post on 'Enter'"
-msgstr ""
+msgstr "Постави на 'Enter'"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:64
 msgid "Post planning items with Event"
@@ -13005,7 +13005,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:91
 msgid "Preformatted text"
-msgstr ""
+msgstr "Преформатирани текст"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:92
 msgid "Preserve Desk"
@@ -13089,7 +13089,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar-components/integration-wrapper/print-preview-button.tsx:13
 msgid "Print preview"
-msgstr ""
+msgstr "Преглед штампе"
 
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:131
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:129
@@ -13248,7 +13248,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:104
 msgid "Proofreading Theme"
-msgstr ""
+msgstr "Тема за лектуру"
 
 #: scripts/core/auth/reset-password.html:11
 msgid ""
@@ -13516,7 +13516,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:28
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:85
 msgid "Quote"
-msgstr ""
+msgstr "Цитат"
 
 #: ../superdesk-planning/client/validators/events.ts:103
 msgid "RECURRING ENDS ON must be greater than START DATE"
@@ -13588,7 +13588,7 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-topbar.html:41
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:179
 msgid "Read-only"
-msgstr ""
+msgstr "Само за читање"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:206
 msgid "Rearrange Groups"
@@ -13690,7 +13690,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:44
 #: scripts/core/editor3/components/toolbar/index.tsx:473
 msgid "Redo"
-msgstr ""
+msgstr "Понови"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:220
 #: ../superdesk-planning/client/components/fields/resources/events.ts:42
@@ -13762,16 +13762,16 @@ msgstr ""
 
 #: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:163
 msgid "Reject"
-msgstr ""
+msgstr "Одбиј"
 
 #: scripts/apps/authoring-react/article-widgets/suggestions.tsx:74
 #: scripts/apps/authoring/track-changes/views/suggestions-widget.html:9
 msgid "Rejected"
-msgstr ""
+msgstr "Одбијено"
 
 #: scripts/apps/authoring/track-changes/views/suggestions-widget.html:38
 msgid "Rejected by"
-msgstr ""
+msgstr "Одбио"
 
 #: scripts/apps/authoring-react/article-widgets/suggestions.tsx:127
 msgid "Rejected by {{user}}"
@@ -13946,7 +13946,7 @@ msgstr ""
 
 #: scripts/apps/authoring/multiedit/views/sd-multiedit-article.html:4
 msgid "Remove Item"
-msgstr ""
+msgstr "Уклони ставку"
 
 #: ../superdesk-planning/client/components/GeoLookupInput/LocationItem.tsx:49
 msgid "Remove Location"
@@ -13970,7 +13970,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/index.tsx:386
 msgid "Remove all formatting"
-msgstr ""
+msgstr "Уклони сво форматирање"
 
 #: scripts/apps/authoring-react/multi-edit-modal.tsx:131
 msgid "Remove article"
@@ -14006,7 +14006,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/index.tsx:377
 msgid "Remove formatting"
-msgstr ""
+msgstr "Уклони форматирање"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningItem.tsx:83
 msgid "Remove from Feature Stories"
@@ -14033,11 +14033,11 @@ msgstr "Уклони ставку"
 
 #: scripts/core/editor3/highlightsConfig.ts:119
 msgid "Remove link"
-msgstr ""
+msgstr "Уклони линк"
 
 #: scripts/apps/authoring/multiedit/views/multiedit.html:17
 msgid "Remove panel"
-msgstr ""
+msgstr "Уклони панел"
 
 #: scripts/apps/products/views/products.html:32
 msgid "Remove product"
@@ -14138,7 +14138,7 @@ msgstr ""
 #: scripts/apps/authoring/editor/views/find-replace.html:28
 #: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:91
 msgid "Replace"
-msgstr ""
+msgstr "Замени"
 
 #: scripts/apps/authoring/editor/views/find-replace.html:29
 msgid "Replace All"
@@ -14150,7 +14150,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:106
 msgid "Replace link"
-msgstr ""
+msgstr "Замени линк"
 
 #: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:88
 #: scripts/apps/authoring/editor/views/find-replace.html:13
@@ -14163,11 +14163,11 @@ msgstr ""
 
 #: scripts/apps/authoring/track-changes/views/suggestions-widget.html:25
 msgid "Replace:"
-msgstr ""
+msgstr "Замени:"
 
 #: scripts/core/editor3/components/comments/CommentPopup.tsx:218
 msgid "Reply"
-msgstr ""
+msgstr "Одговори"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsModal.js:94
 msgid "Report Schedule created!"
@@ -14284,16 +14284,16 @@ msgstr "Ресетуј лозинку"
 
 #: scripts/core/editor3/components/comments/CommentPopup.tsx:173
 msgid "Resolve"
-msgstr ""
+msgstr "Разреши"
 
 #: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:176
 #: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:4
 msgid "Resolved"
-msgstr ""
+msgstr "Разрешено"
 
 #: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:39
 msgid "Resolved by"
-msgstr ""
+msgstr "Разрешио"
 
 #: scripts/apps/authoring-react/article-widgets/suggestions.tsx:18
 msgid "Resolved suggestions"
@@ -14756,7 +14756,7 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-topbar.html:270
 #: scripts/apps/templates/views/create-template.html:5
 msgid "Save as template"
-msgstr ""
+msgstr "Сачувај као шаблон"
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:245
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:245
@@ -15352,7 +15352,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar/multi-edit-toolbar-action.tsx:35
 msgid "Select articles"
-msgstr ""
+msgstr "Изабери чланке"
 
 #: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:70
 msgid "Select at most 1 file to upload."
@@ -15369,7 +15369,7 @@ msgstr ""
 
 #: scripts/apps/authoring/compare-versions/views/compare-versions.html:12
 msgid "Select current version."
-msgstr ""
+msgstr "Изабери тренутну верзију."
 
 #: scripts/apps/search/views/edit-time-interval.html:5
 msgid "Select days"
@@ -15382,7 +15382,7 @@ msgstr ""
 #: scripts/apps/authoring-react/toolbar/mark-for-desks/mark-for-desks-modal.tsx:43
 #: scripts/apps/master-desk/components/HeaderComponent.tsx:224
 msgid "Select desks"
-msgstr ""
+msgstr "Изабери дескове"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:18
 msgid "Select desks for view"
@@ -15405,7 +15405,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/SelectItemModal.tsx:29
 #: scripts/apps/authoring/multiedit/views/sd-multiedit-inner-dropdown.html:2
 msgid "Select item"
-msgstr ""
+msgstr "Изабери ставку"
 
 #: scripts/apps/monitoring/index.ts:117
 msgid "Select next item on focused stage or group"
@@ -15456,13 +15456,13 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar/version-header.tsx:29
 msgid "Select version"
-msgstr ""
+msgstr "Изабери верзију"
 
 #: ../superdesk-planning/client/components/Events/EventMetadata/RelatedEventListItem.tsx:93
 #: ../superdesk-planning/client/components/RelatedPlannings/PlanningMetaData/RelatedPlanningListItem.tsx:101
 #: scripts/core/editor3/components/toolbar/FloatingCharacterCount.tsx:46
 msgid "Selected"
-msgstr ""
+msgstr "Изабрано"
 
 #: scripts/core/views/sdSearchList.html:21
 msgid "Selected item"
@@ -15475,7 +15475,7 @@ msgstr ""
 #: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:77
 #: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:33
 msgid "Selected text:"
-msgstr ""
+msgstr "Изабрани текст:"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:200
 msgid "Selections automatically removed"
@@ -15493,7 +15493,7 @@ msgstr ""
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/send-correction.tsx:13
 #: scripts/apps/authoring/views/authoring-topbar.html:214
 msgid "Send Correction"
-msgstr ""
+msgstr "Пошаљи исправку"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:117
 msgid "Send Email"
@@ -15516,7 +15516,7 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-topbar.html:86
 #: scripts/apps/authoring/views/authoring-topbar.html:87
 msgid "Send and duplicate"
-msgstr ""
+msgstr "Пошаљи и дуплирај"
 
 #: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:157
 msgid "Send and open"
@@ -15528,7 +15528,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/send-kill-action.tsx:13
 msgid "Send kill"
-msgstr ""
+msgstr "Пошаљи уништење"
 
 #: scripts/core/lang/missing-translations-strings.ts:14
 msgid "Send notifications via email"
@@ -15940,7 +15940,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/media/MediaBlock.tsx:13
 msgid "Single Usage"
-msgstr ""
+msgstr "Једнократно коришћење"
 
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:57
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:214
@@ -16076,7 +16076,7 @@ msgstr ""
 
 #: scripts/apps/authoring/multiedit/multiedit.ts:85
 msgid "Some articles failed to unlock"
-msgstr ""
+msgstr "Неки чланци нису успели да се откључају"
 
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:42
 #: ../superdesk-planning/client/planning-extension/src/extension.ts:57
@@ -16332,7 +16332,7 @@ msgstr ""
 
 #: scripts/core/editor3/highlightsConfig.ts:83
 msgid "Split paragraph"
-msgstr ""
+msgstr "Подели пасус"
 
 #: scripts/apps/desks/views/actionpicker.html:15
 #: scripts/apps/internal-destinations/InternalDestinations.tsx:48
@@ -16572,7 +16572,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:40
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:78
 msgid "Strikethrough"
-msgstr ""
+msgstr "Прецртано"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:41
 msgid "Strong"
@@ -16700,7 +16700,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:39
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:92
 msgid "Subscript"
-msgstr ""
+msgstr "Индекс"
 
 #: ../superdesk-analytics/client/charts/views/chart-form-options.html:15
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:15
@@ -16728,11 +16728,11 @@ msgstr ""
 #: scripts/apps/authoring/track-changes/suggestions.ts:91
 #: scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx:84
 msgid "Suggestions"
-msgstr ""
+msgstr "Сугестије"
 
 #: scripts/apps/authoring/suggest/SuggestView.html:8
 msgid "Suggestions will appear here once the article's body starts changing..."
-msgstr ""
+msgstr "Сугестије ће се појавити овде када се тело чланка почне мењати..."
 
 #: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:278
 #: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:29
@@ -16774,7 +16774,7 @@ msgstr "Superdesk лого"
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:38
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:93
 msgid "Superscript"
-msgstr ""
+msgstr "Експонент"
 
 #: scripts/apps/desks/directives/DeskConfigModal.ts:37
 #: scripts/apps/monitoring/directives/utils.ts:103
@@ -16880,7 +16880,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:33
 #: scripts/core/editor3/components/toolbar/index.tsx:310
 msgid "Table"
-msgstr ""
+msgstr "Табела"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:191
 msgid "Table Header"
@@ -16948,7 +16948,7 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-topbar.html:138
 #: scripts/apps/authoring/views/authoring-topbar.html:139
 msgid "Takedown"
-msgstr ""
+msgstr "Уклањање"
 
 #: scripts/apps/authoring/authoring/index.ts:333
 msgid "Takedown item"
@@ -17083,7 +17083,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:187
 #: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:384
 msgid "Template name"
-msgstr ""
+msgstr "Назив шаблона"
 
 #: scripts/apps/templates/directives/TemplatesDirective.ts:248
 msgid "Template saved."
@@ -17095,7 +17095,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar/template-modal.tsx:117
 msgid "Template will be updated"
-msgstr ""
+msgstr "Шаблон ће бити ажуриран"
 
 #: scripts/apps/templates/index.ts:46
 #: scripts/apps/templates/views/templates.html:3
@@ -17242,7 +17242,7 @@ msgstr "Токен за активацију није исправан."
 #: scripts/core/editor3/components/annotations/AnnotationInput.tsx:220
 #: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:85
 msgid "The annotation will be deleted. Are you sure?"
-msgstr ""
+msgstr "Анотација ће бити обрисана. Да ли сте сигурни?"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:107
 msgid "The assignment has been accepted"
@@ -17262,7 +17262,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/comments/CommentPopup.tsx:151
 msgid "The comment will be deleted. Are you sure?"
-msgstr ""
+msgstr "Коментар ће бити обрисан. Да ли сте сигурни?"
 
 #: ../superdesk-planning/client/components/UI/Form/InputArray/index.tsx:94
 msgid "The coverage has been removed"
@@ -17373,7 +17373,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/comments/CommentPopup.tsx:155
 msgid "The reply will be deleted. Are you sure?"
-msgstr ""
+msgstr "Одговор ће бити обрисан. Да ли сте сигурни?"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:23
 #: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:23
@@ -17518,7 +17518,7 @@ msgstr ""
 msgid ""
 "There are no public attachments yet. Upload some first using Attachments "
 "widget."
-msgstr ""
+msgstr "Још увек нема јавних прилога. Прво их отпремите помоћу виџета Прилози."
 
 #: scripts/apps/authoring-react/article-widgets/suggestions.tsx:208
 msgid "There are no resolved suggestions"
@@ -17742,7 +17742,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/embeds/EmbedInput.tsx:92
 msgid "This URL could not be embedded."
-msgstr ""
+msgstr "Овај URL није могуће уградити."
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:23
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:15
@@ -17874,7 +17874,7 @@ msgstr "Ова ставка ће бити трајно обрисана."
 
 #: scripts/core/editor3/components/BaseUnstyledComponent.tsx:130
 msgid "This link is not embeddable."
-msgstr ""
+msgstr "Овај линк није могуће уградити."
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModalSubnav.tsx:66
 msgid "This list contains unposted changes!"
@@ -17986,7 +17986,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/media/MediaBlock.tsx:15
 msgid "Time Restricted"
-msgstr ""
+msgstr "Временски ограничено"
 
 #: ../superdesk-planning/client/components/Events/EventDateTime.tsx:59
 msgid "Time TBC"
@@ -18092,14 +18092,14 @@ msgstr ""
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:15
 #: scripts/extensions/predefinedTextField/src/config.tsx:23
 msgid "Title"
-msgstr ""
+msgstr "Наслов"
 
 #: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:125
 #: scripts/apps/authoring/views/item-association.html:70
 #: scripts/apps/authoring/views/item-carousel.html:93
 #: scripts/core/editor3/components/media/MediaBlock.tsx:163
 msgid "Title:"
-msgstr ""
+msgstr "Наслов:"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:50
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:262
@@ -18123,7 +18123,7 @@ msgstr ""
 #: scripts/apps/search/constants.ts:13
 #: scripts/apps/search/views/search-parameters.html:115
 msgid "To Desk"
-msgstr ""
+msgstr "На деск"
 
 #: ../superdesk-planning/client/constants/assignments.ts:200
 #: scripts/apps/dashboard/workspace-tasks/tasks.ts:9
@@ -18147,7 +18147,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/embeds/EmbedInput.tsx:152
 msgid "To get a responsive embed code, paste a URL."
-msgstr ""
+msgstr "За добијање прилагодљивог кода за уграђивање, налепите URL."
 
 #: scripts/apps/authoring-react/fields/media/difference.tsx:72
 msgid ""
@@ -18191,11 +18191,11 @@ msgstr ""
 
 #: scripts/core/editor3/highlightsConfig.ts:78
 msgid "Toggle"
-msgstr ""
+msgstr "Прикажи/сакриј"
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:88
 msgid "Toggle Header"
-msgstr ""
+msgstr "Прикажи/сакриј заглавље"
 
 #: scripts/apps/authoring/widgets/widgets.ts:519
 msgid "Toggle Nth widget, where 'N' is order of widget it appears"
@@ -18208,7 +18208,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:89
 msgid "Toggle Suggestions Mode"
-msgstr ""
+msgstr "Укључи/искључи режим сугестија"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:142
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:54
@@ -18217,7 +18217,7 @@ msgstr ""
 
 #: scripts/core/editor3/highlightsConfig.ts:43
 msgid "Toggle bold"
-msgstr ""
+msgstr "Укључи/искључи подебљано"
 
 #: scripts/apps/authoring-react/authoring-section/get-field-container.tsx:70
 msgid "Toggle field"
@@ -18232,7 +18232,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:90
 msgid "Toggle formatting marks"
-msgstr ""
+msgstr "Прикажи/сакриј ознаке форматирања"
 
 #: scripts/apps/archive/views/preview.html:79
 msgid "Toggle header info"
@@ -18240,7 +18240,7 @@ msgstr ""
 
 #: scripts/core/editor3/highlightsConfig.ts:49
 msgid "Toggle italic"
-msgstr ""
+msgstr "Укључи/искључи курзив"
 
 #: scripts/core/menu/views/menu.html:15
 msgid "Toggle main menu"
@@ -18256,24 +18256,24 @@ msgstr ""
 
 #: scripts/core/editor3/highlightsConfig.ts:73
 msgid "Toggle strikethrough"
-msgstr ""
+msgstr "Укључи/искључи прецртано"
 
 #: scripts/core/editor3/highlightsConfig.ts:61
 msgid "Toggle subscript"
-msgstr ""
+msgstr "Укључи/искључи индекс"
 
 #: scripts/core/editor3/highlightsConfig.ts:67
 msgid "Toggle superscript"
-msgstr ""
+msgstr "Укључи/искључи експонент"
 
 #: scripts/apps/authoring-react/toolbar-components/integration-wrapper/toggle-theme-button.tsx:13
 #: scripts/apps/authoring/views/authoring.html:33
 msgid "Toggle theme"
-msgstr ""
+msgstr "Промени тему"
 
 #: scripts/core/editor3/highlightsConfig.ts:55
 msgid "Toggle underline"
-msgstr ""
+msgstr "Укључи/искључи подвучено"
 
 #: scripts/apps/publish/views/subscribers.html:311
 msgid "Token expiry"
@@ -18346,7 +18346,7 @@ msgstr ""
 #: scripts/extensions/ai-widget/src/translations/translations-footer.tsx:81
 #: scripts/extensions/ai-widget/src/translations/translations-widget.tsx:83
 msgid "Translate"
-msgstr ""
+msgstr "Преведи"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:352
 msgid "Translate item to"
@@ -18453,7 +18453,7 @@ msgstr ""
 #: scripts/apps/authoring-react/generic-widgets/comments/CommentsWidget.tsx:184
 #: scripts/core/editor3/components/comments/CommentTextArea.tsx:122
 msgid "Type your comment..."
-msgstr ""
+msgstr "Унесите свој коментар..."
 
 #: ../superdesk-planning/client/components/fields/list/ItemType.tsx:18
 #: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:173
@@ -18482,7 +18482,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/unspike.tsx:9
 msgid "UNSPIKE"
-msgstr ""
+msgstr "ВРАТИ"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:149
 msgid "UP"
@@ -18495,16 +18495,16 @@ msgstr ""
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/update-action.tsx:10
 #: scripts/apps/authoring/views/authoring-header.html:57
 msgid "UPDATE"
-msgstr ""
+msgstr "АЖУРИРАЈ"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:97
 #: scripts/core/editor3/components/links/LinkInput.tsx:67
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 #: scripts/core/editor3/components/embeds/EmbedInput.tsx:95
 msgid "URL not found."
-msgstr ""
+msgstr "URL није пронађен."
 
 #: scripts/apps/vocabularies/views/settings.html:34
 msgid "URLs"
@@ -18552,13 +18552,13 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:77
 msgid "Underline (Ctrl+U)"
-msgstr ""
+msgstr "Подвучено (Ctrl+U)"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:201
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:43
 #: scripts/core/editor3/components/toolbar/index.tsx:462
 msgid "Undo"
-msgstr ""
+msgstr "Опозови"
 
 #: scripts/apps/archive/views/metadata-view.html:203
 #: scripts/apps/content-filters/views/production-test-view.html:19
@@ -18604,7 +18604,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:73
 msgid "Unknown Type ({{qcode}})"
-msgstr ""
+msgstr "Непознат тип ({{qcode}})"
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:365
 msgid "Unknown error occured, Try descheduling again."
@@ -18705,7 +18705,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:86
 msgid "Unordered list"
-msgstr ""
+msgstr "Ненумерисана листа"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:119
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:122
@@ -18723,7 +18723,7 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-topbar.html:147
 #: scripts/apps/authoring/views/authoring-topbar.html:148
 msgid "Unpublish"
-msgstr ""
+msgstr "Повуци објаву"
 
 #: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:69
 msgid "Unpublish related items:"
@@ -18740,7 +18740,7 @@ msgstr ""
 #: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:168
 #: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:3
 msgid "Unresolved"
-msgstr ""
+msgstr "Неразрешено"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:499
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:123
@@ -18824,7 +18824,7 @@ msgstr ""
 #: scripts/apps/workspace/views/workspace-dropdown.html:6
 #: scripts/core/utils.tsx:452
 msgid "Untitled"
-msgstr ""
+msgstr "Без наслова"
 
 #: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:138
 #: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:401
@@ -19275,7 +19275,7 @@ msgstr ""
 #: scripts/apps/archive/views/export.html:18
 #: scripts/apps/authoring-react/toolbar/export-modal.tsx:104
 msgid "Validate"
-msgstr ""
+msgstr "Провери"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:299
 msgid "Validate Characters"
@@ -19519,9 +19519,9 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-header.html:42
 msgid "WORD"
 msgid_plural "WORDS"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "РЕЧ"
+msgstr[1] "РЕЧИ"
+msgstr[2] "РЕЧИ"
 
 #: scripts/api/article-send.tsx:103
 #: scripts/apps/system-messages/components/system-messages-settings.tsx:24
@@ -19909,7 +19909,7 @@ msgstr ""
 #: scripts/core/editor3/components/media/MediaBlock.tsx:301
 #: scripts/core/editor3/components/media/MediaBlock.tsx:306
 msgid "[No Value]"
-msgstr ""
+msgstr "[Нема вредности]"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:103
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:97
@@ -20015,7 +20015,7 @@ msgstr ""
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-article.html:7
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:7
 msgid "author"
-msgstr ""
+msgstr "аутор"
 
 #: scripts/core/lang/missing-translations-strings.ts:27
 msgid "authoring"
@@ -20053,7 +20053,7 @@ msgstr ""
 #: scripts/apps/authoring/versioning/versions/views/versions.html:7
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:2
 msgid "by"
-msgstr ""
+msgstr "од"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:210
 msgid "by {{user}}"
@@ -20088,7 +20088,7 @@ msgstr "изменио је следећу оригиналну ставку. О
 #: scripts/apps/authoring/authoring/directives/CharacterCount.ts:13
 #: scripts/core/editor3/components/toolbar/FloatingCharacterCount.tsx:48
 msgid "characters"
-msgstr ""
+msgstr "знакови"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:583
 msgid "city"
@@ -20114,7 +20114,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/TableControls.tsx:102
 msgid "column"
-msgstr ""
+msgstr "колона"
 
 #: scripts/core/menu/notifications/views/notifications.html:31
 msgid "commented on"
@@ -20237,7 +20237,7 @@ msgstr ""
 #: scripts/apps/search/components/ItemContainer.tsx:13
 #: scripts/core/itemList/views/relatedItem-list-widget.html:38
 msgid "desk:"
-msgstr ""
+msgstr "деск:"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:272
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:272
@@ -20898,7 +20898,7 @@ msgstr[2] ""
 
 #: scripts/core/editor3/components/article-embed/article-embed.tsx:32
 msgid "open in a new window"
-msgstr ""
+msgstr "отвори у новом прозору"
 
 #: scripts/extensions/markForUser/dist/src/extension.js:48
 #: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/extension.js:48
@@ -20918,7 +20918,7 @@ msgstr ""
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:73
 #: scripts/core/editor3/helpers/highlights.ts:67
 msgid "ordered list"
-msgstr ""
+msgstr "нумерисана листа"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:320
 #: scripts/apps/contacts/constants.ts:71
@@ -21005,7 +21005,7 @@ msgstr ""
 
 #: scripts/core/editor3/helpers/highlights.ts:68 scripts/core/utils.tsx:289
 msgid "preformatted"
-msgstr ""
+msgstr "преформатирано"
 
 #: scripts/apps/authoring/macros/views/macros-replace.html:7
 #: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:443
@@ -21050,7 +21050,7 @@ msgstr ""
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:75
 #: scripts/core/editor3/helpers/highlights.ts:65
 msgid "quote"
-msgstr ""
+msgstr "цитат"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:98
 msgid "redo"
@@ -21092,7 +21092,7 @@ msgstr ""
 #: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:181
 #: scripts/core/editor3/directive.tsx:452
 msgid "required"
-msgstr ""
+msgstr "обавезно"
 
 #: scripts/apps/users/views/edit-form.html:208
 msgid "reset password"
@@ -21124,7 +21124,7 @@ msgstr ""
 
 #: scripts/core/editor3/components/toolbar/TableControls.tsx:90
 msgid "row"
-msgstr ""
+msgstr "ред"
 
 #: scripts/core/lang/missing-translations-strings.ts:12
 msgid "scheduled"
@@ -21210,7 +21210,7 @@ msgstr ""
 #: scripts/apps/authoring/versioning/versions/views/versions.html:14
 #: scripts/core/itemList/views/relatedItem-list-widget.html:39
 msgid "stage:"
-msgstr ""
+msgstr "фаза:"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:94
 #: scripts/extensions/availability-manager/dist/src/utils.js:94
@@ -21350,7 +21350,7 @@ msgstr ""
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:72
 #: scripts/core/editor3/helpers/highlights.ts:66
 msgid "unordered list"
-msgstr ""
+msgstr "ненумерисана листа"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:121
 msgid "unpost"
@@ -21455,7 +21455,7 @@ msgstr ""
 #: scripts/apps/authoring/versioning/history/views/history.html:91
 #: scripts/apps/authoring/versioning/versions/views/versions.html:18
 msgid "version"
-msgstr ""
+msgstr "верзија"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:117
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:121
@@ -21504,11 +21504,11 @@ msgstr ""
 #: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:110
 #: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:95
 msgid "with"
-msgstr ""
+msgstr "са"
 
 #: scripts/apps/authoring/track-changes/views/suggestions-widget.html:27
 msgid "with:"
-msgstr ""
+msgstr "са:"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:112
 #: scripts/extensions/availability-manager/dist/src/utils.js:112

--- a/po/sr.po
+++ b/po/sr.po
@@ -17,15 +17,15 @@ msgstr "\"ЖАНР 'није дозвољена нул вредност'"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:199
 msgid "\"Name\" is a required field"
-msgstr ""
+msgstr "\"Назив\" је обавезно поље"
 
 #: ../superdesk-planning/client/components/ContentProfiles/utils.ts:16
 msgid "\"{{fieldName}}\" field is required by the system"
-msgstr ""
+msgstr "\"{{fieldName}}\" поље је обавезно у систему"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:204
 msgid "\"{{language}}\" translation is required"
-msgstr ""
+msgstr "\"{{language}}\" превод је обавезан"
 
 #: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:240
 msgid "\"{{x}}\" field is required"
@@ -116,11 +116,11 @@ msgstr "(као што је дефинисано за све групе)"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:237
 msgid "(custom text field)"
-msgstr ""
+msgstr "(прилагођено текстуално поље)"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:238
 msgid "(custom vocabulary)"
-msgstr ""
+msgstr "(прилагођени вокабулар)"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:170
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:170
@@ -218,7 +218,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/filters.ts:97
 msgid "108h"
-msgstr ""
+msgstr "108ч"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:183
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:183
@@ -496,7 +496,7 @@ msgstr "6. ажурирање"
 
 #: ../superdesk-planning/client/utils/filters.ts:95
 msgid "70th"
-msgstr ""
+msgstr "70."
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:41
 #: ../superdesk-planning/client/utils/filters.ts:75
@@ -588,7 +588,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/api/locations.ts:30
 msgid "A location matching this one already exists"
-msgstr ""
+msgstr "Локација која одговара овој већ постоји"
 
 #: scripts/apps/authoring-react/toolbar/template-modal.tsx:107
 msgid "A new template will be created"
@@ -641,7 +641,7 @@ msgstr "ПОВЕЗАНА XMP ДАТОТЕКА"
 
 #: ../superdesk-planning/client/validators/events.ts:242
 msgid "ATTACHED FILE {{ index }} is required"
-msgstr ""
+msgstr "ПРИЛОЖЕНА ДАТОТЕКА {{ index }} је обавезна"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx:95
 msgid "ATTACHMENTS"
@@ -835,9 +835,9 @@ msgstr "Додај"
 #: ../superdesk-planning/client/utils/confirmAddingRelatedItems.tsx:56
 msgid "Add 1 item"
 msgid_plural "Add {{n}} items"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Додај 1 ставку"
+msgstr[1] "Додај {{n}} ставке"
+msgstr[2] "Додај {{n}} ставки"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:96
 msgid "Add Abbreviation"
@@ -845,21 +845,21 @@ msgstr "Додај скраћеницу"
 
 #: ../superdesk-planning/client/constants/planning.ts:140
 msgid "Add As Event"
-msgstr ""
+msgstr "Додај као догађај"
 
 #: ../superdesk-planning/client/components/Contacts/ContactEditor.tsx:88
 #: ../superdesk-planning/client/components/Contacts/ContactField.tsx:126
 msgid "Add Contact"
-msgstr ""
+msgstr "Додај контакт"
 
 #: ../superdesk-planning/client/components/Editor/bookmarks/AddCoverageBookmark.tsx:56
 #: ../superdesk-planning/client/components/Editor/bookmarks/AddCoverageBookmark.tsx:92
 msgid "Add Coverage"
-msgstr ""
+msgstr "Додај извештавање"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:323
 msgid "Add Coverage To Workflow"
-msgstr ""
+msgstr "Додај извештавање у радни ток"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:267
 msgid "Add Coverages"
@@ -947,11 +947,11 @@ msgstr "Додај нови речник"
 
 #: ../superdesk-planning/client/components/GeoLookupInput/CreateNewGeoLookup.tsx:129
 msgid "Add New Event Location"
-msgstr ""
+msgstr "Додај нову локацију догађаја"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:215
 msgid "Add New Filter"
-msgstr ""
+msgstr "Додај нови филтер"
 
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:43
 msgid "Add New Filter Condition"
@@ -988,7 +988,7 @@ msgstr "Додај нови шаблон"
 
 #: ../superdesk-planning/client/components/Editor/bookmarks/AddPlanningBookmark.tsx:30
 msgid "Add Planning Item"
-msgstr ""
+msgstr "Додај ставку планирања"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:84
 msgid "Add Rule"
@@ -1004,7 +1004,7 @@ msgstr "Додај овај виџет"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/TimeInputs.tsx:95
 msgid "Add Time"
-msgstr ""
+msgstr "Додај време"
 
 #: scripts/apps/authoring/authoring/article-url-fields.tsx:103
 msgid "Add URL"
@@ -1017,7 +1017,7 @@ msgstr "Додај извештавање"
 
 #: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:239
 msgid "Add a new location"
-msgstr ""
+msgstr "Додај нову локацију"
 
 #: scripts/apps/authoring-react/multi-edit-modal.tsx:318
 msgid "Add article"
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid ""
 "Add article to Planning - select an existing Planning Item or create a new "
 "one"
-msgstr ""
+msgstr "Додај чланак у планирање - изаберите постојећу ставку планирања или креирајте нову"
 
 #: ../superdesk-planning/client/components/Planning/PlanningItem.tsx:317
 #: ../superdesk-planning/client/components/Planning/PlanningItem.tsx:322
@@ -1038,17 +1038,17 @@ msgstr "Додај као извештавање"
 #: ../superdesk-planning/client/utils/events.tsx:717
 msgid "Add as related event"
 msgid_plural "Add as related events"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Додај као повезан догађај"
+msgstr[1] "Додај као повезане догађаје"
+msgstr[2] "Додај као повезане догађаје"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:181
 #: ../superdesk-planning/client/utils/planning.tsx:818
 msgid "Add as related planning"
 msgid_plural "Add as related plannings"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Додај као повезано планирање"
+msgstr[1] "Додај као повезана планирања"
+msgstr[2] "Додај као повезана планирања"
 
 #: scripts/apps/authoring/media/views/media-metadata-editor-directive.html:122
 #: scripts/apps/authoring/views/authoring-header.html:614
@@ -1066,7 +1066,7 @@ msgstr "Додај слаглајн садржаја"
 #: ../superdesk-planning/client/constants/planning.ts:144
 #: ../superdesk-planning/client/constants/planning.ts:147
 msgid "Add coverage"
-msgstr ""
+msgstr "Додај извештавање"
 
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:58
 msgid "Add description"
@@ -1080,11 +1080,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:113
 msgid "Add field after"
-msgstr ""
+msgstr "Додај поље после"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:69
 msgid "Add field before"
-msgstr ""
+msgstr "Додај поље пре"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-filter.html:8
 msgid "Add filter"
@@ -1092,21 +1092,21 @@ msgstr "Додај филтер"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldList.tsx:43
 msgid "Add first field"
-msgstr ""
+msgstr "Додај прво поље"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupList.tsx:113
 msgid "Add first group"
-msgstr ""
+msgstr "Додај прву групу"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupElementTemplate.tsx:80
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupList.tsx:92
 msgid "Add group after"
-msgstr ""
+msgstr "Додај групу после"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupElementTemplate.tsx:43
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupList.tsx:55
 msgid "Add group before"
-msgstr ""
+msgstr "Додај групу пре"
 
 #: scripts/validate-instance-configuration.tsx:59
 msgid "Add it via Settings > Metadata"
@@ -1140,7 +1140,7 @@ msgstr "Додај нови виџет"
 
 #: ../superdesk-planning/client/components/Editor/bookmarks/AddPlanningBookmark.tsx:42
 msgid "Add planning item"
-msgstr ""
+msgstr "Додај ставку планирања"
 
 #: scripts/apps/ingest/views/settings/ingest-rules-content.html:65
 msgid "Add rule"
@@ -1197,7 +1197,7 @@ msgstr "Додај у речник"
 
 #: ../superdesk-planning/client/constants/planning.ts:145
 msgid "Add to featured stories"
-msgstr ""
+msgstr "Додај у истакнуте приче"
 
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:283
 msgid "Add to highlight"
@@ -1499,7 +1499,7 @@ msgstr "Сви"
 
 #: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:32
 msgid "All Calendars"
-msgstr ""
+msgstr "Сви календари"
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:303
 msgid "All Coverage has been cancelled"
@@ -1585,7 +1585,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/WorkqueueContainer/index.tsx:25
 msgid "All open items"
-msgstr ""
+msgstr "Све отворене ставке"
 
 #: scripts/apps/authoring/views/opened-articles.html:2
 msgid "All opened items"
@@ -1930,7 +1930,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ConfirmationModal.tsx:162
 msgid "Are you sure ?"
-msgstr ""
+msgstr "Да ли сте сигурни?"
 
 #: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:214
 #: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:226
@@ -2073,7 +2073,7 @@ msgstr "Подразумеване вредности чланка"
 #: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:215
 #: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:297
 msgid "Article Template"
-msgstr ""
+msgstr "Шаблон чланка"
 
 #: scripts/apps/archive/views/preview.html:17
 msgid "Article Type"
@@ -2103,7 +2103,7 @@ msgstr "Тип чланка: {{articleType}}"
 #: scripts/apps/search/components/TypeIcon.tsx:49
 #: scripts/core/directives/FiletypeIconDirective.ts:39
 msgid "Article Type: {{type}}"
-msgstr ""
+msgstr "Тип чланка: {{type}}"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:577
 msgid ""
@@ -2321,11 +2321,11 @@ msgstr "Додели права:"
 
 #: ../superdesk-planning/client/constants/planning.ts:143
 msgid "Assign to agenda"
-msgstr ""
+msgstr "Додели агенди"
 
 #: ../superdesk-planning/client/constants/events.ts:168
 msgid "Assign to calendar"
-msgstr ""
+msgstr "Додели календару"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/State.tsx:29
 #: ../superdesk-planning/client/utils/index.ts:385
@@ -2465,7 +2465,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:315
 msgid "Associated Event"
-msgstr ""
+msgstr "Повезан догађај"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/index.tsx:210
 #: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:233
@@ -2490,7 +2490,7 @@ msgstr "Путања повезаног/истакнутог медија"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:66
 msgid "At least 2 languages must be selected"
-msgstr ""
+msgstr "Морају бити изабрана најмање 2 језика"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:198
 msgid "At least one of [{{list}}] is required."
@@ -2884,7 +2884,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:38
 #: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:40
 msgid "Browse"
-msgstr ""
+msgstr "Прегледај"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:546
 msgid "Building, Suite, Unit, Apartment, Floor, etc."
@@ -2947,11 +2947,11 @@ msgstr "CID"
 
 #: ../superdesk-planning/client/validators/planning.ts:232
 msgid "COVERAGE SCHEDULE is required"
-msgstr ""
+msgstr "РАСПОРЕД ИЗВЕШТАВАЊА је обавезан"
 
 #: ../superdesk-planning/client/validators/planning.ts:256
 msgid "COVERAGE SCHEDULED DATE cannot be in the past"
-msgstr ""
+msgstr "ЗАКАЗАНИ ДАТУМ ИЗВЕШТАВАЊА не може бити у прошлости"
 
 #: scripts/apps/workspace/views/workspace-dropdown.html:32
 msgid "CREATE NEW WORKSPACE"
@@ -2983,7 +2983,7 @@ msgstr "Календар:"
 
 #: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:37
 msgid "Calendar: {{activeCalendarName}}"
-msgstr ""
+msgstr "Календар: {{activeCalendarName}}"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:143
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/calendars.ts:36
@@ -3213,7 +3213,7 @@ msgstr "Откажи избор"
 
 #: ../superdesk-planning/client/constants/planning.ts:139
 msgid "Cancel all Coverage(s)"
-msgstr ""
+msgstr "Откажи сва извештавања"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:152
 msgid "Cancel all recurring events or just this one?"
@@ -3264,7 +3264,7 @@ msgstr "Није могуће обрисати вокабулар"
 
 #: ../superdesk-planning/client/validators/events.ts:289
 msgid "Cannot end with \".\""
-msgstr ""
+msgstr "Не може се завршити са \".\""
 
 #: ../superdesk-planning/client/actions/main.ts:905
 msgid "Cannot load more data as filter type is not selected."
@@ -3355,7 +3355,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:181
 msgid "Changes will be lost, if they are not saved."
-msgstr ""
+msgstr "Измене ће бити изгубљене ако не буду сачуване."
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditorTools.js:32
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorTools.js:32
@@ -3870,7 +3870,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/constants/assignments.ts:193
 msgid "Complete Assignment"
-msgstr ""
+msgstr "Заврши задатак"
 
 #: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:28
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:66
@@ -3942,7 +3942,7 @@ msgstr "Потврди"
 
 #: ../superdesk-planning/client/constants/assignments.ts:197
 msgid "Confirm Availability"
-msgstr ""
+msgstr "Потврди доступност"
 
 #: scripts/apps/authoring/authoring/components/publish-warning-confirm-modal.tsx:24
 msgid "Confirm Publish Warnings"
@@ -3964,7 +3964,7 @@ msgstr "Потврди нову лозинку"
 
 #: ../superdesk-planning/client/components/ConfirmationModal.tsx:149
 msgid "Confirmation"
-msgstr ""
+msgstr "Потврда"
 
 #: scripts/apps/ingest/directives/authenticate-ingest-provider.tsx:20
 msgid "Connect an account"
@@ -4043,7 +4043,7 @@ msgstr "Истек садржаја"
 
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:332
 msgid "Content Fields"
-msgstr ""
+msgstr "Поља садржаја"
 
 #: scripts/apps/content-filters/views/manage-filters.html:107
 #: scripts/apps/ingest/views/settings/ingest-routing-filter.html:2
@@ -4189,7 +4189,7 @@ msgstr "Претвори текст у велика слова"
 
 #: ../superdesk-planning/client/constants/events.ts:163
 msgid "Convert to Recurring Event"
-msgstr ""
+msgstr "Конвертуј у понављајући догађај"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:110
 msgid "Convert to a recurring event"
@@ -4330,7 +4330,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/api/editor/item_planning.ts:125
 msgid "Could not link event - Please close the item and try linking again"
-msgstr ""
+msgstr "Догађај није могао бити повезан - затворите ставку и покушајте поново"
 
 #: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:42
 #: scripts/core/ui/components/Form/LinkInput.tsx:27
@@ -4397,7 +4397,7 @@ msgstr "Статус доделе извештавања"
 
 #: ../superdesk-planning/client/utils/assignments.ts:206
 msgid "Coverage Contact"
-msgstr ""
+msgstr "Контакт извештавања"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:191
 msgid "Coverage Provider"
@@ -4508,7 +4508,7 @@ msgstr "Извештавања"
 
 #: ../superdesk-planning/client/api/planning.ts:299
 msgid "Coverages added to workflow."
-msgstr ""
+msgstr "Извештавања додата у радни ток."
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:433
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:219
@@ -4550,11 +4550,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/GeoLookupInput/CreateNewGeoLookup.tsx:180
 msgid "Create Location"
-msgstr ""
+msgstr "Креирај локацију"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:189
 msgid "Create New Location"
-msgstr ""
+msgstr "Креирај нову локацију"
 
 #: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:45
 msgid "Create New Task"
@@ -4567,16 +4567,16 @@ msgstr "Креирај пакет"
 
 #: ../superdesk-planning/client/components/Editor/EditorBookmarksBar.tsx:64
 msgid "Create Planning"
-msgstr ""
+msgstr "Креирај планирање"
 
 #: ../superdesk-planning/client/constants/events.ts:157
 msgid "Create Planning Item"
-msgstr ""
+msgstr "Креирај ставку планирања"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:105
 #: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:179
 msgid "Create Scheduled Export"
-msgstr ""
+msgstr "Креирај заказани извоз"
 
 #: scripts/apps/monitoring/index.ts:126
 msgid "Create a broadcast"
@@ -4585,11 +4585,11 @@ msgstr "Креирај емисију"
 #: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:49
 #: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:50
 msgid "Create a new location"
-msgstr ""
+msgstr "Креирај нову локацију"
 
 #: ../superdesk-planning/client/constants/events.ts:158
 msgid "Create and Open Planning Item"
-msgstr ""
+msgstr "Креирај и отвори ставку планирања"
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary.js:50
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:63
@@ -4687,7 +4687,7 @@ msgstr "Креирај пакет"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:239
 msgid "Create planning"
-msgstr ""
+msgstr "Креирај планирање"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:259
 msgid "Create planning for all events or just this one?"
@@ -4835,7 +4835,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:129
 msgid "Creation Date"
-msgstr ""
+msgstr "Датум креирања"
 
 #: ../superdesk-planning/client/components/fields/editor/DatesGroup.tsx:80
 msgid "Creation date"
@@ -4895,7 +4895,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/constants/assignments.ts:209
 msgid "Current Assignments"
-msgstr ""
+msgstr "Тренутни задаци"
 
 #: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:78
 msgid "Current Date"
@@ -4932,7 +4932,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:221
 #: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:316
 msgid "Custom Layout"
-msgstr ""
+msgstr "Прилагођен распоред"
 
 #: scripts/core/editor3/components/toolbar/index.tsx:358
 msgid "Custom block"
@@ -4988,7 +4988,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/filters.ts:45
 msgid "Daily @ {{ time }} to {{ desk }}"
-msgstr ""
+msgstr "Дневно у {{ time }} на {{ desk }}"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:67
 msgid "Daily at {{hour}}"
@@ -5078,7 +5078,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/validators/planning.ts:253
 msgid "Date is in the past"
-msgstr ""
+msgstr "Датум је у прошлости"
 
 #: scripts/apps/search/directives/DateFilters.ts:84
 msgid "Date modified"
@@ -5233,7 +5233,7 @@ msgstr "Подразумевани језик"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:69
 msgid "Default language is a required field"
-msgstr ""
+msgstr "Подразумевани језик је обавезно поље"
 
 #: scripts/apps/desks/views/desk-config-modal.html:131
 msgid "Default monitoring view"
@@ -5299,7 +5299,7 @@ msgstr "Обриши"
 
 #: ../superdesk-planning/client/constants/tooltips.ts:26
 msgid "Delete Agenda"
-msgstr ""
+msgstr "Обриши агенду"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/store/assets/actions.js:324
 #: scripts/extensions/sams/dist/src/extensions/sams/src/store/assets/actions.js:331
@@ -5312,14 +5312,14 @@ msgstr ""
 
 #: ../superdesk-planning/client/constants/tooltips.ts:36
 msgid "Delete Filter"
-msgstr ""
+msgstr "Обриши филтер"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:203
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:304
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:70
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:85
 msgid "Delete Item?"
-msgstr ""
+msgstr "Обрисати ставку?"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:70
 msgid "Delete Rule"
@@ -5331,7 +5331,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:114
 msgid "Delete Scheduled Export"
-msgstr ""
+msgstr "Обриши заказани извоз"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/store/sets/actions.js:95
 #: scripts/extensions/sams/dist/src/store/sets/actions.js:95
@@ -5345,7 +5345,7 @@ msgstr "Обриши празне пасусе"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:101
 msgid "Delete failed! Field is required by the system"
-msgstr ""
+msgstr "Брисање није успело! Поље је обавезно у систему"
 
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:248
 msgid "Delete item?"
@@ -5468,15 +5468,15 @@ msgstr "Опис"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:291
 msgid "Description Long"
-msgstr ""
+msgstr "Дугачак опис"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:273
 msgid "Description Short"
-msgstr ""
+msgstr "Кратак опис"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:305
 msgid "Description Text"
-msgstr ""
+msgstr "Опис у тексту"
 
 #: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:135
 msgid "Description:"
@@ -5485,7 +5485,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:328
 #: scripts/apps/search/views/multi-image-edit.html:33
 msgid "Deselect All"
-msgstr ""
+msgstr "Поништи избор за све"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:495
 #: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-parameters.html:9
@@ -5768,7 +5768,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:379
 #: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:217
 msgid "Discard All"
-msgstr ""
+msgstr "Одбаци све"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:104
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:116
@@ -5837,7 +5837,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:264
 msgid "Do you want to link it to that assignment ?"
-msgstr ""
+msgstr "Желите ли да повежете са тим задатком?"
 
 #: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:50
 msgid "Do you want to publish the article?"
@@ -5884,15 +5884,15 @@ msgstr "Не поклапа се"
 
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:326
 msgid "Don't Fulfil Assignment"
-msgstr ""
+msgstr "Не извршавај задатак"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:273
 msgid "Don't Save"
-msgstr ""
+msgstr "Не чувати"
 
 #: ../superdesk-planning/client/components/AddToPlanningModal/index.tsx:77
 msgid "Don't add"
-msgstr ""
+msgstr "Не додај"
 
 #: scripts/core/auth/reset-password.html:70
 msgid "Don't have token? Get it."
@@ -6006,7 +6006,7 @@ msgstr "Пустите догађаје овде"
 
 #: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:87
 msgid "Drop files here to upload"
-msgstr ""
+msgstr "Пустите датотеке овде за отпремање"
 
 #: scripts/apps/users/views/change-avatar.html:29
 msgid "Drop it here"
@@ -6184,33 +6184,33 @@ msgstr ""
 
 #: ../superdesk-planning/client/validators/events.ts:87
 msgid "END DATE cannot be in the past"
-msgstr ""
+msgstr "КРАЈЊИ ДАТУМ не може бити у прошлости"
 
 #: ../superdesk-planning/client/validators/events.ts:20
 msgid "END DATE is a required field"
-msgstr ""
+msgstr "КРАЈЊИ ДАТУМ је обавезно поље"
 
 #: ../superdesk-planning/client/validators/events.ts:60
 msgid "END DATE should be after START DATE"
-msgstr ""
+msgstr "КРАЈЊИ ДАТУМ треба да буде после ПОЧЕТНОГ ДАТУМА"
 
 #: ../superdesk-planning/client/validators/events.ts:41
 msgid "END TIME is a required field"
-msgstr ""
+msgstr "КРАЈЊЕ ВРЕМЕ је обавезно поље"
 
 #: ../superdesk-planning/client/validators/events.ts:57
 msgid "END TIME should be after START TIME"
-msgstr ""
+msgstr "КРАЈЊЕ ВРЕМЕ треба да буде после ПОЧЕТНОГ ВРЕМЕНА"
 
 #: ../superdesk-planning/client/validators/events.ts:290
 msgid "EXTERNAL LINK {{ index }} cannot end with \".\""
-msgstr ""
+msgstr "СПОЉАШЊИ ЛИНК {{ index }} не може се завршити са \".\""
 
 #: ../superdesk-planning/client/validators/events.ts:284
 msgid ""
 "EXTERNAL LINK {{ index }} must start with \"http://\", \"https://\" or \"www."
 "\""
-msgstr ""
+msgstr "СПОЉАШЊИ ЛИНК {{ index }} мора почињати са \"http://\", \"https://\" или \"www.\""
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:35
 #: ../superdesk-planning/client/components/fields/resources/common.tsx:16
@@ -6316,7 +6316,7 @@ msgstr "Уреди речник скраћеница"
 
 #: ../superdesk-planning/client/constants/tooltips.ts:23
 msgid "Edit Agenda"
-msgstr ""
+msgstr "Уреди агенду"
 
 #: scripts/apps/authoring/attachments/AttachmentsEditorModal.tsx:41
 #: scripts/extensions/sams/dist/src/components/attachments/editAttachmentModal.js:122
@@ -6328,7 +6328,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:76
 #: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:77
 msgid "Edit Contact"
-msgstr ""
+msgstr "Уреди контакт"
 
 #: scripts/apps/content-filters/views/manage-filters.html:20
 #: scripts/apps/content-filters/views/manage-filters.html:32
@@ -6354,7 +6354,7 @@ msgstr "Уреди догађај"
 #: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:96
 #: ../superdesk-planning/client/constants/tooltips.ts:35
 msgid "Edit Filter"
-msgstr ""
+msgstr "Уреди филтер"
 
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:23
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:42
@@ -6375,7 +6375,7 @@ msgstr "Уреди линију"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:190
 msgid "Edit Location"
-msgstr ""
+msgstr "Уреди локацију"
 
 #: scripts/apps/authoring/authoring/index.ts:254
 msgid "Edit Media Metadata"
@@ -6387,7 +6387,7 @@ msgstr "Уреди планирање"
 
 #: ../superdesk-planning/client/constants/assignments.ts:194
 msgid "Edit Priority"
-msgstr ""
+msgstr "Уреди приоритет"
 
 #: scripts/apps/users/views/settings-roles.html:29
 msgid "Edit Role"
@@ -6410,7 +6410,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:106
 #: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:180
 msgid "Edit Scheduled Export"
-msgstr ""
+msgstr "Уреди заказани извоз"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:30
 msgid "Edit Scheme"
@@ -6594,11 +6594,11 @@ msgstr ""
 #: ../superdesk-planning/client/utils/contentProfiles.ts:295
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:147
 msgid "Editorial Note"
-msgstr ""
+msgstr "Уредничка напомена"
 
 #: ../superdesk-planning/client/components/Archive/ArchivePreview/ArchivePreviewMetadataList.tsx:33
 msgid "Editorial Note:"
-msgstr ""
+msgstr "Уредничка напомена:"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:348
 msgid "Editorial note"
@@ -6687,7 +6687,7 @@ msgstr "Омогући корисника"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:232
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:268
 msgid "Enabled"
-msgstr ""
+msgstr "Омогућено"
 
 #: scripts/apps/publish/views/subscribers.html:96
 msgid "End Date"
@@ -6703,7 +6703,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/validators/events.ts:84
 msgid "End date is in the past"
-msgstr ""
+msgstr "Крајњи датум је у прошлости"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:162
 msgid "End date is required"
@@ -6712,15 +6712,15 @@ msgstr ""
 #: ../superdesk-planning/client/validators/profile.ts:49
 #: ../superdesk-planning/client/validators/profile.ts:50
 msgid "End date must be set"
-msgstr ""
+msgstr "Крајњи датум мора бити подешен"
 
 #: ../superdesk-planning/client/validators/events.ts:59
 msgid "End date should be after start date"
-msgstr ""
+msgstr "Крајњи датум треба да буде после почетног датума"
 
 #: ../superdesk-planning/client/validators/events.ts:56
 msgid "End time should be after start time"
-msgstr ""
+msgstr "Крајње време треба да буде после почетног времена"
 
 #: scripts/apps/publish/views/amazon-sqs-fifo-config.html:3
 msgid "Endpoint URL"
@@ -7113,7 +7113,7 @@ msgstr "Догађај"
 
 #: ../superdesk-planning/client/utils/events.tsx:479
 msgid "Event \"{{name}}\" is already added as related"
-msgstr ""
+msgstr "Догађај \"{{name}}\" је већ додат као повезан"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:43
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:57
@@ -7150,7 +7150,7 @@ msgstr "Догађај се завршава"
 
 #: ../superdesk-planning/client/api/contentProfiles.ts:212
 msgid "Event Fields"
-msgstr ""
+msgstr "Поља догађаја"
 
 #: ../superdesk-planning/client/components/Events/EventEditor/index.tsx:182
 msgid "Event Name"
@@ -7184,7 +7184,7 @@ msgstr "Догађај отказан"
 
 #: ../superdesk-planning/client/validators/events.ts:154
 msgid "Event duration is greater than {{maxDuration}} days."
-msgstr ""
+msgstr "Трајање догађаја је дуже од {{maxDuration}} дана."
 
 #: ../superdesk-planning/client/actions/events/ui.ts:136
 msgid "Event has been cancelled"
@@ -7266,7 +7266,7 @@ msgstr "Сваких"
 #: ../superdesk-planning/client/utils/filters.ts:163
 #: ../superdesk-planning/client/utils/filters.ts:180
 msgid "Every Hour"
-msgstr ""
+msgstr "Сваког сата"
 
 #: scripts/apps/search/views/edit-time-interval.html:4
 msgid "Every day"
@@ -7278,19 +7278,19 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/events.tsx:1402
 msgid "Every {{interval}} day(s)"
-msgstr ""
+msgstr "Сваких {{interval}} дан(а)"
 
 #: ../superdesk-planning/client/utils/events.tsx:1395
 msgid "Every {{interval}} month(s) on day {{day}}"
-msgstr ""
+msgstr "Сваких {{interval}} месец(и) {{day}}. дана"
 
 #: ../superdesk-planning/client/utils/events.tsx:1405
 msgid "Every {{interval}} week(s)"
-msgstr ""
+msgstr "Сваких {{interval}} недеља(е)"
 
 #: ../superdesk-planning/client/utils/events.tsx:1388
 msgid "Every {{interval}} year(s) on {{date}}"
-msgstr ""
+msgstr "Сваких {{interval}} година(е) на {{date}}"
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:6
 msgid "Exact"
@@ -7331,7 +7331,7 @@ msgstr "Изостави корпу"
 
 #: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:359
 msgid "Exclude all locked items"
-msgstr ""
+msgstr "Изостави све закључане ставке"
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:67
 msgid "Exclude rewrites"
@@ -7343,7 +7343,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:151
 msgid "Existing Locations"
-msgstr ""
+msgstr "Постојеће локације"
 
 #: scripts/apps/authoring/multiedit/views/multiedit.html:3
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:87
@@ -7424,7 +7424,7 @@ msgstr "Шаблон извоза"
 
 #: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:255
 msgid "Export as article"
-msgstr ""
+msgstr "Извези као чланак"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:353
 #: scripts/apps/authoring/versioning/history/views/history.html:116
@@ -7488,7 +7488,7 @@ msgstr "Додавање календара у догађај није успе�
 
 #: ../superdesk-planning/client/api/planning.ts:306
 msgid "Failed to add coverages to workflow"
-msgstr ""
+msgstr "Додавање извештавања у радни ток није успело"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:328
 #: ../superdesk-planning/client/actions/planning/ui.ts:369
@@ -7540,7 +7540,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/api/locations.ts:33
 msgid "Failed to create the location"
-msgstr ""
+msgstr "Креирање локације није успело"
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:197
 msgid "Failed to create/update Events and Planning view filter"
@@ -7560,7 +7560,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/api/locations.ts:91
 msgid "Failed to delete the location"
-msgstr ""
+msgstr "Брисање локације није успело"
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:194
 msgid "Failed to delete the saved report"
@@ -7586,7 +7586,7 @@ msgstr "Преузимање свих филтера није успело"
 #: ../superdesk-planning/client/controllers/AssignmentPreviewController.tsx:107
 #: ../superdesk-planning/client/controllers/AssignmentPreviewController.tsx:73
 msgid "Failed to fetch assignment information."
-msgstr ""
+msgstr "Преузимање информација о задатку није успело."
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:242
 msgid "Failed to fetch featured stories!"
@@ -7594,7 +7594,7 @@ msgstr "Преузимање истакнутих прича није успел
 
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:72
 msgid "Failed to fetch item from archive"
-msgstr ""
+msgstr "Преузимање ставке из архиве није успело"
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:633
 msgid "Failed to fetch planning item."
@@ -7603,7 +7603,7 @@ msgstr "Преузимање ставке планирања није успел
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:115
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:65
 msgid "Failed to find an Assignment to link to!"
-msgstr ""
+msgstr "Није пронађен задатак за повезивање!"
 
 #: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:407
 msgid "Failed to generate picture crops."
@@ -7666,7 +7666,7 @@ msgstr "Преузимање ставке из реда није успело"
 
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:254
 msgid "Failed to link to requested assignment!"
-msgstr ""
+msgstr "Повезивање са траженим задатком није успело!"
 
 #: scripts/extensions/sams/dist/src/api/sets.js:23
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:23
@@ -7686,16 +7686,16 @@ msgstr "Учитавање дуплираног догађаја није усп
 
 #: ../superdesk-planning/client/api/locks.ts:80
 msgid "Failed to load item locks"
-msgstr ""
+msgstr "Учитавање закључавања ставки није успело"
 
 #: ../superdesk-planning/client/api/locks.ts:73
 msgid "Failed to load locked items"
-msgstr ""
+msgstr "Учитавање закључаних ставки није успело"
 
 #: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:229
 #: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:286
 msgid "Failed to load the item."
-msgstr ""
+msgstr "Учитавање ставке није успело."
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:241
 msgid "Failed to load the saved report!"
@@ -7712,7 +7712,7 @@ msgstr "Закључавање радње истакнуте приче није
 
 #: ../superdesk-planning/client/api/locks.ts:226
 msgid "Failed to lock item"
-msgstr ""
+msgstr "Закључавање ставке није успело"
 
 #: scripts/extensions/sams/dist/src/api/assets.js:486
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:486
@@ -7722,7 +7722,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:273
 msgid "Failed to lock the item."
-msgstr ""
+msgstr "Закључавање ставке није успело."
 
 #: ../superdesk-planning/client/actions/main.ts:485
 msgid "Failed to post the {{ itemType }}"
@@ -7833,7 +7833,7 @@ msgstr "Чување шаблона догађаја није успело"
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:190
 #: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:135
 msgid "Failed to save the profile!"
-msgstr ""
+msgstr "Чување профила није успело!"
 
 #: ../superdesk-planning/client/actions/main.ts:351
 msgid "Failed to save the {{itemType}}!"
@@ -7855,7 +7855,7 @@ msgstr "Премештање догађаја у корпу није успел�
 #: ../superdesk-planning/client/api/locks.ts:354
 #: ../superdesk-planning/client/api/locks.ts:396
 msgid "Failed to unlock item"
-msgstr ""
+msgstr "Откључавање ставке није успело"
 
 #: scripts/extensions/sams/dist/src/api/assets.js:504
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:504
@@ -7883,7 +7883,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/api/locations.ts:69
 msgid "Failed to update location"
-msgstr ""
+msgstr "Ажурирање локације није успело"
 
 #: scripts/extensions/sams/dist/src/api/assets.js:468
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:468
@@ -8070,7 +8070,7 @@ msgstr "Тип\n                                    поља"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:200
 msgid "Field \"{{field}}\" will be permanently deleted."
-msgstr ""
+msgstr "Поље \"{{field}}\" ће бити трајно обрисано."
 
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:88
 msgid "Field ID to prefill from"
@@ -8144,7 +8144,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:297
 msgid "Files"
-msgstr ""
+msgstr "Датотеке"
 
 #: ../superdesk-planning/client/components/UI/SubNav/Dropdown.tsx:227
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:815
@@ -8157,7 +8157,7 @@ msgstr "Филтер"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:69
 msgid "Filter \"{{ name }}\" will be permanently deleted."
-msgstr ""
+msgstr "Филтер \"{{ name }}\" ће бити трајно обрисан."
 
 #: scripts/apps/content-filters/views/manage-filters.html:102
 msgid "Filter Condition"
@@ -8171,7 +8171,7 @@ msgstr "Услови филтера"
 #: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:183
 #: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:36
 msgid "Filter Details"
-msgstr ""
+msgstr "Детаљи филтера"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:89
 msgid "Filter Large"
@@ -8179,11 +8179,11 @@ msgstr "Велики филтер"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:225
 msgid "Filter Name"
-msgstr ""
+msgstr "Назив филтера"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:140
 msgid "Filter Schedule"
-msgstr ""
+msgstr "Распоред филтера"
 
 #: scripts/apps/content-filters/views/settings.html:19
 msgid "Filter Search"
@@ -8227,7 +8227,7 @@ msgstr "Филтер:"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:76
 msgid "Filtered By"
-msgstr ""
+msgstr "Филтрирано по"
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:48
 #: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:48
@@ -8275,7 +8275,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/filters.ts:63
 msgid "First"
-msgstr ""
+msgstr "Прво"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:35
 msgid "First Day"
@@ -8408,7 +8408,7 @@ msgstr "Унапред танко"
 
 #: ../superdesk-planning/client/utils/filters.ts:145
 msgid "Fr"
-msgstr ""
+msgstr "Пе"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:16
 msgid "Frequency"
@@ -8449,7 +8449,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:327
 msgid "Fulfil Assignment with this item?"
-msgstr ""
+msgstr "Извршити задатак овом ставком?"
 
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:152
 msgid "Fulfil assignment"
@@ -8483,7 +8483,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/constants/assignments.ts:215
 msgid "Future Assignments"
-msgstr ""
+msgstr "Будући задаци"
 
 #: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:247
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:247
@@ -8623,7 +8623,7 @@ msgstr "Иди"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:268
 msgid "Go Back"
-msgstr ""
+msgstr "Иди назад"
 
 #: scripts/apps/master-desk/components/HeaderComponent.tsx:208
 msgid "Go To Desk"
@@ -8677,11 +8677,11 @@ msgstr "Велики приказ мреже"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:298
 msgid "Group \"{{group}}\" and all its fields will be permanently deleted."
-msgstr ""
+msgstr "Група \"{{group}}\" и сва њена поља биће трајно обрисани."
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:301
 msgid "Group \"{{group}}\" will be permanently deleted."
-msgstr ""
+msgstr "Група \"{{group}}\" ће бити трајно обрисана."
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:2
 #: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:2
@@ -8704,7 +8704,7 @@ msgstr "Групиши по дану"
 
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:326
 msgid "Groups"
-msgstr ""
+msgstr "Групе"
 
 #: scripts/core/lang/missing-translations-strings.ts:22
 msgid "Groups Management"
@@ -8750,7 +8750,7 @@ msgstr "НАСЛОВ је предугачак"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/TimeInputs.tsx:45
 msgid "HOUR"
-msgstr ""
+msgstr "САТ"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:161
 msgid "Half"
@@ -8975,7 +8975,7 @@ msgstr "Сваког сата"
 
 #: ../superdesk-planning/client/utils/filters.ts:42
 msgid "Hourly to {{ desk }}"
-msgstr ""
+msgstr "Сваког сата на {{ desk }}"
 
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:148
 #: scripts/core/ui/views/sd-timepicker-popup.html:9
@@ -9023,7 +9023,7 @@ msgstr "ИД мора бити јединствен."
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:93
 msgid "Icon"
-msgstr ""
+msgstr "Икона"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:85
 msgid "Id: {{id}}"
@@ -9086,7 +9086,7 @@ msgstr "Игнориши"
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:155
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:168
 msgid "Ignore changes?"
-msgstr ""
+msgstr "Игнорисати измене?"
 
 #: scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx:74
 msgid "Ignore word"
@@ -9224,7 +9224,7 @@ msgstr "Укључи у корпи"
 
 #: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:358
 msgid "Include all locked items"
-msgstr ""
+msgstr "Укључи све закључане ставке"
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:64
 msgid "Include rewrites"
@@ -9365,7 +9365,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/AuditInformation/index.tsx:49
 msgid "Ingest: {{ name }}"
-msgstr ""
+msgstr "Пријем: {{ name }}"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:19
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:28
@@ -9447,7 +9447,7 @@ msgstr "Интерна напомена"
 
 #: ../superdesk-planning/client/components/InternalNoteLabel/index.tsx:83
 msgid "Internal Note:"
-msgstr ""
+msgstr "Интерна напомена:"
 
 #: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-parameters.html:22
 #: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-preview.html:9
@@ -9472,11 +9472,11 @@ msgstr "Неисправно време"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:146
 msgid "Invalid value for latitude"
-msgstr ""
+msgstr "Неисправна вредност за географску ширину"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:148
 msgid "Invalid value for longitude"
-msgstr ""
+msgstr "Неисправна вредност за географску дужину"
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:69
 #: ../superdesk-planning/client/components/fields/preview/index.ts:278
@@ -9502,7 +9502,7 @@ msgstr[2] ""
 
 #: ../superdesk-planning/client/utils/confirmAddingRelatedItems.tsx:29
 msgid "Issues detected:"
-msgstr ""
+msgstr "Откривене грешке:"
 
 #: scripts/apps/templates/views/create-template.html:26
 msgid "It will create a new template."
@@ -9523,15 +9523,15 @@ msgstr "Курзив (Ctrl+I)"
 
 #: ../superdesk-planning/client/utils/index.ts:599
 msgid "Item"
-msgstr ""
+msgstr "Ставка"
 
 #: ../superdesk-planning/client/utils/planning.tsx:523
 msgid "Item \"{{name}}\" is already added as related"
-msgstr ""
+msgstr "Ставка \"{{name}}\" је већ додата као повезана"
 
 #: ../superdesk-planning/client/utils/planning.tsx:511
 msgid "Item \"{{name}}\" is locked and can not be added as related"
-msgstr ""
+msgstr "Ставка \"{{name}}\" је закључана и не може бити додата као повезана"
 
 #: scripts/apps/archive/controllers/DuplicateController.ts:20
 #: scripts/apps/search/controllers/get-multi-actions.tsx:256
@@ -9574,13 +9574,13 @@ msgstr "Радње над ставком"
 #: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:242
 #: ../superdesk-planning/client/controllers/FulfilAssignmentController.tsx:186
 msgid "Item already linked to a Planning item"
-msgstr ""
+msgstr "Ставка је већ повезана са ставком планирања"
 
 #: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:258
 #: ../superdesk-planning/client/controllers/FulfilAssignmentController.tsx:192
 #: ../superdesk-planning/client/controllers/UnlinkAssignmentController.tsx:38
 msgid "Item already locked."
-msgstr ""
+msgstr "Ставка је већ закључана."
 
 #: scripts/core/editor3/components/article-embed/can-add-article-embed.ts:30
 msgid "Item content profile is not configured to allow embedding."
@@ -9655,7 +9655,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/controllers/UnlinkAssignmentController.tsx:27
 msgid "Item not linked to a Planning item."
-msgstr ""
+msgstr "Ставка није повезана са ставком планирања."
 
 #: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:205
 #: scripts/apps/search/views/item-preview.html:2
@@ -9987,7 +9987,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:301
 msgid "Latitude"
-msgstr ""
+msgstr "Географска ширина"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:50
 msgid ""
@@ -10223,15 +10223,15 @@ msgstr "Детаљи локације"
 
 #: ../superdesk-planning/client/api/locations.ts:86
 msgid "Location deleted"
-msgstr ""
+msgstr "Локација обрисана"
 
 #: ../superdesk-planning/client/controllers/LocationsController.tsx:27
 msgid "Locations"
-msgstr ""
+msgstr "Локације"
 
 #: ../superdesk-planning/client/apps/LocationsApp.tsx:13
 msgid "Locations Content"
-msgstr ""
+msgstr "Садржај локација"
 
 #: ../superdesk-analytics/client/utils.js:170
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:127
@@ -10284,7 +10284,7 @@ msgstr "Дугачак опис"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:310
 msgid "Longitude"
-msgstr ""
+msgstr "Географска дужина"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:19
 msgid "Lowercase"
@@ -10390,7 +10390,7 @@ msgstr "Управљај шаблонима догађаја"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:202
 msgid "Manage Events & Planning Filters"
-msgstr ""
+msgstr "Управљај филтерима догађаја и планирања"
 
 #: scripts/core/lang/missing-translations-strings.ts:18
 msgid "Manage Global Saved Searches"
@@ -10398,7 +10398,7 @@ msgstr "Управљај глобалним сачуваним претрага�
 
 #: ../superdesk-planning/index.ts:28 ../superdesk-planning/index.ts:29
 msgid "Manage Locations"
-msgstr ""
+msgstr "Управљај локацијама"
 
 #: ../superdesk-planning/client/api/contentProfiles.ts:183
 #: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:29
@@ -10487,12 +10487,12 @@ msgstr ""
 
 #: ../superdesk-planning/client/constants/events.ts:162
 msgid "Mark as Postponed"
-msgstr ""
+msgstr "Означи као одложено"
 
 #: ../superdesk-planning/client/constants/events.ts:170
 #: ../superdesk-planning/client/utils/assignments.ts:263
 msgid "Mark as completed"
-msgstr ""
+msgstr "Означи као завршено"
 
 #: scripts/extensions/markForUser/dist/src/extension.js:44
 #: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/extension.js:44
@@ -10546,7 +10546,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:311
 msgid "Marked For Not Publication"
-msgstr ""
+msgstr "Означено да није за објаву"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:88
 msgid "Marked by"
@@ -10772,7 +10772,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/filters.ts:133
 msgid "Mo"
-msgstr ""
+msgstr "По"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:131
 msgid "Mobile"
@@ -10851,7 +10851,7 @@ msgstr "Месечно"
 
 #: ../superdesk-planning/client/utils/filters.ts:51
 msgid "Monthly on the {{ day }} day @ {{ time }} to {{ desk }}"
-msgstr ""
+msgstr "Месечно {{ day }}. дана у {{ time }} на {{ desk }}"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:78
 msgid "Monthly on the {{day}} day at {{hour}}"
@@ -10973,15 +10973,15 @@ msgstr "Више садржаја"
 
 #: ../superdesk-planning/client/validators/events.ts:129
 msgid "Must be greater than 1"
-msgstr ""
+msgstr "Мора бити веће од 1"
 
 #: ../superdesk-planning/client/validators/events.ts:102
 msgid "Must be greater than starting date"
-msgstr ""
+msgstr "Мора бити након почетног датума"
 
 #: ../superdesk-planning/client/validators/events.ts:126
 msgid "Must be less than {{ maximum }}"
-msgstr ""
+msgstr "Мора бити мање од {{ maximum }}"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:46
 msgid ""
@@ -10995,7 +10995,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/validators/events.ts:283
 msgid "Must start with \"http://\", \"https://\" or \"www.\""
-msgstr ""
+msgstr "Мора почињати са \"http://\", \"https://\" или \"www.\""
 
 #: ../superdesk-planning/client/components/Assignments/DesksSubNavDropDown.tsx:20
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:75
@@ -11115,7 +11115,7 @@ msgstr "Назив ({{language}})"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:131
 msgid "Name Translations"
-msgstr ""
+msgstr "Преводи назива"
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:218
 msgid ""
@@ -11131,7 +11131,7 @@ msgstr "Назив није јединствен."
 #: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:77
 #: scripts/extensions/auto-tagging-widget/src/new-item.tsx:187
 msgid "Name is required."
-msgstr ""
+msgstr "Назив је обавезан."
 
 #: scripts/apps/publish/views/email-config.html:30
 msgid "Name of the rendition to attach to the email"
@@ -11243,7 +11243,7 @@ msgstr "Није додељена агенда"
 
 #: ../superdesk-planning/client/components/Agendas/AgendaNameList.tsx:14
 msgid "No Agenda Assigned."
-msgstr ""
+msgstr "Није додељена агенда."
 
 #: scripts/extensions/sams/dist/src/components/assets/assetListPanel.js:62
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetListPanel.js:62
@@ -11260,7 +11260,7 @@ msgstr "Није додељен календар"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:337
 msgid "No Content Linking"
-msgstr ""
+msgstr "Без повезивања садржаја"
 
 #: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:23
 msgid "No Coverage Assigned"
@@ -11356,7 +11356,7 @@ msgstr "Нема доступних превода"
 
 #: ../superdesk-planning/client/components/PlanningTemplatesModal/TemplatesListView.tsx:38
 msgid "No calendar"
-msgstr ""
+msgstr "Нема календара"
 
 #: ../superdesk-planning/client/components/fields/calendars.tsx:80
 msgid "No calendars assigned"
@@ -11516,7 +11516,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:179
 msgid "No options available for this field"
-msgstr ""
+msgstr "Нема доступних опција за ово поље"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:101
 msgid "No planning items have been added"
@@ -11538,7 +11538,7 @@ msgstr "Нема повезаних ставки планирања."
 
 #: ../superdesk-planning/client/components/Locations/LocationsList.tsx:79
 msgid "No result"
-msgstr ""
+msgstr "Нема резултата"
 
 #: scripts/apps/dashboard/user-activity/components/Group.tsx:55
 msgid "No results for this user"
@@ -11547,7 +11547,7 @@ msgstr "Нема резултата за овог корисника"
 #: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:205
 #: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:230
 msgid "No results found"
-msgstr ""
+msgstr "Нису пронађени резултати"
 
 #: scripts/core/ui/components/SelectUser.tsx:102
 msgid "No results found."
@@ -11615,11 +11615,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/PlanningTemplatesModal/TemplatesListView.tsx:73
 msgid "No templates available in this calendar group."
-msgstr ""
+msgstr "Нема доступних шаблона у овој групи календара."
 
 #: ../superdesk-planning/client/components/PlanningTemplatesModal/TemplatesListView.tsx:83
 msgid "No templates found."
-msgstr ""
+msgstr "Нису пронађени шаблони."
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:251
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:251
@@ -11763,11 +11763,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/validators/profile.ts:100
 msgid "Not enough"
-msgstr ""
+msgstr "Недовољно"
 
 #: ../superdesk-planning/client/validators/profile.ts:101
 msgid "Not enough {{ name }}"
-msgstr ""
+msgstr "Недовољно {{ name }}"
 
 #: ../superdesk-planning/client/components/fields/preview/Flags.tsx:23
 msgid "Not for Publication"
@@ -11887,7 +11887,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:281
 msgid "Occur Status"
-msgstr ""
+msgstr "Статус појаве"
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/occurrence-status.ts:34
 #: ../superdesk-planning/client/components/fields/editor/EventOccurenceStatus.tsx:30
@@ -11943,9 +11943,9 @@ msgid ""
 msgid_plural ""
 "{{ count }} items that were selected are locked. By default locked items are "
 "not included in the export."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Једна од изабраних ставки је закључана. Подразумевано, закључане ставке нису укључене у извоз."
+msgstr[1] "{{ count }} изабраних ставки је закључано. Подразумевано, закључане ставке нису укључене у извоз."
+msgstr[2] "{{ count }} изабраних ставки је закључано. Подразумевано, закључане ставке нису укључене у извоз."
 
 #: scripts/apps/users/components/UserAvatar.tsx:99
 #: scripts/apps/users/controllers/UserListController.ts:156
@@ -11961,7 +11961,7 @@ msgstr[2] ""
 
 #: ../superdesk-planning/client/utils/planning.tsx:541
 msgid "Only 1 item can be linked. Adding this would exceed the limit"
-msgstr ""
+msgstr "Само 1 ставка може бити повезана. Додавање ове прешло би лимит"
 
 #: ../superdesk-planning/client/components/fields/editor/OnlyPosted.tsx:15
 msgid "Only Posted"
@@ -12025,7 +12025,7 @@ msgstr "Отвори"
 #: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:43
 #: ../superdesk-planning/client/constants/assignments.ts:196
 msgid "Open Coverage"
-msgstr ""
+msgstr "Отвори извештавање"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:47
 msgid "Open advanced search panel by default"
@@ -12091,7 +12091,7 @@ msgstr "Отвори радни простор / контролну таблу"
 
 #: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:40
 msgid "OpenStreetMap Details"
-msgstr ""
+msgstr "OpenStreetMap детаљи"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:18
 msgid "Opened"
@@ -12134,7 +12134,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/OrderBar/OrderFieldInput.tsx:21
 msgid "Order By: {{ name }}"
-msgstr ""
+msgstr "Сортирано по: {{ name }}"
 
 #: ../superdesk-analytics/client/charts/views/chart-form-options.html:44
 msgid "Order Data In:"
@@ -12179,7 +12179,7 @@ msgstr ""
 #: scripts/apps/authoring/views/change-image.html:232
 #: scripts/apps/authoring/views/change-image.html:92
 msgid "Original"
-msgstr ""
+msgstr "Оригинал"
 
 #: scripts/apps/authoring/views/article-edit.html:306
 msgid ""
@@ -12251,7 +12251,7 @@ msgstr "Остала извештавања"
 
 #: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:100
 msgid "Other Names"
-msgstr ""
+msgstr "Остали називи"
 
 #: scripts/apps/vocabularies/views/settings.html:37
 msgid "Other fields"
@@ -12289,7 +12289,7 @@ msgstr "Излаз/послато"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:313
 msgid "Override Auto Assign to Workflow"
-msgstr ""
+msgstr "Заобиђи аутоматско додавање у радни ток"
 
 #: scripts/apps/master-desk/MasterDesk.tsx:36
 #: scripts/apps/users/controllers/UserEditController.ts:14
@@ -12322,7 +12322,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/validators/planning.ts:29
 msgid "PLANNING DATE cannot be in the past"
-msgstr ""
+msgstr "ДАТУМ ПЛАНИРАЊА не може бити у прошлости"
 
 #: ../superdesk-analytics/client/email_report/directives/EmailReportModal.js:92
 #: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsList.js:102
@@ -12467,7 +12467,7 @@ msgstr "Лозинка је промењена. Можете се пријави
 #: ../superdesk-planning/client/utils/events.tsx:871
 #: ../superdesk-planning/client/utils/events.tsx:885
 msgid "Past Events"
-msgstr ""
+msgstr "Прошли догађаји"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:141
 msgid "Paste"
@@ -12550,7 +12550,7 @@ msgstr "Лични простор"
 
 #: ../superdesk-planning/client/constants/index.ts:170
 msgid "Personal Workspace"
-msgstr ""
+msgstr "Лични радни простор"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:33
 msgid ""
@@ -12710,7 +12710,7 @@ msgstr "Детаљи планирања"
 
 #: ../superdesk-planning/client/api/contentProfiles.ts:185
 msgid "Planning Fields"
-msgstr ""
+msgstr "Поља планирања"
 
 #: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:43
 #: ../superdesk-planning/client/utils/index.ts:583
@@ -12755,7 +12755,7 @@ msgstr "Планирање отказано:"
 
 #: ../superdesk-planning/client/validators/planning.ts:26
 msgid "Planning date is in the past"
-msgstr ""
+msgstr "Датум планирања је у прошлости"
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:256
 msgid "Planning duplicated"
@@ -12768,7 +12768,7 @@ msgstr "Ставка планирања додата као истакнута �
 
 #: ../superdesk-planning/client/utils/events.tsx:501
 msgid "Planning item already has one related event. Can not add more."
-msgstr ""
+msgstr "Ставка планирања већ има један повезан догађај. Више није могуће додати."
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:72
 msgid "Planning item created"
@@ -12789,11 +12789,11 @@ msgstr "Само планирање"
 
 #: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:66
 msgid "Planning templates"
-msgstr ""
+msgstr "Шаблони планирања"
 
 #: ../superdesk-planning/client/components/Editor/bookmarks/AssociatedPlanningsBookmark.tsx:55
 msgid "Planning: {{ name }}"
-msgstr ""
+msgstr "Планирање: {{ name }}"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:150
 msgid "Play"
@@ -13034,7 +13034,7 @@ msgstr "Сачувај објављен садржај"
 #: scripts/extensions/sams/dist/src/utils/assets.js:39
 #: scripts/extensions/sams/src/utils/assets.ts:51
 msgid "Preview"
-msgstr ""
+msgstr "Преглед"
 
 #: scripts/apps/authoring/views/preview-formatted.html:6
 msgid "Preview Formatted Story"
@@ -13122,7 +13122,7 @@ msgstr "Приоритет:"
 
 #: ../superdesk-planning/client/components/PriorityLabel/index.tsx:51
 msgid "Priority: {{ name }}"
-msgstr ""
+msgstr "Приоритет: {{ name }}"
 
 #: scripts/apps/contacts/views/list.html:27
 msgid "Privacy Level:"
@@ -13520,27 +13520,27 @@ msgstr "Цитат"
 
 #: ../superdesk-planning/client/validators/events.ts:103
 msgid "RECURRING ENDS ON must be greater than START DATE"
-msgstr ""
+msgstr "ПОНАВЉАЊЕ СЕ ЗАВРШАВА мора бити након ПОЧЕТНОГ ДАТУМА"
 
 #: ../superdesk-planning/client/validators/events.ts:119
 msgid "RECURRING REPEAT COUNT is a required field"
-msgstr ""
+msgstr "БРОЈ ПОНАВЉАЊА је обавезно поље"
 
 #: ../superdesk-planning/client/validators/events.ts:130
 msgid "RECURRING REPEAT COUNT must be greater than 1"
-msgstr ""
+msgstr "БРОЈ ПОНАВЉАЊА мора бити већи од 1"
 
 #: ../superdesk-planning/client/validators/events.ts:127
 msgid "RECURRING REPEAT COUNT must be less than {{ maximum }}"
-msgstr ""
+msgstr "БРОЈ ПОНАВЉАЊА мора бити мањи од {{ maximum }}"
 
 #: ../superdesk-planning/client/validators/events.ts:108
 msgid "RECURRING REPEAT ON is a required field"
-msgstr ""
+msgstr "ПОНАВЉАЊЕ У је обавезно поље"
 
 #: ../superdesk-planning/client/validators/events.ts:113
 msgid "RECURRING REPEAT UNTIL is a required field"
-msgstr ""
+msgstr "ПОНАВЉАЊЕ ДО је обавезно поље"
 
 #: scripts/apps/authoring/views/authoring-header.html:53
 msgid "RELATED"
@@ -13668,7 +13668,7 @@ msgstr "Понављајуће"
 
 #: ../superdesk-planning/client/components/ItemIcon.tsx:26
 msgid "Recurring Event"
-msgstr ""
+msgstr "Понављајући догађај"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:120
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:73
@@ -13680,7 +13680,7 @@ msgstr "Понављајући догађај(и)"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:263
 msgid "Recurring Rules"
-msgstr ""
+msgstr "Правила понављања"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:60
 msgid "Red"
@@ -13913,12 +13913,12 @@ msgstr "Уклони сво форматирање"
 
 #: ../superdesk-planning/client/constants/assignments.ts:195
 msgid "Remove Assignment"
-msgstr ""
+msgstr "Уклони задатак"
 
 #: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:83
 #: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:85
 msgid "Remove Contact"
-msgstr ""
+msgstr "Уклони контакт"
 
 #: scripts/apps/content-filters/views/manage-filters.html:21
 msgid "Remove Content Filter"
@@ -13950,7 +13950,7 @@ msgstr "Уклони ставку"
 
 #: ../superdesk-planning/client/components/GeoLookupInput/LocationItem.tsx:49
 msgid "Remove Location"
-msgstr ""
+msgstr "Уклони локацију"
 
 #: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:154
 msgid "Remove Scheduled Update"
@@ -13998,7 +13998,7 @@ msgstr "Уклони радњу преузимања"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:98
 msgid "Remove field"
-msgstr ""
+msgstr "Уклони поље"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-filter.html:16
 msgid "Remove filter"
@@ -14014,12 +14014,12 @@ msgstr "Уклони из истакнутих прича"
 
 #: ../superdesk-planning/client/constants/planning.ts:146
 msgid "Remove from featured stories"
-msgstr ""
+msgstr "Уклони из истакнутих прича"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupElementTemplate.tsx:71
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupList.tsx:83
 msgid "Remove group"
-msgstr ""
+msgstr "Уклони групу"
 
 #: scripts/apps/authoring/metadata/views/meta-place-directive.html:33
 #: scripts/apps/authoring/metadata/views/metadata-target-publishing.html:20
@@ -14120,7 +14120,7 @@ msgstr "Сажетак понављања"
 #: ../superdesk-planning/client/validators/profile.ts:44
 #: ../superdesk-planning/client/validators/profile.ts:45
 msgid "Repeat must be set"
-msgstr ""
+msgstr "Понављање мора бити подешено"
 
 #: ../superdesk-planning/client/components/Events/EventScheduleInput/index.tsx:100
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:160
@@ -14331,7 +14331,7 @@ msgstr "Врати"
 
 #: ../superdesk-planning/client/constants/assignments.ts:198
 msgid "Revert Availability"
-msgstr ""
+msgstr "Врати доступност"
 
 #: scripts/apps/publish/views/subscribers.html:283
 msgid "Revoke"
@@ -14549,19 +14549,19 @@ msgstr ""
 
 #: ../superdesk-planning/client/validators/events.ts:79
 msgid "START DATE cannot be in the past"
-msgstr ""
+msgstr "ПОЧЕТНИ ДАТУМ не може бити у прошлости"
 
 #: ../superdesk-planning/client/validators/events.ts:15
 msgid "START DATE is a required field"
-msgstr ""
+msgstr "ПОЧЕТНИ ДАТУМ је обавезно поље"
 
 #: ../superdesk-planning/client/validators/events.ts:36
 msgid "START TIME is a required field"
-msgstr ""
+msgstr "ПОЧЕТНО ВРЕМЕ је обавезно поље"
 
 #: ../superdesk-planning/client/validators/events.ts:30
 msgid "START TIME is required when END TIME is set"
-msgstr ""
+msgstr "ПОЧЕТНО ВРЕМЕ је обавезно када је подешено КРАЈЊЕ ВРЕМЕ"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:123
 msgid "SU"
@@ -14569,7 +14569,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/filters.ts:148
 msgid "Sa"
-msgstr ""
+msgstr "Су"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:188
 msgid "Sample content"
@@ -14704,7 +14704,7 @@ msgstr "Сачувај &amp; настави"
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:388
 #: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:225
 msgid "Save All"
-msgstr ""
+msgstr "Сачувај све"
 
 #: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:35
 #: scripts/apps/search/views/save-search.html:15
@@ -14718,7 +14718,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:179
 msgid "Save Changes?"
-msgstr ""
+msgstr "Сачувати измене?"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:67
 msgid "Save Event"
@@ -14837,7 +14837,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/constants/events.ts:169
 msgid "Save event as a template"
-msgstr ""
+msgstr "Сачувај догађај као шаблон"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:364
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:364
@@ -14948,7 +14948,7 @@ msgstr "Закажи ажурирање"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:84
 msgid "Schedule will be permanently deleted."
-msgstr ""
+msgstr "Распоред ће бити трајно обрисан."
 
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:132
 #: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:25
@@ -14972,7 +14972,7 @@ msgstr "Заказани излаз деска"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:151
 msgid "Scheduled Export"
-msgstr ""
+msgstr "Заказани извоз"
 
 #: scripts/apps/workspace/content/constants.ts:38
 msgid "Scheduled Time"
@@ -15006,11 +15006,11 @@ msgstr "Заказано од {{start}} до {{end}}"
 
 #: ../superdesk-planning/client/validators/planning.ts:320
 msgid "Scheduled updates have to be after the previous updates."
-msgstr ""
+msgstr "Заказана ажурирања морају бити после претходних ажурирања."
 
 #: ../superdesk-planning/client/validators/planning.ts:324
 msgid "Scheduled updates should have a date/time."
-msgstr ""
+msgstr "Заказана ажурирања морају имати датум/време."
 
 #: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:73
 msgid "Scheduled:"
@@ -15128,7 +15128,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:160
 msgid "Search OpenStreetMap"
-msgstr ""
+msgstr "Претражи OpenStreetMap"
 
 #: scripts/apps/search-providers/directive.ts:92
 msgid "Search Provider deleted."
@@ -15175,11 +15175,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Contacts/SelectSearchContactsField/SelectListPopup.tsx:226
 msgid "Search for a contact"
-msgstr ""
+msgstr "Тражи контакт"
 
 #: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupInput.tsx:289
 msgid "Search for a location"
-msgstr ""
+msgstr "Тражи локацију"
 
 #: scripts/apps/dashboard/world-clock/configuration.html:34
 msgid "Search for clock"
@@ -15187,7 +15187,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:91
 msgid "Search icons...."
-msgstr ""
+msgstr "Тражи иконе...."
 
 #: scripts/apps/content-api/index.ts:22
 msgid "Search items is content API"
@@ -15216,7 +15216,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:81
 msgid "Search templates"
-msgstr ""
+msgstr "Претражи шаблоне"
 
 #: scripts/apps/search/directives/SaveSearch.ts:72
 msgid "Search was saved successfully"
@@ -15230,7 +15230,7 @@ msgstr "Претрага..."
 
 #: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:31
 msgid "Search/Browse Locations"
-msgstr ""
+msgstr "Претрага/преглед локација"
 
 #: scripts/core/ui/views/sd-timepicker-popup.html:21
 msgid "Seconds"
@@ -15340,7 +15340,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:332
 msgid "Select all"
-msgstr ""
+msgstr "Изабери све"
 
 #: scripts/apps/users/views/user-preferences.html:149
 msgid "Select all categories"
@@ -15348,7 +15348,7 @@ msgstr "Изабери све категорије"
 
 #: ../superdesk-planning/client/components/FulFilAssignmentModal/index.tsx:76
 msgid "Select an Assignment"
-msgstr ""
+msgstr "Изабери задатак"
 
 #: scripts/apps/authoring-react/toolbar/multi-edit-toolbar-action.tsx:35
 msgid "Select articles"
@@ -15390,7 +15390,7 @@ msgstr "Изабери дескове за приказ"
 
 #: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:41
 msgid "Select either Search or Browse the locations"
-msgstr ""
+msgstr "Изаберите или Претрагу или Преглед локација"
 
 #: scripts/extensions/predefinedTextField/dist/src/editor.js:34
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/editor.js:34
@@ -15743,7 +15743,7 @@ msgstr "Пречице"
 #: ../superdesk-planning/client/validators/planning.ts:305
 #: ../superdesk-planning/client/validators/planning.ts:307
 msgid "Should be after the previous scheduled update/coverage"
-msgstr ""
+msgstr "Треба да буде после претходног заказаног ажурирања/извештавања"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:56
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:16
@@ -15775,7 +15775,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:121
 msgid "Show Bookmark"
-msgstr ""
+msgstr "Прикажи обележивач"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:332
 msgid "Show Crops"
@@ -15866,7 +15866,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Location/index.tsx:54
 #: ../superdesk-planning/client/components/Locations/LocationsList.tsx:93
 msgid "Show on map"
-msgstr ""
+msgstr "Прикажи на мапи"
 
 #: scripts/apps/workspace/content/components/WidgetsConfig.tsx:57
 msgid "Show or hide the widgets in the right toolbar in the editor workspace."
@@ -16284,7 +16284,7 @@ msgstr "Премести ставку(е) у корпу"
 
 #: ../superdesk-planning/client/constants/planning.ts:135
 msgid "Spike planning"
-msgstr ""
+msgstr "Премести планирање у корпу"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:72
 msgid "Spike {{event}}"
@@ -16389,7 +16389,7 @@ msgstr "Почетно време (укључиво)"
 
 #: ../superdesk-planning/client/constants/assignments.ts:191
 msgid "Start Working"
-msgstr ""
+msgstr "Започни рад"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:174
 msgid "Start date cannot be greater than today"
@@ -16397,7 +16397,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/validators/events.ts:76
 msgid "Start date is in the past"
-msgstr ""
+msgstr "Почетни датум је у прошлости"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:160
 msgid "Start date is required"
@@ -16545,12 +16545,12 @@ msgstr "Прича је повезана као ажурирање."
 
 #: ../superdesk-planning/client/reducers/featuredPlanning.ts:177
 msgid "Story with slugline \"{{ slugline }}\" is added to the list"
-msgstr ""
+msgstr "Прича са слаглајном \"{{ slugline }}\" је додата на листу"
 
 #: ../superdesk-planning/client/reducers/featuredPlanning.ts:195
 #: ../superdesk-planning/client/reducers/featuredPlanning.ts:215
 msgid "Story with slugline \"{{ slugline }}\" is removed from the list"
-msgstr ""
+msgstr "Прича са слаглајном \"{{ slugline }}\" је уклоњена са листе"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:180
 msgid "Stream"
@@ -16584,7 +16584,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/filters.ts:130
 msgid "Su"
-msgstr ""
+msgstr "Не"
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:6
 #: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:6
@@ -16623,7 +16623,7 @@ msgstr "Тема"
 
 #: ../superdesk-planning/client/validators/planning.ts:109
 msgid "Subject is a required field"
-msgstr ""
+msgstr "Тема је обавезно поље"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:39
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:150
@@ -16651,7 +16651,7 @@ msgstr "Пошаљи"
 #: ../superdesk-planning/client/utils/index.ts:396
 #: scripts/apps/search/components/fields/state.tsx:34
 msgid "Submitted"
-msgstr ""
+msgstr "Поднето"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:109
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:202
@@ -16861,7 +16861,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/validators/events.ts:25
 msgid "TIMEZONE is a required field"
-msgstr ""
+msgstr "ВРЕМЕНСКА ЗОНА је обавезно поље"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:83
 msgid "TU"
@@ -16913,7 +16913,7 @@ msgstr ""
 #: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:171
 #: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:196
 msgid "Tags"
-msgstr ""
+msgstr "Ознаке"
 
 #: scripts/apps/authoring-react/field-adapters/anpa_take_key.ts:20
 #: scripts/apps/workspace/content/constants.ts:10
@@ -17059,7 +17059,7 @@ msgstr "Шаблон"
 
 #: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:49
 msgid "Template Content"
-msgstr ""
+msgstr "Садржај шаблона"
 
 #: scripts/apps/templates/views/template-editor-modal.html:46
 msgid "Template Type"
@@ -17135,7 +17135,7 @@ msgstr "Формат текста"
 
 #: ../superdesk-planning/client/utils/filters.ts:142
 msgid "Th"
-msgstr ""
+msgstr "Че"
 
 #: ../superdesk-planning/client/actions/agenda.ts:407
 msgid "The Agenda you were viewing was deleted!"
@@ -17270,7 +17270,7 @@ msgstr "Извештавање је уклоњено"
 
 #: ../superdesk-planning/client/constants/tooltips.ts:29
 msgid "The event has been killed"
-msgstr ""
+msgstr "Догађај је уништен"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:64
 msgid "The event(s) have been spiked"
@@ -17325,7 +17325,7 @@ msgstr ""
 #: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:207
 #: ../superdesk-planning/client/controllers/FulfilAssignmentController.tsx:173
 msgid "The item was unlocked by \"{{ username }}\""
-msgstr ""
+msgstr "Ставку је откључао \"{{ username }}\""
 
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:396
 msgid "The item with unsaved changes must be closed before you can filter."
@@ -17333,11 +17333,11 @@ msgstr "Ставка са несачуваним изменама мора би�
 
 #: ../superdesk-planning/client/api/locations.ts:24
 msgid "The location has been created"
-msgstr ""
+msgstr "Локација је креирана"
 
 #: ../superdesk-planning/client/api/locations.ts:62
 msgid "The location has been updated"
-msgstr ""
+msgstr "Локација је ажурирана"
 
 #: scripts/apps/users/views/change-avatar.html:33
 msgid "The minimum image resolution is 200x200 pixels."
@@ -17463,23 +17463,23 @@ msgstr "Постоје ставке које су закључане или ни
 
 #: ../superdesk-planning/client/components/ItemActionsMenu/ActionsMenuPopup.tsx:91
 msgid "There are no actions available."
-msgstr ""
+msgstr "Нема доступних радњи."
 
 #: ../superdesk-planning/client/constants/assignments.ts:207
 msgid "There are no assignments completed"
-msgstr ""
+msgstr "Нема завршених задатака"
 
 #: ../superdesk-planning/client/constants/assignments.ts:213
 msgid "There are no assignments for today"
-msgstr ""
+msgstr "Нема задатака за данас"
 
 #: ../superdesk-planning/client/constants/assignments.ts:204
 msgid "There are no assignments in progress"
-msgstr ""
+msgstr "Нема задатака у току"
 
 #: ../superdesk-planning/client/constants/assignments.ts:201
 msgid "There are no assignments to do"
-msgstr ""
+msgstr "Нема задатака за рад"
 
 #: scripts/apps/authoring-react/fields/media/difference.tsx:29
 msgid "There are no changes"
@@ -17487,15 +17487,15 @@ msgstr ""
 
 #: ../superdesk-planning/client/constants/assignments.ts:210
 msgid "There are no current assignments"
-msgstr ""
+msgstr "Нема тренутних задатака"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/FiltersList.tsx:52
 msgid "There are no events and planing view filters."
-msgstr ""
+msgstr "Нема филтера приказа догађаја и планирања."
 
 #: ../superdesk-planning/client/constants/assignments.ts:216
 msgid "There are no future assignments"
-msgstr ""
+msgstr "Нема будућих задатака"
 
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:586
 msgid "There are no items matching the search."
@@ -17564,12 +17564,12 @@ msgstr "Постоје несачуване измене. Сачувајте и�
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:163
 msgid "There are unsaved changes, but the form is invalid"
-msgstr ""
+msgstr "Постоје несачуване измене, али је формулар неисправан"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:113
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:170
 msgid "There are unsaved changes."
-msgstr ""
+msgstr "Постоје несачуване измене."
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:28
 msgid ""
@@ -17595,7 +17595,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:269
 msgid "There is an update assignment for this story due at ''."
-msgstr ""
+msgstr "Постоји задатак ажурирања за ову причу са роком у ''."
 
 #: scripts/apps/publish/views/subscribers.html:296
 msgid "There is no token for subscriber."
@@ -17811,7 +17811,7 @@ msgstr "Ово поље је обавезно"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:190
 msgid "This field is required by the system"
-msgstr ""
+msgstr "Ово поље је обавезно у систему"
 
 #: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:72
 #: scripts/apps/contacts/components/Form/MultiTextInput.tsx:34
@@ -18187,7 +18187,7 @@ msgstr "Данас"
 
 #: ../superdesk-planning/client/constants/assignments.ts:212
 msgid "Todays Assignments"
-msgstr ""
+msgstr "Данашњи задаци"
 
 #: scripts/core/editor3/highlightsConfig.ts:78
 msgid "Toggle"
@@ -18290,7 +18290,7 @@ msgstr "Сутра"
 
 #: ../superdesk-planning/client/validators/profile.ts:61
 msgid "Too long"
-msgstr ""
+msgstr "Предугачко"
 
 #: scripts/apps/authoring/attachments/AttachmentsWidget.tsx:24
 msgid "Too many files selected. Only 1 file is allowed"
@@ -18302,11 +18302,11 @@ msgstr[2] ""
 #: ../superdesk-planning/client/validators/profile.ts:58
 #: ../superdesk-planning/client/validators/profile.ts:59
 msgid "Too many {{ name }}"
-msgstr ""
+msgstr "Превише {{ name }}"
 
 #: ../superdesk-planning/client/validators/profile.ts:103
 msgid "Too short"
-msgstr ""
+msgstr "Прекратко"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:432
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:440
@@ -18401,7 +18401,7 @@ msgstr "Покушај поновног повезивања...<br>Сачека�
 
 #: ../superdesk-planning/client/utils/filters.ts:136
 msgid "Tu"
-msgstr ""
+msgstr "Ут"
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:109
 msgid "Tue"
@@ -18780,7 +18780,7 @@ msgstr "Вратити све понављајуће догађаје из ко�
 
 #: ../superdesk-planning/client/constants/planning.ts:136
 msgid "Unspike planning"
-msgstr ""
+msgstr "Врати планирање из корпе"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:78
 msgid "Unspike {{event}}"
@@ -18892,7 +18892,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/constants/events.ts:160
 msgid "Update time"
-msgstr ""
+msgstr "Ажурирај време"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:90
 msgid "Update time of {{event}}"
@@ -19054,11 +19054,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:119
 msgid "Uploading {{current}} of {{total}}"
-msgstr ""
+msgstr "Отпремање {{current}} од {{total}}"
 
 #: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:118
 msgid "Uploading..."
-msgstr ""
+msgstr "Отпремање..."
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:18
 msgid "Uppercase"
@@ -19131,7 +19131,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:111
 msgid "Use Togglebox"
-msgstr ""
+msgstr "Користи прекидач"
 
 #: scripts/apps/publish/views/ftp-config.html:18
 msgid "Use Transport Layer Security (FTPS)"
@@ -19536,7 +19536,7 @@ msgstr "Знак упозорења"
 
 #: ../superdesk-planning/client/utils/filters.ts:139
 msgid "We"
-msgstr ""
+msgstr "Ср"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:48
 msgid ""
@@ -19582,7 +19582,7 @@ msgstr "Недељно"
 
 #: ../superdesk-planning/client/utils/filters.ts:48
 msgid "Weekly @ {{ time }} to {{ desk }}"
-msgstr ""
+msgstr "Недељно у {{ time }} на {{ desk }}"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:71
 msgid "Weekly on {{days}} at {{hour}}"
@@ -19722,7 +19722,7 @@ msgstr "Виџет светског сата"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:339
 msgid "XMP File"
-msgstr ""
+msgstr "XMP датотека"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:33
 msgid "Year(s)"
@@ -19783,7 +19783,7 @@ msgstr "Није вам дозвољено да креирате чланак у
 msgid ""
 "You are trying to add multiple related events when only one is allowed. Only "
 "the first event({{name}}) will be added."
-msgstr ""
+msgstr "Покушавате да додате више повезаних догађаја када је дозвољен само један. Биће додат само први догађај ({{name}})."
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageForm.tsx:233
 msgid "You can associate only one XMP file"
@@ -19862,7 +19862,7 @@ msgstr "Ваше измене ће бити изгубљене ако сада �
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:285
 msgid "Your changes will be lost if you switch now. What would you like to do?"
-msgstr ""
+msgstr "Ваше измене ће бити изгубљене ако сада промените. Шта желите да урадите?"
 
 #: scripts/apps/dashboard/world-clock/configuration.html:12
 msgid "Your clock"
@@ -20337,11 +20337,11 @@ msgstr "грешка"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:71
 msgid "event"
-msgstr ""
+msgstr "догађај"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:71
 msgid "events"
-msgstr ""
+msgstr "догађаји"
 
 #: scripts/apps/publish/views/ftp-config.html:26
 msgid "example"
@@ -20410,11 +20410,11 @@ msgstr "име"
 
 #: ../superdesk-planning/client/utils/tests/index_test.ts:208
 msgid "foo"
-msgstr ""
+msgstr "foo"
 
 #: ../superdesk-planning/client/utils/events.tsx:1428
 msgid "for"
-msgstr ""
+msgstr "за"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:9
 msgid "for \"{{currentDesk.name}}\" Desk"
@@ -20438,7 +20438,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/events.tsx:1428
 msgid "for {{ repeatCount }} repeats"
-msgstr ""
+msgstr "за {{ repeatCount }} понављања"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:87
 msgid "formatting marks"
@@ -20618,7 +20618,7 @@ msgstr "за 30 мин"
 
 #: ../superdesk-planning/client/components/RelatedPlannings/index.tsx:76
 msgid "in agenda"
-msgstr ""
+msgstr "у агенди"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:72
 msgid "in the last 24 hours."
@@ -20875,7 +20875,7 @@ msgstr "укључено"
 
 #: ../superdesk-planning/client/utils/events.tsx:1443
 msgid "on all week (including weekends)"
-msgstr ""
+msgstr "целе недеље (укључујући викенд)"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:100
 msgid "on assignment by"
@@ -20887,7 +20887,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/events.tsx:1440
 msgid "on week days"
-msgstr ""
+msgstr "радним данима"
 
 #: scripts/apps/authoring/authoring/components/text-statistics.tsx:22
 msgid "one word"
@@ -20971,11 +20971,11 @@ msgstr "слика"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:75
 msgid "planning item"
-msgstr ""
+msgstr "ставка планирања"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:75
 msgid "planning items"
-msgstr ""
+msgstr "ставке планирања"
 
 #: scripts/apps/users/views/edit-form.html:141
 msgid "please provide a valid email address"
@@ -20997,7 +20997,7 @@ msgstr "поштански број"
 
 #: ../superdesk-planning/client/utils/history.tsx:84
 msgid "posted"
-msgstr ""
+msgstr "објављено"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:74
 msgid "pre"
@@ -21358,11 +21358,11 @@ msgstr "поништи објаву"
 
 #: ../superdesk-planning/client/utils/history.tsx:87
 msgid "unposted"
-msgstr ""
+msgstr "необјављено"
 
 #: ../superdesk-planning/client/utils/events.tsx:1413
 msgid "until {{until}}"
-msgstr ""
+msgstr "до {{until}}"
 
 #: scripts/core/lang/missing-translations-strings.ts:27
 msgid "update"
@@ -21543,7 +21543,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:78
 msgid "{{ count }} {{ type }} selected"
-msgstr ""
+msgstr "{{ count }} {{ type }} изабрано"
 
 #: ../superdesk-planning/client/actions/main.ts:325
 msgid "{{ itemType }} created"
@@ -21553,7 +21553,7 @@ msgstr "{{ itemType }} креиран"
 #: ../superdesk-planning/client/validators/planning.ts:170
 #: ../superdesk-planning/client/validators/planning.ts:210
 msgid "{{ key }} is a required field"
-msgstr ""
+msgstr "{{ key }} је обавезно поље"
 
 #: scripts/apps/authoring/macros/views/macros-widget.html:17
 #: scripts/apps/authoring/macros/views/macros-widget.html:26
@@ -21583,15 +21583,15 @@ msgstr "{{ name }} ({{ language }})"
 #: ../superdesk-planning/client/validators/profile.ts:78
 #: ../superdesk-planning/client/validators/profile.ts:86
 msgid "{{ name }} is a required field"
-msgstr ""
+msgstr "{{ name }} је обавезно поље"
 
 #: ../superdesk-planning/client/validators/profile.ts:62
 msgid "{{ name }} is too long"
-msgstr ""
+msgstr "{{ name }} је предугачко"
 
 #: ../superdesk-planning/client/validators/profile.ts:104
 msgid "{{ name }} is too short"
-msgstr ""
+msgstr "{{ name }} је прекратко"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:117
 #: scripts/apps/monitoring/views/aggregate-settings.html:138
@@ -21612,7 +21612,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Archive/ArchivePreview/ArchivePreviewMetadataList.tsx:16
 msgid "{{ wordCount }} words"
-msgstr ""
+msgstr "{{ wordCount }} речи"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:25
 msgid "{{:: monitoring.getGroupLabel(card, aggregate.settings.type)}}"
@@ -21776,7 +21776,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/utils/confirmAddingRelatedItems.tsx:44
 msgid "{{some}} of {{total}} items can not be added as related"
-msgstr ""
+msgstr "{{some}} од {{total}} ставки не може бити додато као повезано"
 
 #: scripts/core/lang/missing-translations-strings.ts:40
 msgid "{{status}} Ingest Channel {{name}}"

--- a/po/sr.po
+++ b/po/sr.po
@@ -157,11 +157,11 @@ msgstr "*потребан је барем један видљив или скр�
 
 #: ../superdesk-analytics/client/utils.js:193
 msgid "1 day"
-msgstr ""
+msgstr "1 дан"
 
 #: ../superdesk-analytics/client/utils.js:199
 msgid "1 hour"
-msgstr ""
+msgstr "1 сат"
 
 #: scripts/core/ArticlesListByQueryWithFilters.tsx:316
 msgid "1 item selected"
@@ -172,7 +172,7 @@ msgstr[2] ""
 
 #: ../superdesk-analytics/client/utils.js:205
 msgid "1 minute"
-msgstr ""
+msgstr "1 минут"
 
 #: scripts/apps/publish/controllers/SubscriberTokenController.ts:22
 msgid "1 month"
@@ -187,7 +187,7 @@ msgstr[2] "Још {{n}} ставки"
 
 #: ../superdesk-analytics/client/utils.js:210
 msgid "1 second"
-msgstr ""
+msgstr "1 секунда"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:270
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:270
@@ -250,7 +250,7 @@ msgstr "12 сати"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:204
 msgid "12:00am"
-msgstr ""
+msgstr "12:00am"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:46
 #: ../superdesk-planning/client/utils/filters.ts:85
@@ -535,12 +535,12 @@ msgstr ": УКЉУЧЕНО"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:206
 msgid ":00am"
-msgstr ""
+msgstr ":00am"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:208
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:210
 msgid ":00pm"
-msgstr ""
+msgstr ":00pm"
 
 #: scripts/apps/workspace/content/views/profile-settings.html:85
 msgid ""
@@ -556,7 +556,7 @@ msgid ""
 "<p>Generate a report showing usage of the Planning module.<br></p>\n"
 "    <p>This provides a statistics on who is and who isn't creating items in "
 "the Planning module</p>"
-msgstr ""
+msgstr "<p>Генериши извештај који приказује коришћење модула планирања.<br></p>\n    <p>Ово пружа статистику о томе ко креира, а ко не креира ставке у модулу планирања</p>"
 
 #: scripts/apps/users/views/edit-form.html:6
 msgid ""
@@ -578,7 +578,7 @@ msgstr "Профил садржаја са овим називом већ пос
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:274
 msgid "A desk is required"
-msgstr ""
+msgstr "Деск је обавезан"
 
 #: scripts/core/auth/reset-password.html:43
 msgid ""
@@ -596,7 +596,7 @@ msgstr "Биће креиран нови шаблон"
 
 #: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:226
 msgid "A user is required"
-msgstr ""
+msgstr "Корисник је обавезан"
 
 #: scripts/apps/search/views/search-parameters.html:218
 msgid "AAP Image Keyword"
@@ -867,7 +867,7 @@ msgstr "Додај извештавања"
 
 #: ../superdesk-analytics/client/utils.js:176
 msgid "Add Featuremedia"
-msgstr ""
+msgstr "Додај истакнути медиј"
 
 #: scripts/extensions/sams/dist/src/containers/FileUploadModal.js:232
 #: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:232
@@ -1288,7 +1288,7 @@ msgstr "Администратор"
 #: ../superdesk-analytics/client/update_time_report/views/update-time-report-panel.html:14
 #: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-panel.html:14
 msgid "Advanced"
-msgstr ""
+msgstr "Напредно"
 
 #: scripts/apps/search/views/search-panel.html:8
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:215
@@ -1999,11 +1999,11 @@ msgstr ""
 
 #: ../superdesk-analytics/client/saved_reports/directives/SavedReportList.js:122
 msgid "Are you sure you want to delete the saved report?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете сачувани извештај?"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsList.js:204
 msgid "Are you sure you want to delete the scheduled report?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете заказани извештај?"
 
 #: scripts/apps/templates/directives/TemplatesDirective.ts:363
 msgid "Are you sure you want to delete the template?"
@@ -2144,7 +2144,7 @@ msgstr "Растуће"
 
 #: ../superdesk-analytics/client/charts/views/chart-form-options.html:50
 msgid "Ascending Order"
-msgstr ""
+msgstr "Растући редослед"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:45
 msgid "Asia/Almaty"
@@ -2706,7 +2706,7 @@ msgstr "Доступни избори"
 #: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:30
 #: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:24
 msgid "Average"
-msgstr ""
+msgstr "Просек"
 
 #: scripts/apps/authoring/metadata/views/metadata-terms.html:33
 #: scripts/apps/dashboard/views/workspace.html:89
@@ -2749,7 +2749,7 @@ msgstr "Круг забране"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:87
 msgid "Bar"
-msgstr ""
+msgstr "Стубови"
 
 #: scripts/apps/authoring/comments/views/comments-widget.html:24
 msgid "Be the first one..."
@@ -2785,7 +2785,7 @@ msgstr "Биографија"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:46
 msgid "Black"
-msgstr ""
+msgstr "Црна"
 
 #: scripts/apps/search/views/search-parameters.html:258
 msgid "Black&White"
@@ -2806,7 +2806,7 @@ msgstr "Блокирање"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:56
 msgid "Blue"
-msgstr ""
+msgstr "Плава"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:57
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:166
@@ -2959,7 +2959,7 @@ msgstr "КРЕИРАЈ НОВИ РАДНИ ПРОСТОР"
 
 #: ../superdesk-analytics/client/charts/views/chart.html:26
 msgid "CSV File"
-msgstr ""
+msgstr "CSV датотека"
 
 #: scripts/apps/workspace/views/workspace-dropdown.html:20
 msgid "CUSTOM WORKSPACES"
@@ -3311,12 +3311,12 @@ msgstr "Категорија"
 
 #: ../superdesk-analytics/client/utils.js:180
 msgid "Change Image"
-msgstr ""
+msgstr "Промени слику"
 
 #: ../superdesk-analytics/client/utils.js:177
 #: ../superdesk-analytics/client/utils.js:178
 msgid "Change POI"
-msgstr ""
+msgstr "Промени тачку од интереса"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:235
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:235
@@ -3342,7 +3342,7 @@ msgstr "Промените изглед Superdesk-а кроз целу апли�
 
 #: ../superdesk-analytics/client/charts/views/table.html:23
 msgid "Change the search filters and try again!"
-msgstr ""
+msgstr "Промените филтере претраге и покушајте поново!"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:167
 msgid "Change view"
@@ -3351,7 +3351,7 @@ msgstr "Промени приказ"
 #: ../superdesk-analytics/client/featuremedia_updates_report/controllers/FeaturemediaUpdatesReportController.js:143
 #: ../superdesk-analytics/client/featuremedia_updates_report/directives/FeaturemediaUpdatesReportPreview.js:21
 msgid "Changes to Featuremedia"
-msgstr ""
+msgstr "Измене истакнутог медија"
 
 #: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:181
 msgid "Changes will be lost, if they are not saved."
@@ -3410,11 +3410,11 @@ msgstr[2] "Карактери {{chars}} нису дозвољени у пољу 
 #: ../superdesk-analytics/client/update_time_report/views/update-time-report-panel.html:55
 #: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-panel.html:55
 msgid "Chart"
-msgstr ""
+msgstr "Графикон"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:23
 msgid "Chart Colours"
-msgstr ""
+msgstr "Боје графикона"
 
 #: ../superdesk-analytics/client/charts/views/chart-form-options.html:26
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:24
@@ -3422,7 +3422,7 @@ msgstr ""
 #: ../superdesk-analytics/client/production_time_report/views/production-time-report-preview.html:20
 #: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:24
 msgid "Chart Type"
-msgstr ""
+msgstr "Тип графикона"
 
 #: scripts/core/views/sdselect.html:13
 msgid "Check all"
@@ -3786,7 +3786,7 @@ msgstr "Боја"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:90
 msgid "Column"
-msgstr ""
+msgstr "Колоне"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:196
 msgid "Columns:"
@@ -4076,11 +4076,11 @@ msgstr "Профили садржаја"
 
 #: ../superdesk-analytics/client/content_publishing_report/index.js:44
 msgid "Content Publishing"
-msgstr ""
+msgstr "Објављивање садржаја"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:479
 msgid "Content State"
-msgstr ""
+msgstr "Стање садржаја"
 
 #: ../superdesk-planning/client/components/fields/editor/ContentTemplate.tsx:82
 msgid "Content Template"
@@ -4326,7 +4326,7 @@ msgstr "Линк исправке је уклоњен"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:575
 msgid "Corrections"
-msgstr ""
+msgstr "Исправке"
 
 #: ../superdesk-planning/client/api/editor/item_planning.ts:125
 msgid "Could not link event - Please close the item and try linking again"
@@ -4546,7 +4546,7 @@ msgstr ""
 
 #: ../superdesk-analytics/client/utils.js:175
 msgid "Create Highlight"
-msgstr ""
+msgstr "Креирај истицање"
 
 #: ../superdesk-planning/client/components/GeoLookupInput/CreateNewGeoLookup.tsx:180
 msgid "Create Location"
@@ -4660,7 +4660,7 @@ msgstr ""
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:55
 msgid "Create new schedule"
-msgstr ""
+msgstr "Креирај нови распоред"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-modal.js:48
 #: scripts/extensions/broadcasting/dist/src/shows/create-show-modal.js:48
@@ -4956,7 +4956,7 @@ msgstr "Прилагођена поља за текст"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:76
 msgid "Customer Installation No.:"
-msgstr ""
+msgstr "Број инсталације корисника:"
 
 #: scripts/apps/dashboard/index.ts:54
 msgid "Customize your widgets and views"
@@ -4984,7 +4984,7 @@ msgstr "ГОТОВО"
 #: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-preview.html:11
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:34
 msgid "Daily"
-msgstr ""
+msgstr "Дневно"
 
 #: ../superdesk-planning/client/utils/filters.ts:45
 msgid "Daily @ {{ time }} to {{ desk }}"
@@ -4992,31 +4992,31 @@ msgstr "Дневно у {{ time }} на {{ desk }}"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:67
 msgid "Daily at {{hour}}"
-msgstr ""
+msgstr "Дневно у {{hour}}"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:58
 msgid "Dark Blue"
-msgstr ""
+msgstr "Тамноплава"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:47
 msgid "Dark Gray"
-msgstr ""
+msgstr "Тамносива"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:69
 msgid "Dark Magenta"
-msgstr ""
+msgstr "Тамномагента"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:66
 msgid "Dark Orange"
-msgstr ""
+msgstr "Тамнонаранџаста"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:70
 msgid "Dark Violet"
-msgstr ""
+msgstr "Тамнољубичаста"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:48
 msgid "Darker Gray"
-msgstr ""
+msgstr "Тамнија сива"
 
 #: scripts/apps/dashboard/controllers/DashboardController.ts:38
 #: scripts/apps/dashboard/index.ts:70
@@ -5056,7 +5056,7 @@ msgstr "Филтер датума"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:3
 msgid "Date Filter:"
-msgstr ""
+msgstr "Филтер датума:"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:108
 #: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:16
@@ -5074,7 +5074,7 @@ msgstr "Датум креирања"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:183
 msgid "Date field is required"
-msgstr ""
+msgstr "Поље датума је обавезно"
 
 #: ../superdesk-planning/client/validators/planning.ts:253
 msgid "Date is in the past"
@@ -5104,7 +5104,7 @@ msgstr "Датум време (AUTHORING-REACT)"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:415
 msgid "Date/Time"
-msgstr ""
+msgstr "Датум/време"
 
 #: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:113
 #: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:88
@@ -5164,7 +5164,7 @@ msgstr "Дани"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:68
 msgid "Deep Pink"
-msgstr ""
+msgstr "Тамнорозе"
 
 #: scripts/apps/monitoring/views/monitoring-group-header.html:31
 #: scripts/apps/monitoring/views/monitoring-group-header.html:43
@@ -5327,7 +5327,7 @@ msgstr "Обриши правило"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:33
 msgid "Delete Saved Report"
-msgstr ""
+msgstr "Обриши сачувани извештај"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:114
 msgid "Delete Scheduled Export"
@@ -5363,7 +5363,7 @@ msgstr "Обриши претрагу"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:35
 msgid "Delete this Schedule"
-msgstr ""
+msgstr "Обриши овај распоред"
 
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:87
 msgid "Delete vocabulary?"
@@ -5396,7 +5396,7 @@ msgstr "Опадајуће"
 
 #: ../superdesk-analytics/client/charts/views/chart-form-options.html:49
 msgid "Descending Order"
-msgstr ""
+msgstr "Опадајући редослед"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:437
 #: ../superdesk-analytics/client/utils.js:156
@@ -5509,7 +5509,7 @@ msgstr "Деск"
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:500
 #: ../superdesk-analytics/client/desk_activity_report/index.js:45
 msgid "Desk Activity"
-msgstr ""
+msgstr "Активност деска"
 
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:64
 msgid "Desk Assignments"
@@ -5547,7 +5547,7 @@ msgstr "Шаблони деска"
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:367
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:371
 msgid "Desk Transitions"
-msgstr ""
+msgstr "Прелази деска"
 
 #: scripts/apps/desks/views/desk-config-modal.html:93
 #: scripts/apps/desks/views/settings.html:82
@@ -6139,7 +6139,7 @@ msgstr "Дуплирано"
 
 #: ../superdesk-analytics/client/utils.js:152
 msgid "Duplicated From"
-msgstr ""
+msgstr "Дуплирано из"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:146
 #: scripts/apps/authoring/versioning/history/views/history.html:30
@@ -6296,7 +6296,7 @@ msgstr "Уреди"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:8
 msgid "Edit \"' + schedule.name + '\" Schedule"
-msgstr ""
+msgstr "Уреди распоред \"' + schedule.name + '\""
 
 #: scripts/apps/desks/views/desk-config-modal.html:5
 msgid "Edit \"{{name}}\" Desk"
@@ -6566,7 +6566,7 @@ msgstr "Уреди извор"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:28
 msgid "Edit this Schedule"
-msgstr ""
+msgstr "Уреди овај распоред"
 
 #: scripts/extensions/videoEditor/dist/src/extension.js:15
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/extension.js:15
@@ -6621,7 +6621,7 @@ msgstr ""
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:21
 msgid "Email this report"
-msgstr ""
+msgstr "Пошаљи имејлом овај извештај"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:405
 #: scripts/apps/search/components/fields/embargo.tsx:46
@@ -6699,7 +6699,7 @@ msgstr "Крајње време (искључиво)"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:177
 msgid "End date cannot be greater than today"
-msgstr ""
+msgstr "Крајњи датум не може бити већи од данашњег"
 
 #: ../superdesk-planning/client/validators/events.ts:84
 msgid "End date is in the past"
@@ -6707,7 +6707,7 @@ msgstr "Крајњи датум је у прошлости"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:162
 msgid "End date is required"
-msgstr ""
+msgstr "Крајњи датум је обавезан"
 
 #: ../superdesk-planning/client/validators/profile.ts:49
 #: ../superdesk-planning/client/validators/profile.ts:50
@@ -6739,7 +6739,7 @@ msgstr "Уверите се да је исправна крајња тачка �
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:163
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:535
 msgid "Enter Desk Actions"
-msgstr ""
+msgstr "Радње уласка на деск"
 
 #: scripts/core/editor3/components/embeds/EmbedInput.tsx:164
 msgid "Enter URL or code to embed"
@@ -6824,26 +6824,26 @@ msgstr "Грешка. Сесије нису могле бити очишћене
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:315
 #: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:270
 msgid "Error. The Desk Activity report could not be generated!"
-msgstr ""
+msgstr "Грешка. Извештај о активности деска није могао бити генерисан!"
 
 #: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:223
 msgid "Error. The Planning Usage Report could not be generated!"
-msgstr ""
+msgstr "Грешка. Извештај о коришћењу планирања није могао бити генерисан!"
 
 #: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:240
 msgid "Error. The Production Time report could not be generated!"
-msgstr ""
+msgstr "Грешка. Извештај о времену продукције није могао бити генерисан!"
 
 #: ../superdesk-analytics/client/content_publishing_report/controllers/ContentPublishingReportController.js:275
 #: ../superdesk-analytics/client/featuremedia_updates_report/controllers/FeaturemediaUpdatesReportController.js:216
 #: ../superdesk-analytics/client/publishing_performance_report/controllers/PublishingPerformanceReportController.ts:280
 #: ../superdesk-analytics/client/update_time_report/controllers/UpdateTimeReportController.js:243
 msgid "Error. The Publishing Report could not be generated!"
-msgstr ""
+msgstr "Грешка. Извештај о објављивању није могао бити генерисан!"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/controller.js:246
 msgid "Error. The report could not be generated."
-msgstr ""
+msgstr "Грешка. Извештај није могао бити генерисан."
 
 #: scripts/apps/users/controllers/UserDeleteCommand.ts:24
 msgid "Error. User Profile cannot be disabled."
@@ -7314,7 +7314,7 @@ msgstr "Знак узвика"
 #: ../superdesk-analytics/client/search/views/source-fitlers.html:44
 #: ../superdesk-analytics/client/search/views/source-fitlers.html:73
 msgid "Exclude"
-msgstr ""
+msgstr "Изостави"
 
 #: ../superdesk-planning/client/components/fields/editor/ExcludeRescheduledAndCancelled.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:79
@@ -7323,7 +7323,7 @@ msgstr "Изостави поново заказане и отказане"
 
 #: ../superdesk-analytics/client/search/views/source-fitlers.html:304
 msgid "Exclude Rewrites"
-msgstr ""
+msgstr "Изостави прераде"
 
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:173
 msgid "Exclude Spike"
@@ -7335,7 +7335,7 @@ msgstr "Изостави све закључане ставке"
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:67
 msgid "Exclude rewrites"
-msgstr ""
+msgstr "Изостави прераде"
 
 #: scripts/apps/search/views/search-parameters.html:151
 msgid "Exclude spiked content"
@@ -7354,7 +7354,7 @@ msgstr "Излаз"
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:173
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:556
 msgid "Exit Desk Actions"
-msgstr ""
+msgstr "Радње изласка са деска"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:79
 #: scripts/core/editor3/components/Editor3Component.tsx:901
@@ -7386,7 +7386,7 @@ msgstr "Истек"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:82
 msgid "Expiry Date:"
-msgstr ""
+msgstr "Датум истека:"
 
 #: scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx:64
 msgid "Explanation"
@@ -7412,11 +7412,11 @@ msgstr "Извоз"
 
 #: ../superdesk-analytics/client/charts/views/chart.html:23
 msgid "Export Chart As..."
-msgstr ""
+msgstr "Извези графикон као..."
 
 #: ../superdesk-analytics/client/utils.js:174
 msgid "Export Highlight"
-msgstr ""
+msgstr "Извези истицање"
 
 #: ../superdesk-planning/client/components/fields/editor/ExportTemplate.tsx:48
 msgid "Export Template"
@@ -7455,7 +7455,7 @@ msgstr "Отворено око"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:107
 msgid "FR"
-msgstr ""
+msgstr "ПЕ"
 
 #: scripts/apps/publish/views/ftp-config.html:27
 msgid "FTP File Extension"
@@ -7530,7 +7530,7 @@ msgstr "Креирање архивске ставке није успело."
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsModal.js:102
 msgid "Failed to create the Report Schedule!"
-msgstr ""
+msgstr "Креирање распореда извештаја није успело!"
 
 #: scripts/extensions/sams/dist/src/api/sets.js:46
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:46
@@ -7564,7 +7564,7 @@ msgstr "Брисање локације није успело"
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:194
 msgid "Failed to delete the saved report"
-msgstr ""
+msgstr "Брисање сачуваног извештаја није успело"
 
 #: scripts/apps/authoring/authoring/services/MultiEditUnsavedChangesService.ts:60
 msgid "Failed to discard some changes"
@@ -7577,7 +7577,7 @@ msgstr "Дуплирање ставке није успело"
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:61
 #: ../superdesk-analytics/client/charts/services/ChartManager.js:30
 msgid "Failed to export the chart;"
-msgstr ""
+msgstr "Извоз графикона није успео;"
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:239
 msgid "Failed to fetch all filters"
@@ -7699,7 +7699,7 @@ msgstr "Учитавање ставке није успело."
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:241
 msgid "Failed to load the saved report!"
-msgstr ""
+msgstr "Учитавање сачуваног извештаја није успело!"
 
 #: ../superdesk-planning/client/actions/autosave.ts:32
 msgid "Failed to load {{ itemType }} autosaves."
@@ -7800,7 +7800,7 @@ msgstr "Чување записа истакнуте приче није усп�
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:169
 msgid "Failed to save report"
-msgstr ""
+msgstr "Чување извештаја није успело"
 
 #: scripts/apps/authoring/authoring/services/MultiEditUnsavedChangesService.ts:72
 msgid "Failed to save some articles"
@@ -7808,7 +7808,7 @@ msgstr "Чување неких чланака није успело"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsModal.js:103
 msgid "Failed to save the Report Schedule!"
-msgstr ""
+msgstr "Чување распореда извештаја није успело!"
 
 #: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:461
 msgid "Failed to save the area of interest:"
@@ -7845,7 +7845,7 @@ msgstr "Чување није успело, ставка типа {{itemType}} �
 
 #: ../superdesk-analytics/client/email_report/services/EmailReportService.js:69
 msgid "Failed to send report email!"
-msgstr ""
+msgstr "Слање имејла извештаја није успело!"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:69
 #: ../superdesk-planning/client/actions/events/ui.ts:86
@@ -7981,11 +7981,11 @@ msgstr "Истакнуте приче којима сте управљали о�
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:20
 msgid "Featuremedia History"
-msgstr ""
+msgstr "Историја истакнутог медија"
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/index.js:50
 msgid "Featuremedia Updates"
-msgstr ""
+msgstr "Ажурирања истакнутог медија"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:99
 msgid "Feed Parser"
@@ -8005,7 +8005,7 @@ msgstr "Фид сервис"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:64
 msgid "Fern Green"
-msgstr ""
+msgstr "Папратно зелена"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:434
 #: ../superdesk-analytics/client/utils.js:151 scripts/apps/ingest/index.ts:129
@@ -8271,7 +8271,7 @@ msgstr "Пронађите своје колеге"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:67
 msgid "Fire Brick"
-msgstr ""
+msgstr "Опека"
 
 #: ../superdesk-planning/client/utils/filters.ts:63
 msgid "First"
@@ -8445,7 +8445,7 @@ msgstr "Из шаблона"
 
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:30
 msgid "From:"
-msgstr ""
+msgstr "Од:"
 
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:327
 msgid "Fulfil Assignment with this item?"
@@ -8512,34 +8512,34 @@ msgstr "Генериши из URL-а"
 
 #: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-parameters.html:1
 msgid "Generate a report showing activity on a desk."
-msgstr ""
+msgstr "Генериши извештај који приказује активност на деску."
 
 #: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:1
 msgid ""
 "Generate a report showing average and maximum time it took to produce "
 "content per desk."
-msgstr ""
+msgstr "Генериши извештај који приказује просечно и максимално време потребно за продукцију садржаја по деску."
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-parameters.html:1
 #: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-parameters.html:1
 msgid "Generate a report showing statistics for published content."
-msgstr ""
+msgstr "Генериши извештај који приказује статистике објављеног садржаја."
 
 #: ../superdesk-analytics/client/update_time_report/views/update-time-report-parameters.html:1
 msgid ""
 "Generate a report showing the time between original publish and update "
 "publish."
-msgstr ""
+msgstr "Генериши извештај који приказује време између оригиналне објаве и објаве ажурирања."
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-parameters.html:1
 msgid ""
 "Generate a report showing updates to featuremedia items after initial "
 "publish."
-msgstr ""
+msgstr "Генериши извештај који приказује ажурирања ставки истакнутог медија након првобитне објаве."
 
 #: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-parameters.html:1
 msgid "Generate a report showing user activity."
-msgstr ""
+msgstr "Генериши извештај који приказује активност корисника."
 
 #: scripts/apps/authoring-react/fields/embed/editor.tsx:40
 msgid "Generate from URL"
@@ -8585,7 +8585,7 @@ msgstr "Преузми токен"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:15
 msgid "Global"
-msgstr ""
+msgstr "Глобално"
 
 #: scripts/apps/content-filters/views/manage-filters.html:51
 msgid "Global Block"
@@ -8602,7 +8602,7 @@ msgstr "Глобално читање:"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-list.html:28
 msgid "Global Saved Reports"
-msgstr ""
+msgstr "Глобални сачувани извештаји"
 
 #: scripts/apps/search/views/saved-searches.html:36
 msgid "Global Saved Searches"
@@ -8657,15 +8657,15 @@ msgstr "Графика"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:50
 msgid "Gray"
-msgstr ""
+msgstr "Сива"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:52
 msgid "Gray Text"
-msgstr ""
+msgstr "Сиви текст"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:59
 msgid "Green"
-msgstr ""
+msgstr "Зелена"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:99
 msgid "Grid View"
@@ -8686,12 +8686,12 @@ msgstr "Група \"{{group}}\" ће бити трајно обрисана."
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:2
 #: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:2
 msgid "Group By"
-msgstr ""
+msgstr "Групиши по"
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-parameters.html:7
 #: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-parameters.html:7
 msgid "Group By:"
-msgstr ""
+msgstr "Групиши по:"
 
 #: scripts/apps/authoring-react/macros/macros.tsx:359
 #: scripts/apps/authoring/macros/views/macros-widget.html:3
@@ -8814,7 +8814,7 @@ msgstr "Наслов"
 
 #: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-tooltip.html:3
 msgid "Headline:"
-msgstr ""
+msgstr "Наслов:"
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines-widget.js:49
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/main-panel.js:14
@@ -8901,7 +8901,7 @@ msgstr "Висок приоритет"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:35
 msgid "Highcharts {{licenseType}} License"
-msgstr ""
+msgstr "Highcharts {{licenseType}} лиценца"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:109
 msgid "Highlight Package"
@@ -9109,7 +9109,7 @@ msgstr ""
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:82
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:185
 msgid "Image Width"
-msgstr ""
+msgstr "Ширина слике"
 
 #: scripts/core/upload/crop-directive.ts:41
 msgid ""
@@ -9207,7 +9207,7 @@ msgstr "Укључи уништено"
 
 #: ../superdesk-analytics/client/search/views/source-fitlers.html:303
 msgid "Include Rewrites"
-msgstr ""
+msgstr "Укључи прераде"
 
 #: ../superdesk-planning/client/components/fields/editor/IncludeScheduledUpdates.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:95
@@ -9228,7 +9228,7 @@ msgstr "Укључи све закључане ставке"
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:64
 msgid "Include rewrites"
-msgstr ""
+msgstr "Укључи прераде"
 
 #: scripts/apps/search/views/search-parameters.html:152
 msgid "Include spiked content"
@@ -9236,16 +9236,16 @@ msgstr "Укључи садржај у корпи"
 
 #: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:15
 msgid "Included Statistics"
-msgstr ""
+msgstr "Укључене статистике"
 
 #: ../superdesk-analytics/client/production_time_report/views/production-time-report-preview.html:13
 msgid "Included Stats"
-msgstr ""
+msgstr "Укључене статистике"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:372
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:425
 msgid "Incoming"
-msgstr ""
+msgstr "Долазно"
 
 #: scripts/apps/desks/views/desk-config-modal.html:386
 msgid "Incoming Rule"
@@ -9328,7 +9328,7 @@ msgstr "Провајдер пријема:"
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:151
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:493
 msgid "Ingest Providers"
-msgstr ""
+msgstr "Провајдери пријема"
 
 #: scripts/apps/ingest/views/settings/settings.html:15
 msgid "Ingest Routing"
@@ -9408,7 +9408,7 @@ msgstr "Instagram"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:87
 msgid "Installed Version:"
-msgstr ""
+msgstr "Инсталирана верзија:"
 
 #: scripts/apps/authoring/authoring/index.ts:474
 msgid "Instant Spellchecking, when automatic spellchecking turned off"
@@ -9452,7 +9452,7 @@ msgstr "Интерна напомена:"
 #: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-parameters.html:22
 #: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-preview.html:9
 msgid "Interval"
-msgstr ""
+msgstr "Интервал"
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/index.tsx:191
 msgid "Invalid Date"
@@ -9647,7 +9647,7 @@ msgstr "Ставка није додата. Прекорачен је макси
 
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:65
 msgid "Item not found!"
-msgstr ""
+msgstr "Ставка није пронађена!"
 
 #: scripts/apps/search/directives/ItemGlobalSearch.ts:49
 msgid "Item not found..."
@@ -9720,7 +9720,7 @@ msgstr "Број ставки"
 
 #: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:241
 msgid "Items Created"
-msgstr ""
+msgstr "Креиране ставке"
 
 #: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions-bulk.js:21
 #: scripts/extensions/markForUser/dist/src/get-article-actions-bulk.js:21
@@ -9751,7 +9751,7 @@ msgstr "Ставке које не могу бити преузете"
 #: ../superdesk-analytics/client/email_report/directives/EmailReportModal.js:91
 #: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsList.js:101
 msgid "JPEG Image"
-msgstr ""
+msgstr "JPEG слика"
 
 #: scripts/apps/users/views/edit-form.html:186
 msgid "Jabber Identifier (JID)"
@@ -9828,7 +9828,7 @@ msgstr "Уништио"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:574
 msgid "Kills"
-msgstr ""
+msgstr "Уништавања"
 
 #: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:58
 #: scripts/apps/authoring-react/fields/date/config.tsx:37
@@ -9944,7 +9944,7 @@ msgstr "Последња недеља"
 #: ../superdesk-analytics/client/search/views/date-filters.html:31
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:26
 msgid "Last Year"
-msgstr ""
+msgstr "Прошла година"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/PreviewArticle.tsx:83
 #: scripts/apps/authoring/preview/fullPreview.tsx:77
@@ -9971,19 +9971,19 @@ msgstr "Последње ажурирано"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:735
 msgid "Last {{days}} days"
-msgstr ""
+msgstr "Последњих {{days}} дана"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:728
 msgid "Last {{hours}} hours"
-msgstr ""
+msgstr "Последњих {{hours}} сати"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:780
 msgid "Last {{months}} months"
-msgstr ""
+msgstr "Последњих {{months}} месеци"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:751
 msgid "Last {{weeks}} weeks"
-msgstr ""
+msgstr "Последњих {{weeks}} недеља"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:301
 msgid "Latitude"
@@ -10026,27 +10026,27 @@ msgstr "Правна архива"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:70
 msgid "License ID:"
-msgstr ""
+msgstr "ИД лиценце:"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:45
 msgid "License Type"
-msgstr ""
+msgstr "Тип лиценце"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:56
 msgid "Licensee Contact:"
-msgstr ""
+msgstr "Контакт носиоца лиценце:"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:50
 msgid "Licensee:"
-msgstr ""
+msgstr "Носилац лиценце:"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:53
 msgid "Light Gray"
-msgstr ""
+msgstr "Светлосива"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:54
 msgid "Lighter Gray"
-msgstr ""
+msgstr "Светлија сива"
 
 #: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:163
 msgid "Limit further typing"
@@ -10054,7 +10054,7 @@ msgstr "Ограничи даље куцање"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:99
 msgid "Line"
-msgstr ""
+msgstr "Линија"
 
 #: ../superdesk-analytics/client/utils.js:160
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:120
@@ -10306,7 +10306,7 @@ msgstr ""
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:75
 msgid "MO"
-msgstr ""
+msgstr "ПО"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:411
 msgid "MORE"
@@ -10332,7 +10332,7 @@ msgstr "Главни мени"
 
 #: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:26
 msgid "Make Global"
-msgstr ""
+msgstr "Учини глобалним"
 
 #: scripts/apps/templates/views/template-editor-modal.html:59
 msgid "Make Public"
@@ -10477,7 +10477,7 @@ msgstr "Маркер на мапи"
 
 #: ../superdesk-analytics/client/utils.js:172
 msgid "Mark"
-msgstr ""
+msgstr "Означи"
 
 #: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:38
 #: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:38
@@ -10671,11 +10671,11 @@ msgstr "Галерија медија"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:57
 msgid "Medium Blue"
-msgstr ""
+msgstr "Средње плава"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:49
 msgid "Medium Gray"
-msgstr ""
+msgstr "Средње сива"
 
 #: scripts/apps/users/views/edit-form.html:61
 msgid "Member since"
@@ -10855,7 +10855,7 @@ msgstr "Месечно {{ day }}. дана у {{ time }} на {{ desk }}"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:78
 msgid "Monthly on the {{day}} day at {{hour}}"
-msgstr ""
+msgstr "Месечно {{day}}. дана у {{hour}}"
 
 #: ../superdesk-planning/client/components/ItemActionsMenu/index.tsx:71
 #: scripts/apps/authoring/views/authoring-topbar.html:260
@@ -10886,11 +10886,11 @@ msgstr "Премести садржај на други деск"
 
 #: ../superdesk-analytics/client/utils.js:167
 msgid "Move From"
-msgstr ""
+msgstr "Премести из"
 
 #: ../superdesk-analytics/client/utils.js:168
 msgid "Move To"
-msgstr ""
+msgstr "Премести у"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:209
 msgid "Move down"
@@ -10991,7 +10991,7 @@ msgstr ""
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:165
 msgid "Must select at least one day"
-msgstr ""
+msgstr "Морате изабрати најмање један дан"
 
 #: ../superdesk-planning/client/validators/events.ts:283
 msgid "Must start with \"http://\", \"https://\" or \"www.\""
@@ -11023,7 +11023,7 @@ msgstr "Мој профил"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-list.html:12
 msgid "My Saved Reports"
-msgstr ""
+msgstr "Моји сачувани извештаји"
 
 #: scripts/apps/search/views/saved-searches.html:7
 msgid "My Saved Searches"
@@ -11139,7 +11139,7 @@ msgstr "Назив варијанте за прилагање имејлу"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:71
 msgid "Navy"
-msgstr ""
+msgstr "Морнаричка"
 
 #: scripts/apps/search/views/search-filters.html:11
 #: scripts/apps/search/views/search-filters.html:111
@@ -11156,7 +11156,7 @@ msgstr "Негирај"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:51
 msgid "Neutral Gray"
-msgstr ""
+msgstr "Неутрална сива"
 
 #: scripts/apps/publish/views/subscribers.html:278
 msgid "Never"
@@ -11168,7 +11168,7 @@ msgstr "Никад не истиче"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:573
 msgid "New"
-msgstr ""
+msgstr "Ново"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:135
 msgid "New Document"
@@ -11393,7 +11393,7 @@ msgstr ""
 
 #: ../superdesk-analytics/client/charts/views/table.html:22
 msgid "No data found"
-msgstr ""
+msgstr "Подаци нису пронађени"
 
 #: scripts/apps/users/views/edit-form.html:222
 msgid "No desk selected"
@@ -11842,7 +11842,7 @@ msgstr "Број ставки"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:27
 msgid "OEM"
-msgstr ""
+msgstr "OEM"
 
 #: scripts/apps/desks/views/desk-config-modal.html:312
 #: scripts/apps/desks/views/desk-config-modal.html:317
@@ -11922,7 +11922,7 @@ msgstr "У реду"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:65
 msgid "Old Gold"
-msgstr ""
+msgstr "Стара златна"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:37
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.js:73
@@ -12103,12 +12103,12 @@ msgstr "Отворио"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:637
 msgid "Operation"
-msgstr ""
+msgstr "Операција"
 
 #: ../superdesk-analytics/client/user_activity_report/views/item-timeline-tooltip.html:4
 #: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-tooltip.html:5
 msgid "Operations:"
-msgstr ""
+msgstr "Операције:"
 
 #: scripts/apps/content-filters/views/filter-search.html:18
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:68
@@ -12130,7 +12130,7 @@ msgstr ""
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:62
 msgid "Orange"
-msgstr ""
+msgstr "Наранџаста"
 
 #: ../superdesk-planning/client/components/OrderBar/OrderFieldInput.tsx:21
 msgid "Order By: {{ name }}"
@@ -12138,7 +12138,7 @@ msgstr "Сортирано по: {{ name }}"
 
 #: ../superdesk-analytics/client/charts/views/chart-form-options.html:44
 msgid "Order Data In:"
-msgstr ""
+msgstr "Сортирај податке по:"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:137
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:26
@@ -12191,7 +12191,7 @@ msgstr "Оригинал ({{item.renditions.original.width}} x {{item.renditions
 msgid ""
 "Original ({{preview.item.update.update.renditions.original.width}} x "
 "{{preview.item.update.update.renditions.original.height}} px)"
-msgstr ""
+msgstr "Оригинал ({{preview.item.update.update.renditions.original.width}} x {{preview.item.update.update.renditions.original.height}} px)"
 
 #: scripts/apps/search/components/fields/translations.tsx:26
 msgid "Original Article"
@@ -12208,7 +12208,7 @@ msgstr "Оригинални ИД"
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:19
 msgid "Original Image"
-msgstr ""
+msgstr "Оригинална слика"
 
 #: scripts/apps/archive/views/metadata-associateditem-view.html:27
 #: scripts/apps/archive/views/metadata-view.html:31
@@ -12260,7 +12260,7 @@ msgstr "Остала поља"
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:373
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:426
 msgid "Outgoing"
-msgstr ""
+msgstr "Одлазно"
 
 #: scripts/apps/desks/views/desk-config-modal.html:408
 msgid "Outgoing Rule"
@@ -12318,7 +12318,7 @@ msgstr ""
 #: ../superdesk-analytics/client/email_report/directives/EmailReportModal.js:95
 #: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsList.js:105
 msgid "PDF File"
-msgstr ""
+msgstr "PDF датотека"
 
 #: ../superdesk-planning/client/validators/planning.ts:29
 msgid "PLANNING DATE cannot be in the past"
@@ -12327,7 +12327,7 @@ msgstr "ДАТУМ ПЛАНИРАЊА не може бити у прошлост
 #: ../superdesk-analytics/client/email_report/directives/EmailReportModal.js:92
 #: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsList.js:102
 msgid "PNG Image"
-msgstr ""
+msgstr "PNG слика"
 
 #: scripts/apps/authoring-react/subcomponents/content-profile-dropdown.tsx:32
 #: scripts/apps/authoring/views/authoring-header.html:24
@@ -12403,7 +12403,7 @@ msgstr "Страница"
 
 #: ../superdesk-analytics/client/charts/views/chart-form-options.html:57
 msgid "Page Size"
-msgstr ""
+msgstr "Величина странице"
 
 #: scripts/core/list/views/sdPagination.html:2
 msgid "Page Size:"
@@ -12606,7 +12606,7 @@ msgstr "Слика"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:102
 msgid "Pie"
-msgstr ""
+msgstr "Пита"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:149
 #: scripts/apps/authoring-react/widget-header-component.tsx:24
@@ -12733,16 +12733,16 @@ msgstr "Управљање планирањем"
 
 #: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:150
 msgid "Planning Module (Items created per user)"
-msgstr ""
+msgstr "Модул планирања (ставке креиране по кориснику)"
 
 #: ../superdesk-analytics/client/planning_usage_report/directives/PlanningUsageReportPreview.js:21
 #: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:21
 msgid "Planning Module Usage"
-msgstr ""
+msgstr "Коришћење модула планирања"
 
 #: ../superdesk-analytics/client/planning_usage_report/index.js:45
 msgid "Planning Usage"
-msgstr ""
+msgstr "Коришћење планирања"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:56
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:69
@@ -13212,16 +13212,16 @@ msgstr ""
 
 #: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:276
 msgid "Production Stats"
-msgstr ""
+msgstr "Статистика продукције"
 
 #: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:293
 #: ../superdesk-analytics/client/production_time_report/index.js:45
 msgid "Production Time"
-msgstr ""
+msgstr "Време продукције"
 
 #: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:173
 msgid "Production Times"
-msgstr ""
+msgstr "Времена продукције"
 
 #: scripts/apps/products/index.ts:20
 #: scripts/apps/products/views/settings.html:9
@@ -13335,11 +13335,11 @@ msgstr "Објави и настави"
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:445
 #: ../superdesk-analytics/client/utils.js:157
 msgid "Publish Embargo"
-msgstr ""
+msgstr "Ембарго објаве"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:577
 msgid "Publish Pars"
-msgstr ""
+msgstr "Параметри објаве"
 
 #: scripts/apps/publish/index.ts:51
 msgid "Publish Queue"
@@ -13353,7 +13353,7 @@ msgstr "Распоред објављивања"
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:444
 #: ../superdesk-analytics/client/utils.js:155
 msgid "Publish Scheduled"
-msgstr ""
+msgstr "Заказана објава"
 
 #: scripts/apps/authoring/views/confirm-media-associated.html:18
 msgid "Publish Without Media"
@@ -13388,11 +13388,11 @@ msgstr "Објављен садржај"
 
 #: ../superdesk-analytics/client/publishing_performance_report/controllers/PublishingPerformanceReportController.ts:383
 msgid "Published Content for {{group}}: {{data}}"
-msgstr ""
+msgstr "Објављен садржај за {{group}}: {{data}}"
 
 #: ../superdesk-analytics/client/publishing_performance_report/controllers/PublishingPerformanceReportController.ts:389
 msgid "Published Content per {{group}}"
-msgstr ""
+msgstr "Објављен садржај по {{group}}"
 
 #: scripts/apps/legal-archive/views/legal_archive.html:84
 msgid "Published From"
@@ -13400,15 +13400,15 @@ msgstr "Објављено од"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:234
 msgid "Published Stories"
-msgstr ""
+msgstr "Објављене приче"
 
 #: ../superdesk-analytics/client/content_publishing_report/controllers/ContentPublishingReportController.js:377
 msgid "Published Stories per {{group}}"
-msgstr ""
+msgstr "Објављене приче по {{group}}"
 
 #: ../superdesk-analytics/client/content_publishing_report/controllers/ContentPublishingReportController.js:371
 msgid "Published Stories per {{group}} with {{subgroup}} breakdown"
-msgstr ""
+msgstr "Објављене приче по {{group}} са поделом по {{subgroup}}"
 
 #: scripts/apps/legal-archive/views/legal_archive.html:88
 msgid "Published Until"
@@ -13438,16 +13438,16 @@ msgstr "Радња објављивања"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/index.js:47
 msgid "Publishing Actions"
-msgstr ""
+msgstr "Радње објављивања"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/index.js:48
 msgid "Publishing Actions Widget"
-msgstr ""
+msgstr "Виџет радњи објављивања"
 
 #: ../superdesk-analytics/client/publishing_performance_report/index.js:48
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/controller.js:81
 msgid "Publishing Performance"
-msgstr ""
+msgstr "Перформансе објављивања"
 
 #: scripts/apps/authoring/authoring/constants.ts:16
 msgid "Publishing actions"
@@ -13464,7 +13464,7 @@ msgstr "Pubstatus"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:63
 msgid "Purple"
-msgstr ""
+msgstr "Љубичаста"
 
 #: scripts/apps/publish/views/ftp-config.html:30
 msgid "Push associated/feature media items"
@@ -13557,11 +13557,11 @@ msgstr "Насумично"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:9
 msgid "Range"
-msgstr ""
+msgstr "Опсег"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:168
 msgid "Range cannot be greater than {{max}} days"
-msgstr ""
+msgstr "Опсег не може бити већи од {{max}} дана"
 
 #: scripts/apps/search/views/search-panel.html:15
 msgid "Raw"
@@ -13684,7 +13684,7 @@ msgstr "Правила понављања"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:60
 msgid "Red"
-msgstr ""
+msgstr "Црвена"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:162
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:44
@@ -13832,23 +13832,23 @@ msgstr "Повезане ставке"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:16
 msgid "Relative Days"
-msgstr ""
+msgstr "Релативни дани"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:13
 msgid "Relative Hours"
-msgstr ""
+msgstr "Релативни сати"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:26
 msgid "Relative Months"
-msgstr ""
+msgstr "Релативни месеци"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:21
 msgid "Relative Weeks"
-msgstr ""
+msgstr "Релативне недеље"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:181
 msgid "Relative value is required"
-msgstr ""
+msgstr "Релативна вредност је обавезна"
 
 #: ../superdesk-planning/client/components/Agendas/AgendaListItem.tsx:68
 #: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:58
@@ -13934,7 +13934,7 @@ msgstr "Уклони догађај"
 
 #: ../superdesk-analytics/client/utils.js:179
 msgid "Remove Featuremedia"
-msgstr ""
+msgstr "Уклони истакнути медиј"
 
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:30
 msgid "Remove Filter Condition"
@@ -14086,7 +14086,7 @@ msgstr "Варијанта"
 
 #: ../superdesk-analytics/client/views/renditions-preview.html:11
 msgid "Renditions"
-msgstr ""
+msgstr "Варијанте"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:133
 msgid "Reopened by"
@@ -14171,28 +14171,28 @@ msgstr "Одговори"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsModal.js:94
 msgid "Report Schedule created!"
-msgstr ""
+msgstr "Распоред извештаја креиран!"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsModal.js:95
 msgid "Report Schedule saved!"
-msgstr ""
+msgstr "Распоред извештаја сачуван!"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:67
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:63
 msgid "Report Type"
-msgstr ""
+msgstr "Тип извештаја"
 
 #: ../superdesk-analytics/client/email_report/services/EmailReportService.js:66
 msgid "Report chart emailed!"
-msgstr ""
+msgstr "Графикон извештаја послат имејлом!"
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:185
 msgid "Report deleted!"
-msgstr ""
+msgstr "Извештај обрисан!"
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:151
 msgid "Report saved!"
-msgstr ""
+msgstr "Извештај сачуван!"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:27
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:46
@@ -14270,7 +14270,7 @@ msgstr ""
 
 #: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:13
 msgid "Reset Filters"
-msgstr ""
+msgstr "Ресетуј филтере"
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:247
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:247
@@ -14339,7 +14339,7 @@ msgstr "Опозови"
 
 #: ../superdesk-analytics/client/utils.js:158
 msgid "Rewrite"
-msgstr ""
+msgstr "Прерада"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:467
 #: scripts/apps/authoring/versioning/history/views/history.html:154
@@ -14349,15 +14349,15 @@ msgstr "Линк прераде је уклоњен"
 #: ../superdesk-analytics/client/search/views/preview-source-filter.html:13
 #: ../superdesk-analytics/client/search/views/source-fitlers.html:299
 msgid "Rewrites"
-msgstr ""
+msgstr "Прераде"
 
 #: ../superdesk-analytics/client/search/views/source-fitlers.html:305
 msgid "Rewrites Only"
-msgstr ""
+msgstr "Само прераде"
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:70
 msgid "Rewrites only"
-msgstr ""
+msgstr "Само прераде"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:176
 msgid "Rewritten by"
@@ -14480,7 +14480,7 @@ msgstr ""
 
 #: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:18
 msgid "Run Report"
-msgstr ""
+msgstr "Покрени извештај"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:370
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:297
@@ -14514,7 +14514,7 @@ msgstr ""
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:115
 msgid "SA"
-msgstr ""
+msgstr "СУ"
 
 #: scripts/extensions/sams/dist/src/extension.js:13
 #: scripts/extensions/sams/dist/src/extensions/sams/src/extension.js:13
@@ -14565,7 +14565,7 @@ msgstr "ПОЧЕТНО ВРЕМЕ је обавезно када је подеш
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:123
 msgid "SU"
-msgstr ""
+msgstr "НЕ"
 
 #: ../superdesk-planning/client/utils/filters.ts:148
 msgid "Sa"
@@ -14727,7 +14727,7 @@ msgstr "Сачувај догађај"
 #: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:33
 #: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:3
 msgid "Save Report"
-msgstr ""
+msgstr "Сачувај извештај"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:276
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:276
@@ -14873,13 +14873,13 @@ msgstr "Запис истакнутих прича сачуван"
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:71
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:83
 msgid "Saved Report"
-msgstr ""
+msgstr "Сачуван извештај"
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:166
 msgid ""
 "Saved Report has changed since it was opened. Please re-select the Saved "
 "Report to continue. Regrettably, your changes cannot be saved."
-msgstr ""
+msgstr "Сачувани извештај је измењен откад је отворен. Поново изаберите сачувани извештај да наставите. Нажалост, ваше измене не могу бити сачуване."
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:62
 msgid "Saved Searches"
@@ -14887,7 +14887,7 @@ msgstr "Сачуване претраге"
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:238
 msgid "Saved report not found!"
-msgstr ""
+msgstr "Сачувани извештај није пронађен!"
 
 #: scripts/apps/search/directives/SavedSearches.ts:116
 msgid "Saved search removed"
@@ -14917,7 +14917,7 @@ msgstr "Scanpix ИД(ови)"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:105
 msgid "Scatter"
-msgstr ""
+msgstr "Расути"
 
 #: scripts/apps/templates/views/templates.html:56
 msgid "Sched. Desk / Stage"
@@ -15018,7 +15018,7 @@ msgstr "Заказано:"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:51
 msgid "Scheduling"
-msgstr ""
+msgstr "Заказивање"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:103
 msgid "Scheme details"
@@ -15092,27 +15092,27 @@ msgstr "Претражи задатке"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:432
 msgid "Search Categories"
-msgstr ""
+msgstr "Претражи категорије"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:480
 msgid "Search Content State"
-msgstr ""
+msgstr "Претражи стање садржаја"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:396
 msgid "Search Content Type"
-msgstr ""
+msgstr "Претражи тип садржаја"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:384
 msgid "Search Desks"
-msgstr ""
+msgstr "Претражи дескове"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:536
 msgid "Search Enter Desk Actions"
-msgstr ""
+msgstr "Претражи радње уласка на деск"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:557
 msgid "Search Exit Desk Actions"
-msgstr ""
+msgstr "Претражи радње изласка са деска"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:86
 msgid "Search Filters"
@@ -15120,11 +15120,11 @@ msgstr "Филтери претраге"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:444
 msgid "Search Genre"
-msgstr ""
+msgstr "Претражи жанр"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:494
 msgid "Search Ingest Providers"
-msgstr ""
+msgstr "Претражи провајдере пријема"
 
 #: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:160
 msgid "Search OpenStreetMap"
@@ -15149,11 +15149,11 @@ msgstr "Претражи повезане чланке"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:456
 msgid "Search Source"
-msgstr ""
+msgstr "Претражи извор"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:509
 msgid "Search Stages"
-msgstr ""
+msgstr "Претражи фазе"
 
 #: ../superdesk-planning/client/components/fields/editor/FullText.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:87
@@ -15162,16 +15162,16 @@ msgstr "Текст за претрагу"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:468
 msgid "Search Urgency"
-msgstr ""
+msgstr "Претражи хитност"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:414
 #: ../superdesk-analytics/client/search/views/user-select.html:17
 msgid "Search Users"
-msgstr ""
+msgstr "Претражи кориснике"
 
 #: ../superdesk-analytics/client/email_report/views/email-recipients-input.html:9
 msgid "Search emails"
-msgstr ""
+msgstr "Претражи имејлове"
 
 #: ../superdesk-planning/client/components/Contacts/SelectSearchContactsField/SelectListPopup.tsx:226
 msgid "Search for a contact"
@@ -15204,7 +15204,7 @@ msgstr "Контакти провајдера претраге"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-list.html:6
 msgid "Search saved reports"
-msgstr ""
+msgstr "Претражи сачуване извештаје"
 
 #: scripts/apps/search/views/saved-searches.html:3
 msgid "Search saved searches"
@@ -15497,7 +15497,7 @@ msgstr "Пошаљи исправку"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:117
 msgid "Send Email"
-msgstr ""
+msgstr "Пошаљи имејл"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:221
 msgid "Send Kill"
@@ -15505,7 +15505,7 @@ msgstr "Пошаљи уништење"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:7
 msgid "Send Report via Email"
-msgstr ""
+msgstr "Пошаљи извештај имејлом"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:228
 msgid "Send Takedown"
@@ -15580,7 +15580,7 @@ msgstr "Послати излаз деска"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:443
 msgid "Sent From"
-msgstr ""
+msgstr "Послато из"
 
 #: scripts/apps/monitoring/controllers/AggregateCtrl.ts:41
 msgid "Sent Items"
@@ -15588,7 +15588,7 @@ msgstr "Послате ставке"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:436
 msgid "Sent To"
-msgstr ""
+msgstr "Послато на"
 
 #: scripts/api/article-send.tsx:257
 msgid "Sent successfully"
@@ -15932,7 +15932,7 @@ msgstr "Сигнал"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:10
 msgid "Single Day"
-msgstr ""
+msgstr "Један дан"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:122
 msgid "Single Line"
@@ -16159,7 +16159,7 @@ msgstr ""
 #: ../superdesk-analytics/client/production_time_report/views/production-time-report-preview.html:24
 #: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:28
 msgid "Sort Order"
-msgstr ""
+msgstr "Редослед сортирања"
 
 #: scripts/apps/monitoring/views/monitoring-group-header.html:37
 #: scripts/apps/search/views/item-sortbar.html:12
@@ -16328,7 +16328,7 @@ msgstr "Само садржај у корпи"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:108
 msgid "Spline"
-msgstr ""
+msgstr "Спајн"
 
 #: scripts/core/editor3/highlightsConfig.ts:83
 msgid "Split paragraph"
@@ -16393,7 +16393,7 @@ msgstr "Започни рад"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:174
 msgid "Start date cannot be greater than today"
-msgstr ""
+msgstr "Почетни датум не може бити већи од данашњег"
 
 #: ../superdesk-planning/client/validators/events.ts:76
 msgid "Start date is in the past"
@@ -16401,7 +16401,7 @@ msgstr "Почетни датум је у прошлости"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:160
 msgid "Start date is required"
-msgstr ""
+msgstr "Почетни датум је обавезан"
 
 #: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:31
 msgid "Start routing"
@@ -16449,7 +16449,7 @@ msgstr "Држава/Покрајина/Регион"
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:145
 msgid "States"
-msgstr ""
+msgstr "Стања"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:64
 #: scripts/apps/publish/views/publish-queue.html:115
@@ -16589,11 +16589,11 @@ msgstr "Не"
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:6
 #: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:6
 msgid "Subgroup By"
-msgstr ""
+msgstr "Подгрупиши по"
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-parameters.html:23
 msgid "Subgroup By:"
-msgstr ""
+msgstr "Подгрупиши по:"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:112
 #: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:112
@@ -16628,7 +16628,7 @@ msgstr "Тема је обавезно поље"
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:39
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:150
 msgid "Subject:"
-msgstr ""
+msgstr "Тема:"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:162
 #: scripts/core/lang/missing-translations-strings.ts:12
@@ -16656,7 +16656,7 @@ msgstr "Поднето"
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:109
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:202
 msgid "Submitting...."
-msgstr ""
+msgstr "Слање...."
 
 #: scripts/apps/search/views/saved-search-subscribe.html:34
 #: scripts/apps/search/views/saved-searches.html:21
@@ -16710,7 +16710,7 @@ msgstr "Индекс"
 #: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:15
 #: ../superdesk-analytics/client/update_time_report/views/update-time-report-preview.html:6
 msgid "Subtitle"
-msgstr ""
+msgstr "Поднаслов"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:244
 #: ../superdesk-planning/client/components/fields/resources/locations.ts:40
@@ -16738,7 +16738,7 @@ msgstr "Сугестије ће се појавити овде када се т�
 #: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:29
 #: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:32
 msgid "Sum"
-msgstr ""
+msgstr "Збир"
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/main-panel.js:18
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary-widget.js:48
@@ -16857,7 +16857,7 @@ msgstr "TBC"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:99
 msgid "TH"
-msgstr ""
+msgstr "ЧЕ"
 
 #: ../superdesk-planning/client/validators/events.ts:25
 msgid "TIMEZONE is a required field"
@@ -16865,7 +16865,7 @@ msgstr "ВРЕМЕНСКА ЗОНА је обавезно поље"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:83
 msgid "TU"
-msgstr ""
+msgstr "УТ"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:41
 msgid "Tab"
@@ -16956,12 +16956,12 @@ msgstr "Уклони ставку"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:577
 msgid "Takedowns"
-msgstr ""
+msgstr "Уклањања"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:50
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:90
 msgid "Taken Down"
-msgstr ""
+msgstr "Уклоњено"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:427
 msgid "Taken as a rewrite of"
@@ -17220,12 +17220,12 @@ msgstr "ИД производа се може копирати и користи
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:278
 msgid "The Saved Report you are using was deleted!"
-msgstr ""
+msgstr "Сачувани извештај који користите је обрисан!"
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:270
 msgid ""
 "The Saved Report you are using was updated! Please re-select the Saved Report"
-msgstr ""
+msgstr "Сачувани извештај који користите је ажуриран! Поново изаберите сачувани извештај"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:52
 msgid ""
@@ -17406,7 +17406,7 @@ msgstr "Распоред претплатника је завршен {{date}}, 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:39
 msgid ""
 "The use of Highcharts is provided under a license with the following details:"
-msgstr ""
+msgstr "Коришћење Highcharts-а је омогућено под лиценцом са следећим детаљима:"
 
 #: scripts/apps/dashboard/user-activity/user-activity.ts:14
 msgid ""
@@ -17738,7 +17738,7 @@ msgstr "Овај догађај је заказан да се одржи нак�
 #: ../superdesk-analytics/client/search/views/date-filters.html:28
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:21
 msgid "This Month"
-msgstr ""
+msgstr "Овај месец"
 
 #: scripts/core/editor3/components/embeds/EmbedInput.tsx:92
 msgid "This URL could not be embedded."
@@ -17754,7 +17754,7 @@ msgstr "Ове недеље"
 #: ../superdesk-analytics/client/search/views/date-filters.html:32
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:27
 msgid "This Year"
-msgstr ""
+msgstr "Ова година"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:277
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:365
@@ -18044,7 +18044,7 @@ msgstr "Бирач времена"
 
 #: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:315
 msgid "Time spent producing content"
-msgstr ""
+msgstr "Време утрошено на продукцију садржаја"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:62
 #: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:62
@@ -18059,11 +18059,11 @@ msgstr ""
 
 #: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:559
 msgid "Timeline"
-msgstr ""
+msgstr "Временска линија"
 
 #: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-tooltip.html:4
 msgid "Times:"
-msgstr ""
+msgstr "Времена:"
 
 #: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:249
 #: scripts/core/lang/missing-translations-strings.ts:34
@@ -18158,7 +18158,7 @@ msgstr "Да бисте видели детаљне разлике, упоред
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:129
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:31
 msgid "To:"
-msgstr ""
+msgstr "До:"
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-footer.js:40
 #: scripts/extensions/ai-widget/dist/src/translations/translations-footer.js:40
@@ -18311,7 +18311,7 @@ msgstr "Прекратко"
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:432
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:440
 msgid "Total"
-msgstr ""
+msgstr "Укупно"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:257
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:257
@@ -18621,7 +18621,7 @@ msgstr "Дошло је до непознате грешке"
 
 #: ../superdesk-analytics/client/utils.js:161
 msgid "Unlink"
-msgstr ""
+msgstr "Уклони везу"
 
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:140
 #: ../superdesk-planning/client/planning-extension/src/extension.ts:188
@@ -18678,7 +18678,7 @@ msgstr "Откључано"
 #: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:22
 #: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:77
 msgid "Unmark"
-msgstr ""
+msgstr "Уклони ознаку"
 
 #: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions.js:21
 #: scripts/extensions/markForUser/dist/src/get-article-actions.js:21
@@ -18935,7 +18935,7 @@ msgstr "Ажурирана поља:"
 
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:68
 msgid "Updated In"
-msgstr ""
+msgstr "Ажурирано у"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:104
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:104
@@ -18977,7 +18977,7 @@ msgstr "Ажурирано:"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:576
 msgid "Updates"
-msgstr ""
+msgstr "Ажурирања"
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:34
 msgid ""
@@ -19190,7 +19190,7 @@ msgstr "Активност корисника"
 
 #: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:185
 msgid "User Activity - {{username}}"
-msgstr ""
+msgstr "Активност корисника - {{username}}"
 
 #: scripts/apps/users/config.ts:38
 #: scripts/core/lang/missing-translations-strings.ts:21
@@ -19369,19 +19369,19 @@ msgstr ""
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:28
 msgid "View Latest Item Version"
-msgstr ""
+msgstr "Прикажи најновију верзију ставке"
 
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:120
 msgid "View Original"
-msgstr ""
+msgstr "Прикажи оригинал"
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:33
 msgid "View Original Image"
-msgstr ""
+msgstr "Прикажи оригиналну слику"
 
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:131
 msgid "View Update"
-msgstr ""
+msgstr "Прикажи ажурирање"
 
 #: scripts/apps/monitoring/index.ts:120
 msgid "View an item"
@@ -19389,7 +19389,7 @@ msgstr "Прикажи ставку"
 
 #: ../superdesk-analytics/client/index.js:95
 msgid "View analytics reports"
-msgstr ""
+msgstr "Прикажи аналитичке извештаје"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:168
 msgid "View associated event"
@@ -19454,7 +19454,7 @@ msgstr "Прикажи поново заказан догађај"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:58
 msgid "View schedules"
-msgstr ""
+msgstr "Прикажи распореде"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:155
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:180
@@ -19511,7 +19511,7 @@ msgstr "УПОЗОРЕЊЕ непозната вредност услова фи
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:91
 msgid "WE"
-msgstr ""
+msgstr "СР"
 
 #: scripts/apps/archive/views/preview.html:63
 #: scripts/apps/authoring/suggest/SuggestView.html:16
@@ -19586,7 +19586,7 @@ msgstr "Недељно у {{ time }} на {{ desk }}"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:71
 msgid "Weekly on {{days}} at {{hour}}"
-msgstr ""
+msgstr "Недељно у дане {{days}} у {{hour}}"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:4
 msgid "Welcome to Superdesk"
@@ -19595,7 +19595,7 @@ msgstr ""
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:2
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:9
 msgid "When"
-msgstr ""
+msgstr "Када"
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:38
 #: scripts/apps/highlights/views/highlights_config_modal.html:47
@@ -19608,7 +19608,7 @@ msgstr "Када је омогућено, може слати више став�
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:55
 msgid "White"
-msgstr ""
+msgstr "Бела"
 
 #: scripts/apps/dashboard/views/widget.html:11
 #: scripts/apps/dashboard/views/widget.html:12
@@ -19618,7 +19618,7 @@ msgstr "Подешавања виџета"
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:8
 msgid ""
 "Widget settings <span translate>for \"{{currentDesk.name}}\" Desk</span>"
-msgstr ""
+msgstr "Подешавања виџета <span translate>за деск \"{{currentDesk.name}}\"</span>"
 
 #: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:95
 msgid "Widgets"
@@ -19730,7 +19730,7 @@ msgstr "Година(е)"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:61
 msgid "Yellow"
-msgstr ""
+msgstr "Жута"
 
 #: scripts/core/ui/components/generic-form/input-types/checkbox.tsx:10
 #: scripts/core/ui/components/generic-form/input-types/yes-no.tsx:6
@@ -19746,7 +19746,7 @@ msgstr ""
 #: ../superdesk-analytics/client/search/views/date-filters.html:17
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:8
 msgid "Yesterday"
-msgstr ""
+msgstr "Јуче"
 
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:106
 msgid ""
@@ -20401,7 +20401,7 @@ msgstr "назив датотеке"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:230
 msgid "first"
-msgstr ""
+msgstr "први"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:275
 #: scripts/apps/users/views/edit-form.html:82
@@ -20418,7 +20418,7 @@ msgstr "за"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:9
 msgid "for \"{{currentDesk.name}}\" Desk"
-msgstr ""
+msgstr "за деск \"{{currentDesk.name}}\""
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:2
 msgid "for \"{{name}}\" Desk"
@@ -20685,7 +20685,7 @@ msgstr ""
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:232
 msgid "last"
-msgstr ""
+msgstr "последњи"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:296
 #: scripts/apps/users/views/edit-form.html:94
@@ -20883,7 +20883,7 @@ msgstr "на задатку од"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:23
 msgid "on the"
-msgstr ""
+msgstr "на"
 
 #: ../superdesk-planning/client/utils/events.tsx:1440
 msgid "on week days"
@@ -20932,7 +20932,7 @@ msgstr "остало"
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:400
 #: scripts/core/utils.tsx:346
 msgid "package"
-msgstr ""
+msgstr "пакет"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:60
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:60
@@ -21646,7 +21646,7 @@ msgstr[2] ""
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:123
 #: ../superdesk-analytics/client/utils.js:196
 msgid "{{days}} days"
-msgstr ""
+msgstr "{{days}} дана"
 
 #: scripts/apps/users/views/edit-form.html:144
 msgid "{{error.email}}"
@@ -21701,11 +21701,11 @@ msgstr "Време {{field}} је обавезно!"
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:118
 #: ../superdesk-analytics/client/utils.js:202
 msgid "{{hours}} hours"
-msgstr ""
+msgstr "{{hours}} сати"
 
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:99
 msgid "{{hours}} hours, {{minutes}} minutes"
-msgstr ""
+msgstr "{{hours}} сати, {{minutes}} минута"
 
 #: ../superdesk-analytics/client/charts/views/chart-colour-picker.html:2
 msgid "{{label | translate}}"
@@ -21718,11 +21718,11 @@ msgstr ""
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:105
 #: ../superdesk-analytics/client/utils.js:208
 msgid "{{minutes}} minutes"
-msgstr ""
+msgstr "{{minutes}} минута"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:133
 msgid "{{months}} months"
-msgstr ""
+msgstr "{{months}} месеци"
 
 #: scripts/apps/publish/views/publish-queue.html:84
 msgid "{{multiSelectCount}} Item selected"
@@ -21768,7 +21768,7 @@ msgstr ""
 
 #: ../superdesk-analytics/client/utils.js:213
 msgid "{{seconds}} seconds"
-msgstr ""
+msgstr "{{seconds}} секунди"
 
 #: scripts/apps/users/views/edit.html:19
 msgid "{{section.label}}"
@@ -21794,11 +21794,11 @@ msgstr ""
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:44
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:45
 msgid "{{update.date}} - {{update.operation}} by {{update.user}}"
-msgstr ""
+msgstr "{{update.date}} - {{update.operation}} од {{update.user}}"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:128
 msgid "{{weeks}} weeks"
-msgstr ""
+msgstr "{{weeks}} недеља"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:124
 #: scripts/extensions/sams/dist/src/utils/ui.js:124

--- a/po/sr.po
+++ b/po/sr.po
@@ -889,7 +889,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/dashboard/ingest-sources-list.html:1
 msgid "Add Ingest Sources"
-msgstr ""
+msgstr "Додај изворе доласка"
 
 #: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:436
 msgid "Add Item"
@@ -963,20 +963,20 @@ msgstr "Додај нови производ"
 
 #: scripts/apps/ingest/views/settings/ingest-rules-content.html:31
 msgid "Add New Rule Set"
-msgstr ""
+msgstr "Додај нови скуп правила"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:31
 msgid "Add New Scheme"
-msgstr ""
+msgstr "Додај нову шему"
 
 #: scripts/apps/search-providers/directive.ts:24
 #: scripts/apps/search-providers/views/search-provider-config.html:28
 msgid "Add New Search Provider"
-msgstr ""
+msgstr "Додај новог провајдера претраге"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:58
 msgid "Add New Source"
-msgstr ""
+msgstr "Додај нови извор"
 
 #: scripts/apps/publish/views/subscribers.html:69
 msgid "Add New Subscriber"
@@ -992,11 +992,11 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:84
 msgid "Add Rule"
-msgstr ""
+msgstr "Додај правило"
 
 #: scripts/apps/ingest/views/dashboard/dashboard.html:4
 msgid "Add Sources"
-msgstr ""
+msgstr "Додај изворе"
 
 #: scripts/apps/dashboard/views/workspace.html:99
 msgid "Add This Widget"
@@ -1088,7 +1088,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-routing-filter.html:8
 msgid "Add filter"
-msgstr ""
+msgstr "Додај филтер"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldList.tsx:43
 msgid "Add first field"
@@ -1144,7 +1144,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-rules-content.html:65
 msgid "Add rule"
-msgstr ""
+msgstr "Додај правило"
 
 #: scripts/extensions/datetimeField/dist/src/config.js:54
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:54
@@ -1512,7 +1512,7 @@ msgstr ""
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:64
 #: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:12
 msgid "All Day"
-msgstr ""
+msgstr "Цео дан"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:136
 msgid "All Day Toggle"
@@ -1605,7 +1605,7 @@ msgstr "Дозволи више ставки"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:189
 msgid "Allow Remove Ingested Items"
-msgstr ""
+msgstr "Дозволи уклањање примљених ставки"
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:78
 msgid "Allow adding items that are in progress"
@@ -1775,7 +1775,7 @@ msgstr ""
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:84
 msgid "An error occured when testing config."
-msgstr ""
+msgstr "Дошло је до грешке приликом тестирања конфигурације."
 
 #: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:46
 msgid "An error occured, please try again."
@@ -1939,11 +1939,11 @@ msgstr ""
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:348
 msgid "Are you sure you want to delete Ingest Source?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете извор доласка?"
 
 #: scripts/apps/search-providers/directive.ts:87
 msgid "Are you sure you want to delete Search Provider?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете провајдера претраге?"
 
 #: scripts/apps/highlights/controllers/HighlightsConfig.ts:66
 msgid "Are you sure you want to delete configuration?"
@@ -1979,7 +1979,7 @@ msgstr "Да ли сте сигурни да желите да обришете 
 
 #: scripts/apps/ingest/directives/IngestRulesContent.ts:61
 msgid "Are you sure you want to delete rule set?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете скуп правила?"
 
 #: scripts/apps/search/directives/SavedSearches.ts:112
 msgid "Are you sure you want to delete saved search?"
@@ -2017,11 +2017,11 @@ msgstr ""
 
 #: scripts/apps/ingest/directives/IngestRoutingContent.ts:239
 msgid "Are you sure you want to delete this scheme rule?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете ово правило шеме?"
 
 #: scripts/apps/ingest/directives/IngestRoutingContent.ts:238
 msgid "Are you sure you want to delete this scheme?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете ову шему?"
 
 #: scripts/apps/users/directives/UserRolesDirective.ts:89
 msgid "Are you sure you want to delete user role?"
@@ -2086,7 +2086,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:107
 msgid "Article Type(s)"
-msgstr ""
+msgstr "Тип(ови) чланка"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/RelatedArticlesListComponent.tsx:105
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/RelatedArticlesListComponent.tsx:122
@@ -3365,7 +3365,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:38
 msgid "Channel has gone strangely quiet."
-msgstr ""
+msgstr "Канал је неуобичајено тих."
 
 #: scripts/apps/desks/views/desk-config-modal.html:205
 msgid "Character limit exceeded, desk can not be created/updated."
@@ -3585,7 +3585,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:106
 msgid "Click on a Scheme rules on the left to view details."
-msgstr ""
+msgstr "Кликните на правило шеме лево да бисте видели детаље."
 
 #: scripts/apps/dashboard/views/workspace.html:60
 msgid "Click on the \"+\" button in the top right corner to add some widgets."
@@ -3760,7 +3760,7 @@ msgstr ""
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:9
 #: scripts/apps/search-providers/views/search-provider-config.html:14
 msgid "Closed"
-msgstr ""
+msgstr "Затворено"
 
 #: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:242
 msgid "Closing failed"
@@ -3968,7 +3968,7 @@ msgstr ""
 
 #: scripts/apps/ingest/directives/authenticate-ingest-provider.tsx:20
 msgid "Connect an account"
-msgstr ""
+msgstr "Повежи налог"
 
 #: scripts/core/notification/notification.ts:222
 msgid "Connected to Notification Server!"
@@ -5160,7 +5160,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:4
 msgid "Days"
-msgstr ""
+msgstr "Дани"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:68
 msgid "Deep Pink"
@@ -5247,7 +5247,7 @@ msgstr ""
 
 #: scripts/apps/search-providers/views/search-provider-config.html:53
 msgid "Default view"
-msgstr ""
+msgstr "Подразумевани приказ"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:106
 msgid ""
@@ -5323,7 +5323,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:70
 msgid "Delete Rule"
-msgstr ""
+msgstr "Обриши правило"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:33
 msgid "Delete Saved Report"
@@ -5723,7 +5723,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:192
 msgid "Disable Item Updates"
-msgstr ""
+msgstr "Онемогући ажурирања ставки"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:169
 msgid "Disable selection of an entire category"
@@ -6158,7 +6158,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:124
 #: scripts/extensions/broadcasting/src/rundowns/components/duration-label.tsx:21
 msgid "Duration"
-msgstr ""
+msgstr "Трајање"
 
 #: scripts/apps/authoring-react/fields/duration/index.tsx:20
 msgid "Duration (authoring-react)"
@@ -6363,11 +6363,11 @@ msgstr "Уреди услов филтера"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:109
 msgid "Edit Ingest Source"
-msgstr ""
+msgstr "Уреди извор доласка"
 
 #: scripts/apps/ingest/views/dashboard/ingest-sources-list.html:6
 msgid "Edit Ingest Sources"
-msgstr ""
+msgstr "Уреди изворе доласка"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:75
 msgid "Edit Line"
@@ -6395,11 +6395,11 @@ msgstr "Уреди улогу"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:67
 msgid "Edit Rule"
-msgstr ""
+msgstr "Уреди правило"
 
 #: scripts/apps/ingest/views/settings/ingest-rules-content.html:30
 msgid "Edit Rule set"
-msgstr ""
+msgstr "Уреди скуп правила"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:262
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:262
@@ -6414,16 +6414,16 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:30
 msgid "Edit Scheme"
-msgstr ""
+msgstr "Уреди шему"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:16
 #: scripts/apps/search-providers/views/search-provider-config.html:27
 msgid "Edit Search Provider"
-msgstr ""
+msgstr "Уреди провајдера претраге"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:57
 msgid "Edit Source"
-msgstr ""
+msgstr "Уреди извор"
 
 #: scripts/apps/publish/views/subscribers.html:50
 #: scripts/apps/publish/views/subscribers.html:68
@@ -6549,11 +6549,11 @@ msgstr "Уреди улогу"
 
 #: scripts/apps/ingest/views/settings/ingest-rules-content.html:19
 msgid "Edit rule set"
-msgstr ""
+msgstr "Уреди скуп правила"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:19
 msgid "Edit scheme"
-msgstr ""
+msgstr "Уреди шему"
 
 #: scripts/apps/search/views/saved-searches.html:15
 #: scripts/apps/search/views/saved-searches.html:44
@@ -6562,7 +6562,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:46
 msgid "Edit source"
-msgstr ""
+msgstr "Уреди извор"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:28
 msgid "Edit this Schedule"
@@ -6669,7 +6669,7 @@ msgstr "Омогући преглед нових функција"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:204
 msgid "Enable if config can't be tested on REST server."
-msgstr ""
+msgstr "Омогући ако конфигурација не може бити тестирана на REST серверу."
 
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:488
 msgid "Enable spellchecker"
@@ -6695,7 +6695,7 @@ msgstr "Крајњи датум"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:23
 msgid "End Time (exclusive)"
-msgstr ""
+msgstr "Крајње време (искључиво)"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:177
 msgid "End date cannot be greater than today"
@@ -6778,7 +6778,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:243
 msgid "Error"
-msgstr ""
+msgstr "Грешка"
 
 #: scripts/api/highlights.ts:44 scripts/api/highlights.ts:48
 msgid "Error creating highlight."
@@ -6896,7 +6896,7 @@ msgstr "Грешка:"
 
 #: scripts/apps/search-providers/directive.ts:62
 msgid "Error: A Search Provider with type  already exists."
-msgstr ""
+msgstr "Грешка: провајдер претраге са типом већ постоји."
 
 #: scripts/apps/products/controllers/ProductsConfigController.ts:208
 msgid "Error: Failed to delete product."
@@ -6912,7 +6912,7 @@ msgstr "Грешка: поновно заказивање није успело"
 
 #: scripts/apps/search-providers/directive.ts:66
 msgid "Error: Failed to save Search Provider."
-msgstr ""
+msgstr "Грешка: чување провајдера претраге није успело."
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:228
 msgid "Error: Failed to save Subscriber."
@@ -6962,11 +6962,11 @@ msgstr "Грешка: речник већ постоји."
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:359
 msgid "Error: Unable to delete Ingest Source"
-msgstr ""
+msgstr "Грешка: није могуће обрисати извор доласка"
 
 #: scripts/apps/search-providers/directive.ts:98
 msgid "Error: Unable to delete Search Provider."
-msgstr ""
+msgstr "Грешка: није могуће обрисати провајдера претраге."
 
 #: scripts/api/article.ts:422
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:100
@@ -7648,7 +7648,7 @@ msgstr ""
 
 #: scripts/apps/ingest/controllers/ExternalSourceController.ts:29
 msgid "Failed to get item."
-msgstr ""
+msgstr "Преузимање ставке није успело."
 
 #: scripts/extensions/sams/dist/src/api/assets.js:527
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:527
@@ -7989,7 +7989,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:99
 msgid "Feed Parser"
-msgstr ""
+msgstr "Парсер фида"
 
 #: scripts/core/menu/views/menu.html:105
 msgid "Feedback"
@@ -8001,7 +8001,7 @@ msgstr "Повратне информације/Предлози"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:92
 msgid "Feeding Service"
-msgstr ""
+msgstr "Сервис за довод"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:64
 msgid "Fern Green"
@@ -8016,7 +8016,7 @@ msgstr ""
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:70
 #: scripts/core/interactive-article-actions-panel/actions/fetch-to-action.tsx:116
 msgid "Fetch"
-msgstr ""
+msgstr "Преузми"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:87
 msgid "Fetch As"
@@ -8028,7 +8028,7 @@ msgstr "Преузми садржај на деск"
 
 #: scripts/apps/ingest/index.ts:115 scripts/apps/ingest/index.ts:146
 msgid "Fetch To"
-msgstr ""
+msgstr "Преузми на"
 
 #: scripts/apps/monitoring/index.ts:122
 msgid "Fetch an item"
@@ -8431,7 +8431,7 @@ msgstr "Петак"
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:67
 #: scripts/core/interactive-article-actions-panel/actions/publish-action.tsx:181
 msgid "From"
-msgstr ""
+msgstr "Од"
 
 #: scripts/apps/search/constants.ts:12
 #: scripts/apps/search/views/search-parameters.html:102
@@ -8642,7 +8642,7 @@ msgstr "Иди на профиле садржаја"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:45
 msgid "Go to items"
-msgstr ""
+msgstr "Иди на ставке"
 
 #: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:133
 #: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:92
@@ -8992,11 +8992,11 @@ msgstr "Извините, али дошло је до грешке прилик�
 
 #: scripts/apps/ingest/directives/IngestRoutingContent.ts:188
 msgid "I'm sorry but there was an error when saving the routing scheme."
-msgstr ""
+msgstr "Извините, али дошло је до грешке приликом чувања шеме усмеравања."
 
 #: scripts/apps/ingest/directives/IngestRulesContent.ts:37
 msgid "I'm sorry but there was an error when saving the rule set."
-msgstr ""
+msgstr "Извините, али дошло је до грешке приликом чувања скупа правила."
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:110
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:29
@@ -9297,7 +9297,7 @@ msgstr ""
 #: scripts/apps/ingest/views/settings/settings.html:4
 #: scripts/apps/search/views/item-repo.html:3
 msgid "Ingest"
-msgstr ""
+msgstr "Долазак"
 
 #: scripts/core/lang/missing-translations-strings.ts:18
 msgid "Ingest Channels"
@@ -9306,11 +9306,11 @@ msgstr "Канали доласка"
 #: scripts/apps/ingest/index.ts:92
 #: scripts/apps/ingest/views/dashboard/dashboard.html:2
 msgid "Ingest Dashboard"
-msgstr ""
+msgstr "Контролна табла доласка"
 
 #: scripts/apps/ingest/controllers/IngestDashboardController.ts:36
 msgid "Ingest Dashboard preferences could not be saved."
-msgstr ""
+msgstr "Поставке контролне табле доласка нису могле бити сачуване."
 
 #: scripts/apps/archive/views/metadata-view.html:26
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:263
@@ -9332,11 +9332,11 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/settings.html:15
 msgid "Ingest Routing"
-msgstr ""
+msgstr "Усмеравање доласка"
 
 #: scripts/apps/ingest/views/settings/settings.html:12
 msgid "Ingest Rule sets"
-msgstr ""
+msgstr "Скупови правила доласка"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:99
 msgid "Ingest Source"
@@ -9344,11 +9344,11 @@ msgstr ""
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:353
 msgid "Ingest Source deleted."
-msgstr ""
+msgstr "Извор доласка обрисан."
 
 #: scripts/apps/ingest/views/settings/settings.html:9
 msgid "Ingest Sources"
-msgstr ""
+msgstr "Извори доласка"
 
 #: scripts/apps/ingest/ingest-stats-widget/stats.ts:9
 #: scripts/core/lang/missing-translations-strings.ts:44
@@ -9487,7 +9487,7 @@ msgstr ""
 
 #: scripts/apps/search-providers/views/search-provider-config.html:41
 msgid "Is Default"
-msgstr ""
+msgstr "Је подразумевано"
 
 #: scripts/apps/archive/views/metadata-view.html:165
 msgid "Iso"
@@ -9540,7 +9540,7 @@ msgstr ""
 
 #: scripts/apps/ingest/controllers/ExternalSourceController.ts:25
 msgid "Item Fetched."
-msgstr ""
+msgstr "Ставка преузета."
 
 #: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:56
 msgid "Item History"
@@ -9678,7 +9678,7 @@ msgstr ""
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:11
 msgid "Item type stats"
-msgstr ""
+msgstr "Статистика типа ставке"
 
 #: scripts/apps/highlights/services/HighlightsService.ts:125
 msgid "Item unmarked"
@@ -9913,7 +9913,7 @@ msgstr "Последњи дан"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:34
 msgid "Last Item Arrived"
-msgstr ""
+msgstr "Последња ставка стигла"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:27
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:20
@@ -9929,7 +9929,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:30
 msgid "Last Time Updated"
-msgstr ""
+msgstr "Последње ажурирано"
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:14
 msgid "Last Updated"
@@ -10275,7 +10275,7 @@ msgstr "Пријави се преко Google-а"
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:41
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:87
 msgid "Log Messages"
-msgstr ""
+msgstr "Поруке дневника"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:239
 #: ../superdesk-planning/client/components/fields/resources/events.ts:20
@@ -11124,7 +11124,7 @@ msgstr "Поље назива треба да садржи само алфану
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:79
 msgid "Name is not unique."
-msgstr ""
+msgstr "Назив није јединствен."
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:153
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:77
@@ -11284,7 +11284,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:7
 msgid "No Fetch actions defined"
-msgstr ""
+msgstr "Нису дефинисане радње преузимања"
 
 #: scripts/apps/highlights/views/search_highlights_dropdown_directive.html:6
 msgid "No Filter"
@@ -11296,7 +11296,7 @@ msgstr "Нема пронађених производа"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:39
 msgid "No Publish actions defined"
-msgstr ""
+msgstr "Нису дефинисане радње објављивања"
 
 #: scripts/apps/publish/views/subscribers.html:57
 msgid "No Subscribers Found"
@@ -11383,7 +11383,7 @@ msgstr "За сада нема коментара."
 #: scripts/apps/ingest/views/settings/ingest-routing-filter.html:5
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:11
 msgid "No content filter defined"
-msgstr ""
+msgstr "Није дефинисан филтер садржаја"
 
 #: scripts/extensions/availability-manager/dist/src/correspondent-availability/with-availability-records.js:54
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/correspondent-availability/with-availability-records.js:54
@@ -11431,7 +11431,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:20
 msgid "No fetch or publish actions defined"
-msgstr ""
+msgstr "Нису дефинисане радње преузимања ни објављивања"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:1080
 msgid ""
@@ -11563,11 +11563,11 @@ msgstr "Још нису креиране улоге."
 
 #: scripts/apps/ingest/views/settings/ingest-rules-content.html:63
 msgid "No rules defined in a set."
-msgstr ""
+msgstr "Нема дефинисаних правила у скупу."
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:58
 msgid "No rules defined yet"
-msgstr ""
+msgstr "Још нису дефинисана правила"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:180
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningSelectedList.tsx:25
@@ -11685,7 +11685,7 @@ msgstr "Ниједан"
 #: scripts/apps/ingest/directives/IngestRoutingAction.ts:67
 #: scripts/core/interactive-article-actions-panel/subcomponents/controlled-vocabulary-select.tsx:46
 msgid "Not"
-msgstr ""
+msgstr "Не"
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:432
 msgid "Not Active"
@@ -11805,7 +11805,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/NotificationModal.tsx:44
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:227
 msgid "Notification"
-msgstr ""
+msgstr "Обавештење"
 
 #: scripts/apps/monitoring/views/desk-notifications.html:15
 msgid "Notification list"
@@ -11820,7 +11820,7 @@ msgstr "Обавештења"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:150
 msgid "Notify when idle for more than"
-msgstr ""
+msgstr "Обавести када је неактиван дуже од"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:84
 #: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:67
@@ -11899,7 +11899,7 @@ msgstr ""
 #: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx:82
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:41
 msgid "Off"
-msgstr ""
+msgstr "Искључено"
 
 #: scripts/apps/users/components/UserAvatar.tsx:100
 msgid "Offline"
@@ -12029,7 +12029,7 @@ msgstr ""
 
 #: scripts/apps/search-providers/views/search-provider-config.html:47
 msgid "Open advanced search panel by default"
-msgstr ""
+msgstr "Подразумевано отвори напредни панел претраге"
 
 #: scripts/apps/workspace/index.ts:34
 msgid "Open highlights"
@@ -12095,7 +12095,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:18
 msgid "Opened"
-msgstr ""
+msgstr "Отворено"
 
 #: scripts/apps/monitoring/views/desk-notifications.html:35
 msgid "Opened by"
@@ -13009,7 +13009,7 @@ msgstr "Преформатирани текст"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:92
 msgid "Preserve Desk"
-msgstr ""
+msgstr "Сачувај деск"
 
 #: scripts/apps/desks/views/desk-config-modal.html:86
 msgid "Preserve Published Content"
@@ -13267,15 +13267,15 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:77
 msgid "Provider Name"
-msgstr ""
+msgstr "Назив провајдера"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:72
 msgid "Provider Type"
-msgstr ""
+msgstr "Тип провајдера"
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:563
 msgid "Provider saved!"
-msgstr ""
+msgstr "Провајдер сачуван!"
 
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:88
 msgid "Provider sequence"
@@ -13326,7 +13326,7 @@ msgstr ""
 #: scripts/core/interactive-article-actions-panel/action-tabs.tsx:24
 #: scripts/core/interactive-article-actions-panel/actions/publish-action.tsx:304
 msgid "Publish"
-msgstr ""
+msgstr "Објави"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:99
 msgid "Publish & Continue"
@@ -13958,7 +13958,7 @@ msgstr ""
 
 #: scripts/apps/search-providers/views/search-provider-config.html:17
 msgid "Remove Search Provider"
-msgstr ""
+msgstr "Уклони провајдера претраге"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:164
 msgid "Remove Sign"
@@ -13994,7 +13994,7 @@ msgstr "Уклони речник"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:14
 msgid "Remove fetch action"
-msgstr ""
+msgstr "Уклони радњу преузимања"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:98
 msgid "Remove field"
@@ -14002,7 +14002,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-routing-filter.html:16
 msgid "Remove filter"
-msgstr ""
+msgstr "Уклони филтер"
 
 #: scripts/core/editor3/components/toolbar/index.tsx:377
 msgid "Remove formatting"
@@ -14045,7 +14045,7 @@ msgstr "Уклони производ"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:46
 msgid "Remove publish action"
-msgstr ""
+msgstr "Уклони радњу објављивања"
 
 #: scripts/apps/users/views/settings-roles.html:18
 msgid "Remove role"
@@ -14053,15 +14053,15 @@ msgstr "Уклони улогу"
 
 #: scripts/apps/ingest/views/settings/ingest-rules-content.html:20
 msgid "Remove rule set"
-msgstr ""
+msgstr "Уклони скуп правила"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:20
 msgid "Remove scheme"
-msgstr ""
+msgstr "Уклони шему"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:47
 msgid "Remove source"
-msgstr ""
+msgstr "Уклони извор"
 
 #: scripts/apps/authoring-react/fields/attachments/difference-row.tsx:35
 msgid "Removed"
@@ -14445,11 +14445,11 @@ msgstr "Управљање правилима усмеравања"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:219
 msgid "Routing Scheme"
-msgstr ""
+msgstr "Шема усмеравања"
 
 #: scripts/apps/ingest/directives/IngestRoutingContent.ts:182
 msgid "Routing scheme saved."
-msgstr ""
+msgstr "Шема усмеравања сачувана."
 
 #: scripts/apps/dashboard/closed-desk/views/top-menu-info.html:12
 msgid "Routing to:"
@@ -14457,20 +14457,20 @@ msgstr "Усмеравање на:"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:53
 msgid "Rule name"
-msgstr ""
+msgstr "Назив правила"
 
 #: scripts/apps/ingest/views/settings/ingest-rules-content.html:38
 #: scripts/apps/ingest/views/settings/ingest-rules-content.html:39
 msgid "Rule set name"
-msgstr ""
+msgstr "Назив скупа правила"
 
 #: scripts/apps/ingest/directives/IngestRulesContent.ts:34
 msgid "Rule set saved."
-msgstr ""
+msgstr "Скуп правила сачуван."
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:210
 msgid "Ruleset"
-msgstr ""
+msgstr "Скуп правила"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:410
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:410
@@ -14741,7 +14741,7 @@ msgstr ""
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:713
 msgid "Save all other changes before performing this action."
-msgstr ""
+msgstr "Сачувајте све друге измене пре извођења ове радње."
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:60
 msgid "Save and publish"
@@ -14928,7 +14928,7 @@ msgstr "Зак. деск / фаза"
 #: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:2
 #: scripts/apps/search/views/edit-time-interval.html:1
 msgid "Schedule"
-msgstr ""
+msgstr "Распоред"
 
 #: scripts/apps/templates/views/template-editor-modal.html:175
 msgid "Schedule Desk"
@@ -15022,15 +15022,15 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:103
 msgid "Scheme details"
-msgstr ""
+msgstr "Детаљи шеме"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:41
 msgid "Scheme name"
-msgstr ""
+msgstr "Назив шеме"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:49
 msgid "Scheme rules"
-msgstr ""
+msgstr "Правила шеме"
 
 #: scripts/apps/production-api-keys/config.ts:18
 msgid "Scopes"
@@ -15132,16 +15132,16 @@ msgstr ""
 
 #: scripts/apps/search-providers/directive.ts:92
 msgid "Search Provider deleted."
-msgstr ""
+msgstr "Провајдер претраге обрисан."
 
 #: scripts/apps/search-providers/directive.ts:53
 msgid "Search Provider saved."
-msgstr ""
+msgstr "Провајдер претраге сачуван."
 
 #: scripts/apps/search-providers/index.ts:37
 #: scripts/apps/search-providers/views/settings.html:4
 msgid "Search Providers"
-msgstr ""
+msgstr "Провајдери претраге"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:118
 msgid "Search Related Articles"
@@ -15283,7 +15283,7 @@ msgstr "Изабери датотеке"
 #: scripts/apps/archive/views/resend-configuration.html:10
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:55
 msgid "Select Subscribers"
-msgstr ""
+msgstr "Изабери претплатнике"
 
 #: scripts/apps/workspace/views/workspace-dropdown.html:5
 msgid "Select Workspace"
@@ -15365,7 +15365,7 @@ msgstr ""
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:20
 msgid "Select color"
-msgstr ""
+msgstr "Изабери боју"
 
 #: scripts/apps/authoring/compare-versions/views/compare-versions.html:12
 msgid "Select current version."
@@ -15431,7 +15431,7 @@ msgstr ""
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:7
 msgid "Select source"
-msgstr ""
+msgstr "Изабери извор"
 
 #: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:62
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:85
@@ -15753,7 +15753,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:31
 #: scripts/extensions/broadcasting/src/rundowns/components/select-show.tsx:35
 msgid "Show"
-msgstr ""
+msgstr "Прикажи"
 
 #: ../superdesk-planning/client/components/fields/related_events.tsx:46
 msgid "Show 1 event"
@@ -15801,7 +15801,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:93
 msgid "Show all messages"
-msgstr ""
+msgstr "Прикажи све поруке"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:19
 #: scripts/extensions/broadcasting/dist/src/shows/manage-shows.js:19
@@ -15815,7 +15815,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:101
 msgid "Show error messages"
-msgstr ""
+msgstr "Прикажи поруке грешке"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:302
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:302
@@ -16004,7 +16004,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:203
 msgid "Skip config test"
-msgstr ""
+msgstr "Прескочи тест конфигурације"
 
 #: scripts/apps/desks/views/desk-config-modal.html:59
 msgid "Slack Channel Name"
@@ -16217,11 +16217,11 @@ msgstr "Извор"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:85
 msgid "Source Name"
-msgstr ""
+msgstr "Назив извора"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:3
 msgid "Source Type:"
-msgstr ""
+msgstr "Тип извора:"
 
 #: scripts/apps/desks/views/desk-config-modal.html:44
 msgid "Source for User Created Articles"
@@ -16229,7 +16229,7 @@ msgstr "Извор за чланке које су креирали корисн
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:9
 msgid "Source stats"
-msgstr ""
+msgstr "Статистика извора"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/tag-popover.js:20
 #: scripts/extensions/auto-tagging-widget/dist/src/tag-popover.js:20
@@ -16385,7 +16385,7 @@ msgstr "Почетни датум"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:18
 msgid "Start Time (inclusive)"
-msgstr ""
+msgstr "Почетно време (укључиво)"
 
 #: ../superdesk-planning/client/constants/assignments.ts:191
 msgid "Start Working"
@@ -16485,7 +16485,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:11
 msgid "Status: {{filter}}"
-msgstr ""
+msgstr "Статус: {{filter}}"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:179
 msgid "Stop"
@@ -17007,7 +17007,7 @@ msgstr "Циљни тип:"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:67
 msgid "Target Types"
-msgstr ""
+msgstr "Циљни типови"
 
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:131
 msgid "Target regions"
@@ -17512,7 +17512,7 @@ msgstr "Још нема ставки."
 
 #: scripts/apps/search-providers/directive.ts:24
 msgid "There are no providers available."
-msgstr ""
+msgstr "Нема доступних провајдера."
 
 #: scripts/core/editor3/components/links/AttachmentList.tsx:83
 msgid ""
@@ -17712,11 +17712,11 @@ msgstr "Дошло је до грешке. Улога не може бити о�
 
 #: scripts/apps/ingest/directives/IngestRoutingContent.ts:55
 msgid "There was an error. Routing scheme cannot be deleted."
-msgstr ""
+msgstr "Дошло је до грешке. Шема усмеравања не може бити обрисана."
 
 #: scripts/apps/ingest/directives/IngestRulesContent.ts:54
 msgid "There was an error. Rule set cannot be deleted."
-msgstr ""
+msgstr "Дошло је до грешке. Скуп правила не може бити обрисан."
 
 #: scripts/apps/templates/directives/TemplatesDirective.ts:371
 msgid "There was an error. Template cannot be deleted."
@@ -17978,7 +17978,7 @@ msgstr "Четвртак"
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:79
 #: scripts/apps/search/views/edit-time-interval.html:15
 msgid "Time"
-msgstr ""
+msgstr "Време"
 
 #: scripts/apps/authoring-react/fields/time/index.tsx:20
 msgid "Time (authoring-react)"
@@ -18836,7 +18836,7 @@ msgstr "Без наслова"
 #: scripts/apps/authoring/views/authoring-topbar.html:120
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:231
 msgid "Update"
-msgstr ""
+msgstr "Ажурирај"
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:256
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:470
@@ -18845,7 +18845,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:4
 msgid "Update Cycle:"
-msgstr ""
+msgstr "Циклус ажурирања:"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:200
 msgid "Update Due:"
@@ -18880,7 +18880,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:121
 msgid "Update every"
-msgstr ""
+msgstr "Ажурирај сваких"
 
 #: scripts/validate-instance-configuration.tsx:42
 msgid "Update or disable incompatible extensions."
@@ -19093,7 +19093,7 @@ msgstr "Хитност"
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:10
 msgid "Urgency stats"
-msgstr ""
+msgstr "Статистика хитности"
 
 #: ../superdesk-planning/client/components/fields/urgency.tsx:21
 msgid "Urgency:"
@@ -20106,7 +20106,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:41
 msgid "closed"
-msgstr ""
+msgstr "затворено"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:112
 msgid "color"
@@ -20549,7 +20549,7 @@ msgstr "ч"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:162
 msgid "hrs"
-msgstr ""
+msgstr "ч"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extension.js:26
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/extension.js:26
@@ -20622,7 +20622,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:72
 msgid "in the last 24 hours."
-msgstr ""
+msgstr "у последња 24 сата."
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "in-progress"
@@ -20694,7 +20694,7 @@ msgstr "презиме"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:80
 msgid "last update and last item arrived."
-msgstr ""
+msgstr "последње ажурирање и последња ставка стигла."
 
 #: scripts/apps/authoring/authoring/directives/ReadingTime.ts:20
 #: scripts/apps/authoring/authoring/directives/ReadingTime.ts:54
@@ -20871,7 +20871,7 @@ msgstr "од"
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:22
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:11
 msgid "on"
-msgstr ""
+msgstr "укључено"
 
 #: ../superdesk-planning/client/utils/events.tsx:1443
 msgid "on all week (including weekends)"
@@ -21140,15 +21140,15 @@ msgstr "претрага"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:118
 msgid "search provider password"
-msgstr ""
+msgstr "лозинка провајдера претраге"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:110
 msgid "search provider username"
-msgstr ""
+msgstr "корисничко име провајдера претраге"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:144
 msgid "sec"
-msgstr ""
+msgstr "сек"
 
 #: scripts/core/views/sdSearchList.html:5
 msgid "selected"
@@ -21164,7 +21164,7 @@ msgstr "слање"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:20
 msgid "since"
-msgstr ""
+msgstr "од"
 
 #: scripts/apps/content-filters/controllers/FilterSearchController.ts:31
 msgid "single value is required"
@@ -21192,7 +21192,7 @@ msgstr ""
 
 #: scripts/apps/search-providers/views/search-provider-config.html:90
 msgid "source of the search provider"
-msgstr ""
+msgstr "извор провајдера претраге"
 
 #: scripts/core/lang/missing-translations-strings.ts:12
 msgid "spiked"
@@ -21309,7 +21309,7 @@ msgstr "текст"
 #: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:61
 #: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:121
 msgid "to"
-msgstr ""
+msgstr "до"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:41
 msgid "to '{{ desk }}'"
@@ -21398,7 +21398,7 @@ msgstr "велика слова"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:98
 msgid "url of the search provider"
-msgstr ""
+msgstr "URL провајдера претраге"
 
 #: scripts/core/lang/missing-translations-strings.ts:37
 msgid "user {{user}} has been added to desk {{desk}}: Please re-login."

--- a/po/sr.po
+++ b/po/sr.po
@@ -137,7 +137,7 @@ msgstr ""
 #: scripts/apps/search/MultiImageEdit.ts:290
 #: scripts/apps/search/MultiImageEdit.ts:311
 msgid "(multiple values)"
-msgstr ""
+msgstr "(више вредности)"
 
 #: scripts/core/ui/views/sd-timezone.html:12
 msgid "(no matches)"
@@ -600,7 +600,7 @@ msgstr ""
 
 #: scripts/apps/search/views/search-parameters.html:218
 msgid "AAP Image Keyword"
-msgstr ""
+msgstr "AAP кључна реч слике"
 
 #: scripts/core/lang/missing-translations-strings.ts:47
 msgid "ABSTRACT is too long"
@@ -696,7 +696,7 @@ msgstr "Прихватио"
 
 #: scripts/apps/authoring-react/article-widgets/suggestions.tsx:126
 msgid "Accepted by {{user}}"
-msgstr ""
+msgstr "Прихватио {{user}}"
 
 #: scripts/apps/publish/views/amazon-sqs-fifo-config.html:33
 msgid "Access Key ID"
@@ -767,7 +767,7 @@ msgstr "Радње"
 #: scripts/apps/authoring-react/subcomponents/authoring-actions-menu.tsx:42
 #: scripts/apps/authoring-react/subcomponents/authoring-actions-menu.tsx:71
 msgid "Actions menu"
-msgstr ""
+msgstr "Мени радњи"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:16
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:243
@@ -1021,7 +1021,7 @@ msgstr "Додај нову локацију"
 
 #: scripts/apps/authoring-react/multi-edit-modal.tsx:318
 msgid "Add article"
-msgstr ""
+msgstr "Додај чланак"
 
 #: ../superdesk-planning/client/components/AddToPlanningModal/index.tsx:72
 msgid ""
@@ -1175,7 +1175,7 @@ msgstr "Додај наслов"
 
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:268
 msgid "Add to Current Package"
-msgstr ""
+msgstr "Додај у тренутни пакет"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningItem.tsx:111
 msgid "Add to Feature Stories"
@@ -1201,7 +1201,7 @@ msgstr "Додај у истакнуте приче"
 
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:283
 msgid "Add to highlight"
-msgstr ""
+msgstr "Додај у истицање"
 
 #: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:138
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:129
@@ -1211,7 +1211,7 @@ msgstr "Додај у радни ток"
 
 #: scripts/apps/authoring-react/fields/urls/editor.tsx:85
 msgid "Add url"
-msgstr ""
+msgstr "Додај URL"
 
 #: scripts/apps/dashboard/views/workspace.html:13
 #: scripts/apps/dashboard/views/workspace.html:14
@@ -1220,7 +1220,7 @@ msgstr "Додај виџет"
 
 #: scripts/apps/authoring-react/fields/attachments/difference-row.tsx:25
 msgid "Added"
-msgstr ""
+msgstr "Додато"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:90
 msgid "Added to featured stories"
@@ -1295,7 +1295,7 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:215
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:233
 msgid "Advanced Search"
-msgstr ""
+msgstr "Напредна претрага"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentFilterPanel.tsx:104
 #: ../superdesk-planning/client/components/Main/SearchPanel.tsx:113
@@ -1310,11 +1310,11 @@ msgstr "Напредни режим"
 
 #: scripts/apps/search/views/search-panel.html:58
 msgid "Advanced search"
-msgstr ""
+msgstr "Напредна претрага"
 
 #: scripts/apps/search/views/search-panel.html:2
 msgid "Advanced search panel"
-msgstr ""
+msgstr "Панел напредне претраге"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:10
 msgid "Africa/Abidjan"
@@ -1551,7 +1551,7 @@ msgstr ""
 
 #: scripts/apps/search/components/fields/authors.tsx:107
 msgid "All authors"
-msgstr ""
+msgstr "Сви аутори"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelPlanningCoveragesForm.tsx:139
 msgid "All coverages cancelled:"
@@ -1581,7 +1581,7 @@ msgstr "Све ставке су учитане"
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:327
 msgid "All items were published successfully."
-msgstr ""
+msgstr "Све ставке су успешно објављене."
 
 #: ../superdesk-planning/client/components/WorkqueueContainer/index.tsx:25
 msgid "All open items"
@@ -1609,15 +1609,15 @@ msgstr "Дозволи уклањање примљених ставки"
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:78
 msgid "Allow adding items that are in progress"
-msgstr ""
+msgstr "Дозволи додавање ставки које су у току"
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:94
 msgid "Allow adding items that are published"
-msgstr ""
+msgstr "Дозволи додавање ставки које су објављене"
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:68
 msgid "Allow audio"
-msgstr ""
+msgstr "Дозволи аудио"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:362
 msgid "Allow field to be toggled"
@@ -1625,11 +1625,11 @@ msgstr "Дозволи укључивање/искључивање поља"
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:38
 msgid "Allow picture"
-msgstr ""
+msgstr "Дозволи слику"
 
 #: scripts/apps/authoring-react/fields/dropdown/config-main.tsx:122
 msgid "Allow selecting multiple values"
-msgstr ""
+msgstr "Дозволи избор више вредности"
 
 #: scripts/extensions/predefinedTextField/dist/src/config.js:80
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:80
@@ -1639,7 +1639,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:58
 msgid "Allow video"
-msgstr ""
+msgstr "Дозволи видео"
 
 #: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:258
 #: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:156
@@ -1667,7 +1667,7 @@ msgstr "Алтернативни текст:"
 
 #: scripts/apps/authoring-react/article-widgets/demo-widget.tsx:27
 msgid "Alter slugline"
-msgstr ""
+msgstr "Измени слаглајн"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:21
 msgid "America/Anchorage"
@@ -1831,7 +1831,7 @@ msgstr "Тип анотације"
 #: scripts/apps/archive/views/html-preview.html:2
 #: scripts/apps/authoring-react/article-widgets/metadata/AnnotationsPreview.tsx:20
 msgid "Annotations"
-msgstr ""
+msgstr "Анотације"
 
 #: scripts/extensions/annotationsLibrary/dist/src/extension.js:70
 #: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/extension.js:70
@@ -1908,7 +1908,7 @@ msgstr "Опис архиве"
 
 #: scripts/apps/search/views/item-repo.html:6
 msgid "Archived"
-msgstr ""
+msgstr "Архивирано"
 
 #: scripts/apps/content-filters/views/manage-filters.html:54
 msgid "Archived Block"
@@ -1926,7 +1926,7 @@ msgstr "Архивирано из"
 
 #: scripts/apps/search/components/ItemContainer.tsx:14
 msgid "Archived from {{desk}}"
-msgstr ""
+msgstr "Архивирано из {{desk}}"
 
 #: ../superdesk-planning/client/components/ConfirmationModal.tsx:162
 msgid "Are you sure ?"
@@ -1935,7 +1935,7 @@ msgstr "Да ли сте сигурни?"
 #: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:214
 #: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:226
 msgid "Are you sure to remove this subscription?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да уклоните ову претплату?"
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:348
 msgid "Are you sure you want to delete Ingest Source?"
@@ -1983,7 +1983,7 @@ msgstr "Да ли сте сигурни да желите да обришете 
 
 #: scripts/apps/search/directives/SavedSearches.ts:112
 msgid "Are you sure you want to delete saved search?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете сачувану претрагу?"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/store/sets/actions.js:95
 #: scripts/extensions/sams/dist/src/store/sets/actions.js:95
@@ -2038,7 +2038,7 @@ msgstr ""
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:188
 msgid "Are you sure you want to spike the items?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да преместите ставке у корпу?"
 
 #: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:64
 msgid "Are you sure you want to unpublish item \"{{headline}}\"?"
@@ -2082,7 +2082,7 @@ msgstr ""
 #: scripts/apps/search/components/TypeIcon.tsx:39
 #: scripts/apps/search/components/TypeIcon.tsx:50
 msgid "Article Type {{type}}"
-msgstr ""
+msgstr "Тип чланка {{type}}"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:107
 msgid "Article Type(s)"
@@ -2116,11 +2116,11 @@ msgstr "Подразумеване вредности чланка"
 
 #: scripts/apps/authoring-react/packages.tsx:116
 msgid "Article is not linked to any packages"
-msgstr ""
+msgstr "Чланак није повезан ни са једним пакетом"
 
 #: scripts/apps/search/components/fields/scheduledDateTime.tsx:23
 msgid "Article is scheduled for {{schedule}}"
-msgstr ""
+msgstr "Чланак је заказан за {{schedule}}"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:304
 msgid "Article preview"
@@ -2461,7 +2461,7 @@ msgstr "Повежи XMP датотеку"
 
 #: scripts/apps/search/components/Associations.tsx:40
 msgid "Associated"
-msgstr ""
+msgstr "Повезано"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:315
 msgid "Associated Event"
@@ -2474,7 +2474,7 @@ msgstr "Повезани догађаји"
 
 #: scripts/apps/search/constants.ts:19
 msgid "Associated Feature Media"
-msgstr ""
+msgstr "Повезани истакнути медиј"
 
 #: ../superdesk-planning/client/components/Coverages/CoveragePreview/index.tsx:151
 msgid "Associated XMP File"
@@ -2499,7 +2499,7 @@ msgstr "Потребно је најмање једно од [{{list}}]."
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:146
 msgid ""
 "At least two versions are needed for comparison. This article has only one."
-msgstr ""
+msgstr "За поређење су потребне најмање две верзије. Овај чланак има само једну."
 
 #: scripts/extensions/sams/dist/src/components/assets/selectAssetModal.js:153
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/selectAssetModal.js:153
@@ -2545,7 +2545,7 @@ msgstr "Прилози"
 
 #: scripts/apps/authoring-react/fields/attachments/index.tsx:41
 msgid "Attachments (authoring-react)"
-msgstr ""
+msgstr "Прилози (authoring-react)"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:45
 #: ../superdesk-planning/client/utils/index.ts:597
@@ -2719,7 +2719,7 @@ msgstr "Назад"
 
 #: scripts/apps/search/views/search-panel.html:5
 msgid "Back / Cancel"
-msgstr ""
+msgstr "Назад / откажи"
 
 #: ../superdesk-planning/client/components/Assignments/SubNavBar.tsx:51
 msgid "Back to group list view"
@@ -2769,7 +2769,7 @@ msgstr ""
 
 #: scripts/apps/search/components/fields/state.tsx:41
 msgid "Being Corrected"
-msgstr ""
+msgstr "У исправљању"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:48
 msgid "Bell"
@@ -2789,7 +2789,7 @@ msgstr ""
 
 #: scripts/apps/search/views/search-parameters.html:258
 msgid "Black&White"
-msgstr ""
+msgstr "Црно-бело"
 
 #: scripts/apps/authoring/packages/views/packages-widget.html:15
 #: scripts/apps/packaging/views/sd-package-item-preview.html:20
@@ -2829,7 +2829,7 @@ msgstr "Подножје тела"
 
 #: scripts/apps/authoring-react/field-adapters/body_footer.ts:36
 msgid "Body footer / Helplines / Contact Information"
-msgstr ""
+msgstr "Подножје тела / помоћне линије / контакт информације"
 
 #: scripts/apps/authoring/views/theme-select.html:107
 #: scripts/apps/authoring/views/theme-select.html:56
@@ -2847,7 +2847,7 @@ msgstr "Подебљано (Ctrl+B)"
 
 #: scripts/apps/authoring-react/fields/boolean/index.ts:23
 msgid "Boolean"
-msgstr ""
+msgstr "Логичко"
 
 #: ../superdesk-planning/client/utils/eventsplanning.ts:23
 #: ../superdesk-planning/client/utils/eventsplanning.ts:26
@@ -3289,7 +3289,7 @@ msgstr "Осетљиво на велика и мала слова"
 
 #: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:96
 msgid "Case sensitive"
-msgstr ""
+msgstr "Осетљиво на велика и мала слова"
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:121
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:431
@@ -3390,9 +3390,9 @@ msgstr "Поставке лимита карактера"
 #: scripts/apps/authoring-react/fields/editor3/editor.tsx:384
 msgid "Character {{chars}} is not allowed"
 msgid_plural "The following characters are not allowed {{chars}}"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Карактер {{chars}} није дозвољен"
+msgstr[1] "Следећи карактери нису дозвољени {{chars}}"
+msgstr[2] "Следећи карактери нису дозвољени {{chars}}"
 
 #: scripts/apps/authoring/authoring/ValidateCharacters.tsx:23
 msgid "Character {{chars}} not allowed in the {{field}}."
@@ -3491,7 +3491,7 @@ msgstr "Очисти налепљени HTML"
 
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:67
 msgid "Clean pasted HTML"
-msgstr ""
+msgstr "Очисти налепљени HTML"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentFilterPanel.tsx:126
 #: ../superdesk-planning/client/components/Main/SearchPanel.tsx:135
@@ -3516,7 +3516,7 @@ msgstr "Очисти све"
 
 #: scripts/apps/search/views/search-parameters.html:261
 msgid "Clear Edge"
-msgstr ""
+msgstr "Очисти ивицу"
 
 #: scripts/apps/authoring/views/article-edit.html:577
 msgid "Clear Embed"
@@ -3552,7 +3552,7 @@ msgstr "Очисти датум и време"
 
 #: scripts/apps/authoring-react/fields/embed/editor.tsx:78
 msgid "Clear embed"
-msgstr ""
+msgstr "Очисти уграђени садржај"
 
 #: scripts/apps/contacts/views/search-panel.html:86
 #: scripts/apps/content-api/views/search-panel.html:22
@@ -3750,7 +3750,7 @@ msgstr "Затвори панел"
 
 #: scripts/apps/search/views/item-preview.html:27
 msgid "Close preview"
-msgstr ""
+msgstr "Затвори преглед"
 
 #: scripts/apps/production-api-keys/utils.tsx:17
 msgid "Close this panel?"
@@ -3778,7 +3778,7 @@ msgstr "Скупи"
 
 #: scripts/apps/authoring-react/multi-edit-modal.tsx:158
 msgid "Collapse widgets"
-msgstr ""
+msgstr "Скупи виџете"
 
 #: scripts/apps/vocabularies/services/SchemaFactory.ts:8
 msgid "Color"
@@ -3848,7 +3848,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:185
 msgid "Compare"
-msgstr ""
+msgstr "Упореди"
 
 #: scripts/apps/authoring/compare-versions/views/compare-versions.html:2
 msgid "Compare Versions"
@@ -3866,7 +3866,7 @@ msgstr "Упореди верзије"
 
 #: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:124
 msgid "Comparing \"{{x}}\"(primary) to \"{{y}}\"(secondary)"
-msgstr ""
+msgstr "Поређење \"{{x}}\" (примарно) са \"{{y}}\" (секундарно)"
 
 #: ../superdesk-planning/client/constants/assignments.ts:193
 msgid "Complete Assignment"
@@ -4151,11 +4151,11 @@ msgstr "Садржај закључан"
 
 #: scripts/apps/search/components/TypeIcon.tsx:26
 msgid "Content profile: {{name}}"
-msgstr ""
+msgstr "Профил садржаја: {{name}}"
 
 #: scripts/apps/search/views/search-filters.html:2
 msgid "Content types"
-msgstr ""
+msgstr "Типови садржаја"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:95
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:77
@@ -4274,7 +4274,7 @@ msgstr "Обавештење о ауторским правима:"
 
 #: scripts/apps/search/views/multi-image-edit.html:69
 msgid "Copyright:"
-msgstr ""
+msgstr "Ауторска права:"
 
 #: ../superdesk-analytics/client/utils.js:159
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/correct-action.tsx:10
@@ -4292,7 +4292,7 @@ msgstr "Исправи ставку"
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:87
 #: scripts/apps/search/components/fields/state.tsx:39
 msgid "Corrected"
-msgstr ""
+msgstr "Исправљено"
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:182
 msgid "Corrected by"
@@ -4313,7 +4313,7 @@ msgstr "Исправку отказао"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:485
 msgid "Correction cancelled by {{user}}"
-msgstr ""
+msgstr "Исправку отказао {{user}}"
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:467
 msgid "Correction has been removed"
@@ -4787,7 +4787,7 @@ msgstr "Креирао овај корисник"
 
 #: scripts/apps/search/directives/DateFilters.ts:77
 msgid "Created from"
-msgstr ""
+msgstr "Креирано из"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:92
 msgid "Created from 'update repetitions'"
@@ -4811,7 +4811,7 @@ msgstr "Креирано из истицања"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:380
 msgid "Created from highlight({{x}}) by {{user}}"
-msgstr ""
+msgstr "Креирано из истицања ({{x}}) од {{user}}"
 
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:2
 msgid "Created on"
@@ -4819,7 +4819,7 @@ msgstr "Креирано"
 
 #: scripts/apps/search/directives/DateFilters.ts:78
 msgid "Created to"
-msgstr ""
+msgstr "Креирано до"
 
 #: scripts/extensions/sams/dist/src/components/common/versionUserDateLines.js:95
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/versionUserDateLines.js:66
@@ -4845,7 +4845,7 @@ msgstr "Датум креирања"
 #: scripts/apps/search/constants.ts:11
 #: scripts/apps/search/views/search-parameters.html:131
 msgid "Creator"
-msgstr ""
+msgstr "Креатор"
 
 #: scripts/apps/production-api-keys/config.ts:49
 msgid "Credentials"
@@ -4869,7 +4869,7 @@ msgstr "Заслуге:"
 
 #: scripts/apps/search/views/search-filters.html:57
 msgid "Credits"
-msgstr ""
+msgstr "Заслуге"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:248
 #: scripts/apps/publish/views/subscribers.html:234
@@ -4915,7 +4915,7 @@ msgstr "Тренутно изабрано"
 
 #: scripts/apps/search/views/multi-image-edit.html:93
 msgid "Currently editing: {{getSelectedItemsLength()}} items"
-msgstr ""
+msgstr "Тренутно се уређује: {{getSelectedItemsLength()}} ставки"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningSelectedList.tsx:23
 msgid "Currently selected"
@@ -5042,7 +5042,7 @@ msgstr "Датум"
 
 #: scripts/apps/authoring-react/fields/date/index.tsx:17
 msgid "Date (authoring-react)"
-msgstr ""
+msgstr "Датум (authoring-react)"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:177
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:91
@@ -5070,7 +5070,7 @@ msgstr "Датум ажурирања"
 
 #: scripts/apps/search/directives/DateFilters.ts:76
 msgid "Date created"
-msgstr ""
+msgstr "Датум креирања"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:183
 msgid "Date field is required"
@@ -5082,7 +5082,7 @@ msgstr "Датум је у прошлости"
 
 #: scripts/apps/search/directives/DateFilters.ts:84
 msgid "Date modified"
-msgstr ""
+msgstr "Датум измене"
 
 #: ../superdesk-planning/client/apps/Planning/SubNavDatePicker.tsx:71
 #: ../superdesk-planning/client/components/UI/Form/DateInput/index.tsx:209
@@ -5092,15 +5092,15 @@ msgstr "Бирач датума"
 #: scripts/apps/search/constants.ts:21
 #: scripts/apps/search/directives/DateFilters.ts:92
 msgid "Date published"
-msgstr ""
+msgstr "Датум објаве"
 
 #: scripts/apps/search/directives/DateFilters.ts:100
 msgid "Date scheduled"
-msgstr ""
+msgstr "Заказани датум"
 
 #: scripts/apps/authoring-react/fields/datetime/preview.tsx:16
 msgid "Date time (AUTHORING-REACT)"
-msgstr ""
+msgstr "Датум време (AUTHORING-REACT)"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:415
 msgid "Date/Time"
@@ -5121,7 +5121,7 @@ msgstr "Датумска линија"
 
 #: scripts/apps/authoring-react/fields/dateline/index.tsx:27
 msgid "Dateline (authoring-react)"
-msgstr ""
+msgstr "Датумска линија (authoring-react)"
 
 #: ../superdesk-planning/client/components/fields/editor/DatesGroup.tsx:40
 #: ../superdesk-planning/client/components/fields/index.tsx:232
@@ -5137,7 +5137,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/fields/datetime/index.tsx:24
 msgid "Datetime (authoring-react)"
-msgstr ""
+msgstr "Датум-време (authoring-react)"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:157
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:77
@@ -5359,7 +5359,7 @@ msgstr "Обриши линк"
 #: scripts/apps/search/views/saved-searches.html:16
 #: scripts/apps/search/views/saved-searches.html:45
 msgid "Delete search"
-msgstr ""
+msgstr "Обриши претрагу"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:35
 msgid "Delete this Schedule"
@@ -5384,7 +5384,7 @@ msgstr "Тип испоруке"
 
 #: scripts/apps/authoring-react/article-widgets/demo-widget.tsx:10
 msgid "Demo widget"
-msgstr ""
+msgstr "Демо виџет"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:169
 #: ../superdesk-planning/client/components/OrderBar/OrderDirectionIcon.tsx:20
@@ -5480,7 +5480,7 @@ msgstr "Опис у тексту"
 
 #: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:135
 msgid "Description:"
-msgstr ""
+msgstr "Опис:"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:328
 #: scripts/apps/search/views/multi-image-edit.html:33
@@ -5589,7 +5589,7 @@ msgstr "Статус деска је застарео, освежите."
 #: scripts/apps/search/views/saved-search-manage-subscribers.html:167
 #: scripts/apps/search/views/saved-search-manage-subscribers.html:88
 msgid "Desk subscription"
-msgstr ""
+msgstr "Претплата деска"
 
 #: scripts/apps/authoring-react/toolbar/template-modal.tsx:126
 msgid "Desk template"
@@ -5706,7 +5706,7 @@ msgstr "Речник са називом {{dictionary.name}} већ постој
 msgid ""
 "Difference view for \"{{type}}\" fields is not implemented. Latter version "
 "is being displayed."
-msgstr ""
+msgstr "Приказ разлика за \"{{type}}\" поља није имплементиран. Приказана је новија верзија."
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:72
 msgid "Digital/Internet"
@@ -5731,7 +5731,7 @@ msgstr "Онемогући избор целе категорије"
 
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:487
 msgid "Disable spellchecker"
-msgstr ""
+msgstr "Онемогући проверу правописа"
 
 #: scripts/apps/users/config.ts:76
 msgid "Disable user"
@@ -5763,7 +5763,7 @@ msgstr "Забрани слање ставки на овај деск"
 
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:76
 msgid "Disallowed characters"
-msgstr ""
+msgstr "Недозвољени карактери"
 
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:379
 #: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:217
@@ -5825,7 +5825,7 @@ msgstr ""
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:167
 msgid "Do you want to delete the items permanently?"
-msgstr ""
+msgstr "Желите ли да трајно обришете ставке?"
 
 #: ../superdesk-planning/client/actions/locations.ts:66
 msgid "Do you want to delete the location \"{{ name }}\"?"
@@ -5833,7 +5833,7 @@ msgstr "Желите ли да обришете локацију \"{{ name }}\"?
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:391
 msgid "Do you want to deschedule articles?"
-msgstr ""
+msgstr "Желите ли да откажете заказивање чланака?"
 
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:264
 msgid "Do you want to link it to that assignment ?"
@@ -6029,7 +6029,7 @@ msgstr "Пустите ставке планирања овде"
 
 #: scripts/apps/authoring-react/fields/dropdown/index.ts:21
 msgid "Dropdown (authoring-react)"
-msgstr ""
+msgstr "Падајући мени (authoring-react)"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:174
 msgid "Dropped item is not a planning item"
@@ -6091,16 +6091,16 @@ msgstr "Дуплирај садржај унутар деска"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:55
 msgid "Duplicate ID: {{x}}"
-msgstr ""
+msgstr "ИД дупликата: {{x}}"
 
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:239
 msgid "Duplicate In Place"
-msgstr ""
+msgstr "Дуплирај на месту"
 
 #: scripts/apps/archive/index.tsx:172
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:225
 msgid "Duplicate To"
-msgstr ""
+msgstr "Дуплирај на"
 
 #: scripts/apps/monitoring/index.ts:125
 msgid "Duplicate an item"
@@ -6148,7 +6148,7 @@ msgstr "Дуплирао"
 
 #: scripts/apps/search/views/item-preview.html:15
 msgid "Duplicates"
-msgstr ""
+msgstr "Дупликати"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:63
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:95
@@ -6162,7 +6162,7 @@ msgstr "Трајање"
 
 #: scripts/apps/authoring-react/fields/duration/index.tsx:20
 msgid "Duration (authoring-react)"
-msgstr ""
+msgstr "Трајање (authoring-react)"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:54
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:60
@@ -6500,7 +6500,7 @@ msgstr "Уреди у новом прозору"
 #: scripts/apps/authoring-react/fields/linked-items/editor.tsx:54
 #: scripts/apps/authoring-react/fields/package-items/editor.tsx:51
 msgid "Edit in new window"
-msgstr ""
+msgstr "Уреди у новом прозору"
 
 #: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:492
 #: ../superdesk-planning/client/constants/events.ts:167
@@ -6558,7 +6558,7 @@ msgstr "Уреди шему"
 #: scripts/apps/search/views/saved-searches.html:15
 #: scripts/apps/search/views/saved-searches.html:44
 msgid "Edit search"
-msgstr ""
+msgstr "Уреди претрагу"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:46
 msgid "Edit source"
@@ -6589,7 +6589,7 @@ msgstr "Уређивач 3"
 
 #: scripts/apps/authoring-react/fields/editor3/index.tsx:57
 msgid "Editor3 (authoring-react)"
-msgstr ""
+msgstr "Editor3 (authoring-react)"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:295
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:147
@@ -6602,7 +6602,7 @@ msgstr "Уредничка напомена:"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:348
 msgid "Editorial note"
-msgstr ""
+msgstr "Уредничка напомена"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:253
 msgid "Ednote"
@@ -6637,19 +6637,19 @@ msgstr ""
 
 #: scripts/apps/search/components/fields/embargo.tsx:23
 msgid "Embargo until {{date}}"
-msgstr ""
+msgstr "Ембарго до {{date}}"
 
 #: scripts/apps/search/components/fields/embargo.tsx:30
 msgid "Embargo: {{text}}"
-msgstr ""
+msgstr "Ембарго: {{text}}"
 
 #: scripts/apps/authoring-react/fields/embed/index.tsx:18
 msgid "Embed (authoring-react)"
-msgstr ""
+msgstr "Уграђени садржај (authoring-react)"
 
 #: scripts/apps/authoring-react/fields/embed/editor.tsx:106
 msgid "Embed code"
-msgstr ""
+msgstr "Код за уграђивање"
 
 #: scripts/core/editor3/components/BaseUnstyledComponent.tsx:103
 msgid "Embedding articles is not configured for this content profile field"
@@ -6673,7 +6673,7 @@ msgstr "Омогући ако конфигурација не може бити 
 
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:488
 msgid "Enable spellchecker"
-msgstr ""
+msgstr "Омогући проверу правописа"
 
 #: scripts/apps/users/config.ts:108
 msgid "Enable user"
@@ -6787,7 +6787,7 @@ msgstr "Грешка приликом креирања истицања."
 #: scripts/apps/search/controllers/get-multi-actions.tsx:339
 #: scripts/apps/search/controllers/get-multi-actions.tsx:381
 msgid "Error on item:"
-msgstr ""
+msgstr "Грешка на ставци:"
 
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:21
 msgid "Error sending as"
@@ -6795,7 +6795,7 @@ msgstr "Грешка приликом слања као"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:74
 msgid "Error sending as {{name}} to {{destination}} at {{date}}"
-msgstr ""
+msgstr "Грешка приликом слања као {{name}} на {{destination}} у {{date}}"
 
 #: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:28
 msgid "Error. Dictionary not saved."
@@ -6811,11 +6811,11 @@ msgstr "Грешка. Ставка није ажурирана."
 
 #: scripts/apps/search/directives/SavedSearches.ts:119
 msgid "Error. Saved search not deleted."
-msgstr ""
+msgstr "Грешка. Сачувана претрага није обрисана."
 
 #: scripts/apps/search/directives/SaveSearch.ts:83
 msgid "Error. Search could not be saved."
-msgstr ""
+msgstr "Грешка. Претрага није могла бити сачувана."
 
 #: scripts/apps/users/controllers/SessionsDeleteCommand.ts:15
 msgid "Error. Sessions could not be cleared."
@@ -7270,11 +7270,11 @@ msgstr "Сваког сата"
 
 #: scripts/apps/search/views/edit-time-interval.html:4
 msgid "Every day"
-msgstr ""
+msgstr "Сваког дана"
 
 #: scripts/apps/search/views/edit-time-interval.html:18
 msgid "Every hour"
-msgstr ""
+msgstr "Сваког сата"
 
 #: ../superdesk-planning/client/utils/events.tsx:1402
 msgid "Every {{interval}} day(s)"
@@ -7339,7 +7339,7 @@ msgstr ""
 
 #: scripts/apps/search/views/search-parameters.html:151
 msgid "Exclude spiked content"
-msgstr ""
+msgstr "Изостави садржај у корпи"
 
 #: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:151
 msgid "Existing Locations"
@@ -7572,7 +7572,7 @@ msgstr "Одбацивање неких измена није успело"
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:258
 msgid "Failed to duplicate the item"
-msgstr ""
+msgstr "Дуплирање ставке није успело"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:61
 #: ../superdesk-analytics/client/charts/services/ChartManager.js:30
@@ -7942,7 +7942,7 @@ msgstr "Преглед нових функција"
 
 #: scripts/apps/authoring-react/field-adapters/feature_media.ts:21
 msgid "Feature media"
-msgstr ""
+msgstr "Истакнути медиј"
 
 #: scripts/apps/users/views/user-preferences.html:13
 #: scripts/apps/users/views/user-preferences.html:27
@@ -8042,7 +8042,7 @@ msgstr ""
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:78
 #: scripts/core/interactive-article-actions-panel/action-tabs.tsx:11
 msgid "Fetch to"
-msgstr ""
+msgstr "Преузми у"
 
 #: scripts/api/article-fetch.tsx:104
 msgid "Fetch valid({{count}})"
@@ -8050,7 +8050,7 @@ msgstr "Преузми важеће ({{count}})"
 
 #: scripts/apps/search/components/fields/state.tsx:33
 msgid "Fetched"
-msgstr ""
+msgstr "Преузето"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:269
 #: scripts/apps/authoring/versioning/history/views/history.html:76
@@ -8074,7 +8074,7 @@ msgstr "Поље \"{{field}}\" ће бити трајно обрисано."
 
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:88
 msgid "Field ID to prefill from"
-msgstr ""
+msgstr "ИД поља за унапред попуњавање"
 
 #: ../superdesk-planning/client/validators/planning.ts:108
 #: scripts/apps/authoring-react/authoring-react.tsx:1007
@@ -8263,7 +8263,7 @@ msgstr "Пронађи и замени"
 
 #: scripts/apps/search/index.ts:108
 msgid "Find live and archived content"
-msgstr ""
+msgstr "Пронађи живи и архивирани садржај"
 
 #: scripts/apps/users/config.ts:39
 msgid "Find your colleagues"
@@ -8301,7 +8301,7 @@ msgstr "Прво креирано"
 
 #: scripts/apps/search/views/search-filters.html:118
 msgid "Flags"
-msgstr ""
+msgstr "Заставице"
 
 #: scripts/apps/archive/views/metadata-view.html:166
 msgid "Flash"
@@ -8436,7 +8436,7 @@ msgstr "Од"
 #: scripts/apps/search/constants.ts:12
 #: scripts/apps/search/views/search-parameters.html:102
 msgid "From Desk"
-msgstr ""
+msgstr "Са деска"
 
 #: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:73
 #: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:84
@@ -8543,7 +8543,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/fields/embed/editor.tsx:40
 msgid "Generate from URL"
-msgstr ""
+msgstr "Генериши из URL-а"
 
 #: scripts/apps/publish/views/subscribers.html:318
 msgid "Generate token"
@@ -8606,7 +8606,7 @@ msgstr ""
 
 #: scripts/apps/search/views/saved-searches.html:36
 msgid "Global Saved Searches"
-msgstr ""
+msgstr "Глобалне сачуване претраге"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:66
 msgid "Global saved searches"
@@ -8712,7 +8712,7 @@ msgstr "Управљање групама"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:402
 msgid "Guid"
-msgstr ""
+msgstr "Guid"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:20
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:79
@@ -8885,11 +8885,11 @@ msgstr "Сакриј медиј"
 
 #: scripts/apps/authoring-react/fields/embed/editor.tsx:55
 msgid "Hide preview"
-msgstr ""
+msgstr "Сакриј преглед"
 
 #: scripts/apps/search/components/fields/nested-link.tsx:27
 msgid "Hide previous items"
-msgstr ""
+msgstr "Сакриј претходне ставке"
 
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:6
 msgid "Hide sent/queued items"
@@ -9039,7 +9039,7 @@ msgstr "Идентификатор медија унутар HTML предлош
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:53
 msgid "Identifiers have to be specified for all items."
-msgstr ""
+msgstr "Идентификатори морају бити наведени за све ставке."
 
 #: scripts/apps/workspace/content/views/profile-settings.html:173
 msgid ""
@@ -9232,7 +9232,7 @@ msgstr ""
 
 #: scripts/apps/search/views/search-parameters.html:152
 msgid "Include spiked content"
-msgstr ""
+msgstr "Укључи садржај у корпи"
 
 #: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:15
 msgid "Included Statistics"
@@ -9361,7 +9361,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:270
 msgid "Ingest sequence"
-msgstr ""
+msgstr "Секвенца пријема"
 
 #: ../superdesk-planning/client/components/AuditInformation/index.tsx:49
 msgid "Ingest: {{ name }}"
@@ -9394,7 +9394,7 @@ msgstr "Тип уноса"
 
 #: scripts/apps/authoring-react/fields/tag-input/editor.tsx:23
 msgid "Input tags here"
-msgstr ""
+msgstr "Унесите ознаке овде"
 
 #: scripts/core/editor3/components/links/LinkInput.tsx:221
 #: scripts/core/editor3/components/links/LinkInput.tsx:253
@@ -9536,7 +9536,7 @@ msgstr "Ставка \"{{name}}\" је закључана и не може би�
 #: scripts/apps/archive/controllers/DuplicateController.ts:20
 #: scripts/apps/search/controllers/get-multi-actions.tsx:256
 msgid "Item Duplicated"
-msgstr ""
+msgstr "Ставка дуплирана"
 
 #: scripts/apps/ingest/controllers/ExternalSourceController.ts:25
 msgid "Item Fetched."
@@ -9610,7 +9610,7 @@ msgstr "Ставка је измењена откад је отворена. З�
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:60
 msgid "Item has not been transmitted to any subscriber"
-msgstr ""
+msgstr "Ставка није пренета ниједном претплатнику"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/index.tsx:41
 #: scripts/apps/authoring/versioning/views/versioning.html:6
@@ -9643,7 +9643,7 @@ msgstr "Ставка означена"
 
 #: scripts/apps/authoring-react/fields/media/editor.tsx:134
 msgid "Item not added. Maximum limit of {{n}} items exceeded."
-msgstr ""
+msgstr "Ставка није додата. Прекорачен је максимални лимит од {{n}} ставки."
 
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:65
 msgid "Item not found!"
@@ -9651,7 +9651,7 @@ msgstr ""
 
 #: scripts/apps/search/directives/ItemGlobalSearch.ts:49
 msgid "Item not found..."
-msgstr ""
+msgstr "Ставка није пронађена..."
 
 #: ../superdesk-planning/client/controllers/UnlinkAssignmentController.tsx:27
 msgid "Item not linked to a Planning item."
@@ -9703,7 +9703,7 @@ msgstr "Објава ставке је успешно повучена."
 
 #: scripts/apps/search/MultiImageEdit.ts:198
 msgid "Item {{headline}} unlocked by another user."
-msgstr ""
+msgstr "Ставку {{headline}} откључао је други корисник."
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:96
 msgid "Item {{headline}} was unlocked by {{username}}."
@@ -9892,19 +9892,19 @@ msgstr "Последње"
 
 #: scripts/apps/search/directives/DateFilters.ts:47
 msgid "Last 24 Hours"
-msgstr ""
+msgstr "Последња 24 сата"
 
 #: scripts/apps/search/directives/DateFilters.ts:31
 msgid "Last 30 Days"
-msgstr ""
+msgstr "Последњих 30 дана"
 
 #: scripts/apps/search/directives/DateFilters.ts:39
 msgid "Last 7 Days"
-msgstr ""
+msgstr "Последњих 7 дана"
 
 #: scripts/apps/search/directives/DateFilters.ts:55
 msgid "Last 8 Hours"
-msgstr ""
+msgstr "Последњих 8 сати"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:63
 #: scripts/core/lang/missing-translations-strings.ts:20
@@ -9958,7 +9958,7 @@ msgstr "Последње освежено у"
 
 #: scripts/apps/search/views/saved-search-subscribe.html:21
 msgid "Last report sent on:"
-msgstr ""
+msgstr "Последњи извештај послат:"
 
 #: scripts/apps/archive/views/metadata-view.html:93
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:381
@@ -10091,11 +10091,11 @@ msgstr "Повезао"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:398
 msgid "Linked by {{user}}"
-msgstr ""
+msgstr "Повезао {{user}}"
 
 #: scripts/apps/authoring-react/fields/linked-items/index.tsx:28
 msgid "Linked items (authoring-react)"
-msgstr ""
+msgstr "Повезане ставке (authoring-react)"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:121
 msgid "LinkedIn"
@@ -10324,7 +10324,7 @@ msgstr "Макрои"
 
 #: scripts/apps/authoring-react/macros/macros.tsx:37
 msgid "Macros widget"
-msgstr ""
+msgstr "Виџет макроа"
 
 #: scripts/core/menu/views/menu.html:85
 msgid "Main menu"
@@ -10340,7 +10340,7 @@ msgstr "Учини јавним"
 
 #: scripts/apps/search/views/save-search-dialog.html:14
 msgid "Make global"
-msgstr ""
+msgstr "Учини глобалним"
 
 #: scripts/apps/users/views/change-avatar.html:53
 msgid "Make sure you're looking the best"
@@ -10357,7 +10357,7 @@ msgstr ""
 #: scripts/extensions/availability-manager/dist/src/settings/availability-settings.js:190
 #: scripts/extensions/availability-manager/src/settings/availability-settings.tsx:330
 msgid "Manage"
-msgstr ""
+msgstr "Управљај"
 
 #: ../superdesk-planning/client/components/Agendas/ManageAgendasModal.tsx:67
 #: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:22
@@ -10453,7 +10453,7 @@ msgstr ""
 #: scripts/apps/search/views/saved-searches.html:27
 #: scripts/apps/search/views/saved-searches.html:56
 msgid "Manage subscription"
-msgstr ""
+msgstr "Управљај претплатом"
 
 #: scripts/apps/users/config.ts:145
 msgid "Manage user roles"
@@ -10465,11 +10465,11 @@ msgstr "Управљај корисницима"
 
 #: scripts/apps/search/views/saved-search-manage-subscribers.html:5
 msgid "Manage:"
-msgstr ""
+msgstr "Управљај:"
 
 #: scripts/apps/authoring-react/fields/dropdown/config-main.tsx:86
 msgid "Manual entry"
-msgstr ""
+msgstr "Ручни унос"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:128
 msgid "Map Marker"
@@ -10536,13 +10536,13 @@ msgstr "Означи ставке за листе истицања/прегле�
 #: scripts/apps/search/constants.ts:17
 #: scripts/apps/search/views/search-parameters.html:71
 msgid "Marked Desks"
-msgstr ""
+msgstr "Означени дескови"
 
 #: scripts/apps/archive/views/marked_item_title.html:13
 #: scripts/apps/search/components/HighlightsList.tsx:74
 #: scripts/apps/search/components/MarkedDesksList.tsx:86
 msgid "Marked For"
-msgstr ""
+msgstr "Означено за"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:311
 msgid "Marked For Not Publication"
@@ -10559,7 +10559,7 @@ msgstr "Означено за"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:319
 msgid "Marked for desk {{x}} by {{user}}"
-msgstr ""
+msgstr "Означено за деск {{x}} од {{user}}"
 
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:256
 #: scripts/apps/authoring-react/toolbar/mark-for-desks/mark-for-desks-modal.tsx:37
@@ -10569,7 +10569,7 @@ msgstr "Означено за дескове"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:285
 msgid "Marked for highlight {{x}} by {{user}}"
-msgstr ""
+msgstr "Означено за истицање {{x}} од {{user}}"
 
 #: scripts/extensions/markForUser/dist/src/extension.js:19
 #: scripts/extensions/markForUser/dist/src/extension.js:64
@@ -10635,7 +10635,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:25
 msgid "Maximum items allowed"
-msgstr ""
+msgstr "Максимални дозвољени број ставки"
 
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:44
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:216
@@ -10655,7 +10655,7 @@ msgstr "Медиј"
 
 #: scripts/apps/authoring-react/fields/media/index.tsx:21
 msgid "Media (authoring-react)"
-msgstr ""
+msgstr "Медиј (authoring-react)"
 
 #: scripts/apps/contacts/index.ts:22
 msgid "Media Contacts"
@@ -10764,7 +10764,7 @@ msgstr "Минути"
 
 #: scripts/apps/authoring-react/macros/macros.tsx:71
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Разно"
 
 #: scripts/apps/authoring/views/authoring-header.html:61
 msgid "Missing Link"
@@ -10798,11 +10798,11 @@ msgstr ""
 
 #: scripts/apps/search/directives/DateFilters.ts:85
 msgid "Modified from"
-msgstr ""
+msgstr "Измењено од"
 
 #: scripts/apps/search/directives/DateFilters.ts:86
 msgid "Modified to"
-msgstr ""
+msgstr "Измењено до"
 
 #: ../superdesk-planning/client/components/UI/List/CreatedUpdatedColumn.tsx:29
 msgid "Modified: {{ datetime }}"
@@ -10894,7 +10894,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:209
 msgid "Move down"
-msgstr ""
+msgstr "Помери доле"
 
 #: scripts/apps/monitoring/index.ts:113
 msgid "Move focus to next stage or group"
@@ -10906,7 +10906,7 @@ msgstr "Премести фокус на претходну фазу или гр
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:197
 msgid "Move up"
-msgstr ""
+msgstr "Помери горе"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:253
 #: scripts/apps/authoring/versioning/history/views/history.html:75
@@ -10946,7 +10946,7 @@ msgstr "Вишеструки избор"
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:124
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:157
 msgid "Multi-edit"
-msgstr ""
+msgstr "Више уређивања"
 
 #: scripts/core/editor3/components/toolbar/index.tsx:320
 msgid "Multi-line quote"
@@ -11027,7 +11027,7 @@ msgstr ""
 
 #: scripts/apps/search/views/saved-searches.html:7
 msgid "My Saved Searches"
-msgstr ""
+msgstr "Моје сачуване претраге"
 
 #: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:92
 msgid "My Templates"
@@ -11152,7 +11152,7 @@ msgstr ""
 #: scripts/apps/search/views/search-filters.html:85
 #: scripts/apps/search/views/search-filters.html:98
 msgid "Negate"
-msgstr ""
+msgstr "Негирај"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:51
 msgid "Neutral Gray"
@@ -11188,7 +11188,7 @@ msgstr "Нова фаза"
 
 #: scripts/apps/search/views/saved-search-subscribe.html:6
 msgid "New subscription"
-msgstr ""
+msgstr "Нова претплата"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:133
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:133
@@ -11209,11 +11209,11 @@ msgstr "Следеће"
 
 #: scripts/apps/search/directives/DateFilters.ts:23
 msgid "Next 3 Months"
-msgstr ""
+msgstr "Следећа 3 месеца"
 
 #: scripts/apps/search/directives/DateFilters.ts:15
 msgid "Next Month"
-msgstr ""
+msgstr "Следећи месец"
 
 #: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:29
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:162
@@ -11223,7 +11223,7 @@ msgstr "Следећа недеља"
 #: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:115
 #: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:114
 msgid "Next match"
-msgstr ""
+msgstr "Следеће поклапање"
 
 #: scripts/apps/users/config.ts:158
 msgid "Next user"
@@ -11402,7 +11402,7 @@ msgstr "Није изабран деск"
 #: scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx:174
 #: scripts/core/interactive-article-actions-panel/actions/send-to-tab.tsx:40
 msgid "No destinations are available."
-msgstr ""
+msgstr "Нема доступних дестинација."
 
 #: scripts/core/spellcheck/spellcheck.ts:527
 msgid "No dictionary available for spell checking."
@@ -11440,7 +11440,7 @@ msgstr "Форматери за {{formats}} нису пронађени прил
 
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:206
 msgid "No highlights have been created yet."
-msgstr ""
+msgstr "Још нису креирана истицања."
 
 #: scripts/apps/users/views/change-avatar.html:15
 msgid "No image"
@@ -11470,7 +11470,7 @@ msgstr "Ниједна ставка није пронађена."
 
 #: scripts/apps/search/components/WidgetItemList.tsx:38
 msgid "No items in this stage"
-msgstr ""
+msgstr "Нема ставки у овој фази"
 
 #: ../superdesk-planning/client/actions/multiSelect.ts:208
 msgid "No items selected."
@@ -11498,7 +11498,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/macros/macros.tsx:317
 msgid "No macros configured."
-msgstr ""
+msgstr "Нема подешених макроа."
 
 #: scripts/extensions/annotationsLibrary/dist/src/AnnotationsSelect.js:24
 #: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/AnnotationsSelect.js:24
@@ -11693,11 +11693,11 @@ msgstr "Неактивно"
 
 #: scripts/apps/search/constants.ts:35
 msgid "Not Category"
-msgstr ""
+msgstr "Није категорија"
 
 #: scripts/apps/search/constants.ts:32
 msgid "Not Desk"
-msgstr ""
+msgstr "Није деск"
 
 #: scripts/apps/desks/views/settings.html:87
 msgid "Not Expired"
@@ -11722,15 +11722,15 @@ msgstr "Није за објаву"
 
 #: scripts/apps/search/constants.ts:34
 msgid "Not Genre"
-msgstr ""
+msgstr "Није жанр"
 
 #: scripts/apps/search/constants.ts:41
 msgid "Not Language"
-msgstr ""
+msgstr "Није језик"
 
 #: scripts/apps/search/constants.ts:39
 msgid "Not Legal"
-msgstr ""
+msgstr "Није правно"
 
 #: ../superdesk-planning/client/components/fields/editor/LockState.tsx:21
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:148
@@ -11739,23 +11739,23 @@ msgstr "Није закључано"
 
 #: scripts/apps/search/constants.ts:38
 msgid "Not Priority"
-msgstr ""
+msgstr "Није приоритет"
 
 #: scripts/apps/search/constants.ts:40
 msgid "Not Sms"
-msgstr ""
+msgstr "Није СМС"
 
 #: scripts/apps/search/constants.ts:37
 msgid "Not Source"
-msgstr ""
+msgstr "Није извор"
 
 #: scripts/apps/search/constants.ts:33
 msgid "Not Type"
-msgstr ""
+msgstr "Није тип"
 
 #: scripts/apps/search/constants.ts:36
 msgid "Not Urgency"
-msgstr ""
+msgstr "Није хитност"
 
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:10
 msgid "Not been transmitted to any subscriber"
@@ -11877,7 +11877,7 @@ msgstr ""
 
 #: scripts/apps/search/views/search-parameters.html:196
 msgid "Object Name (Slugline)"
-msgstr ""
+msgstr "Назив објекта (слаглајн)"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:26
 #: scripts/extensions/auto-tagging-widget/dist/src/groups.js:26
@@ -11995,7 +11995,7 @@ msgstr "Дозвољени су само следећи типови медиј�
 
 #: scripts/apps/authoring-react/fields/media/editor.tsx:159
 msgid "Only the following media types are allowed: {{types}}"
-msgstr ""
+msgstr "Дозвољени су само следећи типови медија: {{types}}"
 
 #: scripts/core/auth/secure-login.html:28
 msgid "Oops! Authentication has been denied."
@@ -12067,7 +12067,7 @@ msgstr "Отвори вишеструко уређивање"
 
 #: scripts/apps/authoring-react/packages.tsx:106
 msgid "Open package"
-msgstr ""
+msgstr "Отвори пакет"
 
 #: scripts/apps/workspace/index.ts:37
 msgid "Open personal"
@@ -12117,7 +12117,7 @@ msgstr "Оператор"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:105
 msgid "Options:"
-msgstr ""
+msgstr "Опције:"
 
 #: scripts/extensions/sams/dist/src/apps/samsAttachmentsWidget.js:199
 #: scripts/extensions/sams/dist/src/apps/samsAttachmentsWidget.js:209
@@ -12195,7 +12195,7 @@ msgstr ""
 
 #: scripts/apps/search/components/fields/translations.tsx:26
 msgid "Original Article"
-msgstr ""
+msgstr "Оригинални чланак"
 
 #: scripts/apps/archive/views/metadata-view.html:102
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:176
@@ -12204,7 +12204,7 @@ msgstr "Оригинални ИД"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:386
 msgid "Original Id"
-msgstr ""
+msgstr "Оригинални ИД"
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:19
 msgid "Original Image"
@@ -12223,7 +12223,7 @@ msgstr "Оригинални креатор"
 
 #: scripts/apps/authoring-react/fields/media/media-metadata.tsx:43
 msgid "Original size"
-msgstr ""
+msgstr "Оригинална величина"
 
 #: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:432
 #: scripts/apps/authoring/tests/changeImage.spec.ts:56
@@ -12374,11 +12374,11 @@ msgstr "Запакуј појединачне ставке"
 #: scripts/apps/authoring-react/data-layer.ts:212
 #: scripts/apps/authoring-react/field-adapters/package_items.ts:9
 msgid "Package items"
-msgstr ""
+msgstr "Ставке пакета"
 
 #: scripts/apps/authoring-react/fields/package-items/index.tsx:36
 msgid "Package items (authoring-react)"
-msgstr ""
+msgstr "Ставке пакета (authoring-react)"
 
 #: scripts/apps/archive/views/item-preview.html:5
 msgid "Package preview"
@@ -12395,7 +12395,7 @@ msgstr "Пакети"
 
 #: scripts/apps/authoring-react/data-layer.ts:223
 msgid "Packages profile"
-msgstr ""
+msgstr "Профил пакета"
 
 #: scripts/core/list/views/sdPaginationAlt.html:2
 msgid "Page"
@@ -12432,7 +12432,7 @@ msgstr "Паралелно објављивање"
 #: scripts/apps/content-api/views/search-panel.html:5
 #: scripts/apps/search/views/search-panel.html:63
 msgid "Parameters"
-msgstr ""
+msgstr "Параметри"
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:642
 msgid "Parent coverage not linked to a news item yet."
@@ -12831,7 +12831,7 @@ msgstr "Потврдите да желите да обришете речник.
 
 #: scripts/apps/search/views/saved-search-subscribe.html:12
 msgid "Please define the frequency and time of your email notifications below."
-msgstr ""
+msgstr "Дефинишите учесталост и време ваших имејл обавештења испод."
 
 #: scripts/core/auth/login-modal.html:4
 msgid "Please log in again."
@@ -13070,7 +13070,7 @@ msgstr "Претходно"
 #: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:107
 #: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:122
 msgid "Previous match"
-msgstr ""
+msgstr "Претходно поклапање"
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:661
 msgid "Previous scheduled update is not linked to a news item yet."
@@ -13203,7 +13203,7 @@ msgstr "Назив производа"
 
 #: scripts/apps/search/views/item-repo.html:4
 msgid "Production"
-msgstr ""
+msgstr "Продукција"
 
 #: scripts/apps/production-api-keys/index.ts:13
 #: scripts/apps/production-api-keys/views/settings.html:5
@@ -13263,7 +13263,7 @@ msgstr "Унет URL слике није исправан."
 #: scripts/apps/search/constants.ts:18
 #: scripts/apps/search/views/search-parameters.html:161
 msgid "Provider"
-msgstr ""
+msgstr "Провајдер"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:77
 msgid "Provider Name"
@@ -13421,12 +13421,12 @@ msgstr "Објавио"
 #: scripts/apps/search/constants.ts:22
 #: scripts/apps/search/directives/DateFilters.ts:93
 msgid "Published from"
-msgstr ""
+msgstr "Објављено од"
 
 #: scripts/apps/search/constants.ts:23
 #: scripts/apps/search/directives/DateFilters.ts:94
 msgid "Published to"
-msgstr ""
+msgstr "Објављено до"
 
 #: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:25
 msgid "Publishing"
@@ -13490,11 +13490,11 @@ msgstr "Четвртина"
 
 #: scripts/apps/search/views/save-search-dialog.html:4
 msgid "Query"
-msgstr ""
+msgstr "Упит"
 
 #: scripts/apps/search/views/raw-search.html:4
 msgid "Query Text"
-msgstr ""
+msgstr "Текст упита"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:158
 msgid "Question Sign"
@@ -13510,7 +13510,7 @@ msgstr "Стављено у ред у"
 
 #: scripts/apps/authoring-react/macros/macros.tsx:57
 msgid "Quick List"
-msgstr ""
+msgstr "Брза листа"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:159
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:28
@@ -13549,7 +13549,7 @@ msgstr "ПОВЕЗАНО"
 #: scripts/apps/search/components/HighlightsList.tsx:98
 #: scripts/apps/search/components/MarkedDesksList.tsx:110
 msgid "REMOVE"
-msgstr ""
+msgstr "УКЛОНИ"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:160
 msgid "Random"
@@ -13565,11 +13565,11 @@ msgstr ""
 
 #: scripts/apps/search/views/search-panel.html:15
 msgid "Raw"
-msgstr ""
+msgstr "Сирово"
 
 #: scripts/apps/search/views/raw-search.html:1
 msgid "Raw search"
-msgstr ""
+msgstr "Сирова претрага"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:42
 msgid "Read Only"
@@ -13635,7 +13635,7 @@ msgstr "Поново додели"
 
 #: scripts/apps/search/components/fields/state.tsx:43
 msgid "Recalled"
-msgstr ""
+msgstr "Опозвано"
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:186
 msgid "Recalled by"
@@ -13775,7 +13775,7 @@ msgstr "Одбио"
 
 #: scripts/apps/authoring-react/article-widgets/suggestions.tsx:127
 msgid "Rejected by {{user}}"
-msgstr ""
+msgstr "Одбио {{user}}"
 
 #: scripts/apps/archive/related-item-widget/relatedItem.ts:114
 msgid "Relate an item"
@@ -13974,7 +13974,7 @@ msgstr "Уклони сво форматирање"
 
 #: scripts/apps/authoring-react/multi-edit-modal.tsx:131
 msgid "Remove article"
-msgstr ""
+msgstr "Уклони чланак"
 
 #: scripts/apps/highlights/views/settings.html:20
 msgid "Remove configuration"
@@ -14065,7 +14065,7 @@ msgstr "Уклони извор"
 
 #: scripts/apps/authoring-react/fields/attachments/difference-row.tsx:35
 msgid "Removed"
-msgstr ""
+msgstr "Уклоњено"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:86
 msgid "Removed from featured stories"
@@ -14094,7 +14094,7 @@ msgstr "Поново отворио"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:443
 msgid "Reopened by {{user}}"
-msgstr ""
+msgstr "Поново отворио {{user}}"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:105
 msgid "Reorder Sections"
@@ -14146,7 +14146,7 @@ msgstr "Замени све"
 
 #: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:141
 msgid "Replace all"
-msgstr ""
+msgstr "Замени све"
 
 #: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:106
 msgid "Replace link"
@@ -14159,7 +14159,7 @@ msgstr "Замени са"
 
 #: scripts/apps/authoring-react/article-widgets/suggestions.tsx:87
 msgid "Replace {{x}} with {{y}}"
-msgstr ""
+msgstr "Замени {{x}} са {{y}}"
 
 #: scripts/apps/authoring/track-changes/views/suggestions-widget.html:25
 msgid "Replace:"
@@ -14297,7 +14297,7 @@ msgstr "Разрешио"
 
 #: scripts/apps/authoring-react/article-widgets/suggestions.tsx:18
 msgid "Resolved suggestions"
-msgstr ""
+msgstr "Разрешене сугестије"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:592
 msgid "Resolving comments"
@@ -14365,7 +14365,7 @@ msgstr "Прерадио"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:504
 msgid "Rewritten by {{user}}"
-msgstr ""
+msgstr "Прерадио {{user}}"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:469
 #: scripts/apps/authoring/versioning/history/views/history.html:157
@@ -14417,7 +14417,7 @@ msgstr "Ротирај десно"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:253
 msgid "Round corners for dropdown items"
-msgstr ""
+msgstr "Заобљени углови за ставке падајућег менија"
 
 #: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:22
 msgid "Route incoming content to"
@@ -14425,7 +14425,7 @@ msgstr "Рутирај долазни садржај у"
 
 #: scripts/apps/search/components/fields/state.tsx:32
 msgid "Routed"
-msgstr ""
+msgstr "Усмерено"
 
 #: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:3
 msgid "Routed from"
@@ -14677,7 +14677,7 @@ msgstr "Сачувај"
 
 #: scripts/apps/search/views/multi-image-edit.html:7
 msgid "Save & Close"
-msgstr ""
+msgstr "Сачувај и затвори"
 
 #: scripts/apps/desks/views/desk-config-modal.html:214
 #: scripts/apps/desks/views/desk-config-modal.html:451
@@ -14709,12 +14709,12 @@ msgstr "Сачувај све"
 #: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:35
 #: scripts/apps/search/views/save-search.html:15
 msgid "Save As"
-msgstr ""
+msgstr "Сачувај као"
 
 #: scripts/apps/search/views/save-search.html:16
 #: scripts/apps/search/views/save-search.html:17
 msgid "Save Changes"
-msgstr ""
+msgstr "Сачувај измене"
 
 #: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:179
 msgid "Save Changes?"
@@ -14737,7 +14737,7 @@ msgstr ""
 
 #: scripts/apps/search/views/save-search.html:10
 msgid "Save Search"
-msgstr ""
+msgstr "Сачувај претрагу"
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:713
 msgid "Save all other changes before performing this action."
@@ -14769,7 +14769,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:220
 #: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:416
 msgid "Save changes"
-msgstr ""
+msgstr "Сачувај измене"
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:340
 msgid "Save changes before adding to top stories ?"
@@ -14851,7 +14851,7 @@ msgstr "Сачувај лозинку"
 
 #: scripts/apps/search/views/save-search.html:23
 msgid "Save search"
-msgstr ""
+msgstr "Сачувај претрагу"
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:22
 #: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:22
@@ -14891,11 +14891,11 @@ msgstr ""
 
 #: scripts/apps/search/directives/SavedSearches.ts:116
 msgid "Saved search removed"
-msgstr ""
+msgstr "Сачувана претрага уклоњена"
 
 #: scripts/apps/search/views/saved-searches.html:1
 msgid "Saved searches"
-msgstr ""
+msgstr "Сачуване претраге"
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:117
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:117
@@ -14913,7 +14913,7 @@ msgstr "Чување..."
 
 #: scripts/apps/search/views/search-parameters.html:249
 msgid "Scanpix ID(s)"
-msgstr ""
+msgstr "Scanpix ИД(ови)"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:105
 msgid "Scatter"
@@ -15208,11 +15208,11 @@ msgstr ""
 
 #: scripts/apps/search/views/saved-searches.html:3
 msgid "Search saved searches"
-msgstr ""
+msgstr "Претражи сачуване претраге"
 
 #: scripts/apps/search/views/save-search-dialog.html:18
 msgid "Search shortcut"
-msgstr ""
+msgstr "Пречица за претрагу"
 
 #: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:81
 msgid "Search templates"
@@ -15220,7 +15220,7 @@ msgstr "Претражи шаблоне"
 
 #: scripts/apps/search/directives/SaveSearch.ts:72
 msgid "Search was saved successfully"
-msgstr ""
+msgstr "Претрага је успешно сачувана"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:157
 #: scripts/core/ui/components/SearchBar/manual.tsx:37
@@ -15260,7 +15260,7 @@ msgstr "Изабери агенду"
 
 #: scripts/apps/search/views/multi-image-edit.html:25
 msgid "Select All"
-msgstr ""
+msgstr "Изабери све"
 
 #: scripts/extensions/sams/dist/src/components/assets/selectAssetModal.js:150
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/selectAssetModal.js:150
@@ -15332,11 +15332,11 @@ msgstr "Изаберите корисника"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-vocabulary/config.tsx:27
 msgid "Select a vocabulary"
-msgstr ""
+msgstr "Изабери вокабулар"
 
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:110
 msgid "Select a vocabulary for predefined snippets"
-msgstr ""
+msgstr "Изабери вокабулар за предефинисане исечке"
 
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:332
 msgid "Select all"
@@ -15373,7 +15373,7 @@ msgstr "Изабери тренутну верзију."
 
 #: scripts/apps/search/views/edit-time-interval.html:5
 msgid "Select days"
-msgstr ""
+msgstr "Изабери дане"
 
 #: scripts/apps/users/views/user-preferences.html:161
 msgid "Select default categories only"
@@ -15400,7 +15400,7 @@ msgstr ""
 
 #: scripts/apps/search/views/edit-time-interval.html:19
 msgid "Select hours"
-msgstr ""
+msgstr "Изабери сате"
 
 #: ../superdesk-planning/client/components/SelectItemModal.tsx:29
 #: scripts/apps/authoring/multiedit/views/sd-multiedit-inner-dropdown.html:2
@@ -15600,7 +15600,7 @@ msgstr "Послато/у реду као"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:89
 msgid "Sent/Queued as {{name}} to {{destination}} at {{date}}"
-msgstr ""
+msgstr "Послато/у реду као {{name}} на {{destination}} у {{date}}"
 
 #: scripts/apps/publish/views/publish-queue.html:104
 msgid "Sequence No"
@@ -15730,7 +15730,7 @@ msgstr "Алтернативно дељење"
 
 #: scripts/apps/search/views/item-preview.html:3
 msgid "Shift preview"
-msgstr ""
+msgstr "Помери преглед"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:37
 msgid "Short"
@@ -15811,7 +15811,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:48
 msgid "Show crops for pictures"
-msgstr ""
+msgstr "Прикажи исечке за слике"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:101
 msgid "Show error messages"
@@ -15833,11 +15833,11 @@ msgstr "Прикажи у прегледу"
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:120
 msgid "Show input for editing description"
-msgstr ""
+msgstr "Прикажи унос за уређивање описа"
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:110
 msgid "Show input for editing title"
-msgstr ""
+msgstr "Прикажи унос за уређивање наслова"
 
 #: ../superdesk-planning/client/components/Archive/ArchivePreview/index.tsx:42
 #: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:93
@@ -15874,11 +15874,11 @@ msgstr "Прикажи или сакриј виџете у десној трац
 
 #: scripts/apps/search/components/fields/nested-link.tsx:28
 msgid "Show previous items"
-msgstr ""
+msgstr "Прикажи претходне ставке"
 
 #: scripts/apps/search/index.ts:138
 msgid "Show search modal"
-msgstr ""
+msgstr "Прикажи модал претраге"
 
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:3
 msgid "Show sent/queued items"
@@ -15893,7 +15893,7 @@ msgstr "Прикажи корисницима\n                                �
 #: scripts/apps/archive/views/item-crops.html:1
 #: scripts/apps/authoring-react/fields/media/media-carousel/image-crops.tsx:22
 msgid "Show/hide crops"
-msgstr ""
+msgstr "Прикажи/сакриј исечке"
 
 #: scripts/apps/users/views/change-avatar.html:17
 msgid "Shows your initials instead"
@@ -15921,7 +15921,7 @@ msgstr "Потпис"
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:364
 #: scripts/apps/search/views/search-parameters.html:22
 msgid "Sign-off"
-msgstr ""
+msgstr "Потпис"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:173
 #: scripts/apps/archive/views/metadata-view.html:45
@@ -16179,7 +16179,7 @@ msgstr ""
 
 #: scripts/apps/search/views/item-sortbar.html:19
 msgid "Sort order"
-msgstr ""
+msgstr "Редослед сортирања"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:266
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:266
@@ -16240,7 +16240,7 @@ msgstr ""
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:133
 #: scripts/apps/search/views/search-filters.html:44
 msgid "Sources"
-msgstr ""
+msgstr "Извори"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:361
 msgid "Spell Checker"
@@ -16302,7 +16302,7 @@ msgstr "У корпи"
 
 #: scripts/apps/search/views/search-parameters.html:145
 msgid "Spiked Content"
-msgstr ""
+msgstr "Садржај у корпи"
 
 #: scripts/apps/monitoring/config.ts:40
 #: scripts/apps/monitoring/views/monitoring-view.html:257
@@ -16324,7 +16324,7 @@ msgstr "Ставке у корпи"
 
 #: scripts/apps/search/views/search-parameters.html:153
 msgid "Spiked only content"
-msgstr ""
+msgstr "Само садржај у корпи"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:108
 msgid "Spline"
@@ -16662,7 +16662,7 @@ msgstr ""
 #: scripts/apps/search/views/saved-searches.html:21
 #: scripts/apps/search/views/saved-searches.html:50
 msgid "Subscribe"
-msgstr ""
+msgstr "Претплати се"
 
 #: scripts/apps/publish/views/publish-queue.html:109
 #: scripts/apps/search/constants.ts:20
@@ -16788,15 +16788,15 @@ msgstr "Промени језик метаподатака"
 
 #: scripts/apps/authoring-react/multi-edit-modal.tsx:115
 msgid "Switch article"
-msgstr ""
+msgstr "Промени чланак"
 
 #: scripts/apps/authoring-react/authoring-swtich.tsx:16
 msgid "Switch authoring"
-msgstr ""
+msgstr "Промени уређивача"
 
 #: scripts/apps/authoring-react/authoring-swtich.tsx:18
 msgid "Switch authoring?"
-msgstr ""
+msgstr "Променити уређивача?"
 
 #: scripts/apps/monitoring/index.ts:111
 msgid "Switch between grouped/single desk view"
@@ -16896,7 +16896,7 @@ msgstr "Листа заглавља табеле"
 
 #: scripts/apps/authoring-react/fields/tag-input/index.tsx:26
 msgid "Tag-input (authoring-react)"
-msgstr ""
+msgstr "Унос ознака (authoring-react)"
 
 #: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:83
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:40
@@ -16930,7 +16930,7 @@ msgstr "Наставак креирао"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:418
 msgid "Take created by {{user}}"
-msgstr ""
+msgstr "Наставак креирао {{user}}"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:299
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:120
@@ -16965,7 +16965,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:427
 msgid "Taken as a rewrite of"
-msgstr ""
+msgstr "Узето као прерада"
 
 #: scripts/core/itemList/views/relatedItem-list-widget.html:31
 msgid "Takes"
@@ -17104,7 +17104,7 @@ msgstr "Шаблони"
 
 #: scripts/apps/authoring-react/field-adapters/usageterms.ts:20
 msgid "Terms of use"
-msgstr ""
+msgstr "Услови коришћења"
 
 #: scripts/apps/content-filters/views/manage-filters.html:138
 msgid "Test"
@@ -17356,7 +17356,7 @@ msgstr "Пакет \"{{name}}\" садржи следеће објављене �
 
 #: scripts/apps/authoring-react/authoring-swtich.tsx:19
 msgid "The page needs to be reloaded in order to do that."
-msgstr ""
+msgstr "Страница мора бити поново учитана да бисте то урадили."
 
 #: scripts/apps/users/directives/ChangePasswordDirective.ts:21
 #: scripts/core/auth/login-modal-directive.ts:75
@@ -17483,7 +17483,7 @@ msgstr "Нема задатака за рад"
 
 #: scripts/apps/authoring-react/fields/media/difference.tsx:29
 msgid "There are no changes"
-msgstr ""
+msgstr "Нема измена"
 
 #: ../superdesk-planning/client/constants/assignments.ts:210
 msgid "There are no current assignments"
@@ -17522,7 +17522,7 @@ msgstr "Још увек нема јавних прилога. Прво их от
 
 #: scripts/apps/authoring-react/article-widgets/suggestions.tsx:208
 msgid "There are no resolved suggestions"
-msgstr ""
+msgstr "Нема разрешених сугестија"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:173
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:173
@@ -17633,7 +17633,7 @@ msgstr "Дошло је до проблема, речник није креир�
 #: scripts/apps/search/directives/ItemGlobalSearch.ts:59
 #: scripts/apps/search/directives/ItemGlobalSearch.ts:91
 msgid "There was a problem, item can not open."
-msgstr ""
+msgstr "Дошло је до проблема, ставка не може бити отворена."
 
 #: scripts/apps/desks/directives/DeskeditPeople.ts:66
 msgid "There was a problem, members not saved. Refresh Desks."
@@ -17649,7 +17649,7 @@ msgstr "Дошло је до проблема, фаза није обрисан�
 
 #: scripts/apps/search/components/ErrorBox.tsx:7
 msgid "There was an error archiving this item"
-msgstr ""
+msgstr "Дошло је до грешке приликом архивирања ове ставке"
 
 #: ../superdesk-planning/client/actions/multiSelect.ts:255
 msgid "There was an error when exporting."
@@ -17828,7 +17828,7 @@ msgid ""
 "This field will initialize with the value of specified field when toggled "
 "from \"off\" to \"on\". Only plain-text gets copied. Formatting options or "
 "links are not preserved."
-msgstr ""
+msgstr "Ово поље ће се иницијализовати вредношћу наведеног поља при пребацивању са \"off\" на \"on\". Копира се само обичан текст. Опције форматирања и линкови се не задржавају."
 
 #: scripts/apps/templates/directives/TemplatesDirective.ts:358
 msgid "This is a default template of the following desk(s): {{deskNames}}."
@@ -17845,7 +17845,7 @@ msgstr "Ово је наслов"
 
 #: scripts/apps/authoring-react/fields/media/editor.tsx:175
 msgid "This item is already added"
-msgstr ""
+msgstr "Ова ставка је већ додата"
 
 #: scripts/apps/relations/directives/RelatedItemsDirective.ts:154
 msgid "This item is already added as related."
@@ -17982,7 +17982,7 @@ msgstr "Време"
 
 #: scripts/apps/authoring-react/fields/time/index.tsx:20
 msgid "Time (authoring-react)"
-msgstr ""
+msgstr "Време (authoring-react)"
 
 #: scripts/core/editor3/components/media/MediaBlock.tsx:15
 msgid "Time Restricted"
@@ -18152,7 +18152,7 @@ msgstr "За добијање прилагодљивог кода за угра�
 #: scripts/apps/authoring-react/fields/media/difference.tsx:72
 msgid ""
 "To see detailed differences, compare primary and secondary items visually"
-msgstr ""
+msgstr "Да бисте видели детаљне разлике, упоредите примарну и секундарну ставку визуелно"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:18
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:129
@@ -18221,14 +18221,14 @@ msgstr "Укључи/искључи подебљано"
 
 #: scripts/apps/authoring-react/authoring-section/get-field-container.tsx:70
 msgid "Toggle field"
-msgstr ""
+msgstr "Прикажи/сакриј поље"
 
 #: scripts/apps/search/views/search.html:3
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:249
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:249
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:376
 msgid "Toggle filters"
-msgstr ""
+msgstr "Прикажи/сакриј филтере"
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:90
 msgid "Toggle formatting marks"
@@ -18252,7 +18252,7 @@ msgstr "Прикажи/сакриј претрагу"
 
 #: scripts/apps/search/index.ts:139
 msgid "Toggle search view"
-msgstr ""
+msgstr "Промени приказ претраге"
 
 #: scripts/core/editor3/highlightsConfig.ts:73
 msgid "Toggle strikethrough"
@@ -18366,7 +18366,7 @@ msgstr "Преведено са"
 #: scripts/apps/search/components/fields/translations.tsx:58
 #: scripts/apps/search/components/fields/translations.tsx:72
 msgid "Translation"
-msgstr ""
+msgstr "Превод"
 
 #: scripts/apps/authoring-react/article-widgets/translations/translations.tsx:14
 #: scripts/apps/authoring/translations/index.ts:12
@@ -18571,7 +18571,7 @@ msgstr "Јединствени назив"
 
 #: scripts/apps/search/views/item-globalsearch.html:11
 msgid "Unique Name/ID/GUID"
-msgstr ""
+msgstr "Јединствени назив/ИД/GUID"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:405
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:197
@@ -18584,7 +18584,7 @@ msgstr "Дошло је до непознате грешке. Покушајте
 
 #: scripts/apps/search/services/TagService.ts:198
 msgid "Unknown"
-msgstr ""
+msgstr "Непознато"
 
 #: scripts/apps/archive/directives/ArchivedItemKill.ts:39
 msgid "Unknown Error: Cannot kill the item"
@@ -18608,12 +18608,12 @@ msgstr "Непознат тип ({{qcode}})"
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:365
 msgid "Unknown error occured, Try descheduling again."
-msgstr ""
+msgstr "Дошло је до непознате грешке, покушајте поново да откажете заказивање."
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:302
 msgid ""
 "Unknown error occured. Try publishing the item from the article edit view."
-msgstr ""
+msgstr "Дошло је до непознате грешке. Покушајте да објавите ставку из приказа за уређивање чланка."
 
 #: scripts/api/article-send.tsx:248
 msgid "Unknown error occurred"
@@ -18647,7 +18647,7 @@ msgstr "Уклонио везу"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:456
 msgid "Unlinked by {{user}}"
-msgstr ""
+msgstr "Везу уклонио {{user}}"
 
 #: ../superdesk-analytics/client/utils.js:171
 #: ../superdesk-planning/client/components/LockContainer/LockContainerPopup.tsx:42
@@ -18692,11 +18692,11 @@ msgstr "Уклонио ознаку"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:336
 msgid "Unmarked from desk({{x}}) by {{user}}"
-msgstr ""
+msgstr "Ознаку са деска ({{x}}) уклонио {{user}}"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:302
 msgid "Unmarked from highlight({{x}}) by {{user}}"
-msgstr ""
+msgstr "Ознаку са истицања ({{x}}) уклонио {{user}}"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:203
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:27
@@ -18731,7 +18731,7 @@ msgstr "Повуци објаву повезаних ставки:"
 
 #: scripts/apps/search/components/fields/state.tsx:44
 msgid "Unpublished"
-msgstr ""
+msgstr "Објава повучена"
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:190
 msgid "Unpublished by"
@@ -18797,15 +18797,15 @@ msgstr "Вратио из корпе"
 
 #: scripts/apps/search/views/saved-search-subscribe.html:29
 msgid "Unsubscribe"
-msgstr ""
+msgstr "Откажи претплату"
 
 #: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:227
 msgid "Unsubscribe desk"
-msgstr ""
+msgstr "Откажи претплату деска"
 
 #: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:215
 msgid "Unsubscribe user"
-msgstr ""
+msgstr "Откажи претплату корисника"
 
 #: scripts/validate-instance-configuration.tsx:32
 msgid ""
@@ -18888,7 +18888,7 @@ msgstr ""
 
 #: scripts/apps/search/views/saved-search-subscribe.html:33
 msgid "Update subscription"
-msgstr ""
+msgstr "Ажурирај претплату"
 
 #: ../superdesk-planning/client/constants/events.ts:160
 msgid "Update time"
@@ -18900,7 +18900,7 @@ msgstr "Ажурирај време {{event}}"
 
 #: scripts/apps/search/components/fields/update.tsx:17
 msgid "Update {{sequence}}"
-msgstr ""
+msgstr "Ажурирање {{sequence}}"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:44
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:130
@@ -18951,7 +18951,7 @@ msgstr "Ажурирао"
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:119
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:135
 msgid "Updated fields:"
-msgstr ""
+msgstr "Ажурирана поља:"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetListItem.js:114
 #: scripts/extensions/sams/dist/src/components/common/versionUserDateLines.js:98
@@ -19101,7 +19101,7 @@ msgstr "Хитност:"
 
 #: scripts/apps/authoring-react/fields/urls/index.tsx:20
 msgid "Urls (authoring-react)"
-msgstr ""
+msgstr "URL-ови (authoring-react)"
 
 #: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:76
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:76
@@ -19170,7 +19170,7 @@ msgstr ""
 #: scripts/apps/search/components/fields/used.tsx:16
 #: scripts/apps/search/views/item-preview.html:21
 msgid "Used"
-msgstr ""
+msgstr "Коришћено"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:508
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:114
@@ -19300,7 +19300,7 @@ msgstr "Вредност мора бити јединствена"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:79
 msgid "Value type"
-msgstr ""
+msgstr "Тип вредности"
 
 #: scripts/apps/content-filters/views/filter-search.html:26
 #: scripts/apps/content-filters/views/filter-search.html:30
@@ -19324,7 +19324,7 @@ msgstr "Креатор верзије"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:76
 msgid "Version: {{n}}"
-msgstr ""
+msgstr "Верзија: {{n}}"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/index.tsx:40
 #: scripts/apps/authoring/versioning/versioning.ts:8
@@ -19334,7 +19334,7 @@ msgstr "Верзије"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/index.tsx:15
 msgid "Versions and item history"
-msgstr ""
+msgstr "Верзије и историја ставке"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:207
 #: ../superdesk-planning/client/utils/index.ts:591
@@ -19415,11 +19415,11 @@ msgstr "Прикажи цео профил"
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:516
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:106
 msgid "View item"
-msgstr ""
+msgstr "Прикажи ставку"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:403
 msgid "View linked item"
-msgstr ""
+msgstr "Прикажи повезану ставку"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:13
 msgid "View name"
@@ -19460,7 +19460,7 @@ msgstr ""
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:180
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:205
 msgid "View source item"
-msgstr ""
+msgstr "Прикажи изворну ставку"
 
 #: scripts/apps/contacts/index.ts:23
 msgid "View/Manage media contacts"
@@ -19478,7 +19478,7 @@ msgstr "Управљање вокабуларима"
 
 #: scripts/apps/authoring-react/fields/dropdown/config-main.tsx:82
 msgid "Vocabulary"
-msgstr ""
+msgstr "Вокабулар"
 
 #: ../superdesk-planning/client/planning-extension/src/extension.ts:283
 msgid "Vocabulary `locators` is not configured!"
@@ -19804,7 +19804,7 @@ msgstr "Можете потпуно блокирати даље писање н�
 
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:154
 msgid "You can't multi-edit, because these articles can't be edited"
-msgstr ""
+msgstr "Не можете уређивати више, јер се ови чланци не могу уређивати"
 
 #: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:35
 msgid "You cannot change workflow status"
@@ -19820,7 +19820,7 @@ msgstr "Немате привилегије за извршавање било �
 
 #: scripts/apps/search/views/saved-search-subscribe.html:12
 msgid "You have chosen to subscribe to"
-msgstr ""
+msgstr "Изабрали сте да се претплатите на"
 
 #: scripts/api/highlights.ts:53 scripts/apps/search/MultiImageEdit.ts:173
 msgid "You have unsaved changes, do you want to continue?"
@@ -19890,7 +19890,7 @@ msgstr "Умањи"
 
 #: scripts/apps/search/views/saved-searches.html:11
 msgid "[Global]"
-msgstr ""
+msgstr "[Глобално]"
 
 #: scripts/apps/authoring-react/fields/media/constants.ts:8
 #: scripts/apps/authoring/media/MediaMetadataView.tsx:16
@@ -19991,7 +19991,7 @@ msgstr "архива"
 
 #: scripts/apps/search/components/ItemContainer.tsx:20
 msgid "archived"
-msgstr ""
+msgstr "архивирано"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:140
 msgid "as rewrite of"
@@ -20038,7 +20038,7 @@ msgstr "претражи"
 
 #: scripts/apps/search/components/SelectBox.tsx:68
 msgid "bulk actions"
-msgstr ""
+msgstr "групне радње"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:43
 #: ../superdesk-planning/client/components/AuditInformation/index.tsx:110
@@ -20057,7 +20057,7 @@ msgstr "од"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:210
 msgid "by {{user}}"
-msgstr ""
+msgstr "од {{user}}"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:223
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:223
@@ -20110,7 +20110,7 @@ msgstr "затворено"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:112
 msgid "color"
-msgstr ""
+msgstr "боја"
 
 #: scripts/core/editor3/components/toolbar/TableControls.tsx:102
 msgid "column"
@@ -20155,7 +20155,7 @@ msgstr "исправљено"
 
 #: scripts/apps/search/components/fields/update.tsx:15
 msgid "correction sequence"
-msgstr ""
+msgstr "секвенца исправке"
 
 #: scripts/apps/authoring/metadata/views/meta-place-directive.html:20
 msgid "country"
@@ -20314,7 +20314,7 @@ msgstr "имејл"
 #: scripts/apps/archive/views/item-state.html:6
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:225
 msgid "embargo"
-msgstr ""
+msgstr "ембарго"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:93
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:9
@@ -20352,7 +20352,7 @@ msgstr "пример"
 #: scripts/apps/search/components/MediaInfo.tsx:37
 #: scripts/apps/search/components/fields/expiry.tsx:15
 msgid "expires"
-msgstr ""
+msgstr "истиче"
 
 #: scripts/apps/publish/views/subscribers.html:276
 msgid "expires:"
@@ -20381,7 +20381,7 @@ msgstr "преузето"
 #: scripts/apps/archive/views/fetched-desks.html:2
 #: scripts/apps/search/components/FetchedDesksInfo.tsx:75
 msgid "fetched in"
-msgstr ""
+msgstr "преузето у"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/form-validation.js:11
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/form-validation.js:20
@@ -20464,7 +20464,7 @@ msgstr "из истицања"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:361
 msgid "from highlight: {{x}}"
-msgstr ""
+msgstr "из истицања: {{x}}"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:238
 msgid "from {{from}} to {{to}}"
@@ -20475,7 +20475,7 @@ msgstr "од {{from}} до {{to}}"
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:260
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:276
 msgid "from:"
-msgstr ""
+msgstr "од:"
 
 #: scripts/apps/users/views/edit-form.html:73
 msgid "full name"
@@ -20657,7 +20657,7 @@ msgstr "курзив"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:429
 msgid "item"
-msgstr ""
+msgstr "ставка"
 
 #: scripts/apps/archive/related-item-widget/relatedItem.ts:166
 msgid "item metadata associated."
@@ -20677,7 +20677,7 @@ msgstr "уништено"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:111
 msgid "label"
-msgstr ""
+msgstr "ознака"
 
 #: scripts/apps/packaging/views/sd-package-item-preview.html:24
 msgid "label: <b>{{label.name}}</b>"
@@ -20745,7 +20745,7 @@ msgstr "место"
 
 #: scripts/apps/search/components/ItemContainer.tsx:16
 msgid "location:"
-msgstr ""
+msgstr "локација:"
 
 #: scripts/core/views/sdSlider.html:2
 msgid "low"
@@ -20817,7 +20817,7 @@ msgstr "цитат у више редова"
 
 #: scripts/apps/search/views/saved-search-subscribe.html:23
 msgid "never"
-msgstr ""
+msgstr "никад"
 
 #: scripts/apps/users/views/edit-form.html:385
 msgid "new"
@@ -21156,7 +21156,7 @@ msgstr ""
 
 #: scripts/apps/search/components/SelectBox.tsx:63
 msgid "selection not allowed"
-msgstr ""
+msgstr "избор није дозвољен"
 
 #: scripts/core/lang/missing-translations-strings.ts:9
 msgid "send"
@@ -21188,7 +21188,7 @@ msgstr "извините, ово корисничко име је већ зау�
 
 #: scripts/apps/search/components/MediaInfo.tsx:26
 msgid "source"
-msgstr ""
+msgstr "извор"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:90
 msgid "source of the search provider"
@@ -21255,7 +21255,7 @@ msgstr "претплата"
 #: scripts/apps/search/views/saved-search-manage-subscribers.html:16
 #: scripts/apps/search/views/search-panel.html:43
 msgid "subscriptions"
-msgstr ""
+msgstr "претплате"
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "success"
@@ -21321,15 +21321,15 @@ msgstr "на доделу извештавања од"
 
 #: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:150
 msgid "toggle difference"
-msgstr ""
+msgstr "прикажи/сакриј разлике"
 
 #: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:134
 msgid "toggle primary"
-msgstr ""
+msgstr "прикажи/сакриј примарно"
 
 #: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:142
 msgid "toggle secondary"
-msgstr ""
+msgstr "прикажи/сакриј секундарно"
 
 #: scripts/apps/authoring/views/authoring-header.html:85
 msgid "translations"
@@ -21461,13 +21461,13 @@ msgstr "верзија"
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:121
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:260
 msgid "version {{n}}"
-msgstr ""
+msgstr "верзија {{n}}"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:161
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:176
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:238
 msgid "version: {{n}}"
-msgstr ""
+msgstr "верзија: {{n}}"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:402
 #: scripts/apps/archive/controllers/UploadController.ts:326
@@ -21518,7 +21518,7 @@ msgstr ""
 
 #: scripts/apps/search/components/ItemContainer.tsx:17
 msgid "workspace"
-msgstr ""
+msgstr "радни простор"
 
 #: scripts/apps/authoring-react/fields/date/config.tsx:86
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:156
@@ -21565,9 +21565,9 @@ msgstr ""
 #: scripts/apps/search/views/multi-action-bar.html:4
 msgid "{{ multi.count}} Item selected"
 msgid_plural "{{ multi.count}} Items selected"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "{{ multi.count}} ставка изабрана"
+msgstr[1] "{{ multi.count}} ставке изабране"
+msgstr[2] "{{ multi.count}} ставки изабрано"
 
 #: ../superdesk-planning/client/components/fields/calendars.tsx:45
 msgid "{{ name }} (disabled)"
@@ -21632,7 +21632,7 @@ msgstr ""
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:370
 msgid "{{count}} articles have been descheduled"
-msgstr ""
+msgstr "{{count}} чланцима је отказано заказивање"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:224
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:224
@@ -21668,7 +21668,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:112
 msgid "{{field}} (optional)"
-msgstr ""
+msgstr "{{field}} (опционо)"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:384
 msgid "{{field}} cannot be earlier than now!"
@@ -21744,23 +21744,23 @@ msgstr[2] "{{n}} слика не може бити преузето јер су 
 
 #: scripts/apps/authoring-react/fields/media/difference.tsx:41
 msgid "{{n}} items added"
-msgstr ""
+msgstr "{{n}} ставки додато"
 
 #: scripts/apps/authoring-react/fields/media/difference.tsx:54
 msgid "{{n}} items modified"
-msgstr ""
+msgstr "{{n}} ставки измењено"
 
 #: scripts/apps/authoring-react/fields/media/difference.tsx:62
 msgid "{{n}} items re-ordered"
-msgstr ""
+msgstr "{{n}} ставки прераспоређено"
 
 #: scripts/apps/authoring-react/fields/media/difference.tsx:47
 msgid "{{n}} items removed"
-msgstr ""
+msgstr "{{n}} ставки уклоњено"
 
 #: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:105
 msgid "{{n}} of {{total}} matches"
-msgstr ""
+msgstr "{{n}} од {{total}} поклапања"
 
 #: scripts/apps/users/views/edit-form.html:65
 msgid "{{roles[user.role].name}}"
@@ -21808,7 +21808,7 @@ msgstr ""
 
 #: scripts/apps/authoring-react/fields/media/media-metadata.tsx:44
 msgid "{{width}} x {{height}} px"
-msgstr ""
+msgstr "{{width}} x {{height}} px"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:55
 msgid "{{wordsCount}} word"
@@ -21828,7 +21828,7 @@ msgstr[2] ""
 
 #: scripts/apps/search/components/fields/linesCount.tsx:14
 msgid "{{x}} lines"
-msgstr ""
+msgstr "{{x}} редова"
 
 #: scripts/extensions/datetimeField/dist/src/editor.js:79
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:84

--- a/po/sr.po
+++ b/po/sr.po
@@ -126,13 +126,13 @@ msgstr "(прилагођени вокабулар)"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:170
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:199
 msgid "(disabled)"
-msgstr ""
+msgstr "(онемогућено)"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:97
 #: scripts/extensions/broadcasting/dist/src/rundowns/manage-rundown-items.js:97
 #: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:176
 msgid "(empty)"
-msgstr ""
+msgstr "(празно)"
 
 #: scripts/apps/search/MultiImageEdit.ts:290
 #: scripts/apps/search/MultiImageEdit.ts:311
@@ -166,9 +166,9 @@ msgstr "1 сат"
 #: scripts/core/ArticlesListByQueryWithFilters.tsx:316
 msgid "1 item selected"
 msgid_plural "{{number}} items selected"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "1 ставка изабрана"
+msgstr[1] "{{number}} ставке изабране"
+msgstr[2] "{{number}} ставки изабрано"
 
 #: ../superdesk-analytics/client/utils.js:205
 msgid "1 minute"
@@ -194,9 +194,9 @@ msgstr "1 секунда"
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:446
 msgid "1 tag can not be displayed"
 msgid_plural "{{n}} tags can not be displayed"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "1 ознака не може бити приказана"
+msgstr[1] "{{n}} ознаке не могу бити приказане"
+msgstr[2] "{{n}} ознака не може бити приказано"
 
 #: scripts/apps/publish/controllers/SubscriberTokenController.ts:20
 msgid "1 week"
@@ -214,7 +214,7 @@ msgstr "10 година"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:186
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:196
 msgid "100MB"
-msgstr ""
+msgstr "100MB"
 
 #: ../superdesk-planning/client/utils/filters.ts:97
 msgid "108h"
@@ -224,7 +224,7 @@ msgstr "108ч"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:183
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:193
 msgid "10MB"
-msgstr ""
+msgstr "10MB"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:44
 #: ../superdesk-planning/client/utils/filters.ts:81
@@ -326,13 +326,13 @@ msgstr "19. ажурирање"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:189
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:199
 msgid "1GB"
-msgstr ""
+msgstr "1GB"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:181
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:181
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:191
 msgid "1MB"
-msgstr ""
+msgstr "1MB"
 
 #: scripts/apps/publish/controllers/SubscriberTokenController.ts:21
 msgid "2 weeks"
@@ -383,13 +383,13 @@ msgstr "24."
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:187
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:197
 msgid "250MB"
-msgstr ""
+msgstr "250MB"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:184
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:184
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:194
 msgid "25MB"
-msgstr ""
+msgstr "25MB"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:59
 #: ../superdesk-planning/client/utils/filters.ts:111
@@ -454,19 +454,19 @@ msgstr "5 година"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:188
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:198
 msgid "500MB"
-msgstr ""
+msgstr "500MB"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:185
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:185
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:195
 msgid "50MB"
-msgstr ""
+msgstr "50MB"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:182
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:182
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:192
 msgid "5MB"
-msgstr ""
+msgstr "5MB"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:39
 #: ../superdesk-planning/client/utils/filters.ts:71
@@ -584,7 +584,7 @@ msgstr "Деск је обавезан"
 msgid ""
 "A link was sent to the specified email address. Please use it to reset your "
 "password. It is valid a limited amount of time."
-msgstr ""
+msgstr "Линк је послат на наведену имејл адресу. Користите га да ресетујете лозинку. Важи ограничено време."
 
 #: ../superdesk-planning/client/api/locations.ts:30
 msgid "A location matching this one already exists"
@@ -873,7 +873,7 @@ msgstr "Додај истакнути медиј"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:232
 #: scripts/extensions/sams/src/containers/FileUploadModal.tsx:288
 msgid "Add File"
-msgstr ""
+msgstr "Додај датотеку"
 
 #: scripts/apps/content-filters/views/manage-filters.html:116
 msgid "Add Filter Statement"
@@ -1076,7 +1076,7 @@ msgstr "Додај опис"
 #: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:50
 #: scripts/extensions/auto-tagging-widget/src/new-item.tsx:74
 msgid "Add entity"
-msgstr ""
+msgstr "Додај ентитет"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:113
 msgid "Add field after"
@@ -1110,11 +1110,11 @@ msgstr "Додај групу пре"
 
 #: scripts/validate-instance-configuration.tsx:59
 msgid "Add it via Settings > Metadata"
-msgstr ""
+msgstr "Додајте преко Подешавања > Метаподаци"
 
 #: scripts/apps/packaging/views/search.html:10
 msgid "Add items"
-msgstr ""
+msgstr "Додај ставке"
 
 #: ../superdesk-planning/client/components/fields/editor/EventLinks.tsx:77
 #: scripts/core/editor3/highlightsConfig.ts:112
@@ -1150,7 +1150,7 @@ msgstr "Додај правило"
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:54
 #: scripts/extensions/datetimeField/src/config.tsx:109
 msgid "Add step"
-msgstr ""
+msgstr "Додај корак"
 
 #: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:66
 msgid "Add task description"
@@ -1189,7 +1189,7 @@ msgstr "Додај у планирање"
 
 #: scripts/apps/packaging/index.ts:74
 msgid "Add to current"
-msgstr ""
+msgstr "Додај у тренутни"
 
 #: scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx:67
 msgid "Add to dictionary"
@@ -1398,19 +1398,19 @@ msgstr "Агенде"
 #: scripts/extensions/ai-widget/src/ai-assistant.tsx:66
 #: scripts/extensions/ai-widget/src/extension.ts:44
 msgid "Ai Assistant"
-msgstr ""
+msgstr "AI асистент"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/airing-info-block.js:24
 #: scripts/extensions/broadcasting/dist/src/rundowns/components/airing-info-block.js:24
 #: scripts/extensions/broadcasting/src/rundowns/components/airing-info-block.tsx:63
 msgid "Air date"
-msgstr ""
+msgstr "Датум емитовања"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/airing-info-block.js:20
 #: scripts/extensions/broadcasting/dist/src/rundowns/components/airing-info-block.js:20
 #: scripts/extensions/broadcasting/src/rundowns/components/airing-info-block.tsx:45
 msgid "Air time"
-msgstr ""
+msgstr "Време емитовања"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:89
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:97
@@ -1422,7 +1422,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:217
 #: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:69
 msgid "Airtime"
-msgstr ""
+msgstr "Време емитовања"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:38
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:47
@@ -1431,7 +1431,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:86
 #: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:84
 msgid "Airtime date from"
-msgstr ""
+msgstr "Датум емитовања од"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:46
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:52
@@ -1440,7 +1440,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:104
 #: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:99
 msgid "Airtime date to"
-msgstr ""
+msgstr "Датум емитовања до"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:22
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:24
@@ -1449,7 +1449,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:50
 #: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:43
 msgid "Airtime time from"
-msgstr ""
+msgstr "Време емитовања од"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:30
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:34
@@ -1458,17 +1458,17 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:68
 #: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:60
 msgid "Airtime time to"
-msgstr ""
+msgstr "Време емитовања до"
 
 #: scripts/apps/system-messages/components/system-messages-settings.tsx:18
 msgid "Alert"
-msgstr ""
+msgstr "Упозорење"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/tag-popover.js:16
 #: scripts/extensions/auto-tagging-widget/dist/src/tag-popover.js:16
 #: scripts/extensions/auto-tagging-widget/src/tag-popover.tsx:26
 msgid "Aliases:"
-msgstr ""
+msgstr "Алијаси:"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:31
 msgid "Align Center"
@@ -1547,7 +1547,7 @@ msgstr "Све ставке планирања"
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:210
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:268
 msgid "All Sets"
-msgstr ""
+msgstr "Сви скупови"
 
 #: scripts/apps/search/components/fields/authors.tsx:107
 msgid "All authors"
@@ -1573,7 +1573,7 @@ msgstr "За сада је све у реду"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:72
 #: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:55
 msgid "All item types"
-msgstr ""
+msgstr "Сви типови ставки"
 
 #: scripts/core/itemList/LazyLoader.tsx:226
 msgid "All items have been loaded"
@@ -1635,7 +1635,7 @@ msgstr "Дозволи избор више вредности"
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:80
 #: scripts/extensions/predefinedTextField/src/config.tsx:152
 msgid "Allow switching to free text input"
-msgstr ""
+msgstr "Дозволи пребацивање на унос слободног текста"
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:58
 msgid "Allow video"
@@ -1648,11 +1648,11 @@ msgstr "Дозволи видео"
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:355
 #: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:164
 msgid "Allowed Desks"
-msgstr ""
+msgstr "Дозвољени дескови"
 
 #: scripts/apps/archive/views/metadata-associateditem-view.html:15
 msgid "Alt Text"
-msgstr ""
+msgstr "Алтернативни текст"
 
 #: scripts/apps/workspace/content/constants.ts:9
 msgid "Alt text"
@@ -1837,13 +1837,13 @@ msgstr "Анотације"
 #: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/extension.js:70
 #: scripts/extensions/annotationsLibrary/src/extension.tsx:101
 msgid "Annotations Library"
-msgstr ""
+msgstr "Библиотека анотација"
 
 #: scripts/extensions/annotationsLibrary/dist/src/extension.js:59
 #: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/extension.js:59
 #: scripts/extensions/annotationsLibrary/src/extension.tsx:89
 msgid "Annotations library"
-msgstr ""
+msgstr "Библиотека анотација"
 
 #: scripts/apps/dashboard/workspace-tasks/views/desk-stages.html:6
 msgid "Any"
@@ -1851,7 +1851,7 @@ msgstr "Било који"
 
 #: scripts/apps/archive/views/metadata-view.html:162
 msgid "Aperture"
-msgstr ""
+msgstr "Бленда"
 
 #: scripts/apps/users/views/user-preferences.html:21
 #: scripts/apps/users/views/user-preferences.html:255
@@ -1882,7 +1882,7 @@ msgstr "Примени"
 
 #: scripts/apps/master-desk/components/FilterPanelComponent.tsx:171
 msgid "Apply Filters"
-msgstr ""
+msgstr "Примени филтере"
 
 #: scripts/apps/vocabularies/components/UploadConfigModal.tsx:80
 msgid "Apply config"
@@ -1971,7 +1971,7 @@ msgstr "Да ли сте сигурни да желите да обришете 
 #: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:118
 #: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:245
 msgid "Are you sure you want to delete it?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете?"
 
 #: scripts/apps/products/controllers/ProductsConfigController.ts:201
 msgid "Are you sure you want to delete product?"
@@ -1989,13 +1989,13 @@ msgstr "Да ли сте сигурни да желите да обришете 
 #: scripts/extensions/sams/dist/src/store/sets/actions.js:95
 #: scripts/extensions/sams/src/store/sets/actions.ts:113
 msgid "Are you sure you want to delete the Set \"{{name}}\"?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете скуп \"{{name}}\"?"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/store/assets/actions.js:324
 #: scripts/extensions/sams/dist/src/store/assets/actions.js:324
 #: scripts/extensions/sams/src/store/assets/actions.ts:383
 msgid "Are you sure you want to delete the asset \"{{name}}\"?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете ресурс \"{{name}}\"?"
 
 #: ../superdesk-analytics/client/saved_reports/directives/SavedReportList.js:122
 msgid "Are you sure you want to delete the saved report?"
@@ -2013,7 +2013,7 @@ msgstr "Да ли сте сигурни да желите да обришете 
 #: scripts/extensions/sams/dist/src/store/assets/actions.js:331
 #: scripts/extensions/sams/src/store/assets/actions.ts:392
 msgid "Are you sure you want to delete these {{length}} assets"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете ових {{length}} ресурса"
 
 #: scripts/apps/ingest/directives/IngestRoutingContent.ts:239
 msgid "Are you sure you want to delete this scheme rule?"
@@ -2034,7 +2034,7 @@ msgstr "Да ли сте сигурни да желите да означите 
 
 #: scripts/apps/archive/index.tsx:498
 msgid "Are you sure you want to spike the item?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да преместите ставку у корпу?"
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:188
 msgid "Are you sure you want to spike the items?"
@@ -2077,7 +2077,7 @@ msgstr "Шаблон чланка"
 
 #: scripts/apps/archive/views/preview.html:17
 msgid "Article Type"
-msgstr ""
+msgstr "Тип чланка"
 
 #: scripts/apps/search/components/TypeIcon.tsx:39
 #: scripts/apps/search/components/TypeIcon.tsx:50
@@ -2270,25 +2270,25 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:130
 #: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:130
 msgid "Asset Preview"
-msgstr ""
+msgstr "Преглед ресурса"
 
 #: scripts/extensions/sams/dist/src/api/assets.js:438
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:438
 #: scripts/extensions/sams/src/api/assets.ts:554
 msgid "Asset deleted successfully"
-msgstr ""
+msgstr "Ресурс успешно обрисан"
 
 #: scripts/extensions/sams/dist/src/api/assets.js:460
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:460
 #: scripts/extensions/sams/src/api/assets.ts:577
 msgid "Asset updated successfully"
-msgstr ""
+msgstr "Ресурс успешно ажуриран"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/notifications/assets.js:30
 #: scripts/extensions/sams/dist/src/notifications/assets.js:30
 #: scripts/extensions/sams/src/notifications/assets.ts:43
 msgid "Asset was deleted by another user."
-msgstr ""
+msgstr "Ресурс је обрисан од стране другог корисника."
 
 #: scripts/apps/publish/views/http-push-config.html:10
 #: scripts/apps/publish/views/http-push-config.html:9
@@ -2505,7 +2505,7 @@ msgstr "За поређење су потребне најмање две вер
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/selectAssetModal.js:153
 #: scripts/extensions/sams/src/components/assets/selectAssetModal.tsx:172
 msgid "Attach Asset(s)"
-msgstr ""
+msgstr "Приложи ресурс(е)"
 
 #: scripts/apps/authoring/attachments/AttachmentsWidgetComponent.tsx:112
 #: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:123
@@ -2562,7 +2562,7 @@ msgstr "Аудио"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:75
 #: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:58
 msgid "Audio only"
-msgstr ""
+msgstr "Само аудио"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:75
 msgid "Australia/Adelaide"
@@ -2645,13 +2645,13 @@ msgstr "Аутоматски убаци ставке из"
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/extension.js:37
 #: scripts/extensions/availability-manager/src/extension.ts:55
 msgid "Availability"
-msgstr ""
+msgstr "Доступност"
 
 #: scripts/extensions/availability-manager/dist/src/extension.js:49
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/extension.js:51
 #: scripts/extensions/availability-manager/src/extension.ts:73
 msgid "Availability Management"
-msgstr ""
+msgstr "Управљање доступношћу"
 
 #: scripts/extensions/availability-manager/dist/src/extension.js:17
 #: scripts/extensions/availability-manager/dist/src/extension.js:20
@@ -2662,13 +2662,13 @@ msgstr ""
 msgid ""
 "Availability manager extension could not start because vocabulary \"{{id}}\" "
 "is missing"
-msgstr ""
+msgstr "Екстензија управљача доступношћу није могла да се покрене јер недостаје вокабулар \"{{id}}\""
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/availability-settings.js:189
 #: scripts/extensions/availability-manager/dist/src/settings/availability-settings.js:189
 #: scripts/extensions/availability-manager/src/settings/availability-settings.tsx:326
 msgid "Availability schedule"
-msgstr ""
+msgstr "Распоред доступности"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:54
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:74
@@ -2677,13 +2677,13 @@ msgstr ""
 #: scripts/extensions/availability-manager/src/utils.ts:57
 #: scripts/extensions/availability-manager/src/utils.ts:77
 msgid "Available"
-msgstr ""
+msgstr "Доступно"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:70
 #: scripts/extensions/availability-manager/dist/src/utils.js:70
 #: scripts/extensions/availability-manager/src/utils.ts:73
 msgid "Available all day"
-msgstr ""
+msgstr "Доступно цео дан"
 
 #: scripts/apps/dashboard/world-clock/configuration.html:28
 msgid "Available clocks"
@@ -2733,7 +2733,7 @@ msgstr "Назад на оригинални приказ"
 #: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.js:13
 #: scripts/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.tsx:30
 msgid "Back to results"
-msgstr ""
+msgstr "Назад на резултате"
 
 #: scripts/apps/users/views/edit.html:3
 msgid "Back to users list"
@@ -2759,13 +2759,13 @@ msgstr "Будите први..."
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:181
 #: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:361
 msgid "Before airtime"
-msgstr ""
+msgstr "Пре емитовања"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:7
 msgid ""
 "Before you start using your new newsroom, please tell us a little about "
 "yourself:"
-msgstr ""
+msgstr "Пре него што почнете са коришћењем нове редакције, реците нам нешто о себи:"
 
 #: scripts/apps/search/components/fields/state.tsx:41
 msgid "Being Corrected"
@@ -2777,7 +2777,7 @@ msgstr "Звоно"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:39
 msgid "Better"
-msgstr ""
+msgstr "Боље"
 
 #: scripts/apps/users/views/edit-form.html:286
 msgid "Biography"
@@ -2879,7 +2879,7 @@ msgstr "Креирај емисију"
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/extension.js:19
 #: scripts/extensions/broadcasting/src/extension.ts:20
 msgid "Broadcasting"
-msgstr ""
+msgstr "Емитовање"
 
 #: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:38
 #: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:40
@@ -2925,7 +2925,7 @@ msgstr "Потпис"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:244
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:314
 msgid "Bytes"
-msgstr ""
+msgstr "Бајтови"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/correct-action.tsx:11
 #: scripts/apps/authoring/views/authoring-topbar.html:131
@@ -3001,7 +3001,7 @@ msgstr "Календари"
 #: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:89
 #: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:117
 msgid "Camera"
-msgstr ""
+msgstr "Камера"
 
 #: scripts/core/itemList/views/relatedItem-list-widget.html:20
 msgid "Can be associated as a take"
@@ -3221,7 +3221,7 @@ msgstr "Отказати све понављајуће догађаје или �
 
 #: scripts/apps/archive/index.tsx:326
 msgid "Cancel correction"
-msgstr ""
+msgstr "Откажи исправку"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/index.tsx:264
 #: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:51
@@ -3322,7 +3322,7 @@ msgstr "Промени тачку од интереса"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:235
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:323
 msgid "Change Set filter"
-msgstr ""
+msgstr "Промени филтер скупа"
 
 #: scripts/apps/users/config.ts:122 scripts/apps/users/views/edit-form.html:52
 msgid "Change avatar"
@@ -3361,7 +3361,7 @@ msgstr "Измене ће бити изгубљене ако не буду са�
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorTools.js:32
 #: scripts/extensions/videoEditor/src/VideoEditorTools.tsx:76
 msgid "Changing quality is only supported for 480p and higher quality videos."
-msgstr ""
+msgstr "Промена квалитета подржана је само за видео записе квалитета 480p и већег."
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:38
 msgid "Channel has gone strangely quiet."
@@ -3426,7 +3426,7 @@ msgstr "Тип графикона"
 
 #: scripts/core/views/sdselect.html:13
 msgid "Check all"
-msgstr ""
+msgstr "Означи све"
 
 #: scripts/apps/authoring-react/fields/register-fields.ts:30
 #: scripts/apps/authoring/views/authoring-topbar.html:379
@@ -3472,7 +3472,7 @@ msgstr "Изабери листу истицања"
 #: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:40
 #: scripts/extensions/ai-widget/src/translations/translations-body.tsx:87
 msgid "Choose the language and click the translate button at the bottom"
-msgstr ""
+msgstr "Изаберите језик и кликните на дугме за превод на дну"
 
 #: scripts/apps/contacts/constants.ts:75
 #: scripts/apps/contacts/views/search-panel.html:61
@@ -3539,7 +3539,7 @@ msgstr "Очисти претрагу"
 
 #: scripts/apps/master-desk/components/FilterBarComponent.tsx:34
 msgid "Clear all filters"
-msgstr ""
+msgstr "Очисти све филтере"
 
 #: scripts/apps/users/views/user-preferences.html:155
 msgid "Clear all selected"
@@ -3581,7 +3581,7 @@ msgstr "Очисти сесије"
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:365
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:646
 msgid "Click \"Run\" to generate"
-msgstr ""
+msgstr "Кликните на „Покрени\" за генерисање"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:106
 msgid "Click on a Scheme rules on the left to view details."
@@ -3606,11 +3606,11 @@ msgstr "Кликните да замените сличицу"
 
 #: scripts/apps/production-api-keys/config.ts:54
 msgid "Client ID"
-msgstr ""
+msgstr "ИД клијента"
 
 #: scripts/apps/production-api-keys/config.ts:59
 msgid "Client Secret"
-msgstr ""
+msgstr "Тајни кључ клијента"
 
 #: scripts/apps/dashboard/world-clock/configuration.html:5
 msgid "Clock type"
@@ -3698,7 +3698,7 @@ msgstr "Затвори и настави"
 #: scripts/extensions/ai-widget/dist/src/headlines/headlines-widget.js:48
 #: scripts/extensions/ai-widget/src/headlines/headlines-widget.tsx:71
 msgid "Close Headlines"
-msgstr ""
+msgstr "Затвори наслове"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:61
 msgid "Close Small"
@@ -3708,7 +3708,7 @@ msgstr "Мало затвори"
 #: scripts/extensions/ai-widget/dist/src/summary/summary-widget.js:47
 #: scripts/extensions/ai-widget/src/summary/summary-widget.tsx:67
 msgid "Close Summary"
-msgstr ""
+msgstr "Затвори сажетак"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:62
 msgid "Close Thick"
@@ -3718,7 +3718,7 @@ msgstr "Дебело затвори"
 #: scripts/extensions/ai-widget/dist/src/translations/translations-widget.js:43
 #: scripts/extensions/ai-widget/src/translations/translations-widget.tsx:80
 msgid "Close Translate"
-msgstr ""
+msgstr "Затвори превод"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:65
 #: scripts/apps/authoring/views/authoring-topbar.html:66
@@ -3727,7 +3727,7 @@ msgstr "Затвори и настави"
 
 #: scripts/apps/production-api-keys/utils.tsx:27
 msgid "Close anyway"
-msgstr ""
+msgstr "Затвори ипак"
 
 #: scripts/apps/authoring/authoring/index.ts:469
 msgid "Close current item"
@@ -3754,7 +3754,7 @@ msgstr "Затвори преглед"
 
 #: scripts/apps/production-api-keys/utils.tsx:17
 msgid "Close this panel?"
-msgstr ""
+msgstr "Затворити овај панел?"
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:140
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:9
@@ -3794,7 +3794,7 @@ msgstr "Колоне:"
 
 #: scripts/apps/packaging/index.ts:93
 msgid "Combine with current"
-msgstr ""
+msgstr "Комбинуј са тренутним"
 
 #: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:42
 #: ../superdesk-planning/client/components/fields/editor/ItemType.tsx:18
@@ -3844,7 +3844,7 @@ msgstr "Кодови компанија"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:29
 msgid "Company/Organisation"
-msgstr ""
+msgstr "Компанија/организација"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:185
 msgid "Compare"
@@ -3914,7 +3914,7 @@ msgstr "Подеси теме уређивача"
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:64
 #: scripts/extensions/predefinedTextField/src/config.tsx:101
 msgid "Configure predefined values"
-msgstr ""
+msgstr "Подеси предефинисане вредности"
 
 #: scripts/apps/authoring-react/toolbar-components/integration-wrapper/configure-theme-button.tsx:13
 msgid "Configure themes"
@@ -4035,7 +4035,7 @@ msgstr "Content API"
 #: scripts/apps/content-api/controllers/ContentAPIController.ts:26
 #: scripts/apps/content-api/index.ts:21
 msgid "Content API Search"
-msgstr ""
+msgstr "Content API претрага"
 
 #: scripts/core/lang/missing-translations-strings.ts:26
 msgid "Content Expiry"
@@ -4123,7 +4123,7 @@ msgstr "Поља садржаја"
 
 #: scripts/apps/internal-destinations/InternalDestinations.tsx:31
 msgid "Content filter"
-msgstr ""
+msgstr "Филтер садржаја"
 
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:58
 msgid "Content filter saved."
@@ -4229,7 +4229,7 @@ msgstr "Копирај метаподатке"
 
 #: scripts/apps/production-api-keys/config.ts:64
 msgid "Copy this now, you won't be able to access it again."
-msgstr ""
+msgstr "Копирајте ово сада, нећете моћи поново да приступите."
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:195
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:64
@@ -4300,7 +4300,7 @@ msgstr "Исправио"
 
 #: scripts/core/interactive-article-actions-panel/index-ui.tsx:137
 msgid "Correcting multiple items from authoring pane is not supported"
-msgstr ""
+msgstr "Исправљање више ставки из ауторског панела није подржано"
 
 #: scripts/apps/search/components/fields/state.tsx:40
 #: scripts/core/lang/missing-translations-strings.ts:16
@@ -4542,7 +4542,7 @@ msgstr "Креирај и објави"
 
 #: scripts/apps/archive/index.tsx:246
 msgid "Create Broadcast"
-msgstr ""
+msgstr "Креирај емисију"
 
 #: ../superdesk-analytics/client/utils.js:175
 msgid "Create Highlight"
@@ -4598,7 +4598,7 @@ msgstr "Креирај и отвори ставку планирања"
 #: scripts/extensions/ai-widget/src/summary/summary.tsx:91
 #: scripts/extensions/ai-widget/src/translations/translations-body.tsx:148
 msgid "Create article"
-msgstr ""
+msgstr "Креирај чланак"
 
 #: scripts/apps/highlights/views/settings.html:11
 msgid "Create configuration"
@@ -4626,7 +4626,7 @@ msgstr "Креирај нови"
 #: scripts/extensions/broadcasting/dist/src/page.js:187
 #: scripts/extensions/broadcasting/src/page.tsx:275
 msgid "Create new Show"
-msgstr ""
+msgstr "Креирај нову емисију"
 
 #: scripts/apps/desks/views/desk-config-modal.html:292
 msgid "Create new Stage"
@@ -4656,7 +4656,7 @@ msgstr "Креирај нову ставку планирања"
 #: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:18
 #: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:44
 msgid "Create new rundown template"
-msgstr ""
+msgstr "Креирај нови шаблон редоследа"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:55
 msgid "Create new schedule"
@@ -4666,19 +4666,19 @@ msgstr "Креирај нови распоред"
 #: scripts/extensions/broadcasting/dist/src/shows/create-show-modal.js:48
 #: scripts/extensions/broadcasting/src/shows/create-show-modal.tsx:85
 msgid "Create new show"
-msgstr ""
+msgstr "Креирај нову емисију"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:141
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:141
 #: scripts/extensions/sams/src/components/assets/assetEditor.tsx:135
 msgid "Create new tag: \"{{ tag }}\""
-msgstr ""
+msgstr "Креирај нову ознаку: \"{{ tag }}\""
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:134
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:134
 #: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:261
 msgid "Create new template"
-msgstr ""
+msgstr "Креирај нови шаблон"
 
 #: scripts/apps/packaging/index.ts:50 scripts/apps/packaging/index.ts:59
 #: scripts/core/ui/components/content-create-dropdown/initial-view.tsx:199
@@ -4697,25 +4697,25 @@ msgstr "Креирати планирање за све догађаје или 
 #: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:57
 #: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:103
 msgid "Create rundown"
-msgstr ""
+msgstr "Креирај редослед"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:14
 #: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:14
 #: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:28
 msgid "Create rundown template"
-msgstr ""
+msgstr "Креирај шаблон редоследа"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:161
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:161
 #: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:317
 msgid "Create rundowns automatically"
-msgstr ""
+msgstr "Креирај редоследе аутоматски"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:219
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:219
 #: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:415
 msgid "Create template"
-msgstr ""
+msgstr "Креирај шаблон"
 
 #: scripts/apps/users/views/list.html:3
 msgid "Create user"
@@ -4768,13 +4768,13 @@ msgstr "Креирано до"
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:105
 #: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:187
 msgid "Created at {{date}}"
-msgstr ""
+msgstr "Креирано {{date}}"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:88
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:88
 #: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:165
 msgid "Created at {{time}} by {{user}}"
-msgstr ""
+msgstr "Креирано у {{time}} од {{user}}"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:96
 #: scripts/apps/authoring/versioning/history/views/history.html:6
@@ -4825,13 +4825,13 @@ msgstr "Креирано до"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/versionUserDateLines.js:66
 #: scripts/extensions/sams/src/components/common/versionUserDateLines.tsx:36
 msgid "Created {{ datetime }}"
-msgstr ""
+msgstr "Креирано {{ datetime }}"
 
 #: scripts/extensions/sams/dist/src/components/common/versionUserDateLines.js:96
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/versionUserDateLines.js:67
 #: scripts/extensions/sams/src/components/common/versionUserDateLines.tsx:41
 msgid "Created {{ datetime }} by"
-msgstr ""
+msgstr "Креирано {{ datetime }} од"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:129
 msgid "Creation Date"
@@ -4849,7 +4849,7 @@ msgstr "Креатор"
 
 #: scripts/apps/production-api-keys/config.ts:49
 msgid "Credentials"
-msgstr ""
+msgstr "Акредитиви"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:209
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:72
@@ -4887,11 +4887,11 @@ msgstr "Координате исечка нису дефинисане за и�
 
 #: scripts/apps/profiling/views/profiling.html:35
 msgid "Cumulative time"
-msgstr ""
+msgstr "Кумулативно време"
 
 #: scripts/apps/profiling/views/profiling.html:36
 msgid "Cumulative time per call"
-msgstr ""
+msgstr "Кумулативно време по позиву"
 
 #: ../superdesk-planning/client/constants/assignments.ts:209
 msgid "Current Assignments"
@@ -5133,7 +5133,7 @@ msgstr "Датуми"
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/extension.js:20
 #: scripts/extensions/datetimeField/src/extension.tsx:27
 msgid "Datetime"
-msgstr ""
+msgstr "Датум-време"
 
 #: scripts/apps/authoring-react/fields/datetime/index.tsx:24
 msgid "Datetime (authoring-react)"
@@ -5243,7 +5243,7 @@ msgstr "Подразумевани приказ мониторинга"
 #: scripts/extensions/availability-manager/dist/src/settings/manage-schedule.js:128
 #: scripts/extensions/availability-manager/src/settings/manage-schedule.tsx:199
 msgid "Default schedule"
-msgstr ""
+msgstr "Подразумевани распоред"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:53
 msgid "Default view"
@@ -5263,7 +5263,7 @@ msgstr "Дефинише ширину искачућег прозора у\n    
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:21
 #: scripts/extensions/predefinedTextField/src/config.tsx:30
 msgid "Definition"
-msgstr ""
+msgstr "Дефиниција"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:204
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:305
@@ -5308,7 +5308,7 @@ msgstr "Обриши агенду"
 #: scripts/extensions/sams/src/store/assets/actions.ts:384
 #: scripts/extensions/sams/src/store/assets/actions.ts:393
 msgid "Delete Asset?"
-msgstr ""
+msgstr "Обрисати ресурс?"
 
 #: ../superdesk-planning/client/constants/tooltips.ts:36
 msgid "Delete Filter"
@@ -5337,7 +5337,7 @@ msgstr "Обриши заказани извоз"
 #: scripts/extensions/sams/dist/src/store/sets/actions.js:95
 #: scripts/extensions/sams/src/store/sets/actions.ts:114
 msgid "Delete Set?"
-msgstr ""
+msgstr "Обрисати скуп?"
 
 #: scripts/core/editor3/highlightsConfig.ts:102
 msgid "Delete empty paragraphs"
@@ -5647,7 +5647,7 @@ msgstr "Дестинација"
 
 #: scripts/apps/internal-destinations/InternalDestinations.tsx:14
 msgid "Destination name"
-msgstr ""
+msgstr "Назив дестинације"
 
 #: scripts/apps/publish/views/subscribers.html:216
 msgid "Destinations"
@@ -5755,7 +5755,7 @@ msgstr "Онемогућени календари"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:77
 #: scripts/extensions/sams/src/components/sets/setListPanel.tsx:83
 msgid "Disabled Sets"
-msgstr ""
+msgstr "Онемогућени скупови"
 
 #: scripts/apps/desks/views/desk-config-modal.html:197
 msgid "Disallow sending items to this desk"
@@ -5780,7 +5780,7 @@ msgstr "Одбаци све"
 #: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:231
 #: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:199
 msgid "Discard unsaved changes?"
-msgstr ""
+msgstr "Одбацити несачуване измене?"
 
 #: scripts/core/notification/notification.ts:215
 msgid "Disconnected from Notification Server!"
@@ -5807,7 +5807,7 @@ msgstr "Не приказуј"
 
 #: scripts/apps/settings/index.ts:20
 msgid "Do some admin chores"
-msgstr ""
+msgstr "Обави административне послове"
 
 #: scripts/apps/authoring/views/confirm-media-associated.html:3
 msgid "Do you want to add an image to this update?"
@@ -5817,11 +5817,11 @@ msgstr "Желите ли да додате слику у ово ажурира�
 #: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:26
 #: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:74
 msgid "Do you want to create a rundown template for this show right away?"
-msgstr ""
+msgstr "Желите ли да одмах креирате шаблон редоследа за ову емисију?"
 
 #: scripts/apps/archive/index.tsx:477
 msgid "Do you want to delete the item permanently?"
-msgstr ""
+msgstr "Желите ли да трајно обришете ставку?"
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:167
 msgid "Do you want to delete the items permanently?"
@@ -5866,13 +5866,13 @@ msgstr "Желите ли да вратите ставку(е) из корпе?"
 #: scripts/extensions/sams/dist/src/utils/assets.js:122
 #: scripts/extensions/sams/src/utils/assets.ts:152
 msgid "Document"
-msgstr ""
+msgstr "Документ"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:76
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:76
 #: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:59
 msgid "Documents only"
-msgstr ""
+msgstr "Само документи"
 
 #: scripts/apps/content-filters/views/manage-filters.html:147
 msgid "Does match"
@@ -5968,11 +5968,11 @@ msgstr "Нацрт"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:75
 #: scripts/extensions/sams/src/components/sets/setListPanel.tsx:61
 msgid "Draft Sets"
-msgstr ""
+msgstr "Скупови нацрта"
 
 #: scripts/apps/archive/views/upload.html:37
 msgid "Drag Your Files Here"
-msgstr ""
+msgstr "Превуците датотеке овде"
 
 #: ../superdesk-planning/client/components/UI/Form/FileInput.tsx:200
 #: scripts/core/ui/components/Form/FileInput.tsx:136
@@ -6108,7 +6108,7 @@ msgstr "Дуплирај ставку"
 
 #: scripts/core/interactive-article-actions-panel/actions/duplicate-to-action.tsx:80
 msgid "Duplicate and open"
-msgstr ""
+msgstr "Дуплирај и отвори"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:96
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:78
@@ -6122,15 +6122,15 @@ msgstr "Дупликат креирао"
 
 #: scripts/apps/archive/index.tsx:151
 msgid "Duplicate in place"
-msgstr ""
+msgstr "Дуплирај на месту"
 
 #: scripts/core/interactive-article-actions-panel/action-tabs.tsx:13
 msgid "Duplicate to"
-msgstr ""
+msgstr "Дуплирај на"
 
 #: scripts/apps/archive/index.tsx:200
 msgid "Duplicate to personal"
-msgstr ""
+msgstr "Дуплирај у лично"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:100
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:82
@@ -6171,7 +6171,7 @@ msgstr "Трајање (authoring-react)"
 #: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:122
 #: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:119
 msgid "Duration from"
-msgstr ""
+msgstr "Трајање од"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:62
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:65
@@ -6180,7 +6180,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:140
 #: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:132
 msgid "Duration to"
-msgstr ""
+msgstr "Трајање до"
 
 #: ../superdesk-planning/client/validators/events.ts:87
 msgid "END DATE cannot be in the past"
@@ -6405,7 +6405,7 @@ msgstr "Уреди скуп правила"
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:262
 #: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:404
 msgid "Edit Rundown"
-msgstr ""
+msgstr "Уреди редослед"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:106
 #: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:180
@@ -6442,7 +6442,7 @@ msgstr "Уреди јединствени назив"
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditor.js:486
 #: scripts/extensions/videoEditor/src/VideoEditor.tsx:680
 msgid "Edit Video"
-msgstr ""
+msgstr "Уреди видео"
 
 #: scripts/apps/monitoring/index.ts:121
 msgid "Edit an item"
@@ -6456,7 +6456,7 @@ msgstr "Уреди ставку у новом прозору"
 #: scripts/extensions/availability-manager/dist/src/settings/edit-workday-modal.js:106
 #: scripts/extensions/availability-manager/src/settings/edit-workday-modal.tsx:161
 msgid "Edit availability"
-msgstr ""
+msgstr "Уреди доступност"
 
 #: scripts/apps/highlights/views/settings.html:19
 msgid "Edit configuration"
@@ -6513,7 +6513,7 @@ msgstr "Уреди у искачућем прозору"
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:374
 #: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:649
 msgid "Edit item"
-msgstr ""
+msgstr "Уреди ставку"
 
 #: scripts/core/editor3/highlightsConfig.ts:124
 msgid "Edit link"
@@ -6572,7 +6572,7 @@ msgstr "Уреди овај распоред"
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/extension.js:15
 #: scripts/extensions/videoEditor/src/extension.tsx:22
 msgid "Edit video"
-msgstr ""
+msgstr "Уреди видео"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:27
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:41
@@ -6617,7 +6617,7 @@ msgstr "Имејл"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:14
 msgid "Email Address"
-msgstr ""
+msgstr "Имејл адреса"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:21
 msgid "Email this report"
@@ -6633,7 +6633,7 @@ msgstr "Ембарго"
 
 #: scripts/apps/archive/views/metadata-view.html:132
 msgid "Embargo Timestamp"
-msgstr ""
+msgstr "Временска ознака ембарга"
 
 #: scripts/apps/search/components/fields/embargo.tsx:23
 msgid "Embargo until {{date}}"
@@ -6758,19 +6758,19 @@ msgstr "Унесите веб URL"
 #: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:36
 #: scripts/extensions/auto-tagging-widget/src/new-item.tsx:58
 msgid "Entity"
-msgstr ""
+msgstr "Ентитет"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:60
 #: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:60
 #: scripts/extensions/auto-tagging-widget/src/new-item.tsx:135
 msgid "Entity type"
-msgstr ""
+msgstr "Тип ентитета"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:83
 #: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:83
 #: scripts/extensions/auto-tagging-widget/src/new-item.tsx:195
 msgid "Entity type is required."
-msgstr ""
+msgstr "Тип ентитета је обавезан."
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:76
 msgid "Envelope"
@@ -6993,7 +6993,7 @@ msgstr "Грешка: {{message}}"
 #: scripts/extensions/sams/dist/src/utils/api.js:25
 #: scripts/extensions/sams/src/utils/api.ts:25
 msgid "Error[04002]: Invalid search query"
-msgstr ""
+msgstr "Грешка[04002]: Неисправан упит претраге"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/utils/api.js:46
 #: scripts/extensions/sams/dist/src/extensions/sams/src/utils/api.js:56
@@ -7002,25 +7002,25 @@ msgstr ""
 #: scripts/extensions/sams/src/utils/api.ts:42
 #: scripts/extensions/sams/src/utils/api.ts:53
 msgid "Error[{{number}}]: {{description}}"
-msgstr ""
+msgstr "Грешка[{{number}}]: {{description}}"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/utils/api.js:33
 #: scripts/extensions/sams/dist/src/utils/api.js:33
 #: scripts/extensions/sams/src/utils/api.ts:30
 msgid "Error[{{number}}]: {{error}} not unique"
-msgstr ""
+msgstr "Грешка[{{number}}]: {{error}} није јединствено"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/utils/api.js:39
 #: scripts/extensions/sams/dist/src/utils/api.js:39
 #: scripts/extensions/sams/src/utils/api.ts:35
 msgid "Error[{{number}}]: {{error}} requried"
-msgstr ""
+msgstr "Грешка[{{number}}]: {{error}} је обавезно"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/validation-errors.js:14
 #: scripts/extensions/availability-manager/dist/src/validation-errors.js:14
 #: scripts/extensions/availability-manager/src/validation-errors.tsx:19
 msgid "Errors"
-msgstr ""
+msgstr "Грешке"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:79
 msgid "Europe/Athens"
@@ -7433,7 +7433,7 @@ msgstr "Извезао"
 
 #: scripts/apps/archive/views/metadata-view.html:163
 msgid "Exposure time"
-msgstr ""
+msgstr "Време експозиције"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:81
 msgid "External"
@@ -7536,7 +7536,7 @@ msgstr "Креирање распореда извештаја није успе
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:46
 #: scripts/extensions/sams/src/api/sets.ts:59
 msgid "Failed to create the Set"
-msgstr ""
+msgstr "Креирање скупа није успело"
 
 #: ../superdesk-planning/client/api/locations.ts:33
 msgid "Failed to create the location"
@@ -7550,13 +7550,13 @@ msgstr "Креирање/ажурирање филтера приказа дог
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:449
 #: scripts/extensions/sams/src/api/assets.ts:564
 msgid "Failed to delete the Asset"
-msgstr ""
+msgstr "Брисање ресурса није успело"
 
 #: scripts/extensions/sams/dist/src/api/sets.js:84
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:84
 #: scripts/extensions/sams/src/api/sets.ts:104
 msgid "Failed to delete the Set"
-msgstr ""
+msgstr "Брисање скупа није успело"
 
 #: ../superdesk-planning/client/api/locations.ts:91
 msgid "Failed to delete the location"
@@ -7618,7 +7618,7 @@ msgstr "Генерисање ажурирања није успело: {{message
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:348
 #: scripts/extensions/sams/src/api/assets.ts:437
 msgid "Failed to get Assets"
-msgstr ""
+msgstr "Преузимање ресурса није успело"
 
 #: scripts/apps/authoring/authoring/services/LockService.ts:21
 msgid "Failed to get a lock on the item!"
@@ -7626,25 +7626,25 @@ msgstr "Закључавање ставке није успело!"
 
 #: scripts/extensions/sams/src/api/assets.ts:406
 msgid "Failed to get asset \"\""
-msgstr ""
+msgstr "Преузимање ресурса \"\" није успело"
 
 #: scripts/extensions/sams/dist/src/api/assets.js:305
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:305
 #: scripts/extensions/sams/src/api/assets.ts:389
 msgid "Failed to get assets counts for sets"
-msgstr ""
+msgstr "Преузимање броја ресурса за скупове није успело"
 
 #: scripts/extensions/sams/dist/src/api/assets.js:408
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:408
 #: scripts/extensions/sams/src/api/assets.ts:519
 msgid "Failed to get binary for asset"
-msgstr ""
+msgstr "Преузимање датотеке ресурса није успело"
 
 #: scripts/extensions/sams/dist/src/api/assets.js:427
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:427
 #: scripts/extensions/sams/src/api/assets.ts:541
 msgid "Failed to get compressed binaries for assets"
-msgstr ""
+msgstr "Преузимање компресованих датотека ресурса није успело"
 
 #: scripts/apps/ingest/controllers/ExternalSourceController.ts:29
 msgid "Failed to get item."
@@ -7654,7 +7654,7 @@ msgstr "Преузимање ставке није успело."
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:527
 #: scripts/extensions/sams/src/api/assets.ts:648
 msgid "Failed to get tags"
-msgstr ""
+msgstr "Преузимање ознака није успело"
 
 #: ../superdesk-planning/client/actions/autosave.ts:76
 msgid "Failed to get the autosave entry"
@@ -7672,13 +7672,13 @@ msgstr "Повезивање са траженим задатком није у�
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:23
 #: scripts/extensions/sams/src/api/sets.ts:30
 msgid "Failed to load all sets"
-msgstr ""
+msgstr "Учитавање свих скупова није успело"
 
 #: scripts/extensions/sams/dist/src/api/storageDestinations.js:23
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/storageDestinations.js:23
 #: scripts/extensions/sams/src/api/storageDestinations.ts:34
 msgid "Failed to load all storage destinations"
-msgstr ""
+msgstr "Учитавање свих дестинација складиштења није успело"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:352
 msgid "Failed to load duplicated Event."
@@ -7718,7 +7718,7 @@ msgstr "Закључавање ставке није успело"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:486
 #: scripts/extensions/sams/src/api/assets.ts:604
 msgid "Failed to lock the Asset"
-msgstr ""
+msgstr "Закључавање ресурса није успело"
 
 #: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:273
 msgid "Failed to lock the item."
@@ -7745,7 +7745,7 @@ msgstr "Објављивање и наставак нису успели."
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:249
 #: scripts/extensions/sams/src/api/assets.ts:330
 msgid "Failed to query Assets"
-msgstr ""
+msgstr "Упит ресурса није успео"
 
 #: ../superdesk-planning/client/actions/autosave.ts:199
 msgid "Failed to remove autosave. Not found"
@@ -7861,7 +7861,7 @@ msgstr "Откључавање ставке није успело"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:504
 #: scripts/extensions/sams/src/api/assets.ts:623
 msgid "Failed to unlock the Asset"
-msgstr ""
+msgstr "Откључавање ресурса није успело"
 
 #: ../superdesk-planning/client/actions/main.ts:408
 msgid "Failed to unpost the {{ itemType }}"
@@ -7879,7 +7879,7 @@ msgstr "Ажурирање понављања догађаја није успе
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:365
 #: scripts/extensions/sams/src/api/assets.ts:464
 msgid "Failed to update asset."
-msgstr ""
+msgstr "Ажурирање ресурса није успело."
 
 #: ../superdesk-planning/client/api/locations.ts:69
 msgid "Failed to update location"
@@ -7889,7 +7889,7 @@ msgstr "Ажурирање локације није успело"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:468
 #: scripts/extensions/sams/src/api/assets.ts:585
 msgid "Failed to update the Asset"
-msgstr ""
+msgstr "Ажурирање ресурса није успело"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:511
 msgid "Failed to update the Event time!"
@@ -7899,13 +7899,13 @@ msgstr "Ажурирање времена догађаја није успело
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:66
 #: scripts/extensions/sams/src/api/sets.ts:85
 msgid "Failed to update the Set"
-msgstr ""
+msgstr "Ажурирање скупа није успело"
 
 #: scripts/extensions/sams/dist/src/api/assets.js:43
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:43
 #: scripts/extensions/sams/src/api/assets.ts:61
 msgid "Failed to upload file."
-msgstr ""
+msgstr "Отпремање датотеке није успело."
 
 #: ../superdesk-planning/client/components/fields/editor/EventAttachments.tsx:62
 #: scripts/extensions/sams/dist/src/containers/FileUploadModal.js:208
@@ -8036,7 +8036,7 @@ msgstr "Преузми ставку"
 
 #: scripts/core/interactive-article-actions-panel/actions/fetch-to-action.tsx:101
 msgid "Fetch and open"
-msgstr ""
+msgstr "Преузми и отвори"
 
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:48
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:78
@@ -8103,7 +8103,7 @@ msgstr "Величина датотеке"
 
 #: scripts/apps/profiling/views/profiling.html:37
 msgid "File name/line"
-msgstr ""
+msgstr "Назив датотеке/ред"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:161
 msgid "File types"
@@ -8114,9 +8114,9 @@ msgstr "Типови датотека"
 #: scripts/extensions/sams/src/containers/FileUploadModal.tsx:230
 msgid "File uploaded successfully"
 msgid_plural "{{count}} files uploaded successfully"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Датотека успешно отпремљена"
+msgstr[1] "{{count}} датотеке успешно отпремљене"
+msgstr[2] "{{count}} датотека успешно отпремљено"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:224
 #: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:117
@@ -8134,13 +8134,13 @@ msgstr[2] ""
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:168
 #: scripts/extensions/sams/src/utils/ui.tsx:101
 msgid "Filename"
-msgstr ""
+msgstr "Назив датотеке"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:169
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:169
 #: scripts/extensions/sams/src/components/assets/assetEditor.tsx:169
 msgid "Filename:"
-msgstr ""
+msgstr "Назив датотеке:"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:297
 msgid "Files"
@@ -8305,7 +8305,7 @@ msgstr "Заставице"
 
 #: scripts/apps/archive/views/metadata-view.html:166
 msgid "Flash"
-msgstr ""
+msgstr "Блиц"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:90
 msgid "Flip Horizontal"
@@ -8325,7 +8325,7 @@ msgstr "Окрени вертикално"
 
 #: scripts/apps/archive/views/metadata-view.html:164
 msgid "Focal length"
-msgstr ""
+msgstr "Фокусна дужина"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:92
 msgid "Folder Close"
@@ -8362,7 +8362,7 @@ msgstr "За објаву"
 #: scripts/extensions/sams/dist/src/utils/assets.js:63
 #: scripts/extensions/sams/src/utils/assets.ts:75
 msgid "Force Unlock"
-msgstr ""
+msgstr "Принуди откључавање"
 
 #: scripts/core/auth/login-modal.html:32
 msgid "Forgot password?"
@@ -8471,7 +8471,7 @@ msgstr "Режим пуне ширине"
 #: scripts/extensions/sams/dist/src/utils/assets.js:69
 #: scripts/extensions/sams/src/utils/assets.ts:81
 msgid "Full-screen preview"
-msgstr ""
+msgstr "Преглед у целом екрану"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:96
 msgid "Fullscreen"
@@ -8479,7 +8479,7 @@ msgstr "Цео екран"
 
 #: scripts/apps/profiling/views/profiling.html:38
 msgid "Function"
-msgstr ""
+msgstr "Функција"
 
 #: ../superdesk-planning/client/constants/assignments.ts:215
 msgid "Future Assignments"
@@ -8489,7 +8489,7 @@ msgstr "Будући задаци"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:247
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:317
 msgid "GB"
-msgstr ""
+msgstr "GB"
 
 #: scripts/apps/archive/views/metadata-view.html:199
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:191
@@ -8553,7 +8553,7 @@ msgstr "Генериши токен"
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:191
 #: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:399
 msgid "Generated name for created rundowns"
-msgstr ""
+msgstr "Генерисани назив за креиране редоследе"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:534
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:127
@@ -8627,7 +8627,7 @@ msgstr "Иди назад"
 
 #: scripts/apps/master-desk/components/HeaderComponent.tsx:208
 msgid "Go To Desk"
-msgstr ""
+msgstr "Иди на деск"
 
 #: scripts/apps/production-api-keys/utils.tsx:36
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:46
@@ -8823,7 +8823,7 @@ msgstr "Наслов:"
 #: scripts/extensions/ai-widget/src/headlines/headlines-widget.tsx:74
 #: scripts/extensions/ai-widget/src/main-panel.tsx:25
 msgid "Headlines"
-msgstr ""
+msgstr "Наслови"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:107
 msgid "Heart"
@@ -8833,7 +8833,7 @@ msgstr "Срце"
 #: scripts/extensions/helloWorld/dist/src/extensions/helloWorld/src/extension.js:5
 #: scripts/extensions/helloWorld/src/extension.ts:6
 msgid "Hello world"
-msgstr ""
+msgstr "Здраво свете"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:108
 msgid "Help Large"
@@ -8909,7 +8909,7 @@ msgstr "Пакет истицања"
 
 #: scripts/apps/packaging/views/sd-package-items-edit.html:21
 msgid "Highlight Preview"
-msgstr ""
+msgstr "Преглед истицања"
 
 #: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:159
 msgid "Highlight characters"
@@ -9104,7 +9104,7 @@ msgstr "Слика"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:103
 #: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:114
 msgid "Image Preview"
-msgstr ""
+msgstr "Преглед слике"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:82
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:185
@@ -9130,13 +9130,13 @@ msgstr "Провера величине слике није успела"
 msgid ""
 "Image suggestions are based on generated tags and can be added to article "
 "content by dragging."
-msgstr ""
+msgstr "Сугестије слика заснивају се на генерисаним ознакама и могу се додати у садржај чланка превлачењем."
 
 #: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:73
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:73
 #: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:56
 msgid "Images only"
-msgstr ""
+msgstr "Само слике"
 
 #: scripts/apps/users/import/views/import-user.html:44
 msgid "Import"
@@ -9290,7 +9290,7 @@ msgstr "Знак информације"
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:199
 #: scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.tsx:293
 msgid "Information"
-msgstr ""
+msgstr "Информације"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:115
 #: scripts/apps/ingest/index.ts:182 scripts/apps/ingest/index.ts:83
@@ -9357,7 +9357,7 @@ msgstr "Статистика пријема"
 
 #: scripts/apps/archive/views/metadata-view.html:128
 msgid "Ingest provider sequence"
-msgstr ""
+msgstr "Секвенца провајдера пријема"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:270
 msgid "Ingest sequence"
@@ -9380,7 +9380,7 @@ msgstr "Примљено"
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:24
 #: scripts/extensions/datetimeField/src/config.tsx:32
 msgid "Initial time offset"
-msgstr ""
+msgstr "Почетни временски померај"
 
 #: scripts/apps/authoring-react/article-widgets/inline-comments.tsx:9
 #: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:19
@@ -9434,7 +9434,7 @@ msgstr "Интерно"
 #: scripts/apps/internal-destinations/index.ts:13
 #: scripts/apps/internal-destinations/views/settings.html:5
 msgid "Internal Destinations"
-msgstr ""
+msgstr "Интерне дестинације"
 
 #: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/ScheduledUpdateForm.tsx:145
 #: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:225
@@ -9460,7 +9460,7 @@ msgstr "Неисправан датум"
 
 #: scripts/apps/archive/controllers/file-upload-error-modal.tsx:73
 msgid "Invalid File : {{name}}"
-msgstr ""
+msgstr "Неисправна датотека: {{name}}"
 
 #: scripts/apps/users/views/edit-form.html:258
 msgid "Invalid format. Only Alphanumerics are allowed."
@@ -9491,14 +9491,14 @@ msgstr "Је подразумевано"
 
 #: scripts/apps/archive/views/metadata-view.html:165
 msgid "Iso"
-msgstr ""
+msgstr "ИСО"
 
 #: scripts/validate-instance-configuration.tsx:85
 msgid "Issue with extension \"{{id}}\":"
 msgid_plural "Issues with extension \"{{id}}\":"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Проблем са екстензијом \"{{id}}\":"
+msgstr[1] "Проблеми са екстензијом \"{{id}}\":"
+msgstr[2] "Проблеми са екстензијом \"{{id}}\":"
 
 #: ../superdesk-planning/client/utils/confirmAddingRelatedItems.tsx:29
 msgid "Issues detected:"
@@ -9595,11 +9595,11 @@ msgstr[2] "Ставке дуплиране"
 
 #: scripts/apps/archive/directives/ArchivedItemKill.ts:47
 msgid "Item has been killed."
-msgstr ""
+msgstr "Ставка је уништена."
 
 #: scripts/apps/archive/directives/ResendItem.ts:39
 msgid "Item has been resent."
-msgstr ""
+msgstr "Ставка је поново послата."
 
 #: ../superdesk-planning/client/actions/main.ts:1663 scripts/api/article.ts:294
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:445
@@ -9621,13 +9621,13 @@ msgstr "Историја ставке"
 
 #: scripts/apps/packaging/directives/PackageItemsEdit.ts:21
 msgid "Item is already in this package."
-msgstr ""
+msgstr "Ставка је већ у овом пакету."
 
 #: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:55
 #: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:55
 #: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:151
 msgid "Item is locked and marked user can not be changed."
-msgstr ""
+msgstr "Ставка је закључана и означени корисник не може бити промењен."
 
 #: scripts/apps/authoring/authoring/controllers/AssociationController.ts:299
 msgid "Item is locked. Cannot associate media item."
@@ -9726,7 +9726,7 @@ msgstr "Креиране ставке"
 #: scripts/extensions/markForUser/dist/src/get-article-actions-bulk.js:21
 #: scripts/extensions/markForUser/src/get-article-actions-bulk.tsx:26
 msgid "Items are marked for different users"
-msgstr ""
+msgstr "Ставке су означене за различите кориснике"
 
 #: scripts/apps/dashboard/user-activity/user-activity.ts:22
 msgid "Items created by the user"
@@ -9777,7 +9777,7 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:245
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:315
 msgid "KB"
-msgstr ""
+msgstr "KB"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:118
 msgid "Kanban View"
@@ -9878,7 +9878,7 @@ msgstr "Језици"
 #: scripts/extensions/ai-widget/dist/src/translations/translations-footer.js:32
 #: scripts/extensions/ai-widget/src/translations/translations-footer.tsx:50
 msgid "Languages are not available."
-msgstr ""
+msgstr "Језици нису доступни."
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:76
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:11
@@ -9996,7 +9996,7 @@ msgid ""
 "support, join the discussion on <a href=\"https://forum.sourcefabric.org/"
 "categories/superdesk-dev\" title=\"Superdesk forum\" "
 "target=\"_blank\">Superdesk forums</a>."
-msgstr ""
+msgstr "Сазнајте више о Superdesk-у на <a href=\"https://www.superdesk.org/\" title=\"Superdesk\" target=\"_blank\">www.superdesk.org</a>. За помоћ и подршку, придружите се дискусији на <a href=\"https://forum.sourcefabric.org/categories/superdesk-dev\" title=\"Superdesk forum\" target=\"_blank\">Superdesk форумима</a>."
 
 #: scripts/apps/authoring/authoring/components/toggleFullWithEditor.tsx:20
 msgid "Leave full width mode"
@@ -10156,7 +10156,7 @@ msgstr "Сугестије уживо"
 
 #: scripts/apps/stream/views/activity-stream.html:30
 msgid "Load more"
-msgstr ""
+msgstr "Учитај још"
 
 #: ../superdesk-planning/client/components/Main/ListPanel.tsx:338
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModalSubnav.tsx:52
@@ -10176,7 +10176,7 @@ msgstr "Учитавање прегледа"
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditor.js:78
 #: scripts/extensions/videoEditor/src/VideoEditor.tsx:132
 msgid "Loading video..."
-msgstr ""
+msgstr "Учитавање видеа..."
 
 #: scripts/apps/dashboard/views/workspace.html:63
 #: scripts/apps/search/components/ItemList.tsx:511
@@ -10262,7 +10262,7 @@ msgstr "Закључао овај корисник"
 
 #: scripts/apps/archive/views/item-lock.html:19
 msgid "Locked by you in another browser"
-msgstr ""
+msgstr "Закључано од вас у другом прегледачу"
 
 #: scripts/core/auth/login-modal.html:21
 msgid "Log In"
@@ -10302,7 +10302,7 @@ msgstr "МАСТЕР"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:246
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:316
 msgid "MB"
-msgstr ""
+msgstr "MB"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:75
 msgid "MO"
@@ -10350,7 +10350,7 @@ msgstr "Уверите се да изгледате најбоље"
 msgid ""
 "Make sure you've saved your Client Secret.You won't be able to access it "
 "again after closing"
-msgstr ""
+msgstr "Уверите се да сте сачували тајни кључ клијента. Након затварања нећете моћи поново да приступите."
 
 #: scripts/apps/search/views/search-panel.html:45
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/availability-settings.js:190
@@ -10409,13 +10409,13 @@ msgstr "Управљај профилом планирања"
 #: scripts/extensions/broadcasting/dist/src/page.js:148
 #: scripts/extensions/broadcasting/src/page.tsx:209
 msgid "Manage Rundown Templates"
-msgstr ""
+msgstr "Управљај шаблонима редоследа"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:243
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:243
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:349
 msgid "Manage SAMS"
-msgstr ""
+msgstr "Управљај SAMS-ом"
 
 #: scripts/core/lang/missing-translations-strings.ts:18
 msgid "Manage Search Providers"
@@ -10428,7 +10428,7 @@ msgstr "Управљај провајдерима претраге"
 #: scripts/extensions/sams/src/components/sets/manageSetsModal.tsx:94
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:140
 msgid "Manage Sets"
-msgstr ""
+msgstr "Управљај скуповима"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:151
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:153
@@ -10437,7 +10437,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/page.tsx:223
 #: scripts/extensions/broadcasting/src/page.tsx:228
 msgid "Manage Shows"
-msgstr ""
+msgstr "Управљај емисијама"
 
 #: scripts/core/menu/views/menu.html:72
 msgid "Manage profile"
@@ -10447,7 +10447,7 @@ msgstr "Управљање профилом"
 #: scripts/extensions/broadcasting/dist/src/page.js:150
 #: scripts/extensions/broadcasting/src/page.tsx:214
 msgid "Manage rundown templates"
-msgstr ""
+msgstr "Управљај шаблонима редоследа"
 
 #: scripts/apps/search/views/saved-search-subscribe.html:5
 #: scripts/apps/search/views/saved-searches.html:27
@@ -10483,7 +10483,7 @@ msgstr "Означи"
 #: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:38
 #: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:111
 msgid "Mark and send"
-msgstr ""
+msgstr "Означи и пошаљи"
 
 #: ../superdesk-planning/client/constants/events.ts:162
 msgid "Mark as Postponed"
@@ -10498,7 +10498,7 @@ msgstr "Означи као завршено"
 #: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/extension.js:44
 #: scripts/extensions/markForUser/src/extension.tsx:51
 msgid "Mark for User"
-msgstr ""
+msgstr "Означи за корисника"
 
 #: scripts/apps/desks/index.ts:60 scripts/apps/monitoring/index.ts:130
 msgid "Mark for desk"
@@ -10512,7 +10512,7 @@ msgstr "Означи за истицање"
 #: scripts/extensions/markForUser/dist/src/get-article-actions.js:29
 #: scripts/extensions/markForUser/src/get-article-actions.tsx:32
 msgid "Mark for other user"
-msgstr ""
+msgstr "Означи за другог корисника"
 
 #: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions-bulk.js:24
 #: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions.js:13
@@ -10527,7 +10527,7 @@ msgstr ""
 #: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:61
 #: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:91
 msgid "Mark for user"
-msgstr ""
+msgstr "Означи за корисника"
 
 #: scripts/core/lang/missing-translations-strings.ts:19
 msgid "Mark items for Highlights/Summary Lists"
@@ -10584,7 +10584,7 @@ msgstr "Означено за истицање {{x}} од {{user}}"
 #: scripts/extensions/markForUser/src/get-marked-for-me-component.tsx:140
 #: scripts/extensions/markForUser/src/get-marked-for-me-component.tsx:148
 msgid "Marked for me"
-msgstr ""
+msgstr "Означено за мене"
 
 #: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:99
 msgid "Marked for this user"
@@ -10592,7 +10592,7 @@ msgstr "Означено за овог корисника"
 
 #: scripts/apps/master-desk/index.ts:12 scripts/apps/master-desk/index.ts:23
 msgid "Master Desk"
-msgstr ""
+msgstr "Мастер деск"
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:7
 msgid "Match Any"
@@ -10610,7 +10610,7 @@ msgstr "Макс"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:147
 #: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:149
 msgid "Max Asset Size"
-msgstr ""
+msgstr "Максимална величина ресурса"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:272
 msgid "Max. number of items"
@@ -10631,7 +10631,7 @@ msgstr "Максимално 80 карактера."
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:241
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:301
 msgid "Maximum Asset Size"
-msgstr ""
+msgstr "Максимална величина ресурса"
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:25
 msgid "Maximum items allowed"
@@ -10788,13 +10788,13 @@ msgstr "Измењено"
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:96
 #: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:182
 msgid "Modified at {{time}} by {{user}}"
-msgstr ""
+msgstr "Измењено у {{time}} од {{user}}"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:139
 #: scripts/extensions/availability-manager/dist/src/utils.js:139
 #: scripts/extensions/availability-manager/src/utils.ts:159
 msgid "Modified by {{user}} at {{date}}"
-msgstr ""
+msgstr "Измењено од {{user}} на дан {{date}}"
 
 #: scripts/apps/search/directives/DateFilters.ts:85
 msgid "Modified from"
@@ -10987,7 +10987,7 @@ msgstr "Мора бити мање од {{ maximum }}"
 msgid ""
 "Must be {{MIN_LENGTH}} characters long and contain {{MIN_STRENGTH}} out of 4 "
 "of the following:"
-msgstr ""
+msgstr "Мора бити дуго {{MIN_LENGTH}} карактера и садржати {{MIN_STRENGTH}} од 4 следећа елемента:"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:165
 msgid "Must select at least one day"
@@ -11194,7 +11194,7 @@ msgstr "Нова претплата"
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:133
 #: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:256
 msgid "New template"
-msgstr ""
+msgstr "Нови шаблон"
 
 #: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:185
 #: scripts/apps/monitoring/views/aggregate-settings.html:158
@@ -11249,7 +11249,7 @@ msgstr "Није додељена агенда."
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetListPanel.js:62
 #: scripts/extensions/sams/src/components/assets/assetListPanel.tsx:35
 msgid "No Assets found"
-msgstr ""
+msgstr "Ресурси нису пронађени"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:123
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:248
@@ -11311,7 +11311,7 @@ msgstr "Нема доступних шаблона"
 #: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:39
 #: scripts/extensions/ai-widget/src/translations/translations-body.tsx:84
 msgid "No Translations yet"
-msgstr ""
+msgstr "Још нема превода"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:51
 msgid "No agendas assigned."
@@ -11339,11 +11339,11 @@ msgstr "Нема доступних истицања"
 
 #: scripts/apps/archive/views/package_item_labels_dropdown_directive.html:13
 msgid "No available labels"
-msgstr ""
+msgstr "Нема доступних ознака"
 
 #: scripts/apps/translations/views/TranslationDropdown.html:8
 msgid "No available languages"
-msgstr ""
+msgstr "Нема доступних језика"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:123
 msgid "No available selections"
@@ -11389,7 +11389,7 @@ msgstr "Није дефинисан филтер садржаја"
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/correspondent-availability/with-availability-records.js:54
 #: scripts/extensions/availability-manager/src/correspondent-availability/with-availability-records.tsx:98
 msgid "No data available"
-msgstr ""
+msgstr "Подаци нису доступни"
 
 #: ../superdesk-analytics/client/charts/views/table.html:22
 msgid "No data found"
@@ -11406,19 +11406,19 @@ msgstr "Нема доступних дестинација."
 
 #: scripts/core/spellcheck/spellcheck.ts:527
 msgid "No dictionary available for spell checking."
-msgstr ""
+msgstr "Нема доступног речника за проверу правописа."
 
 #: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:77
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:77
 #: scripts/extensions/sams/src/components/sets/setListPanel.tsx:84
 msgid "No disabled sets configured"
-msgstr ""
+msgstr "Нема подешених онемогућених скупова"
 
 #: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:75
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:75
 #: scripts/extensions/sams/src/components/sets/setListPanel.tsx:62
 msgid "No draft sets configured"
-msgstr ""
+msgstr "Нема подешених скупова нацрта"
 
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:99
 msgid "No events yet, drop some here, or click the plus button"
@@ -11462,7 +11462,7 @@ msgstr "Нису пронађене ставке"
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:176
 #: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:339
 msgid "No items found matching search criteria"
-msgstr ""
+msgstr "Нису пронађене ставке које одговарају критеријумима претраге"
 
 #: scripts/core/ui/components/select2.tsx:194
 msgid "No items found."
@@ -11494,7 +11494,7 @@ msgstr "Још нема ставки"
 
 #: scripts/apps/archive/views/package_item_labels_dropdown_directive.html:4
 msgid "No label"
-msgstr ""
+msgstr "Без ознаке"
 
 #: scripts/apps/authoring-react/macros/macros.tsx:317
 msgid "No macros configured."
@@ -11504,7 +11504,7 @@ msgstr "Нема подешених макроа."
 #: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/AnnotationsSelect.js:24
 #: scripts/extensions/annotationsLibrary/src/AnnotationsSelect.tsx:50
 msgid "No matches found in the library."
-msgstr ""
+msgstr "Нису пронађена поклапања у библиотеци."
 
 #: scripts/apps/authoring/macros/views/macros-replace.html:2
 msgid "No matches found."
@@ -11512,7 +11512,7 @@ msgstr "Нису пронађена поклапања."
 
 #: scripts/apps/profiling/views/profiling.html:32
 msgid "No of calls"
-msgstr ""
+msgstr "Број позива"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:179
 msgid "No options available for this field"
@@ -11555,7 +11555,7 @@ msgstr "Нема резултата."
 
 #: scripts/apps/master-desk/components/UserListComponent.tsx:38
 msgid "No role"
-msgstr ""
+msgstr "Нема улоге"
 
 #: scripts/apps/users/views/settings-roles.html:22
 msgid "No roles created yet."
@@ -11585,13 +11585,13 @@ msgstr "Још увек нема одговора сервера.<br>Покуш�
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:123
 #: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:239
 msgid "No show selected"
-msgstr ""
+msgstr "Није изабрана емисија"
 
 #: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/subitems-view-edit.js:58
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.js:58
 #: scripts/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.tsx:142
 msgid "No subitems"
-msgstr ""
+msgstr "Нема подставки"
 
 #: scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx:91
 msgid "No suggestions available"
@@ -11605,13 +11605,13 @@ msgstr "Ниједна сугестија није разрешена"
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:363
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:642
 msgid "No tags yet"
-msgstr ""
+msgstr "Још нема ознака"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:149
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:149
 #: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:316
 msgid "No template selected"
-msgstr ""
+msgstr "Није изабран шаблон"
 
 #: ../superdesk-planning/client/components/PlanningTemplatesModal/TemplatesListView.tsx:73
 msgid "No templates available in this calendar group."
@@ -11625,19 +11625,19 @@ msgstr "Нису пронађени шаблони."
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:251
 #: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:371
 msgid "No thumbnail"
-msgstr ""
+msgstr "Нема сличице"
 
 #: scripts/extensions/sams/dist/src/api/assets.js:382
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:382
 #: scripts/extensions/sams/src/api/assets.ts:483
 msgid "No usable Sets found. Enable one first"
-msgstr ""
+msgstr "Нису пронађени употребљиви скупови. Прво омогућите један"
 
 #: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:76
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:76
 #: scripts/extensions/sams/src/components/sets/setListPanel.tsx:73
 msgid "No usable sets configured"
-msgstr ""
+msgstr "Нема подешених употребљивих скупова"
 
 #: scripts/apps/users/views/list.html:28
 msgid "No user roles defined!"
@@ -11795,7 +11795,7 @@ msgstr "Још није заказано"
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/components/status-select.js:20
 #: scripts/extensions/availability-manager/src/components/status-select.tsx:41
 msgid "Not set"
-msgstr ""
+msgstr "Није подешено"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:319
 #: ../superdesk-planning/client/components/fields/resources/locations.ts:96
@@ -11873,7 +11873,7 @@ msgstr "ИЛИ"
 #: scripts/extensions/auto-tagging-widget/dist/src/groups.js:25
 #: scripts/extensions/auto-tagging-widget/src/groups.ts:35
 msgid "Object"
-msgstr ""
+msgstr "Објекат"
 
 #: scripts/apps/search/views/search-parameters.html:196
 msgid "Object Name (Slugline)"
@@ -11883,7 +11883,7 @@ msgstr "Назив објекта (слаглајн)"
 #: scripts/extensions/auto-tagging-widget/dist/src/groups.js:26
 #: scripts/extensions/auto-tagging-widget/src/groups.ts:36
 msgid "Objects"
-msgstr ""
+msgstr "Објекти"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:281
 msgid "Occur Status"
@@ -11979,7 +11979,7 @@ msgstr "Прихвата се само једна XMP датотека"
 
 #: scripts/apps/archive/controllers/UploadController.ts:229
 msgid "Only one file can be uploaded"
-msgstr ""
+msgstr "Може се отпремити само једна датотека"
 
 #: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:269
 msgid "Only the following content item types are allowed:"
@@ -11987,7 +11987,7 @@ msgstr "Дозвољени су само следећи типови ставк�
 
 #: scripts/apps/archive/controllers/UploadController.ts:333
 msgid "Only the following files are allowed: {{fileTypes}}"
-msgstr ""
+msgstr "Дозвољене су само следеће датотеке: {{fileTypes}}"
 
 #: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:89
 msgid "Only the following media item types are allowed:"
@@ -12046,7 +12046,7 @@ msgstr "Отвори у новом прозору"
 #: scripts/extensions/broadcasting/src/notifications.ts:22
 #: scripts/extensions/broadcasting/src/notifications.ts:26
 msgid "Open item"
-msgstr ""
+msgstr "Отвори ставку"
 
 #: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:215
 #: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:218
@@ -12126,7 +12126,7 @@ msgstr "Опције:"
 #: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:199
 #: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:224
 msgid "Or select an existing asset"
-msgstr ""
+msgstr "Или изаберите постојећи ресурс"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:62
 msgid "Orange"
@@ -12167,7 +12167,7 @@ msgstr "Контакт организације"
 #: scripts/extensions/auto-tagging-widget/dist/src/groups.js:10
 #: scripts/extensions/auto-tagging-widget/src/groups.ts:16
 msgid "Organisations"
-msgstr ""
+msgstr "Организације"
 
 #: ../superdesk-planning/client/components/Archive/ArchivePreview/index.tsx:63
 #: scripts/apps/archive/views/item-preview.html:24
@@ -12213,7 +12213,7 @@ msgstr "Оригинална слика"
 #: scripts/apps/archive/views/metadata-associateditem-view.html:27
 #: scripts/apps/archive/views/metadata-view.html:31
 msgid "Original Source"
-msgstr ""
+msgstr "Оригинални извор"
 
 #: scripts/apps/archive/views/metadata-view.html:106
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:390
@@ -12313,7 +12313,7 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/utils/assets.js:116
 #: scripts/extensions/sams/src/utils/assets.ts:148
 msgid "PDF"
-msgstr ""
+msgstr "PDF"
 
 #: ../superdesk-analytics/client/email_report/directives/EmailReportModal.js:95
 #: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsList.js:105
@@ -12382,7 +12382,7 @@ msgstr "Ставке пакета (authoring-react)"
 
 #: scripts/apps/archive/views/item-preview.html:5
 msgid "Package preview"
-msgstr ""
+msgstr "Преглед пакета"
 
 #: scripts/apps/workspace/content/constants.ts:7
 msgid "Package story labels"
@@ -12442,7 +12442,7 @@ msgstr "Родитељско извештавање још није повеза
 #: scripts/extensions/availability-manager/dist/src/utils.js:58
 #: scripts/extensions/availability-manager/src/utils.ts:61
 msgid "Partially available"
-msgstr ""
+msgstr "Делимично доступно"
 
 #: scripts/apps/publish/views/ftp-config.html:15
 msgid "Passive mode"
@@ -12458,7 +12458,7 @@ msgstr "Лозинка"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:75
 msgid "Password is too weak."
-msgstr ""
+msgstr "Лозинка је преслаба."
 
 #: scripts/core/auth/auth.ts:114
 msgid "Password was changed. You can login using your new password."
@@ -12517,7 +12517,7 @@ msgstr "Дозвољавање"
 #: scripts/extensions/auto-tagging-widget/dist/src/groups.js:13
 #: scripts/extensions/auto-tagging-widget/src/groups.ts:20
 msgid "Person"
-msgstr ""
+msgstr "Особа"
 
 #: scripts/apps/contacts/services/ContactsService.ts:38
 msgid "Person (Last Name)"
@@ -12646,7 +12646,7 @@ msgstr "Места:"
 #: scripts/extensions/broadcasting/dist/src/rundowns/components/rundown-items.js:40
 #: scripts/extensions/broadcasting/src/rundowns/components/rundown-items.tsx:128
 msgid "Planned"
-msgstr ""
+msgstr "Планирано"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:103
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/airing-info-block.js:16
@@ -12664,7 +12664,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/shows/create-show.tsx:119
 #: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:46
 msgid "Planned duration"
-msgstr ""
+msgstr "Планирано трајање"
 
 #: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:76
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/index.tsx:245
@@ -12983,7 +12983,7 @@ msgstr "Покреће технологија Superdesk-а"
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/extension.js:10
 #: scripts/extensions/predefinedTextField/src/extension.tsx:12
 msgid "Predefined text field"
-msgstr ""
+msgstr "Предефинисано текстуално поље"
 
 #: scripts/core/lang/missing-translations-strings.ts:15
 msgid "Preferred Categories"
@@ -13155,7 +13155,7 @@ msgstr "Привилегије ажуриране."
 #: scripts/apps/packaging/views/sd-package-item-preview.html:37
 #: scripts/apps/packaging/views/sd-package-item-preview.html:8
 msgid "Problems occurred while fetching data."
-msgstr ""
+msgstr "Дошло је до проблема приликом преузимања података."
 
 #: scripts/apps/products/views/products-config-modal.html:12
 msgid "Product Details"
@@ -13208,7 +13208,7 @@ msgstr "Продукција"
 #: scripts/apps/production-api-keys/index.ts:13
 #: scripts/apps/production-api-keys/views/settings.html:5
 msgid "Production API"
-msgstr ""
+msgstr "Production API"
 
 #: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:276
 msgid "Production Stats"
@@ -13236,11 +13236,11 @@ msgstr "Управљање производима"
 
 #: scripts/apps/profiling/views/profiling.html:6
 msgid "Profile:"
-msgstr ""
+msgstr "Профил:"
 
 #: scripts/apps/profiling/index.ts:26
 msgid "Profiling Data"
-msgstr ""
+msgstr "Подаци профилисања"
 
 #: scripts/apps/authoring/views/theme-select.html:66
 msgid "Proofread Theme"
@@ -13254,7 +13254,7 @@ msgstr "Тема за лектуру"
 msgid ""
 "Provide your email in order to get 'Reset Token'. Once you get it, use it to "
 "reset your password."
-msgstr ""
+msgstr "Унесите свој имејл да бисте добили 'Токен за ресет'. Када га добијете, искористите га за ресет лозинке."
 
 #: scripts/apps/users/views/change-avatar.html:47
 msgid "Provided image URL is not valid."
@@ -13297,7 +13297,7 @@ msgstr "Провајдер: {{ name }}"
 
 #: scripts/apps/archive/views/metadata-view.html:123
 msgid "PubStatus"
-msgstr ""
+msgstr "PubStatus"
 
 #: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:95
 #: scripts/apps/contacts/services/ContactsService.ts:56
@@ -13366,11 +13366,11 @@ msgstr "Објави и настави"
 
 #: scripts/core/interactive-article-actions-panel/actions/publish-action.tsx:290
 msgid "Publish from"
-msgstr ""
+msgstr "Објави од"
 
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx:153
 msgid "Publish schedule"
-msgstr ""
+msgstr "Распоред објављивања"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:26
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:81
@@ -13455,7 +13455,7 @@ msgstr "Радње објављивања"
 
 #: scripts/core/interactive-article-actions-panel/index-ui.tsx:104
 msgid "Publishing multiple items from authoring pane is not supported"
-msgstr ""
+msgstr "Објављивање више ставки из ауторског панела није подржано"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:181
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:56
@@ -13482,7 +13482,7 @@ msgstr "QCode"
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorTools.js:30
 #: scripts/extensions/videoEditor/src/VideoEditorTools.tsx:68
 msgid "Quality:"
-msgstr ""
+msgstr "Квалитет:"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:163
 msgid "Quarter"
@@ -13743,7 +13743,7 @@ msgstr "Освежавање..."
 #: scripts/extensions/ai-widget/src/summary/summary.tsx:42
 #: scripts/extensions/ai-widget/src/translations/translations-body.tsx:67
 msgid "Regenerate"
-msgstr ""
+msgstr "Поново генериши"
 
 #: scripts/apps/publish/views/amazon-sqs-fifo-config.html:18
 msgid "Region"
@@ -14254,11 +14254,11 @@ msgstr "Пошаљи поново"
 
 #: scripts/apps/archive/views/resend-configuration.html:4
 msgid "Resend To"
-msgstr ""
+msgstr "Пошаљи поново на"
 
 #: scripts/apps/archive/index.tsx:280
 msgid "Resend item"
-msgstr ""
+msgstr "Пошаљи ставку поново"
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:188
 msgid "Resent by"
@@ -14266,7 +14266,7 @@ msgstr "Поново послао"
 
 #: scripts/apps/profiling/views/profiling.html:22
 msgid "Reset"
-msgstr ""
+msgstr "Ресетуј"
 
 #: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:13
 msgid "Reset Filters"
@@ -14276,7 +14276,7 @@ msgstr "Ресетуј филтере"
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:247
 #: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:359
 msgid "Reset change"
-msgstr ""
+msgstr "Ресетуј измену"
 
 #: scripts/core/auth/reset-password.html:59
 msgid "Reset password"
@@ -14476,7 +14476,7 @@ msgstr "Скуп правила"
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:410
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:782
 msgid "Run"
-msgstr ""
+msgstr "Покрени"
 
 #: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:18
 msgid "Run Report"
@@ -14493,19 +14493,19 @@ msgstr "Покрени аутоматски"
 #: scripts/extensions/broadcasting/dist/src/page.js:174
 #: scripts/extensions/broadcasting/src/page.tsx:256
 msgid "Rundown"
-msgstr ""
+msgstr "Редослед"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:53
 #: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:53
 #: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:89
 msgid "Rundown created"
-msgstr ""
+msgstr "Редослед креиран"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:86
 #: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:86
 #: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:174
 msgid "Rundown name"
-msgstr ""
+msgstr "Назив редоследа"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/send-and-duplicate.tsx:17
 #: scripts/apps/authoring/views/authoring-topbar.html:90
@@ -14520,7 +14520,7 @@ msgstr "СУ"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/extension.js:13
 #: scripts/extensions/sams/src/extension.ts:17
 msgid "SAMS"
-msgstr ""
+msgstr "SAMS"
 
 #: ../superdesk-planning/client/components/Coverages/CoveragePreview/index.tsx:178
 msgid "SCHEDULED UPDATES"
@@ -14733,7 +14733,7 @@ msgstr "Сачувај извештај"
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:276
 #: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:426
 msgid "Save Rundown"
-msgstr ""
+msgstr "Сачувај редослед"
 
 #: scripts/apps/search/views/save-search.html:10
 msgid "Save Search"
@@ -14762,7 +14762,7 @@ msgstr "Сачувај као шаблон"
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:245
 #: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:352
 msgid "Save change"
-msgstr ""
+msgstr "Сачувај измену"
 
 #: scripts/apps/search/views/saved-search-manage-subscribers.html:129
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:220
@@ -14843,7 +14843,7 @@ msgstr "Сачувај догађај као шаблон"
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:364
 #: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:630
 msgid "Save item"
-msgstr ""
+msgstr "Сачувај ставку"
 
 #: scripts/apps/users/views/edit-form.html:401
 msgid "Save password"
@@ -14901,7 +14901,7 @@ msgstr "Сачуване претраге"
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:117
 #: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:181
 msgid "Saving capture thumbnail..."
-msgstr ""
+msgstr "Чување снимљене сличице..."
 
 #: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:131
 #: scripts/apps/desks/directives/DeskeditBasic.ts:31
@@ -15034,7 +15034,7 @@ msgstr "Правила шеме"
 
 #: scripts/apps/production-api-keys/config.ts:18
 msgid "Scopes"
-msgstr ""
+msgstr "Опсези"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentFilterPanel.tsx:131
 #: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:38
@@ -15084,7 +15084,7 @@ msgstr "Претрага"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:238
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:336
 msgid "Search Assets"
-msgstr ""
+msgstr "Претражи ресурсе"
 
 #: ../superdesk-planning/client/components/Assignments/SubNavBar.tsx:72
 msgid "Search Assignments"
@@ -15191,7 +15191,7 @@ msgstr "Тражи иконе...."
 
 #: scripts/apps/content-api/index.ts:22
 msgid "Search items is content API"
-msgstr ""
+msgstr "Претражи ставке у content API-ју"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:116
 #: ../superdesk-planning/client/components/Main/SubNavBar.tsx:29
@@ -15266,7 +15266,7 @@ msgstr "Изабери све"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/selectAssetModal.js:150
 #: scripts/extensions/sams/src/components/assets/selectAssetModal.tsx:162
 msgid "Select Asset(s)"
-msgstr ""
+msgstr "Изабери ресурс(е)"
 
 #: ../superdesk-planning/client/components/Assignments/DesksSubNavDropDown.tsx:49
 msgid "Select Assignments From:"
@@ -15317,13 +15317,13 @@ msgstr "Прво изаберите деск"
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:123
 #: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:240
 msgid "Select a show from the dropdown above."
-msgstr ""
+msgstr "Изаберите емисију из падајућег менија изнад."
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:149
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:149
 #: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:317
 msgid "Select a template from the sidebar."
-msgstr ""
+msgstr "Изаберите шаблон из бочне траке."
 
 #: scripts/core/ui/components/SelectUser.tsx:100
 #: scripts/core/ui/components/SelectUser.tsx:51
@@ -15396,7 +15396,7 @@ msgstr "Изаберите или Претрагу или Преглед лок�
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/editor.js:34
 #: scripts/extensions/predefinedTextField/src/editor.tsx:53
 msgid "Select from a predefined value"
-msgstr ""
+msgstr "Изабери из предефинисане вредности"
 
 #: scripts/apps/search/views/edit-time-interval.html:19
 msgid "Select hours"
@@ -15427,7 +15427,7 @@ msgstr "Изабери сачуване претраге за приказ"
 #: scripts/extensions/broadcasting/dist/src/rundowns/components/select-show.js:21
 #: scripts/extensions/broadcasting/src/rundowns/components/select-show.tsx:53
 msgid "Select show"
-msgstr ""
+msgstr "Изабери емисију"
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:7
 msgid "Select source"
@@ -15442,7 +15442,7 @@ msgstr "Изабери шаблон"
 
 #: scripts/apps/archive/views/upload.html:39
 msgid "Select them from folder"
-msgstr ""
+msgstr "Изаберите их из фасцикле"
 
 #: scripts/apps/authoring/authoring/components/video-thumbnail-editor.tsx:122
 msgid "Select thumbnail"
@@ -15452,7 +15452,7 @@ msgstr "Изабери сличицу"
 #: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:63
 #: scripts/extensions/auto-tagging-widget/src/new-item.tsx:141
 msgid "Select type"
-msgstr ""
+msgstr "Изабери тип"
 
 #: scripts/apps/authoring-react/toolbar/version-header.tsx:29
 msgid "Select version"
@@ -15466,11 +15466,11 @@ msgstr "Изабрано"
 
 #: scripts/core/views/sdSearchList.html:21
 msgid "Selected item"
-msgstr ""
+msgstr "Изабрана ставка"
 
 #: scripts/core/views/sdSearchList.html:14
 msgid "Selected items"
-msgstr ""
+msgstr "Изабране ставке"
 
 #: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:77
 #: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:33
@@ -15484,7 +15484,7 @@ msgstr "Избори аутоматски уклоњени"
 #: scripts/core/directives/views/phone-home-modal-directive.html:39
 #: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:170
 msgid "Send"
-msgstr ""
+msgstr "Пошаљи"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:89
 msgid "Send & duplicate"
@@ -15520,11 +15520,11 @@ msgstr "Пошаљи и дуплирај"
 
 #: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:157
 msgid "Send and open"
-msgstr ""
+msgstr "Пошаљи и отвори"
 
 #: scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx:144
 msgid "Send correction"
-msgstr ""
+msgstr "Пошаљи исправку"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/send-kill-action.tsx:13
 msgid "Send kill"
@@ -15536,18 +15536,18 @@ msgstr "Шаљи обавештења путем имејла"
 
 #: scripts/apps/internal-destinations/InternalDestinations.tsx:70
 msgid "Send only after publish schedule"
-msgstr ""
+msgstr "Шаљи само након распореда објаве"
 
 #: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:183
 msgid "Send package and items"
 msgid_plural "Send packages and items"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Пошаљи пакет и ставке"
+msgstr[1] "Пошаљи пакете и ставке"
+msgstr[2] "Пошаљи пакете и ставке"
 
 #: scripts/apps/packaging/index.ts:110
 msgid "Send package to"
-msgstr ""
+msgstr "Пошаљи пакет у"
 
 #: scripts/apps/authoring/authoring/index.ts:277
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:201
@@ -15633,19 +15633,19 @@ msgstr "Сесије очишћене"
 #: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:166
 #: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:191
 msgid "Set"
-msgstr ""
+msgstr "Скуп"
 
 #: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:132
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:132
 #: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:127
 msgid "Set Details"
-msgstr ""
+msgstr "Детаљи скупа"
 
 #: scripts/extensions/sams/dist/src/components/attachments/samsAttachmentsList.js:116
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/samsAttachmentsList.js:116
 #: scripts/extensions/sams/src/components/attachments/samsAttachmentsList.tsx:129
 msgid "Set Disabled"
-msgstr ""
+msgstr "Постави као онемогућено"
 
 #: scripts/apps/publish/views/amazon-sqs-fifo-config.html:42
 #: scripts/apps/publish/views/amazon-sqs-fifo-config.html:59
@@ -15662,13 +15662,13 @@ msgstr "Постави као подразумевано"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:34
 #: scripts/extensions/sams/src/api/sets.ts:46
 msgid "Set created successfully"
-msgstr ""
+msgstr "Скуп успешно креиран"
 
 #: scripts/extensions/sams/dist/src/api/sets.js:77
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:77
 #: scripts/extensions/sams/src/api/sets.ts:98
 msgid "Set deleted successfully"
-msgstr ""
+msgstr "Скуп успешно обрисан"
 
 #: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:90
 msgid "Set highlights"
@@ -15676,7 +15676,7 @@ msgstr "Постави истицања"
 
 #: scripts/apps/archive/index.tsx:219
 msgid "Set label in current package"
-msgstr ""
+msgstr "Постави ознаку у тренутном пакету"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:131
 msgid "Set maximum items per stages and saved searches for view"
@@ -15695,25 +15695,25 @@ msgstr "Подесите различите мониторе да бисте п�
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:57
 #: scripts/extensions/sams/src/api/sets.ts:76
 msgid "Set updated successfully"
-msgstr ""
+msgstr "Скуп успешно ажуриран"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/notifications/sets.js:45
 #: scripts/extensions/sams/dist/src/notifications/sets.js:45
 #: scripts/extensions/sams/src/notifications/sets.ts:50
 msgid "Set was deleted by another user."
-msgstr ""
+msgstr "Скуп је обрисан од стране другог корисника."
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/notifications/sets.js:25
 #: scripts/extensions/sams/dist/src/notifications/sets.js:25
 #: scripts/extensions/sams/src/notifications/sets.ts:28
 msgid "Set was updated by another user."
-msgstr ""
+msgstr "Скуп је ажуриран од стране другог корисника."
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:176
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:176
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:206
 msgid "Sets"
-msgstr ""
+msgstr "Скупови"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:171
 #: scripts/apps/settings/index.ts:19 scripts/apps/settings/settings.tsx:32
@@ -15734,7 +15734,7 @@ msgstr "Помери преглед"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:37
 msgid "Short"
-msgstr ""
+msgstr "Кратко"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:138
 msgid "Shortcuts"
@@ -15771,7 +15771,7 @@ msgstr[2] "Прикажи {{n}} ставки планирања"
 
 #: scripts/apps/archive/views/provider-menu.html:9
 msgid "Show All"
-msgstr ""
+msgstr "Прикажи све"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:121
 msgid "Show Bookmark"
@@ -15807,7 +15807,7 @@ msgstr "Прикажи све поруке"
 #: scripts/extensions/broadcasting/dist/src/shows/manage-shows.js:19
 #: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:31
 msgid "Show code"
-msgstr ""
+msgstr "Прикажи код"
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:48
 msgid "Show crops for pictures"
@@ -15821,7 +15821,7 @@ msgstr "Прикажи поруке грешке"
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:302
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:509
 msgid "Show image suggestions"
-msgstr ""
+msgstr "Прикажи сугестије слика"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:30
 msgid "Show in embedded form"
@@ -15861,7 +15861,7 @@ msgstr "Прикажи више"
 #: scripts/extensions/broadcasting/src/shows/create-show.tsx:95
 #: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:25
 msgid "Show name"
-msgstr ""
+msgstr "Назив емисије"
 
 #: ../superdesk-planning/client/components/Location/index.tsx:54
 #: ../superdesk-planning/client/components/Locations/LocationsList.tsx:93
@@ -15964,19 +15964,19 @@ msgstr "Један избор"
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:177
 #: scripts/extensions/sams/src/utils/ui.tsx:103
 msgid "Size"
-msgstr ""
+msgstr "Величина"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:247
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:247
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:320
 msgid "Size From:"
-msgstr ""
+msgstr "Величина од:"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:251
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:251
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:334
 msgid "Size To:"
-msgstr ""
+msgstr "Величина до:"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:176
 #: scripts/extensions/sams/dist/src/components/assets/assetGridItem.js:125
@@ -15988,11 +15988,11 @@ msgstr ""
 #: scripts/extensions/sams/src/components/assets/assetGridItem.tsx:155
 #: scripts/extensions/sams/src/components/assets/assetListItem.tsx:137
 msgid "Size:"
-msgstr ""
+msgstr "Величина:"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:41
 msgid "Skip"
-msgstr ""
+msgstr "Прескочи"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:174
 msgid "Skip Next"
@@ -16102,7 +16102,7 @@ msgstr "Неке изабране ставке још нису објављен�
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:53
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:124
 msgid "Some tags can not be displayed"
-msgstr ""
+msgstr "Неке ознаке не могу бити приказане"
 
 #: scripts/core/upload/crop-directive.ts:57
 msgid "Sorry, but avatar must be at least 200x200 pixels big."
@@ -16151,7 +16151,7 @@ msgstr "Корисник није пронађен."
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:138
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:163
 msgid "Sort By"
-msgstr ""
+msgstr "Сортирај по"
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:28
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-preview.html:15
@@ -16175,7 +16175,7 @@ msgstr "Сортирај по:"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:262
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:410
 msgid "Sort by: {{ field }}"
-msgstr ""
+msgstr "Сортирај по: {{ field }}"
 
 #: scripts/apps/search/views/item-sortbar.html:19
 msgid "Sort order"
@@ -16185,13 +16185,13 @@ msgstr "Редослед сортирања"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:266
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:424
 msgid "Sort order: Ascending"
-msgstr ""
+msgstr "Редослед сортирања: растуће"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:267
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:267
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:425
 msgid "Sort order: Descending"
-msgstr ""
+msgstr "Редослед сортирања: опадајуће"
 
 #: scripts/apps/legal-archive/views/legal_archive.html:29
 msgid "Sorting"
@@ -16235,7 +16235,7 @@ msgstr "Статистика извора"
 #: scripts/extensions/auto-tagging-widget/dist/src/tag-popover.js:20
 #: scripts/extensions/auto-tagging-widget/src/tag-popover.tsx:29
 msgid "Source:"
-msgstr ""
+msgstr "Извор:"
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:133
 #: scripts/apps/search/views/search-filters.html:44
@@ -16260,7 +16260,7 @@ msgstr "Премести у корпу"
 
 #: scripts/apps/archive/index.tsx:120
 msgid "Spike Item"
-msgstr ""
+msgstr "Премести ставку у корпу"
 
 #: scripts/apps/monitoring/config.ts:29
 msgid "Spike Monitoring"
@@ -16502,7 +16502,7 @@ msgstr "Заустави рутирање"
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:342
 #: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:154
 msgid "Storage Destination"
-msgstr ""
+msgstr "Дестинација складиштења"
 
 #: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:256
 #: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:153
@@ -16511,19 +16511,19 @@ msgstr ""
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:348
 #: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:159
 msgid "Storage Provider"
-msgstr ""
+msgstr "Провајдер складиштења"
 
 #: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:243
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:243
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:311
 msgid "Storage Unit"
-msgstr ""
+msgstr "Јединица складиштења"
 
 #: scripts/extensions/sams/dist/src/components/sets/setListItem.js:97
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListItem.js:97
 #: scripts/extensions/sams/src/components/sets/setListItem.tsx:85
 msgid "Storage:"
-msgstr ""
+msgstr "Складиштење:"
 
 #: scripts/apps/publish/views/odbc-config.html:11
 #: scripts/apps/publish/views/odbc-config.html:9
@@ -16566,7 +16566,7 @@ msgstr "Адреса улице, поштански фах, назив комп�
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:65
 msgid "Strength"
-msgstr ""
+msgstr "Снага"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:181
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:40
@@ -16576,11 +16576,11 @@ msgstr "Прецртано"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:41
 msgid "Strong"
-msgstr ""
+msgstr "Снажно"
 
 #: scripts/apps/system-messages/components/system-messages-settings.tsx:49
 msgid "Style"
-msgstr ""
+msgstr "Стил"
 
 #: ../superdesk-planning/client/utils/filters.ts:130
 msgid "Su"
@@ -16599,7 +16599,7 @@ msgstr "Подгрупиши по:"
 #: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:112
 #: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:144
 msgid "Subitem attachments"
-msgstr ""
+msgstr "Прилози подставки"
 
 #: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/index.js:13
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/index.js:13
@@ -16608,7 +16608,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/authoring-fields/subitems/index.tsx:30
 #: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:165
 msgid "Subitems"
-msgstr ""
+msgstr "Подставке"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:547
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:117
@@ -16719,7 +16719,7 @@ msgstr "Предграђе"
 
 #: scripts/apps/system-messages/components/system-messages-settings.tsx:27
 msgid "Success"
-msgstr ""
+msgstr "Успех"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:183
 msgid "Suggestion"
@@ -16747,7 +16747,7 @@ msgstr "Збир"
 #: scripts/extensions/ai-widget/src/main-panel.tsx:35
 #: scripts/extensions/ai-widget/src/summary/summary-widget.tsx:70
 msgid "Summary"
-msgstr ""
+msgstr "Сажетак"
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:106
 msgid "Sun"
@@ -16835,7 +16835,7 @@ msgstr "Прекидачи"
 #: scripts/apps/system-messages/components/system-messages-settings.tsx:148
 #: scripts/apps/system-messages/index.ts:34
 msgid "System Message"
-msgstr ""
+msgstr "Системска порука"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:140
 msgid "T"
@@ -16981,7 +16981,7 @@ msgstr "Tansa не одговара. Можете наставити уређи�
 
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:105
 msgid "Target"
-msgstr ""
+msgstr "Циљ"
 
 #: scripts/apps/archive/views/metadata-view.html:151
 #: scripts/apps/products/views/products-config-modal.html:76
@@ -16990,7 +16990,7 @@ msgstr "Циљни региони"
 
 #: scripts/apps/archive/views/metadata-view.html:156
 msgid "Target Subscriber Types"
-msgstr ""
+msgstr "Типови циљних претплатника"
 
 #: scripts/apps/archive/views/metadata-view.html:146
 #: scripts/apps/templates/views/template-editor-modal.html:135
@@ -17011,15 +17011,15 @@ msgstr "Циљни типови"
 
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:131
 msgid "Target regions"
-msgstr ""
+msgstr "Циљни региони"
 
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:106
 msgid "Target subscribers"
-msgstr ""
+msgstr "Циљни претплатници"
 
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:148
 msgid "Target types"
-msgstr ""
+msgstr "Циљни типови"
 
 #: scripts/apps/publish/views/subscribers.html:163
 msgid "Targetable by users"
@@ -17039,13 +17039,13 @@ msgstr "Управљање задацима"
 #: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:58
 #: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:74
 msgid "Tech. title"
-msgstr ""
+msgstr "Тех. наслов"
 
 #: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/subitems-view-edit.js:46
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.js:46
 #: scripts/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.tsx:101
 msgid "Technical information"
-msgstr ""
+msgstr "Техничке информације"
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:19
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:72
@@ -17073,7 +17073,7 @@ msgstr "Шаблон већ постоји. Желите ли да га заме
 #: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:93
 #: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:206
 msgid "Template based settings"
-msgstr ""
+msgstr "Подешавања заснована на шаблону"
 
 #: ../superdesk-planning/client/actions/events/api.ts:796
 #: ../superdesk-planning/client/components/Events/ManageEventTemplatesModal.tsx:72
@@ -17233,7 +17233,7 @@ msgid ""
 "github.com/superdesk\" title=\"Superdesk GitHub\" target=\"_blank\">GitHub</"
 "a> by <a href=\"https://www.sourcefabric.org/\" title=\"Sourcefabric\" "
 "target=\"_blank\">Sourcefabric</a>."
-msgstr ""
+msgstr "Superdesk пројекат развија и одржава <a href=\"https://github.com/superdesk\" title=\"Superdesk GitHub\" target=\"_blank\">GitHub</a> заједница и <a href=\"https://www.sourcefabric.org/\" title=\"Sourcefabric\" target=\"_blank\">Sourcefabric</a>."
 
 #: scripts/core/auth/reset-password.html:74
 msgid "The activation token is not valid."
@@ -17283,9 +17283,9 @@ msgstr "Догађај(и) је(су) враћен(и) из корпе"
 #: scripts/apps/archive/controllers/file-upload-error-modal.tsx:31
 msgid "The file was not uploaded"
 msgid_plural "Some files were not uploaded"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Датотека није отпремљена"
+msgstr[1] "Неке датотеке нису отпремљене"
+msgstr[2] "Неке датотеке нису отпремљене"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:112
 msgid "The following Events are in use and will not be spiked:"
@@ -17295,7 +17295,7 @@ msgstr "Следећи догађаји су у употреби и неће б�
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:66
 #: scripts/extensions/predefinedTextField/src/config.tsx:106
 msgid "The following placeholders are available to be used in definitions:"
-msgstr ""
+msgstr "Следећи плејсхолдери су доступни за коришћење у дефиницијама:"
 
 #: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:246
 #: scripts/apps/relations/directives/RelatedItemsDirective.ts:141
@@ -17308,15 +17308,15 @@ msgstr "Помоћни текст не сме прелазити 120 карак�
 
 #: scripts/core/helpers/crud-manager-http.tsx:52
 msgid "The item has been created."
-msgstr ""
+msgstr "Ставка је креирана."
 
 #: scripts/core/helpers/crud-manager-http.tsx:97
 msgid "The item has been deleted."
-msgstr ""
+msgstr "Ставка је обрисана."
 
 #: scripts/core/helpers/crud-manager-http.tsx:86
 msgid "The item has been updated."
-msgstr ""
+msgstr "Ставка је ажурирана."
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:30
 msgid "The item is read-only."
@@ -17379,11 +17379,11 @@ msgstr "Одговор ће бити обрисан. Да ли сте сигур
 #: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:23
 #: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:64
 msgid "The show {{name}} has been successfully created"
-msgstr ""
+msgstr "Емисија {{name}} је успешно креирана"
 
 #: scripts/apps/archive/controllers/file-upload-error-modal.tsx:61
 msgid "The size of {{filename}} is {{width}}x{{height}}"
-msgstr ""
+msgstr "Величина {{filename}} је {{width}}x{{height}}"
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:401
 msgid ""
@@ -17455,7 +17455,7 @@ msgstr "Тренутно нема ставки"
 
 #: scripts/validate-instance-configuration.tsx:108
 msgid "There are issues with instance configuration"
-msgstr ""
+msgstr "Постоје проблеми са конфигурацијом инстанце"
 
 #: scripts/api/highlights.ts:37
 msgid "There are items locked or not published. Do you want to continue?"
@@ -17528,11 +17528,11 @@ msgstr "Нема разрешених сугестија"
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:173
 #: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:333
 msgid "There are no rundowns yet"
-msgstr ""
+msgstr "Још нема редоследа"
 
 #: scripts/apps/master-desk/components/UsersComponent.tsx:150
 msgid "There are no users assigned to this desk"
-msgstr ""
+msgstr "Нема корисника додељених овом деску"
 
 #: scripts/apps/authoring/metadata/views/prefered-cv-items-config.html:15
 msgid "There are no vocabularies configured."
@@ -17591,7 +17591,7 @@ msgstr "Дошло је до грешке. Повезивање ажурирањ
 #: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:90
 #: scripts/extensions/broadcasting/src/utils/handle-unsaved-rundown-changes.ts:23
 msgid "There is an item open in editing mode. Discard changes?"
-msgstr ""
+msgstr "Постоји ставка отворена у режиму уређивања. Одбацити измене?"
 
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:269
 msgid "There is an update assignment for this story due at ''."
@@ -17667,19 +17667,19 @@ msgstr "Дошло је до грешке приликом чувања кори
 #: scripts/extensions/ai-widget/dist/src/summary/summary.js:22
 #: scripts/extensions/ai-widget/src/summary/summary.tsx:45
 msgid "There was an error when trying to generate a summary."
-msgstr ""
+msgstr "Дошло је до грешке приликом покушаја генерисања сажетка."
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:32
 #: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:32
 #: scripts/extensions/ai-widget/src/translations/translations-body.tsx:70
 msgid "There was an error when trying to generate a translation."
-msgstr ""
+msgstr "Дошло је до грешке приликом покушаја генерисања превода."
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines.js:23
 #: scripts/extensions/ai-widget/dist/src/headlines/headlines.js:23
 #: scripts/extensions/ai-widget/src/headlines/headlines.tsx:49
 msgid "There was an error when trying to generate headlines."
-msgstr ""
+msgstr "Дошло је до грешке приликом покушаја генерисања наслова."
 
 #: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:219
 msgid "There was an error, could not delete Events and Planning view filter."
@@ -17886,7 +17886,7 @@ msgstr "Само ово планирање"
 
 #: scripts/apps/archive/views/preview.html:100
 msgid "This story has been rewritten by:"
-msgstr ""
+msgstr "Ову причу је прерадио:"
 
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:112
 msgid ""
@@ -18010,19 +18010,19 @@ msgstr "Временска зона"
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:59
 #: scripts/extensions/datetimeField/src/editor.tsx:101
 msgid "Time cannot be empty"
-msgstr ""
+msgstr "Време не може бити празно"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:50
 #: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:50
 #: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:92
 msgid "Time from"
-msgstr ""
+msgstr "Време од"
 
 #: scripts/extensions/datetimeField/dist/src/config.js:33
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:33
 #: scripts/extensions/datetimeField/src/config.tsx:57
 msgid "Time increment steps"
-msgstr ""
+msgstr "Кораци прираста времена"
 
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/template-editor.js:20
 #: scripts/extensions/datetimeField/dist/src/template-editor.js:20
@@ -18032,11 +18032,11 @@ msgid ""
 "article is created\n"
 "            based on this template, it's value will initialize to creation "
 "time + {{x}} minutes"
-msgstr ""
+msgstr "Временски померај је подешен на {{x}} минута за ово поље. Када се чланак креира\n            на основу овог шаблона, његова вредност ће се иницијализовати на време креирања + {{x}} минута"
 
 #: scripts/apps/profiling/views/profiling.html:34
 msgid "Time per call"
-msgstr ""
+msgstr "Време по позиву"
 
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:344
 msgid "Time picker"
@@ -18050,12 +18050,12 @@ msgstr "Време утрошено на продукцију садржаја"
 #: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:62
 #: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:125
 msgid "Time to"
-msgstr ""
+msgstr "Време до"
 
 #: scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx:113
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx:180
 msgid "Time zone"
-msgstr ""
+msgstr "Временска зона"
 
 #: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:559
 msgid "Timeline"
@@ -18164,7 +18164,7 @@ msgstr "До:"
 #: scripts/extensions/ai-widget/dist/src/translations/translations-footer.js:40
 #: scripts/extensions/ai-widget/src/translations/translations-footer.tsx:65
 msgid "To: {{ language }}"
-msgstr ""
+msgstr "На: {{ language }}"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:18
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:9
@@ -18236,7 +18236,7 @@ msgstr "Прикажи/сакриј ознаке форматирања"
 
 #: scripts/apps/archive/views/preview.html:79
 msgid "Toggle header info"
-msgstr ""
+msgstr "Прикажи/сакриј информације заглавља"
 
 #: scripts/core/editor3/highlightsConfig.ts:49
 msgid "Toggle italic"
@@ -18317,11 +18317,11 @@ msgstr "Укупно"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:257
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:394
 msgid "Total Assets: {{ total }}"
-msgstr ""
+msgstr "Укупно ресурса: {{ total }}"
 
 #: scripts/apps/profiling/views/profiling.html:33
 msgid "Total time"
-msgstr ""
+msgstr "Укупно време"
 
 #: scripts/apps/search/views/item-sortbar.html:2
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:732
@@ -18444,7 +18444,7 @@ msgstr "Тип"
 #: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:80
 #: scripts/extensions/auto-tagging-widget/src/new-item.tsx:191
 msgid "Type is required."
-msgstr ""
+msgstr "Тип је обавезан."
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:89
 msgid "Type to search or create a new label"
@@ -18522,7 +18522,7 @@ msgstr "Врати из корпе"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/uploadAssetModal.js:148
 #: scripts/extensions/sams/src/components/assets/uploadAssetModal.tsx:122
 msgid "Unable to find Asset associated with the file!"
-msgstr ""
+msgstr "Није могуће пронаћи ресурс повезан са датотеком!"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/index.tsx:227
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:208
@@ -18539,11 +18539,11 @@ msgstr "Недодељено"
 #: scripts/extensions/availability-manager/src/utils.ts:59
 #: scripts/extensions/availability-manager/src/utils.ts:75
 msgid "Unavailable"
-msgstr ""
+msgstr "Недоступно"
 
 #: scripts/core/views/sdselect.html:14
 msgid "Uncheck all"
-msgstr ""
+msgstr "Поништи означавање за све"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:200
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:30
@@ -18588,11 +18588,11 @@ msgstr "Непознато"
 
 #: scripts/apps/archive/directives/ArchivedItemKill.ts:39
 msgid "Unknown Error: Cannot kill the item"
-msgstr ""
+msgstr "Непозната грешка: није могуће уништити ставку"
 
 #: scripts/apps/archive/directives/ResendItem.ts:45
 msgid "Unknown Error: Cannot resend the item"
-msgstr ""
+msgstr "Непозната грешка: није могуће поново послати ставку"
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:436
 msgid "Unknown Error: Item not published."
@@ -18639,7 +18639,7 @@ msgstr "Уклони везу повезаног планирања"
 
 #: scripts/apps/archive/index.tsx:310
 msgid "Unlink update"
-msgstr ""
+msgstr "Уклони везу ажурирања"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:148
 msgid "Unlinked by"
@@ -18684,7 +18684,7 @@ msgstr "Уклони ознаку"
 #: scripts/extensions/markForUser/dist/src/get-article-actions.js:21
 #: scripts/extensions/markForUser/src/get-article-actions.tsx:23
 msgid "Unmark user"
-msgstr ""
+msgstr "Уклони ознаку корисника"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:102
 msgid "Unmarked by"
@@ -18768,7 +18768,7 @@ msgstr "Врати из корпе"
 
 #: scripts/apps/archive/index.tsx:134
 msgid "Unspike Item"
-msgstr ""
+msgstr "Врати ставку из корпе"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:143
 msgid "Unspike Planning Item"
@@ -18811,7 +18811,7 @@ msgstr "Откажи претплату корисника"
 msgid ""
 "Unsupported extension point is being used: "
 "`contributions.authoringHeaderComponents`"
-msgstr ""
+msgstr "Користи се неподржана тачка проширења: `contributions.authoringHeaderComponents`"
 
 #: ../superdesk-planning/client/components/WorkqueueContainer/WorkqueueItem.tsx:41
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:6
@@ -18884,7 +18884,7 @@ msgstr "Ажурирај сваких"
 
 #: scripts/validate-instance-configuration.tsx:42
 msgid "Update or disable incompatible extensions."
-msgstr ""
+msgstr "Ажурирајте или онемогућите некомпатибилне екстензије."
 
 #: scripts/apps/search/views/saved-search-subscribe.html:33
 msgid "Update subscription"
@@ -18941,7 +18941,7 @@ msgstr "Ажурирано у"
 #: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:104
 #: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:178
 msgid "Updated at {{date}}"
-msgstr ""
+msgstr "Ажурирано {{date}}"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:129
 #: scripts/apps/authoring/versioning/history/views/history.html:18
@@ -18963,13 +18963,13 @@ msgstr "Ажурирана поља:"
 #: scripts/extensions/sams/src/components/common/versionUserDateLines.tsx:52
 #: scripts/extensions/sams/src/components/sets/setListItem.tsx:80
 msgid "Updated {{ datetime }}"
-msgstr ""
+msgstr "Ажурирано {{ datetime }}"
 
 #: scripts/extensions/sams/dist/src/components/common/versionUserDateLines.js:99
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/versionUserDateLines.js:70
 #: scripts/extensions/sams/src/components/common/versionUserDateLines.tsx:57
 msgid "Updated {{ datetime }} by"
-msgstr ""
+msgstr "Ажурирано {{ datetime }} од"
 
 #: scripts/apps/contacts/components/ContactFooter.tsx:18
 msgid "Updated:"
@@ -18999,7 +18999,7 @@ msgstr "Отпреми конфигурацију"
 
 #: scripts/apps/archive/controllers/UploadController.ts:165
 msgid "Upload Error:"
-msgstr ""
+msgstr "Грешка отпремања:"
 
 #: scripts/extensions/sams/dist/src/components/assets/uploadAssetModal.js:190
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:245
@@ -19008,7 +19008,7 @@ msgstr ""
 #: scripts/extensions/sams/src/components/assets/uploadAssetModal.tsx:200
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:358
 msgid "Upload New Asset(s)"
-msgstr ""
+msgstr "Отпреми нови ресурс(е)"
 
 #: scripts/apps/vocabularies/components/UploadConfigModal.tsx:69
 msgid "Upload config"
@@ -19022,7 +19022,7 @@ msgstr "Отпреми са рачунара"
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:243
 #: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:342
 msgid "Upload image"
-msgstr ""
+msgstr "Отпреми слику"
 
 #: scripts/apps/archive/index.tsx:106
 #: scripts/apps/search/views/multi-image-edit.html:12
@@ -19038,19 +19038,19 @@ msgstr "Отпреми ново"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetListPanel.js:62
 #: scripts/extensions/sams/src/components/assets/assetListPanel.tsx:36
 msgid "Upload new Assets or change your search filters"
-msgstr ""
+msgstr "Отпремите нове ресурсе или промените филтере претраге"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:256
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:256
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:351
 msgid "Uploaded From:"
-msgstr ""
+msgstr "Отпремљено од:"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:258
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:258
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:361
 msgid "Uploaded To:"
-msgstr ""
+msgstr "Отпремљено до:"
 
 #: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:119
 msgid "Uploading {{current}} of {{total}}"
@@ -19107,7 +19107,7 @@ msgstr "URL-ови (authoring-react)"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:76
 #: scripts/extensions/sams/src/components/sets/setListPanel.tsx:72
 msgid "Usable Sets"
-msgstr ""
+msgstr "Употребљиви скупови"
 
 #: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:85
 msgid "Usage"
@@ -19145,13 +19145,13 @@ msgstr "Користи веб URL"
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:238
 #: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:329
 msgid "Use current frame"
-msgstr ""
+msgstr "Користи тренутни кадар"
 
 #: scripts/extensions/predefinedTextField/dist/src/editor.js:59
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/editor.js:59
 #: scripts/extensions/predefinedTextField/src/editor.tsx:98
 msgid "Use custom value"
-msgstr ""
+msgstr "Користи прилагођену вредност"
 
 #: scripts/apps/publish/views/subscribers.html:210
 msgid "Use priority queue for transmission."
@@ -19165,7 +19165,7 @@ msgstr "Користите GUID чланка за тестирање."
 #: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.js:14
 #: scripts/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.tsx:36
 msgid "Use this"
-msgstr ""
+msgstr "Користи ово"
 
 #: scripts/apps/search/components/fields/used.tsx:16
 #: scripts/apps/search/views/item-preview.html:21
@@ -19353,19 +19353,19 @@ msgstr "Видео"
 #: scripts/extensions/videoEditor/src/VideoEditor.tsx:134
 #: scripts/extensions/videoEditor/src/VideoEditor.tsx:422
 msgid "Video is editing, please wait..."
-msgstr ""
+msgstr "Видео се уређује, сачекајте..."
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:235
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:235
 #: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:322
 msgid "Video thumbnail"
-msgstr ""
+msgstr "Сличица видеа"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:74
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:74
 #: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:57
 msgid "Videos only"
-msgstr ""
+msgstr "Само видео"
 
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:28
 msgid "View Latest Item Version"
@@ -19499,7 +19499,7 @@ msgstr "Вокабулар је обрисан."
 
 #: scripts/validate-instance-configuration.tsx:56
 msgid "Vocabulary with ID \"categories\" is required"
-msgstr ""
+msgstr "Вокабулар са ИД-ом \"categories\" је обавезан"
 
 #: ../superdesk-planning/client/components/Main/CalendarNavigation.tsx:56
 msgid "W"
@@ -19544,11 +19544,11 @@ msgid ""
 "address you have provided. Your data will be kept secure and it won't be "
 "used for any other purpose. You may opt-out of receiving further email "
 "communications at any time."
-msgstr ""
+msgstr "Слаћемо повремена ажурирања о Superdesk развоју на имејл адресу коју сте навели. Ваши подаци ће бити безбедни и неће се користити у друге сврхе. Можете отказати даља имејл обавештења у било ком тренутку."
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:38
 msgid "Weak"
-msgstr ""
+msgstr "Слабо"
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:110
 msgid "Wed"
@@ -19590,7 +19590,7 @@ msgstr "Недељно у дане {{days}} у {{hour}}"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:4
 msgid "Welcome to Superdesk"
-msgstr ""
+msgstr "Добродошли у Superdesk"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:2
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:9
@@ -19685,7 +19685,7 @@ msgstr "Радна фаза"
 #: scripts/extensions/availability-manager/dist/src/settings/working-hours-grid-labels.js:16
 #: scripts/extensions/availability-manager/src/settings/working-hours-grid-labels.tsx:25
 msgid "Working hours"
-msgstr ""
+msgstr "Радно време"
 
 #: scripts/apps/archive/index.tsx:94 scripts/apps/dashboard/index.ts:53
 #: scripts/apps/dashboard/views/workspace.html:24
@@ -19741,7 +19741,7 @@ msgstr "Да"
 #: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:16
 #: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:38
 msgid "Yes, create a template"
-msgstr ""
+msgstr "Да, креирај шаблон"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:17
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:8
@@ -19769,7 +19769,7 @@ msgstr "Тренутно управљате истакнутом причом у
 
 #: scripts/validate-instance-configuration.tsx:38
 msgid "You are likely running an outdated version of auto tagging extension."
-msgstr ""
+msgstr "Вероватно користите застарелу верзију екстензије за аутоматско означавање."
 
 #: scripts/apps/workspace/content/services/ContentService.ts:71
 msgid "You are not allowed to create an article there."
@@ -19844,7 +19844,7 @@ msgid ""
 "Your Client ID and Client Secret will be generated when you save. Make sure "
 "to copy the Client Secret immediately. It will only be shown once and it "
 "cannot be retrieved later."
-msgstr ""
+msgstr "ИД клијента и тајни кључ клијента биће генерисани приликом чувања. Обавезно одмах копирајте тајни кључ клијента. Биће приказан само једном и не може се касније преузети."
 
 #: scripts/apps/users/import/views/import-user.html:11
 msgid "Your Credentials"
@@ -19918,15 +19918,15 @@ msgstr "понављајући догађај"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:51
 msgid "a lower case letter (a-z)"
-msgstr ""
+msgstr "мало слово (a-z)"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:53
 msgid "a number (0-9)"
-msgstr ""
+msgstr "број (0-9)"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:54
 msgid "a special character (!@#$%^&...)"
-msgstr ""
+msgstr "специјални карактер (!@#$%^&...)"
 
 #: scripts/apps/users/views/edit-form.html:36
 msgid "active"
@@ -19971,7 +19971,7 @@ msgstr "догађај"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:52
 msgid "an upper case letter (A-Z)"
-msgstr ""
+msgstr "велико слово (A-Z)"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:56
 msgid "and"
@@ -20063,7 +20063,7 @@ msgstr "од {{user}}"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:223
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:284
 msgid "cancel"
-msgstr ""
+msgstr "откажи"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:88
 msgid "cancelled"
@@ -20102,7 +20102,7 @@ msgstr "очисти"
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:50
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:116
 msgid "close"
-msgstr ""
+msgstr "затвори"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:41
 msgid "closed"
@@ -20243,7 +20243,7 @@ msgstr "деск:"
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:272
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:455
 msgid "details"
-msgstr ""
+msgstr "детаљи"
 
 #: scripts/apps/users/views/edit-form.html:34
 #: scripts/apps/users/views/user-list-item.html:15
@@ -20329,7 +20329,7 @@ msgstr "уградња чланака"
 #: scripts/extensions/availability-manager/dist/src/utils.js:97
 #: scripts/extensions/availability-manager/src/utils.ts:100
 msgid "end time"
-msgstr ""
+msgstr "крајње време"
 
 #: scripts/core/lang/missing-translations-strings.ts:10
 msgid "error"
@@ -20393,7 +20393,7 @@ msgstr "преузето у"
 #: scripts/extensions/broadcasting/src/form-validation.ts:18
 #: scripts/extensions/broadcasting/src/form-validation.ts:22
 msgid "field can not be empty"
-msgstr ""
+msgstr "поље не може бити празно"
 
 #: scripts/api/article-fetch.tsx:135
 msgid "file name"
@@ -20491,7 +20491,7 @@ msgstr "иди на профил"
 
 #: scripts/core/utils.tsx:285 scripts/core/utils.tsx:345
 msgid "graphic"
-msgstr ""
+msgstr "графика"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:66
 msgid "h1"
@@ -20523,7 +20523,7 @@ msgstr "висина"
 
 #: scripts/core/views/sdSlider.html:3
 msgid "high"
-msgstr ""
+msgstr "високо"
 
 #: scripts/core/lang/missing-translations-strings.ts:34
 msgid "highlights"
@@ -20531,7 +20531,7 @@ msgstr "истицања"
 
 #: scripts/core/utils.tsx:347
 msgid "highlights package"
-msgstr ""
+msgstr "пакет истицања"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:255
 msgid "honorific"
@@ -20555,7 +20555,7 @@ msgstr "ч"
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/extension.js:26
 #: scripts/extensions/auto-tagging-widget/src/extension.tsx:28
 msgid "iMatrics"
-msgstr ""
+msgstr "iMatrics"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:270
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:50
@@ -20564,7 +20564,7 @@ msgstr ""
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:111
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:444
 msgid "iMatrics service error"
-msgstr ""
+msgstr "iMatrics грешка сервиса"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:54
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:54
@@ -20572,13 +20572,13 @@ msgstr ""
 msgid ""
 "iMatrics service has returned tags referencing parents that do not exist in "
 "the response."
-msgstr ""
+msgstr "iMatrics сервис је вратио ознаке које реферишу родитеље који не постоје у одговору."
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extension.js:10
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/extension.js:10
 #: scripts/extensions/auto-tagging-widget/src/extension.tsx:11
 msgid "iMatrics tagging"
-msgstr ""
+msgstr "iMatrics означавање"
 
 #: scripts/apps/archive/controllers/UploadController.ts:322
 #: scripts/apps/authoring-react/fields/media/editor.tsx:147
@@ -20590,7 +20590,7 @@ msgstr "слика"
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:198
 #: scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.tsx:279
 msgid "image suggestions ({{n}})"
-msgstr ""
+msgstr "сугестије слика ({{n}})"
 
 #: scripts/core/ui/views/sd-timepicker-popup.html:4
 msgid "in 1 h"
@@ -20649,7 +20649,7 @@ msgstr "instagram"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/samsAttachmentsList.js:114
 #: scripts/extensions/sams/src/components/attachments/samsAttachmentsList.tsx:121
 msgid "internal"
-msgstr ""
+msgstr "интерно"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:82
 msgid "italic"
@@ -20665,11 +20665,11 @@ msgstr "метаподаци ставке повезани."
 
 #: scripts/apps/master-desk/components/OverviewComponent.tsx:235
 msgid "items in production"
-msgstr ""
+msgstr "ставки у продукцији"
 
 #: scripts/apps/master-desk/components/AssignmentsComponent.tsx:168
 msgid "items in total"
-msgstr ""
+msgstr "ставки укупно"
 
 #: scripts/core/lang/missing-translations-strings.ts:12
 msgid "killed"
@@ -20681,7 +20681,7 @@ msgstr "ознака"
 
 #: scripts/apps/packaging/views/sd-package-item-preview.html:24
 msgid "label: <b>{{label.name}}</b>"
-msgstr ""
+msgstr "ознака: <b>{{label.name}}</b>"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:232
 msgid "last"
@@ -20727,7 +20727,7 @@ msgstr "учитавање"
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:197
 #: scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.tsx:278
 msgid "loading image suggestions..."
-msgstr ""
+msgstr "учитавање сугестија слика..."
 
 #: ../superdesk-planning/client/components/Main/ListPanel.tsx:435
 msgid "loading more items..."
@@ -20749,7 +20749,7 @@ msgstr "локација:"
 
 #: scripts/core/views/sdSlider.html:2
 msgid "low"
-msgstr ""
+msgstr "ниско"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:100
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:31
@@ -20759,7 +20759,7 @@ msgstr "мала слова"
 #: scripts/apps/packaging/services/PackagesService.ts:24
 #: scripts/apps/packaging/services/PackagesService.ts:55
 msgid "main"
-msgstr ""
+msgstr "главно"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:390
 msgid "make this mode the default"
@@ -20767,7 +20767,7 @@ msgstr "постави овај режим као подразумевани"
 
 #: scripts/core/views/sdSearchList.html:17
 msgid "many"
-msgstr ""
+msgstr "много"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:76
 msgid "media"
@@ -20795,7 +20795,7 @@ msgstr "мин"
 #: scripts/extensions/datetimeField/src/config.tsx:100
 #: scripts/extensions/datetimeField/src/config.tsx:51
 msgid "minutes"
-msgstr ""
+msgstr "минута"
 
 #: scripts/apps/authoring/macros/views/macros-widget.html:31
 msgid "miscellaneous"
@@ -20848,7 +20848,7 @@ msgstr "ништа"
 
 #: scripts/core/interactive-article-actions-panel/subcomponents/controlled-vocabulary-select.tsx:95
 msgid "not"
-msgstr ""
+msgstr "не"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:650
 msgid "notes"
@@ -20904,7 +20904,7 @@ msgstr "отвори у новом прозору"
 #: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/extension.js:48
 #: scripts/extensions/markForUser/src/extension.tsx:55
 msgid "open item"
-msgstr ""
+msgstr "отвори ставку"
 
 #: scripts/apps/archive/views/upload.html:38
 #: scripts/core/auth/login-modal.html:53
@@ -20938,7 +20938,7 @@ msgstr "пакет"
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:60
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:139
 msgid "parent ID"
-msgstr ""
+msgstr "ИД родитеља"
 
 #: scripts/apps/ingest/views/settings/searchConfig.html:7
 #: scripts/apps/users/import/views/import-user.html:19
@@ -21041,7 +21041,7 @@ msgstr "објављено"
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:59
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:138
 msgid "qcode"
-msgstr ""
+msgstr "qcode"
 
 #: scripts/apps/authoring/macros/views/macros-widget.html:14
 msgid "quick list"
@@ -21152,7 +21152,7 @@ msgstr "сек"
 
 #: scripts/core/views/sdSearchList.html:5
 msgid "selected"
-msgstr ""
+msgstr "изабрано"
 
 #: scripts/apps/search/components/SelectBox.tsx:63
 msgid "selection not allowed"
@@ -21216,14 +21216,14 @@ msgstr "фаза:"
 #: scripts/extensions/availability-manager/dist/src/utils.js:94
 #: scripts/extensions/availability-manager/src/utils.ts:98
 msgid "start time"
-msgstr ""
+msgstr "почетно време"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:100
 #: scripts/extensions/availability-manager/dist/src/utils.js:100
 #: scripts/extensions/availability-manager/src/utils.ts:102
 msgid ""
 "start time cannot be greater than end time ({{start_time}} - {{end_time}})"
-msgstr ""
+msgstr "почетно време не може бити веће од крајњег времена ({{start_time}} - {{end_time}})"
 
 #: scripts/apps/authoring/metadata/views/meta-place-directive.html:19
 msgid "state, region, ..."
@@ -21233,7 +21233,7 @@ msgstr "држава, регион, ..."
 #: scripts/extensions/availability-manager/dist/src/utils.js:109
 #: scripts/extensions/availability-manager/src/utils.ts:114
 msgid "status"
-msgstr ""
+msgstr "статус"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:80
 msgid "strikethrough"
@@ -21293,7 +21293,7 @@ msgstr "табела"
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:58
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:137
 msgid "tag name"
-msgstr ""
+msgstr "назив ознаке"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:398
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:6
@@ -21427,13 +21427,13 @@ msgstr "корисници"
 #: scripts/extensions/broadcasting/dist/src/form-validation.js:27
 #: scripts/extensions/broadcasting/src/form-validation.ts:26
 msgid "value must be greater than zero"
-msgstr ""
+msgstr "вредност мора бити већа од нуле"
 
 #: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:241
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:241
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:304
 msgid "value of 0 will disable this restriction"
-msgstr ""
+msgstr "вредност 0 ће онемогућити ово ограничење"
 
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-article.html:5
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:13
@@ -21485,7 +21485,7 @@ msgstr "прикажи све"
 #: scripts/core/notification/notification.ts:231
 msgid ""
 "vocabulary has been updated. Please re-login to see updated vocabulary values"
-msgstr ""
+msgstr "вокабулар је ажуриран. Поново се пријавите да бисте видели ажуриране вредности вокабулара"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:448
 msgid "website"
@@ -21514,7 +21514,7 @@ msgstr "са:"
 #: scripts/extensions/availability-manager/dist/src/utils.js:112
 #: scripts/extensions/availability-manager/src/utils.ts:118
 msgid "working hours are not set"
-msgstr ""
+msgstr "радно време није подешено"
 
 #: scripts/apps/search/components/ItemContainer.tsx:17
 msgid "workspace"
@@ -21639,9 +21639,9 @@ msgstr "{{count}} чланцима је отказано заказивање"
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:287
 msgid "{{count}} item selected"
 msgid_plural "{{count}} items selected"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "{{count}} ставка изабрана"
+msgstr[1] "{{count}} ставке изабране"
+msgstr[2] "{{count}} ставки изабрано"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:123
 #: ../superdesk-analytics/client/utils.js:196
@@ -21684,7 +21684,7 @@ msgstr "{{field}} не може бити раније од сада!"
 #: scripts/extensions/availability-manager/src/utils.ts:114
 #: scripts/extensions/availability-manager/src/utils.ts:98
 msgid "{{field}} cannot be empty"
-msgstr ""
+msgstr "{{field}} не може бити празно"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:372
 msgid "{{field}} date is required!"
@@ -21804,7 +21804,7 @@ msgstr "{{weeks}} недеља"
 #: scripts/extensions/sams/dist/src/utils/ui.js:124
 #: scripts/extensions/sams/src/utils/ui.tsx:119
 msgid "{{width}} * {{height}}"
-msgstr ""
+msgstr "{{width}} * {{height}}"
 
 #: scripts/apps/authoring-react/fields/media/media-metadata.tsx:44
 msgid "{{width}} x {{height}} px"
@@ -21822,9 +21822,9 @@ msgstr[2] "{{wordsCount}} речи"
 #: scripts/extensions/datetimeField/src/editor.tsx:140
 msgid "{{x}} hour"
 msgid_plural "{{x}} hours"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "{{x}} сат"
+msgstr[1] "{{x}} сата"
+msgstr[2] "{{x}} сати"
 
 #: scripts/apps/search/components/fields/linesCount.tsx:14
 msgid "{{x}} lines"
@@ -21834,7 +21834,7 @@ msgstr "{{x}} редова"
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:84
 #: scripts/extensions/datetimeField/src/editor.tsx:149
 msgid "{{x}} min"
-msgstr ""
+msgstr "{{x}} мин"
 
 #: scripts/apps/authoring/authoring/directives/ReadingTime.ts:22
 #: scripts/apps/authoring/authoring/directives/ReadingTime.ts:52

--- a/po/sr.po
+++ b/po/sr.po
@@ -1318,47 +1318,47 @@ msgstr "Панел напредне претраге"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:10
 msgid "Africa/Abidjan"
-msgstr ""
+msgstr "Африка/Абиџан"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:11
 msgid "Africa/Accra"
-msgstr ""
+msgstr "Африка/Акра"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:12
 msgid "Africa/Cairo"
-msgstr ""
+msgstr "Африка/Каиро"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:13
 msgid "Africa/Casablanca"
-msgstr ""
+msgstr "Африка/Казабланка"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:14
 msgid "Africa/Dakar"
-msgstr ""
+msgstr "Африка/Дакар"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:15
 msgid "Africa/Johannesburg"
-msgstr ""
+msgstr "Африка/Јоханезбург"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:16
 msgid "Africa/Khartoum"
-msgstr ""
+msgstr "Африка/Картум"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:17
 msgid "Africa/Kinshasa"
-msgstr ""
+msgstr "Африка/Киншаса"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:18
 msgid "Africa/Lagos"
-msgstr ""
+msgstr "Африка/Лагос"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:19
 msgid "Africa/Nairobi"
-msgstr ""
+msgstr "Африка/Најроби"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:20
 msgid "Africa/Tunis"
-msgstr ""
+msgstr "Африка/Тунис"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:38
 msgid "After"
@@ -1671,99 +1671,99 @@ msgstr "Измени слаглајн"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:21
 msgid "America/Anchorage"
-msgstr ""
+msgstr "Америка/Енкоридж"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:22
 msgid "America/Argentina/Buenos Aires"
-msgstr ""
+msgstr "Америка/Аргентина/Буенос Ајрес"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:23
 msgid "America/Bogota"
-msgstr ""
+msgstr "Америка/Богота"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:24
 msgid "America/Caracas"
-msgstr ""
+msgstr "Америка/Каракас"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:25
 msgid "America/Chicago"
-msgstr ""
+msgstr "Америка/Чикаго"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:26
 msgid "America/Edmonton"
-msgstr ""
+msgstr "Америка/Едмонтон"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:27
 msgid "America/Guatemala"
-msgstr ""
+msgstr "Америка/Гватемала"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:28
 msgid "America/Halifax"
-msgstr ""
+msgstr "Америка/Халифакс"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:29
 msgid "America/Havana"
-msgstr ""
+msgstr "Америка/Хавана"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:30
 msgid "America/La Paz"
-msgstr ""
+msgstr "Америка/Ла Паз"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:31
 msgid "America/Lima"
-msgstr ""
+msgstr "Америка/Лима"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:32
 msgid "America/Los Angeles"
-msgstr ""
+msgstr "Америка/Лос Анђелес"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:33
 msgid "America/Manaus"
-msgstr ""
+msgstr "Америка/Манаус"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:34
 msgid "America/Mexico City"
-msgstr ""
+msgstr "Америка/Мексико Сити"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:35
 msgid "America/Montevideo"
-msgstr ""
+msgstr "Америка/Монтевидео"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:36
 msgid "America/New York"
-msgstr ""
+msgstr "Америка/Њујорк"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:37
 msgid "America/Phoenix"
-msgstr ""
+msgstr "Америка/Феникс"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:38
 msgid "America/Santiago"
-msgstr ""
+msgstr "Америка/Сантјаго"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:39
 msgid "America/Sao Paulo"
-msgstr ""
+msgstr "Америка/Сао Паоло"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:40
 msgid "America/Tegucigalpa"
-msgstr ""
+msgstr "Америка/Тегусигалпа"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:41
 msgid "America/Tijuana"
-msgstr ""
+msgstr "Америка/Тихуана"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:42
 msgid "America/Toronto"
-msgstr ""
+msgstr "Америка/Торонто"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:43
 msgid "America/Vancouver"
-msgstr ""
+msgstr "Америка/Ванкувер"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:44
 msgid "America/Winnipeg"
-msgstr ""
+msgstr "Америка/Винипег"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:395
 msgid "An Item can't have both Embargo and Publish Schedule."
@@ -2148,123 +2148,123 @@ msgstr "Растући редослед"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:45
 msgid "Asia/Almaty"
-msgstr ""
+msgstr "Азија/Алмати"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:46
 msgid "Asia/Baghdad"
-msgstr ""
+msgstr "Азија/Багдад"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:47
 msgid "Asia/Baku"
-msgstr ""
+msgstr "Азија/Баку"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:48
 msgid "Asia/Bangkok"
-msgstr ""
+msgstr "Азија/Бангкок"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:49
 msgid "Asia/Beirut"
-msgstr ""
+msgstr "Азија/Бејрут"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:50
 msgid "Asia/Colombo"
-msgstr ""
+msgstr "Азија/Коломбо"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:51
 msgid "Asia/Dhaka"
-msgstr ""
+msgstr "Азија/Дака"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:52
 msgid "Asia/Dili"
-msgstr ""
+msgstr "Азија/Дили"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:53
 msgid "Asia/Dubai"
-msgstr ""
+msgstr "Азија/Дубаи"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:54
 msgid "Asia/Irkutsk"
-msgstr ""
+msgstr "Азија/Иркутск"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:55
 msgid "Asia/Jakarta"
-msgstr ""
+msgstr "Азија/Џакарта"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:56
 msgid "Asia/Jerusalem"
-msgstr ""
+msgstr "Азија/Јерусалим"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:57
 msgid "Asia/Kabul"
-msgstr ""
+msgstr "Азија/Кабул"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:58
 msgid "Asia/Karachi"
-msgstr ""
+msgstr "Азија/Карачи"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:59
 msgid "Asia/Kathmandu"
-msgstr ""
+msgstr "Азија/Катманду"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:60
 msgid "Asia/Krasnoyarsk"
-msgstr ""
+msgstr "Азија/Краснојарск"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:61
 msgid "Asia/Kuala Lumpur"
-msgstr ""
+msgstr "Азија/Куала Лумпур"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:62
 msgid "Asia/Manila"
-msgstr ""
+msgstr "Азија/Манила"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:63
 msgid "Asia/Novosibirsk"
-msgstr ""
+msgstr "Азија/Новосибирск"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:64
 msgid "Asia/Pyongyang"
-msgstr ""
+msgstr "Азија/Пјонгјанг"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:65
 msgid "Asia/Rangoon"
-msgstr ""
+msgstr "Азија/Рангун"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:66
 msgid "Asia/Riyadh"
-msgstr ""
+msgstr "Азија/Ријад"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:67
 msgid "Asia/Seoul"
-msgstr ""
+msgstr "Азија/Сеул"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:68
 msgid "Asia/Singapore"
-msgstr ""
+msgstr "Азија/Сингапур"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:69
 msgid "Asia/Tashkent"
-msgstr ""
+msgstr "Азија/Ташкент"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:70
 msgid "Asia/Tehran"
-msgstr ""
+msgstr "Азија/Техеран"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:71
 msgid "Asia/Tokyo"
-msgstr ""
+msgstr "Азија/Токио"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:72
 msgid "Asia/Vladivostok"
-msgstr ""
+msgstr "Азија/Владивосток"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:73
 msgid "Asia/Yakutsk"
-msgstr ""
+msgstr "Азија/Јакутск"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:74
 msgid "Asia/Yekaterinburg"
-msgstr ""
+msgstr "Азија/Јекатеринбург"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:130
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:130
@@ -2566,19 +2566,19 @@ msgstr "Само аудио"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:75
 msgid "Australia/Adelaide"
-msgstr ""
+msgstr "Аустралија/Аделаида"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:76
 msgid "Australia/Melbourne"
-msgstr ""
+msgstr "Аустралија/Мелбурн"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:77
 msgid "Australia/Perth"
-msgstr ""
+msgstr "Аустралија/Перт"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:78
 msgid "Australia/Sydney"
-msgstr ""
+msgstr "Аустралија/Сиднеј"
 
 #: scripts/apps/publish/views/subscribers.html:269
 msgid "Authentication Token"
@@ -2687,7 +2687,7 @@ msgstr "Доступно цео дан"
 
 #: scripts/apps/dashboard/world-clock/configuration.html:28
 msgid "Available clocks"
-msgstr ""
+msgstr "Доступни часовници"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:209
 msgid "Available in user/desk preferences"
@@ -3614,7 +3614,7 @@ msgstr "Тајни кључ клијента"
 
 #: scripts/apps/dashboard/world-clock/configuration.html:5
 msgid "Clock type"
-msgstr ""
+msgstr "Тип часовника"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:104
 #: ../superdesk-planning/client/components/Agendas/ManageAgendasModal.tsx:72
@@ -7024,79 +7024,79 @@ msgstr "Грешке"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:79
 msgid "Europe/Athens"
-msgstr ""
+msgstr "Европа/Атина"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:80
 msgid "Europe/Belgrade"
-msgstr ""
+msgstr "Европа/Београд"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:81
 msgid "Europe/Berlin"
-msgstr ""
+msgstr "Европа/Берлин"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:82
 msgid "Europe/Brussels"
-msgstr ""
+msgstr "Европа/Брисел"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:83
 msgid "Europe/Bucharest"
-msgstr ""
+msgstr "Европа/Букурешт"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:84
 msgid "Europe/Dublin"
-msgstr ""
+msgstr "Европа/Даблин"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:85
 msgid "Europe/Helsinki"
-msgstr ""
+msgstr "Европа/Хелсинки"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:86
 msgid "Europe/Istanbul"
-msgstr ""
+msgstr "Европа/Истанбул"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:87
 msgid "Europe/Kiev"
-msgstr ""
+msgstr "Европа/Кијев"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:88
 msgid "Europe/Lisbon"
-msgstr ""
+msgstr "Европа/Лисабон"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:89
 msgid "Europe/London"
-msgstr ""
+msgstr "Европа/Лондон"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:90
 msgid "Europe/Madrid"
-msgstr ""
+msgstr "Европа/Мадрид"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:91
 msgid "Europe/Minsk"
-msgstr ""
+msgstr "Европа/Минск"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:92
 msgid "Europe/Moscow"
-msgstr ""
+msgstr "Европа/Москва"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:93
 msgid "Europe/Paris"
-msgstr ""
+msgstr "Европа/Париз"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:94
 msgid "Europe/Prague"
-msgstr ""
+msgstr "Европа/Праг"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:95
 msgid "Europe/Rome"
-msgstr ""
+msgstr "Европа/Рим"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:96
 msgid "Europe/Sofia"
-msgstr ""
+msgstr "Европа/Софија"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:97
 msgid "Europe/Stockholm"
-msgstr ""
+msgstr "Европа/Стокхолм"
 
 #: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:40
 #: ../superdesk-planning/client/components/ItemIcon.tsx:23
@@ -11368,7 +11368,7 @@ msgstr "Нису додељени календари."
 
 #: scripts/apps/dashboard/world-clock/configuration.html:20
 msgid "No clock here!"
-msgstr ""
+msgstr "Нема часовника овде!"
 
 #: scripts/apps/authoring-react/generic-widgets/comments/CommentsWidget.tsx:170
 #: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:216
@@ -12341,19 +12341,19 @@ msgstr "ОБЈАВИ"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:98
 msgid "Pacific/Auckland"
-msgstr ""
+msgstr "Пацифик/Окланд"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:99
 msgid "Pacific/Honolulu"
-msgstr ""
+msgstr "Пацифик/Хонолулу"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:100
 msgid "Pacific/Noumea"
-msgstr ""
+msgstr "Пацифик/Нумеа"
 
 #: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:101
 msgid "Pacific/Port Moresby"
-msgstr ""
+msgstr "Пацифик/Порт Морсби"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:256
 msgid "Package"
@@ -15183,7 +15183,7 @@ msgstr "Тражи локацију"
 
 #: scripts/apps/dashboard/world-clock/configuration.html:34
 msgid "Search for clock"
-msgstr ""
+msgstr "Тражи часовник"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:91
 msgid "Search icons...."
@@ -19709,11 +19709,11 @@ msgstr "Светски сат"
 
 #: scripts/apps/dashboard/world-clock/world-clock.ts:42
 msgid "World clock added: {{zone}}"
-msgstr ""
+msgstr "Светски сат додат: {{zone}}"
 
 #: scripts/apps/dashboard/world-clock/world-clock.ts:44
 msgid "World clock removed: {{zone}}"
-msgstr ""
+msgstr "Светски сат уклоњен: {{zone}}"
 
 #: scripts/apps/dashboard/world-clock/world-clock.ts:221
 #: scripts/core/lang/missing-translations-strings.ts:45
@@ -19866,7 +19866,7 @@ msgstr "Ваше измене ће бити изгубљене ако сада �
 
 #: scripts/apps/dashboard/world-clock/configuration.html:12
 msgid "Your clock"
-msgstr ""
+msgstr "Ваш сат"
 
 #: scripts/core/auth/login-modal.html:71
 msgid "Your password has expired. Please change your password."

--- a/po/sr.po
+++ b/po/sr.po
@@ -112,7 +112,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/monitoring-group-header.html:44
 msgid "(as defined for all groups)"
-msgstr ""
+msgstr "(као што је дефинисано за све групе)"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:237
 msgid "(custom text field)"
@@ -617,7 +617,7 @@ msgstr ""
 #: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:88
 #: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:97
 msgid "AND"
-msgstr ""
+msgstr "И"
 
 #: ../superdesk-planning/client/components/fields/editor/Categories.tsx:26
 #: ../superdesk-planning/client/components/fields/preview/index.ts:65
@@ -718,7 +718,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/desk-notifications.html:28
 msgid "Acknowledge"
-msgstr ""
+msgstr "Потврди пријем"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:16
 #: scripts/apps/publish/views/publish-queue.html:117
@@ -1000,7 +1000,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/views/workspace.html:99
 msgid "Add This Widget"
-msgstr ""
+msgstr "Додај овај виџет"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/TimeInputs.tsx:95
 msgid "Add Time"
@@ -1061,7 +1061,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:55
 msgid "Add content slugline"
-msgstr ""
+msgstr "Додај слаглајн садржаја"
 
 #: ../superdesk-planning/client/constants/planning.ts:144
 #: ../superdesk-planning/client/constants/planning.ts:147
@@ -1070,7 +1070,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:58
 msgid "Add description"
-msgstr ""
+msgstr "Додај опис"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:50
 #: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:50
@@ -1136,7 +1136,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/views/workspace.html:69
 msgid "Add new widget"
-msgstr ""
+msgstr "Додај нови виџет"
 
 #: ../superdesk-planning/client/components/Editor/bookmarks/AddPlanningBookmark.tsx:42
 msgid "Add planning item"
@@ -1154,7 +1154,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:66
 msgid "Add task description"
-msgstr ""
+msgstr "Додај опис задатка"
 
 #: ../superdesk-planning/client/actions/agenda.ts:166
 msgid "Add these  events to the planning list?"
@@ -1171,7 +1171,7 @@ msgstr ""
 #: scripts/apps/authoring/views/item-association.html:100
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:56
 msgid "Add title"
-msgstr ""
+msgstr "Додај наслов"
 
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:268
 msgid "Add to Current Package"
@@ -1216,7 +1216,7 @@ msgstr ""
 #: scripts/apps/dashboard/views/workspace.html:13
 #: scripts/apps/dashboard/views/workspace.html:14
 msgid "Add widget"
-msgstr ""
+msgstr "Додај виџет"
 
 #: scripts/apps/authoring-react/fields/attachments/difference-row.tsx:25
 msgid "Added"
@@ -1577,7 +1577,7 @@ msgstr ""
 
 #: scripts/core/itemList/LazyLoader.tsx:226
 msgid "All items have been loaded"
-msgstr ""
+msgstr "Све ставке су учитане"
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:327
 msgid "All items were published successfully."
@@ -1847,7 +1847,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/workspace-tasks/views/desk-stages.html:6
 msgid "Any"
-msgstr ""
+msgstr "Било који"
 
 #: scripts/apps/archive/views/metadata-view.html:162
 msgid "Aperture"
@@ -1955,7 +1955,7 @@ msgstr ""
 
 #: scripts/apps/workspace/services/WorkspaceService.ts:19
 msgid "Are you sure you want to delete current workspace?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете тренутни радни простор?"
 
 #: scripts/apps/content-filters/controllers/FilterConditionsController.ts:120
 msgid "Are you sure you want to delete filter condition?"
@@ -2727,7 +2727,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/monitoring-view.html:10
 msgid "Back to original view"
-msgstr ""
+msgstr "Назад на оригинални приказ"
 
 #: scripts/extensions/annotationsLibrary/dist/src/AnnotationSelectSingleItem.js:13
 #: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.js:13
@@ -2955,7 +2955,7 @@ msgstr ""
 
 #: scripts/apps/workspace/views/workspace-dropdown.html:32
 msgid "CREATE NEW WORKSPACE"
-msgstr ""
+msgstr "КРЕИРАЈ НОВИ РАДНИ ПРОСТОР"
 
 #: ../superdesk-analytics/client/charts/views/chart.html:26
 msgid "CSV File"
@@ -2963,7 +2963,7 @@ msgstr ""
 
 #: scripts/apps/workspace/views/workspace-dropdown.html:20
 msgid "CUSTOM WORKSPACES"
-msgstr ""
+msgstr "ПРИЛАГОЂЕНИ РАДНИ ПРОСТОРИ"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:53
 msgid "Calendar"
@@ -3005,11 +3005,11 @@ msgstr ""
 
 #: scripts/core/itemList/views/relatedItem-list-widget.html:20
 msgid "Can be associated as a take"
-msgstr ""
+msgstr "Може се повезати као наставак"
 
 #: scripts/core/itemList/views/relatedItem-list-widget.html:19
 msgid "Can be associated as an update"
-msgstr ""
+msgstr "Може се повезати као ажурирање"
 
 #: scripts/apps/workspace/content/views/profile-settings.html:172
 msgid "Can be embedded"
@@ -3297,7 +3297,7 @@ msgstr ""
 #: scripts/apps/users/views/user-preferences.html:17
 #: scripts/apps/workspace/content/constants.ts:17
 msgid "Categories"
-msgstr ""
+msgstr "Категорије"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:521
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:99
@@ -3559,7 +3559,7 @@ msgstr ""
 #: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:108
 #: scripts/apps/search/views/save-search.html:9
 msgid "Clear filters"
-msgstr ""
+msgstr "Очисти филтере"
 
 #: scripts/apps/authoring/media/views/media-copy-metadata-directive.html:5
 msgid "Clear saved metadata"
@@ -3571,7 +3571,7 @@ msgstr ""
 #: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:356
 #: scripts/core/list/views/searchbar.html:5
 msgid "Clear search"
-msgstr ""
+msgstr "Очисти претрагу"
 
 #: scripts/apps/users/config.ts:93
 msgid "Clear sessions"
@@ -3589,7 +3589,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/views/workspace.html:60
 msgid "Click on the \"+\" button in the top right corner to add some widgets."
-msgstr ""
+msgstr "Кликните на дугме \"+\" у горњем десном углу да бисте додали виџете."
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:160
 msgid "Click the Plus button to add languages"
@@ -3735,7 +3735,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/closed-desk/index.ts:159
 msgid "Close desk widget"
-msgstr ""
+msgstr "Затвори виџет деска"
 
 #: scripts/apps/authoring/views/change-image.html:155
 msgid "Close details"
@@ -3790,7 +3790,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/monitoring-view.html:196
 msgid "Columns:"
-msgstr ""
+msgstr "Колоне:"
 
 #: scripts/apps/packaging/index.ts:93
 msgid "Combine with current"
@@ -3831,7 +3831,7 @@ msgstr ""
 #: scripts/apps/search/views/search.html:22
 #: scripts/apps/search/views/search.html:23
 msgid "Compact View"
-msgstr ""
+msgstr "Компактан приказ"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:102
 msgid "Compact list"
@@ -4020,7 +4020,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.tsx:119
 #: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:89
 msgid "Content"
-msgstr ""
+msgstr "Садржај"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:219
 msgid ""
@@ -4066,7 +4066,7 @@ msgstr ""
 #: scripts/apps/templates/views/template-editor-modal.html:28
 #: scripts/apps/templates/views/template-editor-modal.html:38
 msgid "Content Profile"
-msgstr ""
+msgstr "Профил садржаја"
 
 #: scripts/apps/workspace/content/index.ts:43
 #: scripts/apps/workspace/content/views/profile-settings.html:4
@@ -4103,7 +4103,7 @@ msgstr ""
 
 #: scripts/core/activity/activity.ts:27
 msgid "Content config"
-msgstr ""
+msgstr "Подешавање садржаја"
 
 #: scripts/apps/users/views/settings-roles.html:65
 msgid "Content creation"
@@ -4131,7 +4131,7 @@ msgstr ""
 
 #: scripts/core/activity/activity.ts:32
 msgid "Content flow"
-msgstr ""
+msgstr "Ток садржаја"
 
 #: ../superdesk-planning/client/actions/assignments/api.ts:265
 msgid "Content items not found!"
@@ -4534,7 +4534,7 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:223
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:245
 msgid "Create"
-msgstr ""
+msgstr "Креирај"
 
 #: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:420
 msgid "Create & Post"
@@ -4558,12 +4558,12 @@ msgstr ""
 
 #: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:45
 msgid "Create New Task"
-msgstr ""
+msgstr "Креирај нови задатак"
 
 #: scripts/apps/monitoring/index.ts:128
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:257
 msgid "Create Package"
-msgstr ""
+msgstr "Креирај пакет"
 
 #: ../superdesk-planning/client/components/Editor/EditorBookmarksBar.tsx:64
 msgid "Create Planning"
@@ -4580,7 +4580,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/index.ts:126
 msgid "Create a broadcast"
-msgstr ""
+msgstr "Креирај емисију"
 
 #: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:49
 #: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:50
@@ -4634,14 +4634,14 @@ msgstr ""
 
 #: scripts/apps/workspace/views/edit-workspace-modal.html:3
 msgid "Create new Workspace"
-msgstr ""
+msgstr "Креирај нови радни простор"
 
 #: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:110
 #: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:114
 #: scripts/apps/monitoring/views/monitoring-view.html:126
 #: scripts/apps/workspace/content/index.ts:54
 msgid "Create new item"
-msgstr ""
+msgstr "Креирај нову ставку"
 
 #: ../superdesk-planning/client/components/Main/ListPanel.tsx:344
 msgid "Create new items or change your search filters"
@@ -4783,7 +4783,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:111
 msgid "Created by this user"
-msgstr ""
+msgstr "Креирао овај корисник"
 
 #: scripts/apps/search/directives/DateFilters.ts:77
 msgid "Created from"
@@ -4815,7 +4815,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:2
 msgid "Created on"
-msgstr ""
+msgstr "Креирано"
 
 #: scripts/apps/search/directives/DateFilters.ts:78
 msgid "Created to"
@@ -4960,7 +4960,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/index.ts:54
 msgid "Customize your widgets and views"
-msgstr ""
+msgstr "Прилагодите своје виџете и приказе"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:69
 msgid "Cut"
@@ -4972,11 +4972,11 @@ msgstr ""
 
 #: scripts/apps/workspace/views/workspace-dropdown.html:11
 msgid "DESKS"
-msgstr ""
+msgstr "ДЕСКОВИ"
 
 #: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:32
 msgid "DONE"
-msgstr ""
+msgstr "ГОТОВО"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:130
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:216
@@ -5022,11 +5022,11 @@ msgstr ""
 #: scripts/apps/dashboard/index.ts:70
 #: scripts/apps/dashboard/views/workspace.html:2
 msgid "Dashboard"
-msgstr ""
+msgstr "Контролна табла"
 
 #: scripts/apps/dashboard/views/workspace.html:59
 msgid "Dashboard is empty"
-msgstr ""
+msgstr "Контролна табла је празна"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:419
 #: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:16
@@ -5170,7 +5170,7 @@ msgstr ""
 #: scripts/apps/monitoring/views/monitoring-group-header.html:43
 #: scripts/apps/search-providers/directive.ts:118
 msgid "Default"
-msgstr ""
+msgstr "Подразумевано"
 
 #: scripts/apps/users/views/user-preferences.html:219
 msgid "Default Agenda"
@@ -5372,7 +5372,7 @@ msgstr ""
 #: scripts/apps/dashboard/views/workspace.html:35
 #: scripts/apps/monitoring/views/monitoring-view.html:220
 msgid "Delete workspace"
-msgstr ""
+msgstr "Обриши радни простор"
 
 #: scripts/core/lang/missing-translations-strings.ts:40
 msgid "Deleted Ingest Channel {{name}}"
@@ -5526,19 +5526,19 @@ msgstr ""
 #: scripts/apps/monitoring/directives/AggregateSettings.ts:56
 #: scripts/apps/workspace/content/constants.ts:66
 msgid "Desk Output"
-msgstr ""
+msgstr "Излаз деска"
 
 #: scripts/apps/dashboard/closed-desk/index.ts:152
 msgid "Desk Router"
-msgstr ""
+msgstr "Рутер деска"
 
 #: scripts/apps/monitoring/directives/AggregateSettings.ts:50
 msgid "Desk Schedule Output"
-msgstr ""
+msgstr "Заказани излаз деска"
 
 #: scripts/apps/monitoring/directives/AggregateSettings.ts:62
 msgid "Desk Sent Output"
-msgstr ""
+msgstr "Послати излаз деска"
 
 #: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:79
 msgid "Desk Templates"
@@ -5584,7 +5584,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/closed-desk/index.ts:26
 msgid "Desk status is outdated, please refresh."
-msgstr ""
+msgstr "Статус деска је застарео, освежите."
 
 #: scripts/apps/search/views/saved-search-manage-subscribers.html:167
 #: scripts/apps/search/views/saved-search-manage-subscribers.html:88
@@ -5918,7 +5918,7 @@ msgstr "Не чувати"
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorHeader.js:11
 #: scripts/extensions/videoEditor/src/VideoEditorHeader.tsx:30
 msgid "Done"
-msgstr ""
+msgstr "Готово"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:71
 msgid "Dots"
@@ -6045,7 +6045,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/preview/index.ts:197
 #: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:75
 msgid "Due"
-msgstr ""
+msgstr "Рок"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:26
 msgid "Due Date"
@@ -6053,11 +6053,11 @@ msgstr ""
 
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:34
 msgid "Due date"
-msgstr ""
+msgstr "Датум рока"
 
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:38
 msgid "Due time"
-msgstr ""
+msgstr "Време рока"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:142
 #: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:172
@@ -6104,7 +6104,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/index.ts:125
 msgid "Duplicate an item"
-msgstr ""
+msgstr "Дуплирај ставку"
 
 #: scripts/core/interactive-article-actions-panel/actions/duplicate-to-action.tsx:80
 msgid "Duplicate and open"
@@ -6446,11 +6446,11 @@ msgstr ""
 
 #: scripts/apps/monitoring/index.ts:121
 msgid "Edit an item"
-msgstr ""
+msgstr "Уреди ставку"
 
 #: scripts/apps/monitoring/index.ts:124
 msgid "Edit an item in a new Window"
-msgstr ""
+msgstr "Уреди ставку у новом прозору"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-workday-modal.js:106
 #: scripts/extensions/availability-manager/dist/src/settings/edit-workday-modal.js:106
@@ -6946,7 +6946,7 @@ msgstr ""
 
 #: scripts/core/itemList/itemList.ts:110
 msgid "Error: Slugline required."
-msgstr ""
+msgstr "Грешка: слаглајн је обавезан."
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:225
 msgid "Error: Subscriber must have at least one destination."
@@ -8032,7 +8032,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/index.ts:122
 msgid "Fetch an item"
-msgstr ""
+msgstr "Преузми ставку"
 
 #: scripts/core/interactive-article-actions-panel/actions/fetch-to-action.tsx:101
 msgid "Fetch and open"
@@ -8107,7 +8107,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/monitoring-view.html:161
 msgid "File types"
-msgstr ""
+msgstr "Типови датотека"
 
 #: scripts/extensions/sams/dist/src/containers/FileUploadModal.js:203
 #: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:203
@@ -8215,7 +8215,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/monitoring-view.html:158
 msgid "Filter file types"
-msgstr ""
+msgstr "Филтрирај типове датотека"
 
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:50
 msgid "Filter statement {{id}} does not have a filter condition."
@@ -8249,7 +8249,7 @@ msgstr ""
 #: scripts/apps/search/views/search-panel.html:64
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:292
 msgid "Filters"
-msgstr ""
+msgstr "Филтери"
 
 #: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:78
 #: scripts/apps/authoring/editor/views/find-replace.html:5
@@ -8610,7 +8610,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:66
 msgid "Global saved searches"
-msgstr ""
+msgstr "Глобалне сачуване претраге"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:97
 msgid "Globe"
@@ -9177,7 +9177,7 @@ msgstr ""
 #: scripts/apps/search/components/fields/state.tsx:35
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:298
 msgid "In Progress"
-msgstr ""
+msgstr "У току"
 
 #: scripts/apps/authoring-react/data-layer.ts:428
 #: scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.ts:72
@@ -9669,7 +9669,7 @@ msgstr ""
 #: scripts/apps/dashboard/workspace-tasks/tasks.ts:190
 #: scripts/apps/dashboard/workspace-tasks/tasks.ts:257
 msgid "Item saved."
-msgstr ""
+msgstr "Ставка сачувана."
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:114
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:29
@@ -9716,7 +9716,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:128
 msgid "Items Count"
-msgstr ""
+msgstr "Број ставки"
 
 #: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:241
 msgid "Items Created"
@@ -9730,19 +9730,19 @@ msgstr ""
 
 #: scripts/apps/dashboard/user-activity/user-activity.ts:22
 msgid "Items created by the user"
-msgstr ""
+msgstr "Ставке које је креирао корисник"
 
 #: scripts/apps/dashboard/user-activity/user-activity.ts:25
 msgid "Items locked by the user"
-msgstr ""
+msgstr "Ставке које је закључао корисник"
 
 #: scripts/apps/dashboard/user-activity/user-activity.ts:28
 msgid "Items marked for the user"
-msgstr ""
+msgstr "Ставке означене за корисника"
 
 #: scripts/apps/dashboard/user-activity/user-activity.ts:31
 msgid "Items moved to a working stage by the user"
-msgstr ""
+msgstr "Ставке које је корисник преместио у радну фазу"
 
 #: scripts/api/article-fetch.tsx:131
 msgid "Items that can not be fetched"
@@ -10018,7 +10018,7 @@ msgstr ""
 #: scripts/apps/templates/views/template-editor-modal.html:108
 #: scripts/core/itemList/views/relatedItem-list-widget.html:33
 msgid "Legal"
-msgstr ""
+msgstr "Правно"
 
 #: scripts/apps/legal-archive/index.ts:37
 msgid "Legal Archive"
@@ -10144,7 +10144,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/directives/utils.ts:88
 msgid "List view"
-msgstr ""
+msgstr "Приказ листе"
 
 #: scripts/apps/authoring/suggest/SuggestView.html:4
 msgid "Live Suggestions"
@@ -10258,7 +10258,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:91
 msgid "Locked by this user"
-msgstr ""
+msgstr "Закључао овај корисник"
 
 #: scripts/apps/archive/views/item-lock.html:19
 msgid "Locked by you in another browser"
@@ -10502,11 +10502,11 @@ msgstr ""
 
 #: scripts/apps/desks/index.ts:60 scripts/apps/monitoring/index.ts:130
 msgid "Mark for desk"
-msgstr ""
+msgstr "Означи за деск"
 
 #: scripts/apps/highlights/index.ts:46 scripts/apps/monitoring/index.ts:129
 msgid "Mark for highlight"
-msgstr ""
+msgstr "Означи за истицање"
 
 #: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions.js:29
 #: scripts/extensions/markForUser/dist/src/get-article-actions.js:29
@@ -10588,7 +10588,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:99
 msgid "Marked for this user"
-msgstr ""
+msgstr "Означено за овог корисника"
 
 #: scripts/apps/master-desk/index.ts:12 scripts/apps/master-desk/index.ts:23
 msgid "Master Desk"
@@ -10707,7 +10707,7 @@ msgstr ""
 #: scripts/apps/templates/views/template-editor-modal.html:102
 #: scripts/apps/vocabularies/index.ts:43
 msgid "Metadata"
-msgstr ""
+msgstr "Метаподаци"
 
 #: scripts/apps/vocabularies/views/settings.html:4
 msgid "Metadata management"
@@ -10819,21 +10819,21 @@ msgstr "Понедељак"
 
 #: scripts/apps/monitoring/aggregate-widget/aggregate.ts:6
 msgid "Monitor"
-msgstr ""
+msgstr "Монитор"
 
 #: scripts/apps/monitoring/config.ts:19 scripts/apps/monitoring/config.ts:7
 #: scripts/apps/monitoring/views/monitoring-view.html:21
 #: scripts/apps/monitoring/views/monitoring-view.html:3
 #: scripts/core/lang/missing-translations-strings.ts:44
 msgid "Monitoring"
-msgstr ""
+msgstr "Мониторинг"
 
 #: scripts/apps/desks/views/settings.html:43
 #: scripts/apps/desks/views/settings.html:47
 #: scripts/apps/monitoring/views/aggregate-settings.html:2
 #: scripts/apps/monitoring/views/monitoring-view.html:107
 msgid "Monitoring settings"
-msgstr ""
+msgstr "Подешавања мониторинга"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:163
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:83
@@ -10864,7 +10864,7 @@ msgstr ""
 #: scripts/apps/monitoring/views/monitoring-view.html:159
 #: scripts/apps/monitoring/views/monitoring-view.html:201
 msgid "More actions"
-msgstr ""
+msgstr "Више радњи"
 
 #: scripts/core/ui/components/content-create-dropdown/more-templates.tsx:49
 msgid "More templates"
@@ -10898,11 +10898,11 @@ msgstr ""
 
 #: scripts/apps/monitoring/index.ts:113
 msgid "Move focus to next stage or group"
-msgstr ""
+msgstr "Премести фокус на следећу фазу или групу"
 
 #: scripts/apps/monitoring/index.ts:115
 msgid "Move focus to previous stage or group"
-msgstr ""
+msgstr "Премести фокус на претходну фазу или групу"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:197
 msgid "Move up"
@@ -10923,7 +10923,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:154
 msgid "Moved to a working stage by this user"
-msgstr ""
+msgstr "Премештено у радну фазу од стране овог корисника"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:134
 #: scripts/apps/authoring-react/multi-edit-modal.tsx:240
@@ -10954,7 +10954,7 @@ msgstr "Цитат у више редова"
 
 #: scripts/apps/workspace/index.ts:39
 msgid "Multi-select (or deselect) an item"
-msgstr ""
+msgstr "Изабери (или поништи избор) више ставки"
 
 #: scripts/apps/authoring/multiedit/views/multiedit.html:2
 #: scripts/apps/authoring/views/authoring-topbar.html:296
@@ -11205,7 +11205,7 @@ msgstr ""
 #: scripts/extensions/availability-manager/src/correspondent-availability/filters.tsx:115
 #: scripts/extensions/availability-manager/src/settings/availability-settings.tsx:313
 msgid "Next"
-msgstr ""
+msgstr "Следеће"
 
 #: scripts/apps/search/directives/DateFilters.ts:23
 msgid "Next 3 Months"
@@ -11542,7 +11542,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/user-activity/components/Group.tsx:55
 msgid "No results for this user"
-msgstr ""
+msgstr "Нема резултата за овог корисника"
 
 #: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:205
 #: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:230
@@ -11809,7 +11809,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/desk-notifications.html:15
 msgid "Notification list"
-msgstr ""
+msgstr "Листа обавештења"
 
 #: scripts/apps/monitoring/views/desk-notifications.html:4
 #: scripts/apps/users/views/user-preferences.html:15
@@ -11867,7 +11867,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:87
 msgid "OR"
-msgstr ""
+msgstr "ИЛИ"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:25
 #: scripts/extensions/auto-tagging-widget/dist/src/groups.js:25
@@ -12012,7 +12012,7 @@ msgstr "Упс! Неисправан имејл корисника.<br>Поку�
 #: scripts/apps/users/views/user-list-item.html:37
 #: scripts/core/list/views/list-view.html:3
 msgid "Oops! There are no items."
-msgstr ""
+msgstr "Упс! Нема ставки."
 
 #: ../superdesk-planning/client/actions/multiSelect.ts:238
 #: scripts/apps/authoring/authoring/index.ts:380
@@ -12033,7 +12033,7 @@ msgstr ""
 
 #: scripts/apps/workspace/index.ts:34
 msgid "Open highlights"
-msgstr ""
+msgstr "Отвори истицања"
 
 #: scripts/apps/authoring/authoring/index.ts:401
 msgid "Open in new Window"
@@ -12059,7 +12059,7 @@ msgstr ""
 
 #: scripts/apps/workspace/index.ts:33
 msgid "Open monitoring"
-msgstr ""
+msgstr "Отвори мониторинг"
 
 #: scripts/apps/authoring-react/toolbar/multi-edit-toolbar-action.tsx:58
 msgid "Open multi edit"
@@ -12071,23 +12071,23 @@ msgstr ""
 
 #: scripts/apps/workspace/index.ts:37
 msgid "Open personal"
-msgstr ""
+msgstr "Отвори лично"
 
 #: scripts/apps/workspace/index.ts:38
 msgid "Open search"
-msgstr ""
+msgstr "Отвори претрагу"
 
 #: scripts/apps/workspace/index.ts:36
 msgid "Open spike"
-msgstr ""
+msgstr "Отвори кош"
 
 #: scripts/apps/workspace/index.ts:35
 msgid "Open tasks"
-msgstr ""
+msgstr "Отвори задатке"
 
 #: scripts/apps/workspace/index.ts:32
 msgid "Open workspace / dashboard"
-msgstr ""
+msgstr "Отвори радни простор / контролну таблу"
 
 #: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:40
 msgid "OpenStreetMap Details"
@@ -12099,7 +12099,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/desk-notifications.html:35
 msgid "Opened by"
-msgstr ""
+msgstr "Отворио"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:637
 msgid "Operation"
@@ -12277,15 +12277,15 @@ msgstr ""
 
 #: scripts/apps/monitoring/directives/AggregateSettings.ts:55
 msgid "Output/Published"
-msgstr ""
+msgstr "Излаз/објављено"
 
 #: scripts/apps/monitoring/directives/AggregateSettings.ts:49
 msgid "Output/Scheduled"
-msgstr ""
+msgstr "Излаз/заказано"
 
 #: scripts/apps/monitoring/directives/AggregateSettings.ts:61
 msgid "Output/Sent"
-msgstr ""
+msgstr "Излаз/послато"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:313
 msgid "Override Auto Assign to Workflow"
@@ -12399,7 +12399,7 @@ msgstr ""
 
 #: scripts/core/list/views/sdPaginationAlt.html:2
 msgid "Page"
-msgstr ""
+msgstr "Страница"
 
 #: ../superdesk-analytics/client/charts/views/chart-form-options.html:57
 msgid "Page Size"
@@ -12407,7 +12407,7 @@ msgstr ""
 
 #: scripts/core/list/views/sdPagination.html:2
 msgid "Page Size:"
-msgstr ""
+msgstr "Величина странице:"
 
 #: scripts/apps/legal-archive/views/legal_archive.html:24
 msgid "Pagination"
@@ -12534,7 +12534,7 @@ msgstr ""
 #: scripts/apps/monitoring/views/aggregate-settings.html:55
 #: scripts/apps/templates/constants.ts:10
 msgid "Personal"
-msgstr ""
+msgstr "Лично"
 
 #: scripts/apps/dictionaries/views/settings.html:28
 msgid "Personal Dictionary"
@@ -12542,11 +12542,11 @@ msgstr ""
 
 #: scripts/apps/monitoring/controllers/AggregateCtrl.ts:40
 msgid "Personal Items"
-msgstr ""
+msgstr "Личне ставке"
 
 #: scripts/apps/monitoring/config.ts:54
 msgid "Personal Space"
-msgstr ""
+msgstr "Лични простор"
 
 #: ../superdesk-planning/client/constants/index.ts:170
 msgid "Personal Workspace"
@@ -12565,7 +12565,7 @@ msgstr ""
 #: scripts/apps/monitoring/config.ts:64
 #: scripts/core/interactive-article-actions-panel/subcomponents/destination-select.tsx:28
 msgid "Personal space"
-msgstr ""
+msgstr "Лични простор"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:145
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:394
@@ -12583,7 +12583,7 @@ msgstr ""
 #: scripts/apps/search/views/search.html:28
 #: scripts/apps/users/directives/UserPreferencesDirective.ts:29
 msgid "Photo Grid View"
-msgstr ""
+msgstr "Приказ мреже фотографија"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:110
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:92
@@ -12596,7 +12596,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/workspace-tasks/tasks.ts:385
 msgid "Pick task"
-msgstr ""
+msgstr "Изабери задатак"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:148
 #: ../superdesk-planning/client/utils/index.ts:589
@@ -13065,7 +13065,7 @@ msgstr ""
 #: scripts/extensions/availability-manager/src/correspondent-availability/filters.tsx:104
 #: scripts/extensions/availability-manager/src/settings/availability-settings.tsx:301
 msgid "Previous"
-msgstr ""
+msgstr "Претходно"
 
 #: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:107
 #: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:122
@@ -13137,7 +13137,7 @@ msgstr "Приватно"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:89
 msgid "Private saved searches"
-msgstr ""
+msgstr "Приватне сачуване претраге"
 
 #: scripts/apps/users/controllers/UserEditController.ts:32
 msgid "Privileges"
@@ -13380,7 +13380,7 @@ msgstr ""
 #: scripts/apps/search/views/item-repo.html:5
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:301
 msgid "Published"
-msgstr ""
+msgstr "Објављено"
 
 #: scripts/apps/desks/views/settings.html:86
 msgid "Published Content"
@@ -13592,11 +13592,11 @@ msgstr "Само за читање"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:206
 msgid "Rearrange Groups"
-msgstr ""
+msgstr "Прераспореди групе"
 
 #: scripts/apps/dashboard/views/workspace.html:5
 msgid "Rearrange widgets"
-msgstr ""
+msgstr "Прераспореди виџете"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:161
 msgid "Reason for Event cancellation:"
@@ -13713,11 +13713,11 @@ msgstr "Прецизирај претрагу"
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:415
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:794
 msgid "Refresh"
-msgstr ""
+msgstr "Освежи"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:99
 msgid "Refresh content"
-msgstr ""
+msgstr "Освежи садржај"
 
 #: scripts/apps/authoring/metadata/views/metadata-tags.html:9
 msgid "Refresh suggestions"
@@ -14073,12 +14073,12 @@ msgstr ""
 
 #: scripts/apps/workspace/views/edit-workspace-modal.html:4
 msgid "Rename Workspace"
-msgstr ""
+msgstr "Преименуј радни простор"
 
 #: scripts/apps/dashboard/views/workspace.html:29
 #: scripts/apps/monitoring/views/monitoring-view.html:213
 msgid "Rename workspace"
-msgstr ""
+msgstr "Преименуј радни простор"
 
 #: scripts/apps/publish/views/email-config.html:29
 msgid "Rendition"
@@ -14098,11 +14098,11 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:105
 msgid "Reorder Sections"
-msgstr ""
+msgstr "Прераспореди секције"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:108
 msgid "Reorder stages and saved searches for monitoring view"
-msgstr ""
+msgstr "Прераспореди фазе и сачуване претраге за приказ мониторинга"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:165
 msgid "Repeat"
@@ -14421,7 +14421,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:22
 msgid "Route incoming content to"
-msgstr ""
+msgstr "Усмери долазни садржај у"
 
 #: scripts/apps/search/components/fields/state.tsx:32
 msgid "Routed"
@@ -14429,15 +14429,15 @@ msgstr ""
 
 #: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:3
 msgid "Routed from"
-msgstr ""
+msgstr "Усмерено са"
 
 #: scripts/apps/dashboard/closed-desk/views/top-menu-info.html:8
 msgid "Routed from other desks"
-msgstr ""
+msgstr "Усмерено са других дескова"
 
 #: scripts/apps/dashboard/closed-desk/views/top-menu-info.html:9
 msgid "Routed from:"
-msgstr ""
+msgstr "Усмерено са:"
 
 #: scripts/core/lang/missing-translations-strings.ts:20
 msgid "Routing Rules Management"
@@ -14453,7 +14453,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/closed-desk/views/top-menu-info.html:12
 msgid "Routing to:"
-msgstr ""
+msgstr "Усмеравање на:"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:53
 msgid "Rule name"
@@ -14883,7 +14883,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:62
 msgid "Saved Searches"
-msgstr ""
+msgstr "Сачуване претраге"
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:238
 msgid "Saved report not found!"
@@ -15078,7 +15078,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/dist/src/page.js:131
 #: scripts/extensions/broadcasting/src/page.tsx:186
 msgid "Search"
-msgstr ""
+msgstr "Претрага"
 
 #: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:238
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:238
@@ -15287,7 +15287,7 @@ msgstr ""
 
 #: scripts/apps/workspace/views/workspace-dropdown.html:5
 msgid "Select Workspace"
-msgstr ""
+msgstr "Изабери радни простор"
 
 #: scripts/apps/desks/views/desk-config-modal.html:179
 msgid ""
@@ -15386,7 +15386,7 @@ msgstr "Изабери дескове"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:18
 msgid "Select desks for view"
-msgstr ""
+msgstr "Изабери дескове за приказ"
 
 #: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:41
 msgid "Select either Search or Browse the locations"
@@ -15409,7 +15409,7 @@ msgstr "Изабери ставку"
 
 #: scripts/apps/monitoring/index.ts:117
 msgid "Select next item on focused stage or group"
-msgstr ""
+msgstr "Изабери следећу ставку у фокусираној фази или групи"
 
 #: scripts/apps/publish-preview/previewModal.tsx:87
 msgid "Select preview target"
@@ -15417,11 +15417,11 @@ msgstr ""
 
 #: scripts/apps/monitoring/index.ts:119
 msgid "Select previous item on focused stage or group"
-msgstr ""
+msgstr "Изабери претходну ставку у фокусираној фази или групи"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:65
 msgid "Select saved searches for view"
-msgstr ""
+msgstr "Изабери сачуване претраге за приказ"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/select-show.js:21
 #: scripts/extensions/broadcasting/dist/src/rundowns/components/select-show.js:21
@@ -15584,7 +15584,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/controllers/AggregateCtrl.ts:41
 msgid "Sent Items"
-msgstr ""
+msgstr "Послате ставке"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:436
 msgid "Sent To"
@@ -15680,7 +15680,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:131
 msgid "Set maximum items per stages and saved searches for view"
-msgstr ""
+msgstr "Подеси максималан број ставки по фазама и сачуваним претрагама за приказ"
 
 #: scripts/apps/monitoring/aggregate-widget/aggregate.ts:17
 msgid ""
@@ -15689,7 +15689,7 @@ msgid ""
 "sensible name, select a saved search or desk or its workflow stages. Monitor "
 "anything, anywhere, anytime. You can have as many Monitor widgets as you "
 "wish."
-msgstr ""
+msgstr "Подесите различите мониторе да бисте пратили било које теме из доласка или продукције, излаза дескова или било ког дела радног тока. Све што вам треба је да им дате смислен назив, изаберете сачувану претрагу или деск или његове радне фазе. Пратите било шта, било где, било када. Можете имати онолико виџета Монитора колико желите."
 
 #: scripts/extensions/sams/dist/src/api/sets.js:57
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:57
@@ -16068,7 +16068,7 @@ msgstr ""
 #: scripts/apps/search/views/search-filters.html:130
 #: scripts/core/itemList/views/relatedItem-list-widget.html:34
 msgid "Sms"
-msgstr ""
+msgstr "СМС"
 
 #: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:24
 msgid "Some Coverages Assigned"
@@ -16137,7 +16137,7 @@ msgstr "Ваш налог је суспендован."
 
 #: scripts/apps/workspace/views/edit-workspace-modal.html:23
 msgid "Sorry, given workspace name is in use"
-msgstr ""
+msgstr "Извините, дати назив радног простора се већ користи"
 
 #: scripts/apps/users/views/settings-roles.html:40
 msgid "Sorry, this role name already exists."
@@ -16165,7 +16165,7 @@ msgstr ""
 #: scripts/apps/search/views/item-sortbar.html:12
 #: scripts/apps/search/views/item-sortbar.html:6
 msgid "Sort by"
-msgstr ""
+msgstr "Сортирај по"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:239
 msgid "Sort by:"
@@ -16199,7 +16199,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/monitoring-group-header.html:28
 msgid "Sorting:"
-msgstr ""
+msgstr "Сортирање:"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:586
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:455
@@ -16264,7 +16264,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/config.ts:29
 msgid "Spike Monitoring"
-msgstr ""
+msgstr "Мониторинг коша"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:138
 msgid "Spike Planning Item"
@@ -16280,7 +16280,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/index.ts:127
 msgid "Spike item(s)"
-msgstr ""
+msgstr "Премести ставку(е) у кош"
 
 #: ../superdesk-planning/client/constants/planning.ts:135
 msgid "Spike planning"
@@ -16298,7 +16298,7 @@ msgstr ""
 #: scripts/apps/search/components/fields/state.tsx:36
 #: scripts/apps/search/constants.ts:14
 msgid "Spiked"
-msgstr ""
+msgstr "У кошу"
 
 #: scripts/apps/search/views/search-parameters.html:145
 msgid "Spiked Content"
@@ -16307,7 +16307,7 @@ msgstr ""
 #: scripts/apps/monitoring/config.ts:40
 #: scripts/apps/monitoring/views/monitoring-view.html:257
 msgid "Spiked Items"
-msgstr ""
+msgstr "Ставке у кошу"
 
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:177
 msgid "Spiked Only"
@@ -16320,7 +16320,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/monitoring-view.html:4
 msgid "Spiked items"
-msgstr ""
+msgstr "Ставке у кошу"
 
 #: scripts/apps/search/views/search-parameters.html:153
 msgid "Spiked only content"
@@ -16369,7 +16369,7 @@ msgstr ""
 #: scripts/apps/monitoring/views/monitoring-view.html:23
 #: scripts/apps/monitoring/views/monitoring-view.html:66
 msgid "Stages"
-msgstr ""
+msgstr "Фазе"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:177
 msgid "Star"
@@ -16405,12 +16405,12 @@ msgstr ""
 
 #: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:31
 msgid "Start routing"
-msgstr ""
+msgstr "Започни усмеравање"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:87
 #: scripts/apps/search/views/item-searchbar.html:19
 msgid "Start search"
-msgstr ""
+msgstr "Започни претрагу"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:571
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:123
@@ -16493,7 +16493,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:37
 msgid "Stop routing"
-msgstr ""
+msgstr "Заустави усмеравање"
 
 #: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:254
 #: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:150
@@ -16780,7 +16780,7 @@ msgstr "Експонент"
 #: scripts/apps/monitoring/directives/utils.ts:103
 #: scripts/apps/users/directives/UserPreferencesDirective.ts:31
 msgid "Swimlane View"
-msgstr ""
+msgstr "Канбан приказ"
 
 #: ../superdesk-planning/client/components/fields/editor/Language.tsx:111
 msgid "Switch Metadata Language"
@@ -16800,11 +16800,11 @@ msgstr ""
 
 #: scripts/apps/monitoring/index.ts:111
 msgid "Switch between grouped/single desk view"
-msgstr ""
+msgstr "Пребацуј између груписаног/појединачног приказа деска"
 
 #: scripts/apps/monitoring/index.ts:109
 msgid "Switch between grouped/single stage view"
-msgstr ""
+msgstr "Пребацуј између груписаног/појединачног приказа фазе"
 
 #: scripts/core/menu/views/menu.html:38
 msgid "Switch to feature preview"
@@ -16969,7 +16969,7 @@ msgstr ""
 
 #: scripts/core/itemList/views/relatedItem-list-widget.html:31
 msgid "Takes"
-msgstr ""
+msgstr "Наставци"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:187
 msgid "Takes Package"
@@ -17029,7 +17029,7 @@ msgstr ""
 #: scripts/apps/dashboard/workspace-tasks/tasks.ts:405
 #: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:2
 msgid "Tasks"
-msgstr ""
+msgstr "Задаци"
 
 #: scripts/core/lang/missing-translations-strings.ts:20
 msgid "Tasks Management"
@@ -17413,7 +17413,7 @@ msgid ""
 "The user activity widget provides information about user activity. Using the "
 "widget, editors can search and select a user. Upon selection a list of "
 "content items is shown categorized as follows:"
-msgstr ""
+msgstr "Виџет активности корисника пружа информације о активности корисника. Користећи виџет, уредници могу претраживати и изабрати корисника. Након избора приказује се листа ставки садржаја категоризована на следећи начин:"
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:226
 msgid "The values should be unique for {{uniqueField}}"
@@ -17451,7 +17451,7 @@ msgstr ""
 #: scripts/apps/search/components/ItemList.tsx:523
 #: scripts/core/itemList/LazyLoader.tsx:216
 msgid "There are currently no items"
-msgstr ""
+msgstr "Тренутно нема ставки"
 
 #: scripts/validate-instance-configuration.tsx:108
 msgid "There are issues with instance configuration"
@@ -18129,7 +18129,7 @@ msgstr "На деск"
 #: scripts/apps/dashboard/workspace-tasks/tasks.ts:9
 #: scripts/apps/master-desk/components/AssignmentsComponent.tsx:40
 msgid "To Do"
-msgstr ""
+msgstr "За урадити"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:195
 msgid "To Lowercase"
@@ -18490,7 +18490,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:18
 msgid "UPCOMING"
-msgstr ""
+msgstr "ПРЕДСТОЈЕЋЕ"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/update-action.tsx:10
 #: scripts/apps/authoring/views/authoring-header.html:57
@@ -18530,7 +18530,7 @@ msgstr ""
 #: scripts/apps/dashboard/workspace-tasks/views/assignee-view.html:8
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:50
 msgid "Unassigned"
-msgstr ""
+msgstr "Недодељено"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:56
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:72
@@ -18927,7 +18927,7 @@ msgstr ""
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:174
 #: scripts/extensions/sams/src/utils/ui.tsx:107
 msgid "Updated"
-msgstr ""
+msgstr "Ажурирано"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:129
 msgid "Updated Fields:"
@@ -19186,7 +19186,7 @@ msgstr ""
 #: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:340
 #: scripts/apps/dashboard/user-activity/user-activity.ts:37
 msgid "User Activity"
-msgstr ""
+msgstr "Активност корисника"
 
 #: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:185
 msgid "User Activity - {{username}}"
@@ -19385,7 +19385,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/index.ts:120
 msgid "View an item"
-msgstr ""
+msgstr "Прикажи ставку"
 
 #: ../superdesk-analytics/client/index.js:95
 msgid "View analytics reports"
@@ -19423,7 +19423,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:13
 msgid "View name"
-msgstr ""
+msgstr "Назив приказа"
 
 #: scripts/core/menu/views/menu.html:49
 msgid "View notifications"
@@ -19613,7 +19613,7 @@ msgstr ""
 #: scripts/apps/dashboard/views/widget.html:11
 #: scripts/apps/dashboard/views/widget.html:12
 msgid "Widget settings"
-msgstr ""
+msgstr "Подешавања виџета"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:8
 msgid ""
@@ -19665,7 +19665,7 @@ msgstr ""
 
 #: scripts/core/activity/activity.ts:22
 msgid "Workflow"
-msgstr ""
+msgstr "Радни ток"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:171
 msgid "Workflow State"
@@ -19692,15 +19692,15 @@ msgstr ""
 #: scripts/apps/dashboard/workspace-tasks/tasks.ts:376
 #: scripts/apps/ingest/index.ts:72 scripts/apps/stream/index.ts:18
 msgid "Workspace"
-msgstr ""
+msgstr "Радни простор"
 
 #: scripts/apps/workspace/views/edit-workspace-modal.html:15
 msgid "Workspace name"
-msgstr ""
+msgstr "Назив радног простора"
 
 #: scripts/apps/workspace/views/workspace-dropdown.html:1
 msgid "Workspace:"
-msgstr ""
+msgstr "Радни простор:"
 
 #: scripts/apps/dashboard/world-clock/world-clock.ts:209
 #: scripts/core/lang/missing-translations-strings.ts:44
@@ -19757,7 +19757,7 @@ msgstr ""
 msgid ""
 "You are changing you personal preferences. If you would like to set the "
 "default order for the desk, you can do so from the settings page."
-msgstr ""
+msgstr "Мењате своје личне поставке. Ако желите да поставите подразумевани редослед за деск, то можете учинити на страници подешавања."
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:249
 msgid "You are creating a new planning item."
@@ -19816,7 +19816,7 @@ msgstr "Немате ниједно обавештење"
 
 #: scripts/apps/monitoring/views/item-actions-menu.html:44
 msgid "You don't have the privileges to perform any action"
-msgstr ""
+msgstr "Немате привилегије за извршавање било које радње"
 
 #: scripts/apps/search/views/saved-search-subscribe.html:12
 msgid "You have chosen to subscribe to"
@@ -19952,7 +19952,7 @@ msgstr ""
 #: scripts/apps/users/views/user-preferences.html:147
 #: scripts/core/utils.tsx:342
 msgid "all"
-msgstr ""
+msgstr "све"
 
 #: scripts/apps/desks/views/desk-config-modal.html:289
 #: scripts/apps/highlights/views/highlights_config_modal.html:15
@@ -20200,11 +20200,11 @@ msgstr ""
 
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:17
 msgid "custom vocabulary"
-msgstr ""
+msgstr "прилагођени вокабулар"
 
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:8
 msgid "date"
-msgstr ""
+msgstr "датум"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:41
 #: scripts/apps/desks/views/content-expiry.html:3
@@ -20319,7 +20319,7 @@ msgstr ""
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:93
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:9
 msgid "embed"
-msgstr ""
+msgstr "уграђени садржај"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:94
 msgid "embed articles"
@@ -20422,7 +20422,7 @@ msgstr ""
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:2
 msgid "for \"{{name}}\" Desk"
-msgstr ""
+msgstr "за деск \"{{name}}\""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:42
 msgid "for '{{ desk }}'"
@@ -20483,7 +20483,7 @@ msgstr ""
 
 #: scripts/core/itemList/views/relatedItem-list-widget.html:42
 msgid "genre:"
-msgstr ""
+msgstr "жанр:"
 
 #: scripts/core/ui/components/UserPopup/UserPopup.tsx:27
 msgid "go to profile"
@@ -20862,7 +20862,7 @@ msgstr ""
 #: scripts/core/list/views/sdPaginationAlt.html:2
 #: scripts/core/views/sdSearchList.html:15
 msgid "of"
-msgstr ""
+msgstr "од"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:63
 #: ../superdesk-planning/client/utils/events.tsx:1467
@@ -21059,7 +21059,7 @@ msgstr ""
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:10
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:7
 msgid "related content"
-msgstr ""
+msgstr "повезани садржај"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:89
 msgid "remove all format"
@@ -21300,7 +21300,7 @@ msgstr ""
 #: scripts/core/lang/missing-translations-strings.ts:9
 #: scripts/core/utils.tsx:291 scripts/core/utils.tsx:343
 msgid "text"
-msgstr ""
+msgstr "текст"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:84
 #: scripts/apps/authoring/versioning/history/views/history.html:83

--- a/po/sr.po
+++ b/po/sr.po
@@ -96,7 +96,7 @@ msgstr "'мора бити типа листе'\""
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:37
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:146
 msgid "'not scheduled yet'"
-msgstr ""
+msgstr "'још није заказано'"
 
 #: scripts/apps/highlights/services/HighlightsService.ts:16
 msgid "(Global)"
@@ -637,7 +637,7 @@ msgstr "ANPA кључ наставка"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx:109
 msgid "ASSOCIATED XMP FILE"
-msgstr ""
+msgstr "ПОВЕЗАНА XMP ДАТОТЕКА"
 
 #: ../superdesk-planning/client/validators/events.ts:242
 msgid "ATTACHED FILE {{ index }} is required"
@@ -645,7 +645,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx:95
 msgid "ATTACHMENTS"
-msgstr ""
+msgstr "ПРИЛОЗИ"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:107
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:88
@@ -1166,7 +1166,7 @@ msgstr "Додати овај догађај на листу планирања?
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:251
 msgid "Add this item to all recurring events or just this one?"
-msgstr ""
+msgstr "Додати ову ставку у све понављајуће догађаје или само у овај?"
 
 #: scripts/apps/authoring/views/item-association.html:100
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:56
@@ -1366,7 +1366,7 @@ msgstr "После"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/createPlanningForm.tsx:46
 msgid "Agenda"
-msgstr ""
+msgstr "Агенда"
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:240
 msgid "Agenda assigned to the planning item."
@@ -1520,7 +1520,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Assignments/DesksSubNavDropDown.tsx:21
 msgid "All Desks"
-msgstr ""
+msgstr "Сви дескови"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:283
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:368
@@ -1555,7 +1555,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelPlanningCoveragesForm.tsx:139
 msgid "All coverages cancelled:"
-msgstr ""
+msgstr "Сва извештавања отказана:"
 
 #: ../superdesk-planning/client/components/Events/EventDateTime.tsx:134
 msgid "All day"
@@ -1593,7 +1593,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:282
 msgid "All planning"
-msgstr ""
+msgstr "Сво планирање"
 
 #: scripts/apps/users/views/list.html:14
 msgid "All user types"
@@ -1890,7 +1890,7 @@ msgstr "Примени конфигурацију"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:244
 msgid "Apply the changes to all recurring planning items or just this one?"
-msgstr ""
+msgstr "Применити измене на све понављајуће ставке планирања или само на ову?"
 
 #: scripts/apps/publish/views/email-config.html:38
 msgid "Apply watermark"
@@ -2302,11 +2302,11 @@ msgstr "Додели"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:131
 msgid "Assign \"{{calendar}}\" Calendar to Series"
-msgstr ""
+msgstr "Додели календар \"{{calendar}}\" серији"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:134
 msgid "Assign Calendar"
-msgstr ""
+msgstr "Додели календар"
 
 #: scripts/apps/authoring-react/fields/media/media-metadata.tsx:27
 #: scripts/apps/authoring/media/MediaMetadataView.tsx:21
@@ -2330,17 +2330,17 @@ msgstr ""
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/State.tsx:29
 #: ../superdesk-planning/client/utils/index.ts:385
 msgid "Assigned"
-msgstr ""
+msgstr "Додељено"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:205
 #: ../superdesk-planning/client/utils/assignments.ts:205
 msgid "Assigned Provider"
-msgstr ""
+msgstr "Додељени провајдер"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:107
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:124
 msgid "Assigned by {{name}}"
-msgstr ""
+msgstr "Доделио {{name}}"
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:27
 msgid "Assigned desks"
@@ -2352,7 +2352,7 @@ msgstr "Додељено агенди '{{ agenda }}'"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:25
 msgid "Assigned to provider"
-msgstr ""
+msgstr "Додељено провајдеру"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:195
 msgid "Assigned to:"
@@ -2360,11 +2360,11 @@ msgstr "Додељено:"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:114
 msgid "Assigned:"
-msgstr ""
+msgstr "Додељено:"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/index.tsx:225
 msgid "Assigned: {{ name }}"
-msgstr ""
+msgstr "Додељено: {{ name }}"
 
 #: ../superdesk-planning/client/components/Coverages/CoveragePreview/CoveragePreviewTopBar.tsx:53
 msgid "Assignee"
@@ -2389,7 +2389,7 @@ msgstr "Задатак"
 #: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:243
 #: ../superdesk-planning/client/components/fields/editor/AssignmentPriority.tsx:28
 msgid "Assignment Priority"
-msgstr ""
+msgstr "Приоритет задатка"
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:192
 msgid "Assignment does not exist"
@@ -2397,7 +2397,7 @@ msgstr "Задатак не постоји"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:50
 msgid "Assignment for"
-msgstr ""
+msgstr "Задатак за"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:144
 msgid "Assignment has been cancelled, unable to reassign"
@@ -2425,7 +2425,7 @@ msgstr "Задатак је закључан, није могуће уклони
 
 #: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:123
 msgid "Assignment locked"
-msgstr ""
+msgstr "Задатак закључан"
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:464
 msgid "Assignment priority has been updated."
@@ -2453,7 +2453,7 @@ msgstr "Задаци"
 #: ../superdesk-planning/client/apps/Assignments/AssignmentsUi.tsx:14
 #: ../superdesk-planning/client/apps/Assignments/FulfilAssignmentUi.tsx:14
 msgid "Assignments Content"
-msgstr ""
+msgstr "Садржај задатака"
 
 #: ../superdesk-planning/client/components/fields/editor/XMPFile.tsx:53
 msgid "Associate an XMP file"
@@ -2723,7 +2723,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Assignments/SubNavBar.tsx:51
 msgid "Back to group list view"
-msgstr ""
+msgstr "Назад на приказ листе група"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:10
 msgid "Back to original view"
@@ -3196,12 +3196,12 @@ msgstr "Откажи"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:86
 msgid "Cancel Event"
-msgstr ""
+msgstr "Откажи догађај"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:150
 #: ../superdesk-planning/client/constants/planning.ts:138
 msgid "Cancel Planning"
-msgstr ""
+msgstr "Откажи планирање"
 
 #: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:127
 msgid "Cancel Scheduled Update"
@@ -3217,7 +3217,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:152
 msgid "Cancel all recurring events or just this one?"
-msgstr ""
+msgstr "Отказати све понављајуће догађаје или само овај?"
 
 #: scripts/apps/archive/index.tsx:326
 msgid "Cancel correction"
@@ -3234,7 +3234,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:84
 msgid "Cancel {{event}}"
-msgstr ""
+msgstr "Откажи {{event}}"
 
 #: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:110
 msgid "Canceling failed"
@@ -3246,7 +3246,7 @@ msgstr "Отказивање није успело"
 #: ../superdesk-planning/client/utils/index.ts:374
 #: ../superdesk-planning/client/utils/index.ts:422
 msgid "Cancelled"
-msgstr ""
+msgstr "Отказано"
 
 #: scripts/apps/relations/directives/RelatedItemsDirective.ts:149
 msgid "Cannot add self as related item."
@@ -3879,7 +3879,7 @@ msgstr ""
 #: ../superdesk-planning/client/utils/index.ts:402
 #: scripts/apps/master-desk/components/AssignmentsComponent.tsx:52
 msgid "Completed"
-msgstr ""
+msgstr "Завршено"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:66
 #: ../superdesk-planning/client/utils/index.ts:595
@@ -4139,7 +4139,7 @@ msgstr "Ставке садржаја нису пронађене!"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:75
 msgid "Content linked"
-msgstr ""
+msgstr "Садржај повезан"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:72
 msgid "Content linked to coverage"
@@ -4147,7 +4147,7 @@ msgstr "Садржај повезан са извештавањем"
 
 #: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:122
 msgid "Content locked"
-msgstr ""
+msgstr "Садржај закључан"
 
 #: scripts/apps/search/components/TypeIcon.tsx:26
 msgid "Content profile: {{name}}"
@@ -4164,7 +4164,7 @@ msgstr "Веза садржаја уклоњена"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Content.tsx:24
 msgid "Content: {{ numberOfContent }}"
-msgstr ""
+msgstr "Садржај: {{ numberOfContent }}"
 
 #: scripts/api/article-send.tsx:93
 #: scripts/apps/desks/views/desk-config-modal.html:421
@@ -4193,7 +4193,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:110
 msgid "Convert to a recurring event"
-msgstr ""
+msgstr "Конвертуј у понављајући догађај"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:80
 msgid "Converted to recurring event"
@@ -4201,7 +4201,7 @@ msgstr "Конвертовано у понављајући догађај"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:92
 msgid "Copied to clipboard"
-msgstr ""
+msgstr "Копирано у клипборд"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:67
 #: scripts/apps/archive/index.tsx:268
@@ -4221,7 +4221,7 @@ msgstr "Копирај"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:89
 msgid "Copy assignment Id"
-msgstr ""
+msgstr "Копирај ИД задатка"
 
 #: scripts/apps/authoring/media/views/media-copy-metadata-directive.html:2
 msgid "Copy metadata"
@@ -4384,11 +4384,11 @@ msgstr "Држава"
 #: scripts/apps/archive/views/assignment-icon.html:1
 #: scripts/apps/search/components/fields/assignment.tsx:17
 msgid "Coverage"
-msgstr ""
+msgstr "Извештавање"
 
 #: ../superdesk-planning/client/components/Assignments/EditCoverageAssignmentModal.tsx:81
 msgid "Coverage Assignment Details"
-msgstr ""
+msgstr "Детаљи доделе извештавања"
 
 #: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:37
 #: ../superdesk-planning/client/components/fields/preview/index.ts:45
@@ -4401,7 +4401,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:191
 msgid "Coverage Provider"
-msgstr ""
+msgstr "Провајдер извештавања"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:133
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:266
@@ -4434,7 +4434,7 @@ msgstr "Извештавање додељено"
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:69
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:72
 msgid "Coverage availability"
-msgstr ""
+msgstr "Доступност извештавања"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:89
 msgid "Coverage availability confirmed"
@@ -4482,7 +4482,7 @@ msgstr "Приоритет извештавања измењен"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:51
 msgid "Coverage re-assigned to"
-msgstr ""
+msgstr "Извештавање поново додељено"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:30
 msgid "Coverage reassigned"
@@ -4691,7 +4691,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:259
 msgid "Create planning for all events or just this one?"
-msgstr ""
+msgstr "Креирати планирање за све догађаје или само за овај?"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:57
 #: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:57
@@ -5202,7 +5202,7 @@ msgstr "Подразумевани филтер догађаја и планир
 
 #: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:72
 msgid "Default Template"
-msgstr ""
+msgstr "Подразумевани шаблон"
 
 #: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:96
 #: scripts/apps/authoring/views/theme-select.html:15
@@ -5513,7 +5513,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:64
 msgid "Desk Assignments"
-msgstr ""
+msgstr "Задаци деска"
 
 #: scripts/apps/desks/views/desk-config-modal.html:68
 msgid "Desk Email"
@@ -5542,7 +5542,7 @@ msgstr "Послати излаз деска"
 
 #: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:79
 msgid "Desk Templates"
-msgstr ""
+msgstr "Шаблони деска"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:367
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:371
@@ -5962,7 +5962,7 @@ msgstr "Преузми конфигурацију"
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:306
 #: scripts/extensions/sams/src/utils/ui.tsx:76
 msgid "Draft"
-msgstr ""
+msgstr "Нацрт"
 
 #: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:75
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:75
@@ -6049,7 +6049,7 @@ msgstr "Рок"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:26
 msgid "Due Date"
-msgstr ""
+msgstr "Датум рока"
 
 #: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:34
 msgid "Due date"
@@ -7122,7 +7122,7 @@ msgstr "Догађај отказан"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:59
 msgid "Event Cancelled:"
-msgstr ""
+msgstr "Догађај отказан:"
 
 #: ../superdesk-planning/client/components/Planning/PlanningEditor/PlanningEditorHeader.tsx:61
 #: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:187
@@ -7163,7 +7163,7 @@ msgstr "Догађај одложен"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:41
 msgid "Event Postponed:"
-msgstr ""
+msgstr "Догађај одложен:"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:39
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:53
@@ -7228,7 +7228,7 @@ msgstr "Догађај враћен из корпе"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:234
 msgid "Event will be changed to a multi-day event!"
-msgstr ""
+msgstr "Догађај ће бити промењен у вишедневни догађај!"
 
 #: ../superdesk-planning/client/components/fields/editor/DatesGroup.tsx:44
 msgid "Event/Planning date"
@@ -8203,7 +8203,7 @@ msgstr "Резултати теста филтера"
 
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:111
 msgid "Filter by day:"
-msgstr ""
+msgstr "Филтрирај по дану:"
 
 #: scripts/apps/content-filters/controllers/FilterConditionsController.ts:99
 msgid "Filter condition saved."
@@ -8577,7 +8577,7 @@ msgstr "Жанр"
 #: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:78
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Genre.tsx:18
 msgid "Genre:"
-msgstr ""
+msgstr "Жанр:"
 
 #: scripts/core/auth/reset-password.html:17
 msgid "Get token"
@@ -9027,7 +9027,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:85
 msgid "Id: {{id}}"
-msgstr ""
+msgstr "ИД: {{id}}"
 
 #: scripts/apps/publish/views/email-config.html:26
 msgid "Identifier for the media in the email template"
@@ -9544,7 +9544,7 @@ msgstr "Ставка преузета."
 
 #: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:56
 msgid "Item History"
-msgstr ""
+msgstr "Историја ставке"
 
 #: scripts/apps/authoring-react/toolbar/translate-modal.tsx:80
 #: scripts/extensions/ai-widget/dist/src/extension.js:32
@@ -9867,7 +9867,7 @@ msgstr "Код језика"
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Language.tsx:17
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx:209
 msgid "Language:"
-msgstr ""
+msgstr "Језик:"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:158
 #: scripts/apps/search/views/search-filters.html:18
@@ -10166,7 +10166,7 @@ msgstr "Учитавање"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentGroupList.tsx:350
 msgid "Loading more..."
-msgstr ""
+msgstr "Учитавање још..."
 
 #: scripts/apps/publish-preview/previewModal.tsx:45
 msgid "Loading preview"
@@ -11000,7 +11000,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Assignments/DesksSubNavDropDown.tsx:20
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:75
 msgid "My Assignments"
-msgstr ""
+msgstr "Моји задаци"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:115
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:254
@@ -11031,7 +11031,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:92
 msgid "My Templates"
-msgstr ""
+msgstr "Моји шаблони"
 
 #: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:17
 #: scripts/apps/authoring/multiedit/views/sd-multiedit-dropdown.html:10
@@ -11651,7 +11651,7 @@ msgstr "Нису дефинисане корисничке улоге!"
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:338
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:231
 msgid "No. of Events"
-msgstr ""
+msgstr "Број догађаја"
 
 #: scripts/apps/publish/views/subscribers.html:148
 msgid "Non-media"
@@ -11829,11 +11829,11 @@ msgstr "Број"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentGroupList.tsx:306
 msgid "Number of Assignments:"
-msgstr ""
+msgstr "Број задатака:"
 
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:83
 msgid "Number of assignments in TO DO"
-msgstr ""
+msgstr "Број задатака у „за урадити\""
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:71
 #: scripts/apps/users/activity-widget/configuration.html:7
@@ -12725,7 +12725,7 @@ msgstr "Ставка планирања је отказана"
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:111
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:214
 msgid "Planning Items"
-msgstr ""
+msgstr "Ставке планирања"
 
 #: scripts/core/lang/missing-translations-strings.ts:19
 msgid "Planning Management"
@@ -12751,7 +12751,7 @@ msgstr "Планирање отказано"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelPlanningCoveragesForm.tsx:142
 msgid "Planning cancelled:"
-msgstr ""
+msgstr "Планирање отказано:"
 
 #: ../superdesk-planning/client/validators/planning.ts:26
 msgid "Planning date is in the past"
@@ -12928,7 +12928,7 @@ msgstr "Поштански број"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:66
 msgid "Post Event"
-msgstr ""
+msgstr "Објави догађај"
 
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.js:75
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.js:70
@@ -12939,7 +12939,7 @@ msgstr "Објави ставке"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:77
 msgid "Post all recurring events or just this one?"
-msgstr ""
+msgstr "Објавити све понављајуће догађаје или само овај?"
 
 #: scripts/apps/authoring/comments/views/comments-widget.html:45
 msgid "Post on 'Enter'"
@@ -12963,11 +12963,11 @@ msgstr "Запис истакнутих прича објављен"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:104
 msgid "Postpone"
-msgstr ""
+msgstr "Одложи"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:102
 msgid "Postpone {{event}}"
-msgstr ""
+msgstr "Одложи {{event}}"
 
 #: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:37
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:208
@@ -13113,7 +13113,7 @@ msgstr "Приоритет"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:63
 msgid "Priority modified to"
-msgstr ""
+msgstr "Приоритет промењен на"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:288
 #: ../superdesk-planning/client/components/fields/priority.tsx:30
@@ -13293,7 +13293,7 @@ msgstr "Провајдер:"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/index.tsx:218
 msgid "Provider: {{ name }}"
-msgstr ""
+msgstr "Провајдер: {{ name }}"
 
 #: scripts/apps/archive/views/metadata-view.html:123
 msgid "PubStatus"
@@ -13600,33 +13600,33 @@ msgstr "Прераспореди виџете"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:161
 msgid "Reason for Event cancellation:"
-msgstr ""
+msgstr "Разлог отказивања догађаја:"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:82
 msgid "Reason for Event postponement:"
-msgstr ""
+msgstr "Разлог одлагања догађаја:"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelPlanningCoveragesForm.tsx:97
 msgid "Reason for cancelling all coverage:"
-msgstr ""
+msgstr "Разлог отказивања свих извештавања:"
 
 #: ../superdesk-planning/client/api/coverages.ts:33
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelCoverageForm.tsx:81
 msgid "Reason for cancelling the coverage"
-msgstr ""
+msgstr "Разлог отказивања извештавања"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelPlanningCoveragesForm.tsx:98
 msgid "Reason for cancelling the planning item:"
-msgstr ""
+msgstr "Разлог отказивања ставке планирања:"
 
 #: ../superdesk-planning/client/api/coverages.ts:54
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelCoverageForm.tsx:80
 msgid "Reason for cancelling the scheduled update"
-msgstr ""
+msgstr "Разлог отказивања заказаног ажурирања"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:179
 msgid "Reason for rescheduling this event:"
-msgstr ""
+msgstr "Разлог поновног заказивања овог догађаја:"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:155
 #: ../superdesk-planning/client/constants/assignments.ts:192
@@ -13676,7 +13676,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:85
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:91
 msgid "Recurring Event(s)"
-msgstr ""
+msgstr "Понављајући догађај(и)"
 
 #: ../superdesk-planning/client/utils/contentProfiles.ts:263
 msgid "Recurring Rules"
@@ -13804,7 +13804,7 @@ msgstr "Повезане ставке планирања"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:220
 msgid "Related Planning(s)"
-msgstr ""
+msgstr "Повезано планирање"
 
 #: ../superdesk-planning/client/components/Editor/bookmarks/AssociatedPlanningsBookmark.tsx:95
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:111
@@ -14230,11 +14230,11 @@ msgstr "Обавезно {{field}} у ставци {{item}}"
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:98
 #: ../superdesk-planning/client/constants/events.ts:161
 msgid "Reschedule"
-msgstr ""
+msgstr "Поново закажи"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:96
 msgid "Reschedule {{event}}"
-msgstr ""
+msgstr "Поново закажи {{event}}"
 
 #: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:34
 #: ../superdesk-planning/client/components/fields/preview/base/converters.ts:206
@@ -14691,7 +14691,7 @@ msgstr "Сачувај и објави"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:64
 msgid "Save & Post Event"
-msgstr ""
+msgstr "Сачувај и објави догађај"
 
 #: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:382
 msgid "Save & Unpost"
@@ -14722,7 +14722,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:67
 msgid "Save Event"
-msgstr ""
+msgstr "Сачувај догађај"
 
 #: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:33
 #: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:3
@@ -14959,7 +14959,7 @@ msgstr ""
 #: ../superdesk-planning/client/utils/index.ts:357
 #: scripts/apps/search/components/fields/state.tsx:38
 msgid "Scheduled"
-msgstr ""
+msgstr "Заказано"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:174
 #: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:88
@@ -15088,7 +15088,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Assignments/SubNavBar.tsx:72
 msgid "Search Assignments"
-msgstr ""
+msgstr "Претражи задатке"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:432
 msgid "Search Categories"
@@ -15200,7 +15200,7 @@ msgstr "Претражи планирање"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:217
 msgid "Search provider contacts"
-msgstr ""
+msgstr "Контакти провајдера претраге"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-list.html:6
 msgid "Search saved reports"
@@ -15270,7 +15270,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Assignments/DesksSubNavDropDown.tsx:49
 msgid "Select Assignments From:"
-msgstr ""
+msgstr "Изабери задатке из:"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:260
 msgid "Select Calendar"
@@ -15438,7 +15438,7 @@ msgstr "Изабери извор"
 #: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:85
 #: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:157
 msgid "Select template"
-msgstr ""
+msgstr "Изабери шаблон"
 
 #: scripts/apps/archive/views/upload.html:39
 msgid "Select them from folder"
@@ -15612,7 +15612,7 @@ msgstr "Подешавања редног броја"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateEventRepetitionsForm.tsx:111
 msgid "Series Start Date"
-msgstr ""
+msgstr "Датум почетка серије"
 
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:128
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:143
@@ -16056,7 +16056,7 @@ msgstr "Поклапање слаглајна"
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:85
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateAssignmentForm.tsx:118
 msgid "Slugline:"
-msgstr ""
+msgstr "Слаглајн:"
 
 #: scripts/apps/archive/views/item-preview.html:11
 #: scripts/apps/archive/views/metadata-view.html:194
@@ -16256,7 +16256,7 @@ msgstr ""
 #: scripts/apps/archive/show-spike-dialog.tsx:61
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:189
 msgid "Spike"
-msgstr ""
+msgstr "Премести у корпу"
 
 #: scripts/apps/archive/index.tsx:120
 msgid "Spike Item"
@@ -16268,7 +16268,7 @@ msgstr "Мониторинг корпе"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:138
 msgid "Spike Planning Item"
-msgstr ""
+msgstr "Премести ставку планирања у корпу"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:146
 msgid "Spike State"
@@ -16276,7 +16276,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:104
 msgid "Spike all recurring events or just this one?"
-msgstr ""
+msgstr "Преместити све понављајуће догађаје у корпу или само овај?"
 
 #: scripts/apps/monitoring/index.ts:127
 msgid "Spike item(s)"
@@ -16288,7 +16288,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:72
 msgid "Spike {{event}}"
-msgstr ""
+msgstr "Премести {{event}} у корпу"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:45
 #: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:40
@@ -17246,11 +17246,11 @@ msgstr "Анотација ће бити обрисана. Да ли сте си
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:107
 msgid "The assignment has been accepted"
-msgstr ""
+msgstr "Задатак је прихваћен"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:105
 msgid "The assignment has been accepted by"
-msgstr ""
+msgstr "Задатак је прихватио"
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:541
 msgid "The assignment has been reverted."
@@ -17289,7 +17289,7 @@ msgstr[2] ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:112
 msgid "The following Events are in use and will not be spiked:"
-msgstr ""
+msgstr "Следећи догађаји су у употреби и неће бити премештени у корпу:"
 
 #: scripts/extensions/predefinedTextField/dist/src/config.js:66
 #: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:66
@@ -17733,7 +17733,7 @@ msgstr "Ово извештавање"
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:261
 msgid ""
 "This Event is scheduled to occur after the end date of its recurring cycle!"
-msgstr ""
+msgstr "Овај догађај је заказан да се одржи након завршетка циклуса понављања!"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:28
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:21
@@ -17760,11 +17760,11 @@ msgstr ""
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:365
 #: ../superdesk-planning/client/constants/events.ts:174
 msgid "This and all future events"
-msgstr ""
+msgstr "Овај и сви будући догађаји"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:276
 msgid "This and all future planning"
-msgstr ""
+msgstr "Ово и све будуће планирање"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:587
 msgid ""
@@ -17774,17 +17774,17 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:25
 msgid "This event is a recurring event!"
-msgstr ""
+msgstr "Овај догађај је понављајући!"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:84
 msgid "This event is a recurring event. Post all recurring events"
-msgstr ""
+msgstr "Овај догађај је понављајући. Објави све понављајуће догађаје"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:271
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:362
 #: ../superdesk-planning/client/constants/events.ts:173
 msgid "This event only"
-msgstr ""
+msgstr "Само овај догађај"
 
 #: scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts:58
 msgid "This field is read-only"
@@ -17836,7 +17836,7 @@ msgstr "Ово је подразумевани шаблон следећих д�
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:351
 msgid "This is a recurring event."
-msgstr ""
+msgstr "Ово је понављајући догађај."
 
 #: scripts/apps/authoring/views/theme-select.html:38
 #: scripts/apps/authoring/views/theme-select.html:89
@@ -17882,7 +17882,7 @@ msgstr "Ова листа садржи необјављене измене!"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:270
 msgid "This planning only"
-msgstr ""
+msgstr "Само ово планирање"
 
 #: scripts/apps/archive/views/preview.html:100
 msgid "This story has been rewritten by:"
@@ -17907,11 +17907,11 @@ msgstr "Овај виџет вам омогућава да креирате бу
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:83
 msgid "This will also post the related event's entire recurring series"
-msgstr ""
+msgstr "Ово ће такође објавити целу понављајућу серију повезаног догађаја"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:118
 msgid "This will also postpone the following planning items"
-msgstr ""
+msgstr "Ово ће такође одложити следеће ставке планирања"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:105
 msgid "This will also remove linked assignments if any"
@@ -17925,11 +17925,11 @@ msgstr "Ово ће такође уклонити друге повезане з
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:51
 msgid "This will also {{action}} the following events"
-msgstr ""
+msgstr "Ово ће такође {{action}} следеће догађаје"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:39
 msgid "This will also {{action}} the following planning items"
-msgstr ""
+msgstr "Ово ће такође {{action}} следеће ставке планирања"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:119
 msgid ""
@@ -17939,15 +17939,15 @@ msgstr "Ово ће се појавити испод поља у\n              
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/convertToRecurringEventForm.tsx:152
 msgid "This will create new events in the remote ({{timeZone}}) timezone"
-msgstr ""
+msgstr "Ово ће креирати нове догађаје у удаљеној ({{timeZone}}) временској зони"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:269
 msgid "This will create the new event in the remote ({{timeZone}}) timezone"
-msgstr ""
+msgstr "Ово ће креирати нови догађај у удаљеној ({{timeZone}}) временској зони"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:222
 msgid "This will mark as rescheduled the following planning items"
-msgstr ""
+msgstr "Ово ће означити следеће ставке планирања као поново заказане"
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:553
 msgid ""
@@ -18107,7 +18107,7 @@ msgstr "Наслов:"
 #: ../superdesk-planning/client/components/fields/editor/EndDateTime.tsx:33
 #: ../superdesk-planning/client/components/fields/preview/index.ts:75
 msgid "To"
-msgstr ""
+msgstr "До"
 
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:357
 #: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:379
@@ -18474,7 +18474,7 @@ msgstr "Тип: {{ type }}"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:152
 msgid "Type: {{type}}"
-msgstr ""
+msgstr "Тип: {{type}}"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:121
 msgid "U"
@@ -18715,7 +18715,7 @@ msgstr "Поништи објаву"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:78
 msgid "Unpost all recurring events or just this one?"
-msgstr ""
+msgstr "Поништити објаву свих понављајућих догађаја или само овог?"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:14
 #: scripts/apps/authoring/authoring/index.ts:426
@@ -18764,7 +18764,7 @@ msgstr "Несачуване измене"
 #: scripts/core/interactive-article-actions-panel/action-tabs.tsx:15
 #: scripts/core/interactive-article-actions-panel/actions/unspike-action.tsx:76
 msgid "Unspike"
-msgstr ""
+msgstr "Врати из корпе"
 
 #: scripts/apps/archive/index.tsx:134
 msgid "Unspike Item"
@@ -18772,11 +18772,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:143
 msgid "Unspike Planning Item"
-msgstr ""
+msgstr "Врати ставку планирања из корпе"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikeEventForm.tsx:99
 msgid "Unspike all recurring events or just this one?"
-msgstr ""
+msgstr "Вратити све понављајуће догађаје из корпе или само овај?"
 
 #: ../superdesk-planning/client/constants/planning.ts:136
 msgid "Unspike planning"
@@ -18784,7 +18784,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:78
 msgid "Unspike {{event}}"
-msgstr ""
+msgstr "Врати {{event}} из корпе"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:49
 msgid "Unspiked"
@@ -18854,29 +18854,29 @@ msgstr "Рок ажурирања:"
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:114
 #: ../superdesk-planning/client/constants/events.ts:164
 msgid "Update Repetitions"
-msgstr ""
+msgstr "Ажурирај понављања"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:113
 msgid "Update Repetitions of the Series"
-msgstr ""
+msgstr "Ажурирај понављања серије"
 
 #: ../superdesk-analytics/client/update_time_report/controllers/UpdateTimeReportController.js:162
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeReportPreview.js:21
 #: ../superdesk-analytics/client/update_time_report/index.js:50
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:93
 msgid "Update Time"
-msgstr ""
+msgstr "Ажурирај време"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/assignCalendarForm.tsx:96
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:352
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:355
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:298
 msgid "Update all recurring events or just this one?"
-msgstr ""
+msgstr "Ажурирати све понављајуће догађаје или само овај?"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:258
 msgid "Update all recurring planning or just this one?"
-msgstr ""
+msgstr "Ажурирати све понављајуће планирање или само ово?"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:121
 msgid "Update every"
@@ -18896,7 +18896,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:90
 msgid "Update time of {{event}}"
-msgstr ""
+msgstr "Ажурирај време {{event}}"
 
 #: scripts/apps/search/components/fields/update.tsx:17
 msgid "Update {{sequence}}"
@@ -19240,7 +19240,7 @@ msgstr "Корисник није пронађен. Налог је можда �
 #: ../superdesk-analytics/client/user_activity_report/views/item-timeline-tooltip.html:2
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:102
 msgid "User:"
-msgstr ""
+msgstr "Корисник:"
 
 #: scripts/apps/ingest/views/settings/searchConfig.html:2
 #: scripts/apps/publish/views/ftp-config.html:7
@@ -19657,7 +19657,7 @@ msgstr "Радне фазе"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:100
 msgid "Work started"
-msgstr ""
+msgstr "Започет рад"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:101
 msgid "Work started on coverage"
@@ -19761,7 +19761,7 @@ msgstr "Мењате своје личне поставке. Ако желите
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:249
 msgid "You are creating a new planning item."
-msgstr ""
+msgstr "Креирате нову ставку планирања."
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:73
 msgid "You are currently managing featured story in another session"
@@ -19837,7 +19837,7 @@ msgstr "Имате несачуване измене. Шта желите да �
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:242
 msgid ""
 "You made changes to this planning item that is part of a recurring event."
-msgstr ""
+msgstr "Направили сте измене на овој ставци планирања која је део понављајућег догађаја."
 
 #: scripts/apps/production-api-keys/config.ts:40
 msgid ""
@@ -19914,7 +19914,7 @@ msgstr "[Нема вредности]"
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:103
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:97
 msgid "a Recurring Event"
-msgstr ""
+msgstr "понављајући догађај"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:51
 msgid "a lower case letter (a-z)"
@@ -19946,7 +19946,7 @@ msgstr "додао нову ставку типа {{type}} са празним �
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:78
 msgid "added to workflow"
-msgstr ""
+msgstr "додато у радни ток"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:167
 #: scripts/apps/users/views/user-preferences.html:147
@@ -19967,7 +19967,7 @@ msgstr "већ постоји"
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:91
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:97
 msgid "an Event"
-msgstr ""
+msgstr "догађај"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:52
 msgid "an upper case letter (A-Z)"
@@ -19975,7 +19975,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:56
 msgid "and"
-msgstr ""
+msgstr "и"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:45
 msgid "and '{{ user }}'"
@@ -20067,7 +20067,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:88
 msgid "cancelled"
-msgstr ""
+msgstr "отказано"
 
 #: scripts/core/lang/missing-translations-strings.ts:14
 msgid "categories"
@@ -20139,7 +20139,7 @@ msgstr "потврди"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:69
 msgid "confirmed"
-msgstr ""
+msgstr "потврђено"
 
 #: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:181
 msgid "contact saved."
@@ -20180,7 +20180,7 @@ msgstr "креирана / ставка(е) планирања"
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:42
 #: ../superdesk-planning/client/components/RelatedPlannings/index.tsx:102
 msgid "created by"
-msgstr ""
+msgstr "креирао"
 
 #: scripts/core/lang/missing-translations-strings.ts:36
 msgid "created new version {{version}} for item {{type}} about \"{{subject}}\""
@@ -20264,7 +20264,7 @@ msgstr "нацрт"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:42
 msgid "due"
-msgstr ""
+msgstr "рок"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:58
 msgid "duplicate id"
@@ -20456,7 +20456,7 @@ msgstr "из садржаја"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:95
 msgid "from coverage assignment by"
-msgstr ""
+msgstr "из доделе извештавања од"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:122
 msgid "from highlight"
@@ -20468,7 +20468,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:238
 msgid "from {{from}} to {{to}}"
-msgstr ""
+msgstr "од {{from}} до {{to}}"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:228
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:244
@@ -20879,7 +20879,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:100
 msgid "on assignment by"
-msgstr ""
+msgstr "на задатку од"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:23
 msgid "on the"
@@ -20989,7 +20989,7 @@ msgstr "користите само слова (a-z), бројеве (0-9), цр
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:121
 msgid "post"
-msgstr ""
+msgstr "објави"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:570
 msgid "postcode"
@@ -21108,7 +21108,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:72
 msgid "reverted"
-msgstr ""
+msgstr "враћено"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:182
 msgid "rewrite id"
@@ -21200,7 +21200,7 @@ msgstr "у корпи"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:91
 msgid "spiked and unlinked"
-msgstr ""
+msgstr "премештено у корпу и веза уклоњена"
 
 #: scripts/core/lang/missing-translations-strings.ts:26
 msgid "stage"
@@ -21317,7 +21317,7 @@ msgstr "на '{{ desk }}'"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:75
 msgid "to coverage assignment by"
-msgstr ""
+msgstr "на доделу извештавања од"
 
 #: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:150
 msgid "toggle difference"
@@ -21354,7 +21354,7 @@ msgstr "ненумерисана листа"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:121
 msgid "unpost"
-msgstr ""
+msgstr "поништи објаву"
 
 #: ../superdesk-planning/client/utils/history.tsx:87
 msgid "unposted"
@@ -21624,7 +21624,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:118
 msgid "{{action}} {{event}}"
-msgstr ""
+msgstr "{{action}} {{event}}"
 
 #: ../superdesk-planning/client/components/Main/ItemEditorModal/EditorModalPanel.tsx:166
 msgid "{{action}} {{type}}"

--- a/po/sr.po
+++ b/po/sr.po
@@ -149,7 +149,7 @@ msgstr "* изаберите верзију чланка из падајућег
 
 #: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:127
 msgid "* fields are required"
-msgstr ""
+msgstr "* поља су обавезна"
 
 #: scripts/apps/publish/views/email-config.html:3
 msgid "*at least one visible or hidden recipient needed"
@@ -676,7 +676,7 @@ msgstr "Сажетак"
 #: scripts/apps/authoring/views/theme-select.html:47
 #: scripts/apps/authoring/views/theme-select.html:98
 msgid "Abstract example"
-msgstr ""
+msgstr "Пример сажетка"
 
 #: scripts/apps/dashboard/views/workspace.html:9
 #: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:160
@@ -1008,7 +1008,7 @@ msgstr "Додај време"
 
 #: scripts/apps/authoring/authoring/article-url-fields.tsx:103
 msgid "Add URL"
-msgstr ""
+msgstr "Додај URL"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageArrayInput.tsx:165
 #: ../superdesk-planning/client/components/fields/editor/Coverages.tsx:139
@@ -1053,11 +1053,11 @@ msgstr[2] "Додај као повезана планирања"
 #: scripts/apps/authoring/media/views/media-metadata-editor-directive.html:122
 #: scripts/apps/authoring/views/authoring-header.html:614
 msgid "Add author"
-msgstr ""
+msgstr "Додај аутора"
 
 #: scripts/apps/authoring/views/item-association.html:110
 msgid "Add caption"
-msgstr ""
+msgstr "Додај натпис"
 
 #: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:55
 msgid "Add content slugline"
@@ -1267,7 +1267,7 @@ msgstr "Подеси"
 
 #: scripts/apps/authoring/views/change-image.html:239
 msgid "Adjust colours"
-msgstr ""
+msgstr "Подеси боје"
 
 #: scripts/core/menu/views/menu.html:95
 msgid "Admin tools"
@@ -1589,7 +1589,7 @@ msgstr "Све отворене ставке"
 
 #: scripts/apps/authoring/views/opened-articles.html:2
 msgid "All opened items"
-msgstr ""
+msgstr "Све отворене ставке"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:282
 msgid "All planning"
@@ -1767,7 +1767,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:395
 msgid "An Item can't have both Embargo and Publish Schedule."
-msgstr ""
+msgstr "Ставка не може имати и ембарго и распоред објављивања."
 
 #: ../superdesk-planning/client/actions/agenda.ts:47
 msgid "An agenda with this name already exists"
@@ -1787,17 +1787,17 @@ msgstr "Дошло је до грешке приликом покушаја пр
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:230
 msgid "An update can not be created"
-msgstr ""
+msgstr "Ажурирање не може бити креирано"
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:52
 msgid "An update can not be created for an item which is not published yet."
-msgstr ""
+msgstr "Ажурирање не може бити креирано за ставку која још није објављена."
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:41
 msgid ""
 "An update for this version of the item already exists. To create another "
 "update, find the latest version of the item."
-msgstr ""
+msgstr "Ажурирање за ову верзију ставке већ постоји. Да бисте креирали ново ажурирање, пронађите најновију верзију ставке."
 
 #: ../superdesk-analytics/client/index.js:94
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:36
@@ -2042,7 +2042,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:64
 msgid "Are you sure you want to unpublish item \"{{headline}}\"?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да повучете објаву ставке \"{{headline}}\"?"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:53
 msgid "Are you sure you want to unpublish item \"{{label}}\"?"
@@ -2108,7 +2108,7 @@ msgstr "Тип чланка: {{type}}"
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:577
 msgid ""
 "Article cannot be published. Please accept or reject all suggestions first."
-msgstr ""
+msgstr "Чланак не може бити објављен. Прво прихватите или одбијте све сугестије."
 
 #: scripts/apps/users/views/user-preferences.html:16
 msgid "Article defaults"
@@ -2510,7 +2510,7 @@ msgstr ""
 #: scripts/apps/authoring/attachments/AttachmentsWidgetComponent.tsx:112
 #: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:123
 msgid "Attach files"
-msgstr ""
+msgstr "Приложи датотеке"
 
 #: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:212
 #: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:209
@@ -2794,7 +2794,7 @@ msgstr ""
 #: scripts/apps/authoring/packages/views/packages-widget.html:15
 #: scripts/apps/packaging/views/sd-package-item-preview.html:20
 msgid "Blank headline received"
-msgstr ""
+msgstr "Примљен празан наслов"
 
 #: scripts/apps/content-filters/views/manage-filters.html:58
 msgid "Block API"
@@ -2834,7 +2834,7 @@ msgstr ""
 #: scripts/apps/authoring/views/theme-select.html:107
 #: scripts/apps/authoring/views/theme-select.html:56
 msgid "Body text example"
-msgstr ""
+msgstr "Пример тела текста"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:49
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:32
@@ -2864,7 +2864,7 @@ msgstr "Морате попунити (или обрисати) и почетн�
 
 #: scripts/apps/authoring/views/change-image.html:242
 msgid "Brightness"
-msgstr ""
+msgstr "Светлина"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:50
 #: scripts/core/lang/missing-translations-strings.ts:15
@@ -3021,7 +3021,7 @@ msgstr "Није могуће уградити у ставку која се с�
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:48
 msgid "Can not update a broadcast version of the story."
-msgstr ""
+msgstr "Није могуће ажурирати емисијску верзију приче."
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:112
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:58
@@ -3285,7 +3285,7 @@ msgstr "Натпис"
 
 #: scripts/apps/authoring/editor/views/find-replace.html:18
 msgid "Case Sensitive"
-msgstr ""
+msgstr "Осетљиво на велика и мала слова"
 
 #: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:96
 msgid "Case sensitive"
@@ -3330,7 +3330,7 @@ msgstr "Промени аватар"
 
 #: scripts/apps/authoring/views/change-image.html:203
 msgid "Change image settings"
-msgstr ""
+msgstr "Промени поставке слике"
 
 #: scripts/core/auth/login-modal.html:86
 msgid "Change password"
@@ -3385,7 +3385,7 @@ msgstr "Прекорачен је лимит карактера, фазу ниј
 
 #: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:124
 msgid "Character limit settings"
-msgstr ""
+msgstr "Поставке лимита карактера"
 
 #: scripts/apps/authoring-react/fields/editor3/editor.tsx:384
 msgid "Character {{chars}} is not allowed"
@@ -3397,9 +3397,9 @@ msgstr[2] ""
 #: scripts/apps/authoring/authoring/ValidateCharacters.tsx:23
 msgid "Character {{chars}} not allowed in the {{field}}."
 msgid_plural "Characters {{chars}} not allowed in the {{field}}."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Карактер {{chars}} није дозвољен у пољу {{field}}."
+msgstr[1] "Карактери {{chars}} нису дозвољени у пољу {{field}}."
+msgstr[2] "Карактери {{chars}} нису дозвољени у пољу {{field}}."
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:55
 #: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:55
@@ -3432,7 +3432,7 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-topbar.html:379
 #: scripts/apps/authoring/views/authoring-topbar.html:388
 msgid "Check spelling"
-msgstr ""
+msgstr "Провери правопис"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:55
 msgid "Chevron Down Thin"
@@ -3452,7 +3452,7 @@ msgstr "Шеврон горе танко"
 
 #: scripts/apps/authoring/metadata/views/metadata-terms.html:36
 msgid "Choose entire category"
-msgstr ""
+msgstr "Изабери целу категорију"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:92
 msgid ""
@@ -3520,7 +3520,7 @@ msgstr ""
 
 #: scripts/apps/authoring/views/article-edit.html:577
 msgid "Clear Embed"
-msgstr ""
+msgstr "Очисти уграђени садржај"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:123
 #: ../superdesk-planning/client/components/Main/SubNavBar.tsx:32
@@ -3563,7 +3563,7 @@ msgstr "Очисти филтере"
 
 #: scripts/apps/authoring/media/views/media-copy-metadata-directive.html:5
 msgid "Clear saved metadata"
-msgstr ""
+msgstr "Очисти сачуване метаподатке"
 
 #: scripts/apps/content-filters/views/filter-search.html:43
 #: scripts/apps/monitoring/views/monitoring-view.html:86
@@ -3602,7 +3602,7 @@ msgstr "Кликните да снимите камером. Уверите се
 
 #: scripts/apps/authoring/authoring/components/video-thumbnail-editor.tsx:108
 msgid "Click to replace thumbnail"
-msgstr ""
+msgstr "Кликните да замените сличицу"
 
 #: scripts/apps/production-api-keys/config.ts:54
 msgid "Client ID"
@@ -3692,7 +3692,7 @@ msgstr "Затвори"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:67
 msgid "Close & Continue"
-msgstr ""
+msgstr "Затвори и настави"
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines-widget.js:48
 #: scripts/extensions/ai-widget/dist/src/headlines/headlines-widget.js:48
@@ -3723,7 +3723,7 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-topbar.html:65
 #: scripts/apps/authoring/views/authoring-topbar.html:66
 msgid "Close and Continue"
-msgstr ""
+msgstr "Затвори и настави"
 
 #: scripts/apps/production-api-keys/utils.tsx:27
 msgid "Close anyway"
@@ -3731,7 +3731,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/index.ts:469
 msgid "Close current item"
-msgstr ""
+msgstr "Затвори тренутну ставку"
 
 #: scripts/apps/dashboard/closed-desk/index.ts:159
 msgid "Close desk widget"
@@ -3739,7 +3739,7 @@ msgstr "Затвори виџет деска"
 
 #: scripts/apps/authoring/views/change-image.html:155
 msgid "Close details"
-msgstr ""
+msgstr "Затвори детаље"
 
 #: scripts/apps/contacts/views/search-panel.html:4
 #: scripts/apps/content-api/views/search-panel.html:11
@@ -3862,7 +3862,7 @@ msgstr "Упореди верзије чланка"
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:132
 #: scripts/apps/authoring/views/authoring-topbar.html:286
 msgid "Compare versions"
-msgstr ""
+msgstr "Упореди верзије"
 
 #: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:124
 msgid "Comparing \"{{x}}\"(primary) to \"{{y}}\"(secondary)"
@@ -3898,7 +3898,7 @@ msgstr "Конфигурација обрисана."
 msgid ""
 "Configuration has changed. {{message}} Would you like to save the story to "
 "your workspace?"
-msgstr ""
+msgstr "Конфигурација је измењена. {{message}} Желите ли да сачувате причу у свој радни простор?"
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:11
 #: scripts/apps/highlights/views/highlights_config_modal.html:12
@@ -3946,7 +3946,7 @@ msgstr "Потврди доступност"
 
 #: scripts/apps/authoring/authoring/components/publish-warning-confirm-modal.tsx:24
 msgid "Confirm Publish Warnings"
-msgstr ""
+msgstr "Потврди упозорења за објаву"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:28
 #: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:41
@@ -3955,7 +3955,7 @@ msgstr "Потврди повлачење објаве"
 
 #: scripts/apps/authoring/views/change-image.html:194
 msgid "Confirm crop"
-msgstr ""
+msgstr "Потврди исечак"
 
 #: scripts/core/auth/login-modal.html:78
 #: scripts/core/auth/reset-password.html:51
@@ -4173,11 +4173,11 @@ msgstr "Настави"
 
 #: scripts/apps/authoring/views/change-image.html:249
 msgid "Contrast"
-msgstr ""
+msgstr "Контраст"
 
 #: scripts/apps/authoring/views/change-image.html:154
 msgid "Controls"
-msgstr ""
+msgstr "Контроле"
 
 #: scripts/core/editor3/components/toolbar/index.tsx:452
 msgid "Convert text to lowercase"
@@ -4225,7 +4225,7 @@ msgstr "Копирај ИД задатка"
 
 #: scripts/apps/authoring/media/views/media-copy-metadata-directive.html:2
 msgid "Copy metadata"
-msgstr ""
+msgstr "Копирај метаподатке"
 
 #: scripts/apps/production-api-keys/config.ts:64
 msgid "Copy this now, you won't be able to access it again."
@@ -4234,7 +4234,7 @@ msgstr ""
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:195
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:64
 msgid "Copyright"
-msgstr ""
+msgstr "Ауторска права"
 
 #: scripts/apps/archive/views/metadata-associateditem-view.html:32
 #: scripts/apps/archive/views/metadata-view.html:173
@@ -4286,7 +4286,7 @@ msgstr "Исправи"
 
 #: scripts/apps/authoring/authoring/index.ts:357
 msgid "Correct item"
-msgstr ""
+msgstr "Исправи ставку"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:38
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:87
@@ -4296,7 +4296,7 @@ msgstr ""
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:182
 msgid "Corrected by"
-msgstr ""
+msgstr "Исправио"
 
 #: scripts/core/interactive-article-actions-panel/index-ui.tsx:137
 msgid "Correcting multiple items from authoring pane is not supported"
@@ -4309,7 +4309,7 @@ msgstr "Исправка"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:165
 msgid "Correction Cancel by"
-msgstr ""
+msgstr "Исправку отказао"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:485
 msgid "Correction cancelled by {{user}}"
@@ -4317,12 +4317,12 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:467
 msgid "Correction has been removed"
-msgstr ""
+msgstr "Исправка је уклоњена"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:495
 #: scripts/apps/authoring/versioning/history/views/history.html:171
 msgid "Correction link is removed"
-msgstr ""
+msgstr "Линк исправке је уклоњен"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:575
 msgid "Corrections"
@@ -4779,7 +4779,7 @@ msgstr ""
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:96
 #: scripts/apps/authoring/versioning/history/views/history.html:6
 msgid "Created by"
-msgstr ""
+msgstr "Креирао"
 
 #: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:111
 msgid "Created by this user"
@@ -4807,7 +4807,7 @@ msgstr "Креирано из догађаја"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:127
 msgid "Created from highlight"
-msgstr ""
+msgstr "Креирано из истицања"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:380
 msgid "Created from highlight({{x}}) by {{user}}"
@@ -4854,7 +4854,7 @@ msgstr ""
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:209
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:72
 msgid "Credit"
-msgstr ""
+msgstr "Заслуге"
 
 #: scripts/apps/authoring-react/fields/media/media-metadata.tsx:19
 #: scripts/apps/authoring/media/MediaMetadataView.tsx:19
@@ -4883,7 +4883,7 @@ msgstr "Исеци"
 
 #: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:181
 msgid "Crop coordinates are not defined for {{cropName}} picture crop."
-msgstr ""
+msgstr "Координате исечка нису дефинисане за исечак слике {{cropName}}."
 
 #: scripts/apps/profiling/views/profiling.html:35
 msgid "Cumulative time"
@@ -4927,7 +4927,7 @@ msgstr "Тренутна величина слике је {{width}}x{{height}}).
 
 #: scripts/apps/authoring/views/dashboard-articles.html:5
 msgid "Currently working on"
-msgstr ""
+msgstr "Тренутно ради на"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:221
 #: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:316
@@ -5409,7 +5409,7 @@ msgstr "Откажи заказивање"
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:113
 #: scripts/apps/authoring/versioning/history/views/history.html:17
 msgid "Descheduled by"
-msgstr ""
+msgstr "Отказао заказивање"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:48
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:53
@@ -5664,7 +5664,7 @@ msgstr "Детаљи"
 
 #: scripts/apps/authoring/views/change-image.html:7
 msgid "Details / Metadata"
-msgstr ""
+msgstr "Детаљи / метаподаци"
 
 #: scripts/apps/dictionaries/index.ts:33
 msgid "Dictionaries"
@@ -5719,7 +5719,7 @@ msgstr "Дигитално/Интернет"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:133
 #: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:159
 msgid "Dimensions"
-msgstr ""
+msgstr "Димензије"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:192
 msgid "Disable Item Updates"
@@ -5811,7 +5811,7 @@ msgstr ""
 
 #: scripts/apps/authoring/views/confirm-media-associated.html:3
 msgid "Do you want to add an image to this update?"
-msgstr ""
+msgstr "Желите ли да додате слику у ово ажурирање?"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:26
 #: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:26
@@ -5842,9 +5842,9 @@ msgstr "Желите ли да повежете са тим задатком?"
 #: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:50
 msgid "Do you want to publish the article?"
 msgid_plural "Do you want to publish {{number}} articles?"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Желите ли да објавите чланак?"
+msgstr[1] "Желите ли да објавите {{number}} чланка?"
+msgstr[2] "Желите ли да објавите {{number}} чланака?"
 
 #: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:148
 msgid "Do you want to remove Abbreviation?"
@@ -5993,12 +5993,12 @@ msgstr "Превуците једну или више датотека овде 
 
 #: scripts/apps/authoring/attachments/AttachmentsWidgetComponent.tsx:126
 msgid "Drag one or more files here to upload them, or just click here."
-msgstr ""
+msgstr "Превуците једну или више датотека овде да их отпремите, или само кликните овде."
 
 #: scripts/apps/authoring/attachments/AttachmentsWidgetComponent.tsx:104
 msgid ""
 "Drag one or more files here to upload them, or just click the button below."
-msgstr ""
+msgstr "Превуците једну или више датотека овде да их отпремите, или само кликните на дугме испод."
 
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:101
 msgid "Drop events here"
@@ -6118,7 +6118,7 @@ msgstr "Дупликат креиран"
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:171
 #: scripts/apps/authoring/versioning/history/views/history.html:52
 msgid "Duplicate created by"
-msgstr ""
+msgstr "Дупликат креирао"
 
 #: scripts/apps/archive/index.tsx:151
 msgid "Duplicate in place"
@@ -6144,7 +6144,7 @@ msgstr ""
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:146
 #: scripts/apps/authoring/versioning/history/views/history.html:30
 msgid "Duplicated by"
-msgstr ""
+msgstr "Дуплирао"
 
 #: scripts/apps/search/views/item-preview.html:15
 msgid "Duplicates"
@@ -6323,7 +6323,7 @@ msgstr "Уреди агенду"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/editAttachmentModal.js:122
 #: scripts/extensions/sams/src/components/attachments/editAttachmentModal.tsx:102
 msgid "Edit Attachment"
-msgstr ""
+msgstr "Уреди прилог"
 
 #: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:76
 #: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:77
@@ -6341,7 +6341,7 @@ msgstr "Уреди профил садржаја"
 
 #: scripts/apps/authoring/views/change-image.html:4
 msgid "Edit Crops"
-msgstr ""
+msgstr "Уреди исечке"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:8
 msgid "Edit Dictionary"
@@ -6379,7 +6379,7 @@ msgstr "Уреди локацију"
 
 #: scripts/apps/authoring/authoring/index.ts:254
 msgid "Edit Media Metadata"
-msgstr ""
+msgstr "Уреди метаподатке медија"
 
 #: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:148
 msgid "Edit Planning"
@@ -6495,7 +6495,7 @@ msgstr "Уреди слику"
 
 #: scripts/apps/authoring/authoring/index.ts:241
 msgid "Edit in new Window"
-msgstr ""
+msgstr "Уреди у новом прозору"
 
 #: scripts/apps/authoring-react/fields/linked-items/editor.tsx:54
 #: scripts/apps/authoring-react/fields/package-items/editor.tsx:51
@@ -6791,7 +6791,7 @@ msgstr ""
 
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:21
 msgid "Error sending as"
-msgstr ""
+msgstr "Грешка приликом слања као"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:74
 msgid "Error sending as {{name}} to {{destination}} at {{date}}"
@@ -6803,11 +6803,11 @@ msgstr "Грешка. Речник није сачуван."
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:626
 msgid "Error. Item not published."
-msgstr ""
+msgstr "Грешка. Ставка није објављена."
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:322
 msgid "Error. Item not updated."
-msgstr ""
+msgstr "Грешка. Ставка није ажурирана."
 
 #: scripts/apps/search/directives/SavedSearches.ts:119
 msgid "Error. Saved search not deleted."
@@ -6987,7 +6987,7 @@ msgstr "Грешка: {{error}}"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:446
 #: scripts/extensions/sams/src/api/assets.ts:562
 msgid "Error: {{message}}"
-msgstr ""
+msgstr "Грешка: {{message}}"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/utils/api.js:25
 #: scripts/extensions/sams/dist/src/utils/api.js:25
@@ -7382,7 +7382,7 @@ msgstr "Истекло"
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:277
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:92
 msgid "Expiry"
-msgstr ""
+msgstr "Истек"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:82
 msgid "Expiry Date:"
@@ -7429,7 +7429,7 @@ msgstr "Извези као чланак"
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:353
 #: scripts/apps/authoring/versioning/history/views/history.html:116
 msgid "Exported by"
-msgstr ""
+msgstr "Извезао"
 
 #: scripts/apps/archive/views/metadata-view.html:163
 msgid "Exposure time"
@@ -7498,7 +7498,7 @@ msgstr "Додавање ставке планирања као истакнут
 #: scripts/apps/archive/directives/ArchivedItemKill.ts:33
 #: scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.ts:97
 msgid "Failed to apply kill template to the item."
-msgstr ""
+msgstr "Примена шаблона уништења на ставку није успела."
 
 #: scripts/apps/archive/related-item-widget/relatedItem.ts:188
 msgid "Failed to associate update: {{message}}"
@@ -7522,7 +7522,7 @@ msgstr "Промена лозинке није успела."
 
 #: scripts/apps/authoring/authoring/services/MultiEditUnsavedChangesService.ts:78
 msgid "Failed to check for unsaved changes"
-msgstr ""
+msgstr "Провера несачуваних измена није успела"
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:710
 msgid "Failed to create an archive item."
@@ -7568,7 +7568,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/services/MultiEditUnsavedChangesService.ts:60
 msgid "Failed to discard some changes"
-msgstr ""
+msgstr "Одбацивање неких измена није успело"
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:258
 msgid "Failed to duplicate the item"
@@ -7607,12 +7607,12 @@ msgstr "Није пронађен задатак за повезивање!"
 
 #: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:407
 msgid "Failed to generate picture crops."
-msgstr ""
+msgstr "Генерисање исечака слике није успело."
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:260
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:474
 msgid "Failed to generate update: {{message}}"
-msgstr ""
+msgstr "Генерисање ажурирања није успело: {{message}}"
 
 #: scripts/extensions/sams/dist/src/api/assets.js:348
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:348
@@ -7622,7 +7622,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/services/LockService.ts:21
 msgid "Failed to get a lock on the item!"
-msgstr ""
+msgstr "Закључавање ставке није успело!"
 
 #: scripts/extensions/sams/src/api/assets.ts:406
 msgid "Failed to get asset \"\""
@@ -7753,7 +7753,7 @@ msgstr "Уклањање аутоматског чувања није успел
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:279
 msgid "Failed to remove link: {{message}}"
-msgstr ""
+msgstr "Уклањање линка није успело: {{message}}"
 
 #: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:327
 #: ../superdesk-planning/client/actions/planning/ui.ts:368
@@ -7804,7 +7804,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/services/MultiEditUnsavedChangesService.ts:72
 msgid "Failed to save some articles"
-msgstr ""
+msgstr "Чување неких чланака није успело"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsModal.js:103
 msgid "Failed to save the Report Schedule!"
@@ -7812,15 +7812,15 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:461
 msgid "Failed to save the area of interest:"
-msgstr ""
+msgstr "Чување области од интереса није успело:"
 
 #: scripts/apps/authoring/tests/changeImage.spec.ts:94
 msgid "Failed to save the area of interest: Failed to call picture_crop."
-msgstr ""
+msgstr "Чување области од интереса није успело: позивање picture_crop није успело."
 
 #: scripts/apps/authoring/tests/changeImage.spec.ts:128
 msgid "Failed to save the area of interest: Failed to call picture_renditions."
-msgstr ""
+msgstr "Чување области од интереса није успело: позивање picture_renditions није успело."
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:469
 msgid "Failed to save the assignment."
@@ -7957,7 +7957,7 @@ msgstr "Истакнуто"
 
 #: scripts/apps/authoring/views/confirm-media-associated.html:8
 msgid "Featured Media"
-msgstr ""
+msgstr "Истакнути медиј"
 
 #: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:75
 msgid "Featured Stories"
@@ -8055,7 +8055,7 @@ msgstr ""
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:269
 #: scripts/apps/authoring/versioning/history/views/history.html:76
 msgid "Fetched by"
-msgstr ""
+msgstr "Преузео"
 
 #: scripts/apps/content-filters/views/filter-search.html:9
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:59
@@ -8095,11 +8095,11 @@ msgstr "Екстензија датотеке"
 
 #: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:201
 msgid "File Name"
-msgstr ""
+msgstr "Назив датотеке"
 
 #: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:211
 msgid "File Size"
-msgstr ""
+msgstr "Величина датотеке"
 
 #: scripts/apps/profiling/views/profiling.html:37
 msgid "File name/line"
@@ -8254,12 +8254,12 @@ msgstr "Филтери"
 #: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:78
 #: scripts/apps/authoring/editor/views/find-replace.html:5
 msgid "Find"
-msgstr ""
+msgstr "Пронађи"
 
 #: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:12
 #: scripts/apps/authoring/editor/find-replace.ts:95
 msgid "Find and Replace"
-msgstr ""
+msgstr "Пронађи и замени"
 
 #: scripts/apps/search/index.ts:108
 msgid "Find live and archived content"
@@ -8317,11 +8317,11 @@ msgstr "Окрени вертикално"
 
 #: scripts/apps/authoring/views/change-image.html:208
 msgid "Flip horizontal"
-msgstr ""
+msgstr "Окрени хоризонтално"
 
 #: scripts/apps/authoring/views/change-image.html:209
 msgid "Flip vertical"
-msgstr ""
+msgstr "Окрени вертикално"
 
 #: scripts/apps/archive/views/metadata-view.html:164
 msgid "Focal length"
@@ -8356,7 +8356,7 @@ msgstr "Само за претплатнике типа Content API дестин
 
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:21
 msgid "For Publication"
-msgstr ""
+msgstr "За објаву"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:63
 #: scripts/extensions/sams/dist/src/utils/assets.js:63
@@ -8465,7 +8465,7 @@ msgstr "Пуно име"
 
 #: scripts/apps/authoring/authoring/components/toggleFullWithEditor.tsx:20
 msgid "Full width mode"
-msgstr ""
+msgstr "Режим пуне ширине"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:69
 #: scripts/extensions/sams/dist/src/utils/assets.js:69
@@ -8508,7 +8508,7 @@ msgstr "Опште"
 
 #: scripts/apps/authoring/views/article-edit.html:580
 msgid "Generate From URL"
-msgstr ""
+msgstr "Генериши из URL-а"
 
 #: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-parameters.html:1
 msgid "Generate a report showing activity on a desk."
@@ -8696,7 +8696,7 @@ msgstr ""
 #: scripts/apps/authoring-react/macros/macros.tsx:359
 #: scripts/apps/authoring/macros/views/macros-widget.html:3
 msgid "Group Macros"
-msgstr ""
+msgstr "Групиши макрое"
 
 #: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:155
 msgid "Group by day"
@@ -8851,7 +8851,7 @@ msgstr "Помоћни\n                                    текст"
 
 #: scripts/apps/authoring/views/article-edit.html:395
 msgid "Helplines/Contact Information"
-msgstr ""
+msgstr "Помоћне линије/контакт информације"
 
 #: scripts/apps/publish/views/email-config.html:11
 msgid "Hidden recipients (blind carbon copy)"
@@ -8877,11 +8877,11 @@ msgstr "Сакриј датум"
 
 #: scripts/apps/authoring/views/article-edit.html:586
 msgid "Hide Preview"
-msgstr ""
+msgstr "Сакриј преглед"
 
 #: scripts/apps/authoring/preview/fullPreviewMultiple.tsx:46
 msgid "Hide media"
-msgstr ""
+msgstr "Сакриј медиј"
 
 #: scripts/apps/authoring-react/fields/embed/editor.tsx:55
 msgid "Hide preview"
@@ -8893,7 +8893,7 @@ msgstr ""
 
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:6
 msgid "Hide sent/queued items"
-msgstr ""
+msgstr "Сакриј послате/ставке у реду"
 
 #: scripts/apps/publish/views/subscribers.html:209
 msgid "High priority"
@@ -8913,7 +8913,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:159
 msgid "Highlight characters"
-msgstr ""
+msgstr "Истакни карактере"
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:15
 msgid "Highlight with name"
@@ -9118,7 +9118,7 @@ msgstr "Слика је већа од {{maxFileSize}}MB, величина отп
 
 #: scripts/apps/authoring/views/change-image.html:217
 msgid "Image size"
-msgstr ""
+msgstr "Величина слике"
 
 #: scripts/api/article-fetch.tsx:111
 msgid "Image size validation failed"
@@ -9184,7 +9184,7 @@ msgstr "У току"
 msgid ""
 "In the story {{slugline}} sent at: {{date}}.{{lineBreak}}This is a corrected "
 "repeat."
-msgstr ""
+msgstr "У причи {{slugline}} послато: {{date}}.{{lineBreak}}Ово је исправљено понављање."
 
 #: ../superdesk-planning/client/utils/index.ts:335
 #: scripts/apps/contacts/components/ContactInfo.tsx:64
@@ -9276,7 +9276,7 @@ msgstr "Увлачење десно"
 #: scripts/apps/authoring/metadata/metadata.ts:1420
 #: scripts/apps/system-messages/components/system-messages-settings.tsx:21
 msgid "Info"
-msgstr ""
+msgstr "Информација"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:113
 msgid "Info Large"
@@ -9412,7 +9412,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/index.ts:474
 msgid "Instant Spellchecking, when automatic spellchecking turned off"
-msgstr ""
+msgstr "Тренутна провера правописа када је аутоматска искључена"
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:181
 msgid "Insufficient privileges to view the assignment"
@@ -9429,7 +9429,7 @@ msgstr "Недовољне привилегије за приказ задатк
 #: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:309
 #: scripts/extensions/sams/src/utils/ui.tsx:68
 msgid "Internal"
-msgstr ""
+msgstr "Интерно"
 
 #: scripts/apps/internal-destinations/index.ts:13
 #: scripts/apps/internal-destinations/views/settings.html:5
@@ -9631,11 +9631,11 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/controllers/AssociationController.ts:299
 msgid "Item is locked. Cannot associate media item."
-msgstr ""
+msgstr "Ставка је закључана. Није могуће повезати медијску ставку."
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:120
 msgid "Item locked"
-msgstr ""
+msgstr "Ставка закључана"
 
 #: scripts/apps/highlights/services/HighlightsService.ts:125
 msgid "Item marked"
@@ -9674,7 +9674,7 @@ msgstr "Ставка сачувана."
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:114
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:29
 msgid "Item sent to Subscriber"
-msgstr ""
+msgstr "Ставка послата претплатнику"
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:11
 msgid "Item type stats"
@@ -9693,13 +9693,13 @@ msgstr "Ставка ажурирана."
 msgid "Item was not added. Only 1 item is allowed for this field."
 msgid_plural ""
 "Item was not added. Only {{number}} items are allowed in this field."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Ставка није додата. У овом пољу је дозвољена само 1 ставка."
+msgstr[1] "Ставка није додата. У овом пољу су дозвољене само {{number}} ставке."
+msgstr[2] "Ставка није додата. У овом пољу је дозвољено само {{number}} ставки."
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:490
 msgid "Item was unpublished successfully."
-msgstr ""
+msgstr "Објава ставке је успешно повучена."
 
 #: scripts/apps/search/MultiImageEdit.ts:198
 msgid "Item {{headline}} unlocked by another user."
@@ -9707,7 +9707,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:96
 msgid "Item {{headline}} was unlocked by {{username}}."
-msgstr ""
+msgstr "Ставку {{headline}} откључао је {{username}}."
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:15
 #: scripts/core/views/sdSearchList.html:36
@@ -9811,7 +9811,7 @@ msgstr "Уништи"
 
 #: scripts/apps/authoring/authoring/index.ts:309
 msgid "Kill item"
-msgstr ""
+msgstr "Уништи ставку"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:32
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:84
@@ -9824,7 +9824,7 @@ msgstr "Уништено"
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:184
 msgid "Killed by"
-msgstr ""
+msgstr "Уништио"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:574
 msgid "Kills"
@@ -10000,7 +10000,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/components/toggleFullWithEditor.tsx:20
 msgid "Leave full width mode"
-msgstr ""
+msgstr "Изађи из режима пуне ширине"
 
 #: scripts/apps/archive/views/item-preview.html:10
 #: scripts/apps/archive/views/metadata-view.html:193
@@ -10050,7 +10050,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:163
 msgid "Limit further typing"
-msgstr ""
+msgstr "Ограничи даље куцање"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:99
 msgid "Line"
@@ -10073,7 +10073,7 @@ msgstr "Контроле линка:"
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:276
 msgid "Link has been removed"
-msgstr ""
+msgstr "Линк је уклоњен"
 
 #: scripts/core/auth/auth.ts:103
 msgid "Link sent. Please check your email inbox."
@@ -10087,7 +10087,7 @@ msgstr "Линк до задатка"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:131
 msgid "Linked by"
-msgstr ""
+msgstr "Повезао"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:398
 msgid "Linked by {{user}}"
@@ -10152,7 +10152,7 @@ msgstr "Сугестије уживо"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:278
 msgid "Live suggestions"
-msgstr ""
+msgstr "Сугестије уживо"
 
 #: scripts/apps/stream/views/activity-stream.html:30
 msgid "Load more"
@@ -10254,7 +10254,7 @@ msgstr "Закључано"
 #: scripts/apps/authoring-react/subcomponents/lock-info.tsx:48
 #: scripts/apps/authoring/views/authoring-topbar.html:20
 msgid "Locked by"
-msgstr ""
+msgstr "Закључао"
 
 #: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:91
 msgid "Locked by this user"
@@ -10296,7 +10296,7 @@ msgstr "M"
 
 #: scripts/apps/authoring/views/authoring-header.html:72
 msgid "MASTER"
-msgstr ""
+msgstr "МАСТЕР"
 
 #: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:246
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:246
@@ -10550,7 +10550,7 @@ msgstr "Означено да није за објаву"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:88
 msgid "Marked by"
-msgstr ""
+msgstr "Означио"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/marked-desks.tsx:11
 #: scripts/apps/authoring-react/toolbar/highlights-management.tsx:74
@@ -10768,7 +10768,7 @@ msgstr ""
 
 #: scripts/apps/authoring/views/authoring-header.html:61
 msgid "Missing Link"
-msgstr ""
+msgstr "Недостаје линк"
 
 #: ../superdesk-planning/client/utils/filters.ts:133
 msgid "Mo"
@@ -10782,7 +10782,7 @@ msgstr "Мобилни"
 #: scripts/apps/authoring-react/fields/attachments/difference-row.tsx:30
 #: scripts/apps/authoring/authoring/modified-info.tsx:20
 msgid "Modified"
-msgstr ""
+msgstr "Измењено"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:96
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:96
@@ -10911,7 +10911,7 @@ msgstr ""
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:253
 #: scripts/apps/authoring/versioning/history/views/history.html:75
 msgid "Moved by"
-msgstr ""
+msgstr "Преместио"
 
 #: scripts/apps/desks/views/desk-config-modal.html:397
 msgid "Moved onto stage Rule"
@@ -11436,7 +11436,7 @@ msgstr "Нису дефинисане радње преузимања ни об�
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:1080
 msgid ""
 "No formatters found for {{formats}} while publishing item having unique name."
-msgstr ""
+msgstr "Форматери за {{formats}} нису пронађени приликом објављивања ставке са јединственим називом."
 
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:206
 msgid "No highlights have been created yet."
@@ -11508,7 +11508,7 @@ msgstr ""
 
 #: scripts/apps/authoring/macros/views/macros-replace.html:2
 msgid "No matches found."
-msgstr ""
+msgstr "Нису пронађена поклапања."
 
 #: scripts/apps/profiling/views/profiling.html:32
 msgid "No of calls"
@@ -11759,7 +11759,7 @@ msgstr ""
 
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:10
 msgid "Not been transmitted to any subscriber"
-msgstr ""
+msgstr "Није пренето ниједном претплатнику"
 
 #: ../superdesk-planning/client/validators/profile.ts:100
 msgid "Not enough"
@@ -11955,9 +11955,9 @@ msgstr "На мрежи"
 #: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:86
 msgid "Only 1 image is allowed in this field"
 msgid_plural "Only {{number}} images are allowed in this field"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "У овом пољу је дозвољена само 1 слика"
+msgstr[1] "У овом пољу су дозвољене само {{number}} слике"
+msgstr[2] "У овом пољу је дозвољено само {{number}} слика"
 
 #: ../superdesk-planning/client/utils/planning.tsx:541
 msgid "Only 1 item can be linked. Adding this would exceed the limit"
@@ -11983,7 +11983,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:269
 msgid "Only the following content item types are allowed:"
-msgstr ""
+msgstr "Дозвољени су само следећи типови ставки садржаја:"
 
 #: scripts/apps/archive/controllers/UploadController.ts:333
 msgid "Only the following files are allowed: {{fileTypes}}"
@@ -11991,7 +11991,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:89
 msgid "Only the following media item types are allowed:"
-msgstr ""
+msgstr "Дозвољени су само следећи типови медијских ставки:"
 
 #: scripts/apps/authoring-react/fields/media/editor.tsx:159
 msgid "Only the following media types are allowed: {{types}}"
@@ -12037,7 +12037,7 @@ msgstr "Отвори истицања"
 
 #: scripts/apps/authoring/authoring/index.ts:401
 msgid "Open in new Window"
-msgstr ""
+msgstr "Отвори у новом прозору"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/notifications.js:10
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/notifications.js:14
@@ -12055,7 +12055,7 @@ msgstr "Отвори линк"
 
 #: scripts/apps/authoring/views/change-image.html:26
 msgid "Open metadata"
-msgstr ""
+msgstr "Отвори метаподатке"
 
 #: scripts/apps/workspace/index.ts:33
 msgid "Open monitoring"
@@ -12185,7 +12185,7 @@ msgstr "Оригинал"
 msgid ""
 "Original ({{item.renditions.original.width}} x "
 "{{item.renditions.original.height}} px)"
-msgstr ""
+msgstr "Оригинал ({{item.renditions.original.width}} x {{item.renditions.original.height}} px)"
 
 #: ../superdesk-analytics/client/views/renditions-preview.html:33
 msgid ""
@@ -12200,7 +12200,7 @@ msgstr ""
 #: scripts/apps/archive/views/metadata-view.html:102
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:176
 msgid "Original ID"
-msgstr ""
+msgstr "Оригинални ИД"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:386
 msgid "Original Id"
@@ -12219,7 +12219,7 @@ msgstr ""
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:390
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:182
 msgid "Original creator"
-msgstr ""
+msgstr "Оригинални креатор"
 
 #: scripts/apps/authoring-react/fields/media/media-metadata.tsx:43
 msgid "Original size"
@@ -12228,12 +12228,12 @@ msgstr ""
 #: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:432
 #: scripts/apps/authoring/tests/changeImage.spec.ts:56
 msgid "Original size cannot be less than the required crop sizes."
-msgstr ""
+msgstr "Оригинална величина не може бити мања од захтеваних величина исечака."
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:188
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:60
 msgid "Original source"
-msgstr ""
+msgstr "Оригинални извор"
 
 #: ../superdesk-planning/client/components/UI/Form/SelectInputWithFreeText.tsx:70
 #: ../superdesk-planning/client/components/fields/editor/base/selectWithFreeText.tsx:171
@@ -12333,7 +12333,7 @@ msgstr ""
 #: scripts/apps/authoring/views/authoring-header.html:24
 #: scripts/apps/authoring/views/authoring-header.html:28
 msgid "PROFILE"
-msgstr ""
+msgstr "ПРОФИЛ"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/publish-correction.tsx:13
 msgid "PUBLISH"
@@ -12391,7 +12391,7 @@ msgstr "Ознаке прича у пакету"
 #: scripts/apps/authoring-react/packages.tsx:22
 #: scripts/apps/authoring/packages/packages.ts:47
 msgid "Packages"
-msgstr ""
+msgstr "Пакети"
 
 #: scripts/apps/authoring-react/data-layer.ts:223
 msgid "Packages profile"
@@ -12479,7 +12479,7 @@ msgstr "Налепи линк"
 
 #: scripts/apps/authoring/media/views/media-copy-metadata-directive.html:3
 msgid "Paste metadata"
-msgstr ""
+msgstr "Налепи метаподатке"
 
 #: scripts/apps/publish/views/ftp-config.html:21
 msgid "Path"
@@ -12615,7 +12615,7 @@ msgstr "Закачи"
 
 #: scripts/apps/authoring/widgets/WidgetHeaderComponent.tsx:24
 msgid "Pin/Unpin"
-msgstr ""
+msgstr "Закачи/откачи"
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/place-field.ts:37
 #: ../superdesk-planning/client/components/fields/editor/Place.tsx:25
@@ -12894,11 +12894,11 @@ msgstr "Тачка контакта"
 
 #: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:171
 msgid "Point of interest is not defined."
-msgstr ""
+msgstr "Тачка од интереса није дефинисана."
 
 #: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:188
 msgid "Point of interest outside the crop {{cropName}} limits"
-msgstr ""
+msgstr "Тачка од интереса је ван граница исечка {{cropName}}"
 
 #: scripts/core/lang/missing-translations-strings.ts:33
 msgid "Populate Abstract"
@@ -13038,7 +13038,7 @@ msgstr "Преглед"
 
 #: scripts/apps/authoring/views/preview-formatted.html:6
 msgid "Preview Formatted Story"
-msgstr ""
+msgstr "Преглед форматиране приче"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:156
 msgid "Preview Mode"
@@ -13050,11 +13050,11 @@ msgstr "URL крајње тачке прегледа"
 
 #: scripts/apps/authoring/authoring/index.ts:472
 msgid "Preview formatted article, when previewFormats feature configured"
-msgstr ""
+msgstr "Преглед форматираног чланка када је функција previewFormats подешена"
 
 #: scripts/apps/authoring/views/authoring-header.html:74
 msgid "Preview master story"
-msgstr ""
+msgstr "Преглед мастер приче"
 
 #: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:171
 #: scripts/apps/monitoring/views/aggregate-settings.html:155
@@ -13244,7 +13244,7 @@ msgstr ""
 
 #: scripts/apps/authoring/views/theme-select.html:66
 msgid "Proofread Theme"
-msgstr ""
+msgstr "Тема за лектуру"
 
 #: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:104
 msgid "Proofreading Theme"
@@ -13279,7 +13279,7 @@ msgstr "Провајдер сачуван!"
 
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:88
 msgid "Provider sequence"
-msgstr ""
+msgstr "Секвенца провајдера"
 
 #: scripts/core/lang/missing-translations-strings.ts:39
 msgid ""
@@ -13330,7 +13330,7 @@ msgstr "Објави"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:99
 msgid "Publish & Continue"
-msgstr ""
+msgstr "Објави и настави"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:445
 #: ../superdesk-analytics/client/utils.js:157
@@ -13348,7 +13348,7 @@ msgstr "Ред објављивања"
 #: scripts/apps/archive/views/metadata-view.html:137
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:416
 msgid "Publish Schedule"
-msgstr ""
+msgstr "Распоред објављивања"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:444
 #: ../superdesk-analytics/client/utils.js:155
@@ -13357,12 +13357,12 @@ msgstr ""
 
 #: scripts/apps/authoring/views/confirm-media-associated.html:18
 msgid "Publish Without Media"
-msgstr ""
+msgstr "Објави без медија"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:97
 #: scripts/apps/authoring/views/authoring-topbar.html:98
 msgid "Publish and Continue"
-msgstr ""
+msgstr "Објави и настави"
 
 #: scripts/core/interactive-article-actions-panel/actions/publish-action.tsx:290
 msgid "Publish from"
@@ -13416,7 +13416,7 @@ msgstr "Објављено до"
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:180
 msgid "Published by"
-msgstr ""
+msgstr "Објавио"
 
 #: scripts/apps/search/constants.ts:22
 #: scripts/apps/search/directives/DateFilters.ts:93
@@ -13430,7 +13430,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:25
 msgid "Publishing"
-msgstr ""
+msgstr "Објављивање"
 
 #: scripts/apps/publish/views/publish-queue.html:108
 msgid "Publishing Action"
@@ -13451,7 +13451,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/constants.ts:16
 msgid "Publishing actions"
-msgstr ""
+msgstr "Радње објављивања"
 
 #: scripts/core/interactive-article-actions-panel/index-ui.tsx:104
 msgid "Publishing multiple items from authoring pane is not supported"
@@ -13460,7 +13460,7 @@ msgstr ""
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:181
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:56
 msgid "Pubstatus"
-msgstr ""
+msgstr "Pubstatus"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:63
 msgid "Purple"
@@ -13544,7 +13544,7 @@ msgstr "ПОНАВЉАЊЕ ДО је обавезно поље"
 
 #: scripts/apps/authoring/views/authoring-header.html:53
 msgid "RELATED"
-msgstr ""
+msgstr "ПОВЕЗАНО"
 
 #: scripts/apps/search/components/HighlightsList.tsx:98
 #: scripts/apps/search/components/MarkedDesksList.tsx:110
@@ -13639,7 +13639,7 @@ msgstr ""
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:186
 msgid "Recalled by"
-msgstr ""
+msgstr "Опозвао"
 
 #: scripts/core/ui/components/content-create-dropdown/initial-view.tsx:151
 msgid "Recent templates"
@@ -13721,11 +13721,11 @@ msgstr "Освежи садржај"
 
 #: scripts/apps/authoring/metadata/views/metadata-tags.html:9
 msgid "Refresh suggestions"
-msgstr ""
+msgstr "Освежи сугестије"
 
 #: scripts/apps/authoring/metadata/views/metadata-tags.html:10
 msgid "Refreshing..."
-msgstr ""
+msgstr "Освежавање..."
 
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines-widget.js:54
 #: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines.js:22
@@ -14090,7 +14090,7 @@ msgstr ""
 
 #: scripts/apps/authoring/versioning/history/views/history.html:133
 msgid "Reopened by"
-msgstr ""
+msgstr "Поново отворио"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:443
 msgid "Reopened by {{user}}"
@@ -14142,7 +14142,7 @@ msgstr "Замени"
 
 #: scripts/apps/authoring/editor/views/find-replace.html:29
 msgid "Replace All"
-msgstr ""
+msgstr "Замени све"
 
 #: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:141
 msgid "Replace all"
@@ -14155,7 +14155,7 @@ msgstr "Замени линк"
 #: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:88
 #: scripts/apps/authoring/editor/views/find-replace.html:13
 msgid "Replace with"
-msgstr ""
+msgstr "Замени са"
 
 #: scripts/apps/authoring-react/article-widgets/suggestions.tsx:87
 msgid "Replace {{x}} with {{y}}"
@@ -14221,7 +14221,7 @@ msgstr "Обавезно"
 
 #: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:24
 msgid "Required field {{key}} is missing. ..."
-msgstr ""
+msgstr "Недостаје обавезно поље {{key}}. ..."
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:116
 msgid "Required {{field}} in item {{item}}"
@@ -14262,7 +14262,7 @@ msgstr ""
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:188
 msgid "Resent by"
-msgstr ""
+msgstr "Поново послао"
 
 #: scripts/apps/profiling/views/profiling.html:22
 msgid "Reset"
@@ -14301,11 +14301,11 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:592
 msgid "Resolving comments"
-msgstr ""
+msgstr "Разрешавање коментара"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:576
 msgid "Resolving suggestions"
-msgstr ""
+msgstr "Разрешавање сугестија"
 
 #: scripts/apps/publish/views/http-push-config.html:5
 #: scripts/apps/publish/views/http-push-config.html:6
@@ -14344,7 +14344,7 @@ msgstr ""
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:467
 #: scripts/apps/authoring/versioning/history/views/history.html:154
 msgid "Rewrite link is removed"
-msgstr ""
+msgstr "Линк прераде је уклоњен"
 
 #: ../superdesk-analytics/client/search/views/preview-source-filter.html:13
 #: ../superdesk-analytics/client/search/views/source-fitlers.html:299
@@ -14361,7 +14361,7 @@ msgstr ""
 
 #: scripts/apps/authoring/versioning/history/views/history.html:176
 msgid "Rewritten by"
-msgstr ""
+msgstr "Прерадио"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:504
 msgid "Rewritten by {{user}}"
@@ -14370,7 +14370,7 @@ msgstr ""
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:469
 #: scripts/apps/authoring/versioning/history/views/history.html:157
 msgid "Rewritten link is removed"
-msgstr ""
+msgstr "Линк прерађеног је уклоњен"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:194
 #: scripts/apps/users/views/edit-form.html:155
@@ -14409,11 +14409,11 @@ msgstr "Ротирај десно"
 
 #: scripts/apps/authoring/views/change-image.html:206
 msgid "Rotate left"
-msgstr ""
+msgstr "Ротирај лево"
 
 #: scripts/apps/authoring/views/change-image.html:207
 msgid "Rotate right"
-msgstr ""
+msgstr "Ротирај десно"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:253
 msgid "Round corners for dropdown items"
@@ -14487,7 +14487,7 @@ msgstr ""
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:297
 #: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:497
 msgid "Run automatically"
-msgstr ""
+msgstr "Покрени аутоматски"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:170
 #: scripts/extensions/broadcasting/dist/src/page.js:174
@@ -14528,7 +14528,7 @@ msgstr "ЗАКАЗАНА АЖУРИРАЊА"
 
 #: scripts/apps/authoring/views/authoring-header.html:45
 msgid "SIGNAL"
-msgstr ""
+msgstr "СИГНАЛ"
 
 #: scripts/core/lang/missing-translations-strings.ts:47
 msgid "SLUGLINE is too long"
@@ -14545,7 +14545,7 @@ msgstr "СМС порука"
 
 #: scripts/apps/authoring/views/authoring-header.html:49
 msgid "SOURCE"
-msgstr ""
+msgstr "ИЗВОР"
 
 #: ../superdesk-planning/client/validators/events.ts:79
 msgid "START DATE cannot be in the past"
@@ -14581,7 +14581,7 @@ msgstr "Суб"
 
 #: scripts/apps/authoring/views/change-image.html:256
 msgid "Saturation"
-msgstr ""
+msgstr "Засићење"
 
 #: ../superdesk-planning/client/utils/events.tsx:1459
 #: scripts/core/datetime/datetime.ts:295
@@ -14745,11 +14745,11 @@ msgstr "Сачувајте све друге измене пре извођењ�
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:60
 msgid "Save and publish"
-msgstr ""
+msgstr "Сачувај и објави"
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:72
 msgid "Save and send"
-msgstr ""
+msgstr "Сачувај и пошаљи"
 
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:230
 #: scripts/apps/authoring-react/toolbar/template-modal.tsx:65
@@ -14833,7 +14833,7 @@ msgstr "Сачувати измене?"
 
 #: scripts/apps/authoring/authoring/index.ts:470
 msgid "Save current item"
-msgstr ""
+msgstr "Сачувај тренутну ставку"
 
 #: ../superdesk-planning/client/constants/events.ts:169
 msgid "Save event as a template"
@@ -14994,7 +14994,7 @@ msgstr "Заказано за"
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:180
 msgid "Scheduled by"
-msgstr ""
+msgstr "Заказао"
 
 #: ../superdesk-planning/client/components/fields/common/PreviewFilterSchedule.tsx:46
 msgid "Scheduled export: {{ description }}"
@@ -15014,7 +15014,7 @@ msgstr "Заказана ажурирања морају имати датум/�
 
 #: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:73
 msgid "Scheduled:"
-msgstr ""
+msgstr "Заказано:"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:51
 msgid "Scheduling"
@@ -15356,12 +15356,12 @@ msgstr "Изабери чланке"
 
 #: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:70
 msgid "Select at most 1 file to upload."
-msgstr ""
+msgstr "Изаберите највише 1 датотеку за отпремање."
 
 #: scripts/apps/archive/controllers/UploadController.ts:233
 #: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:207
 msgid "Select at most {{maxUploads}} files to upload."
-msgstr ""
+msgstr "Изаберите највише {{maxUploads}} датотека за отпремање."
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:20
 msgid "Select color"
@@ -15446,7 +15446,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/components/video-thumbnail-editor.tsx:122
 msgid "Select thumbnail"
-msgstr ""
+msgstr "Изабери сличицу"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:63
 #: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:63
@@ -15488,7 +15488,7 @@ msgstr ""
 
 #: scripts/apps/authoring/views/authoring-topbar.html:89
 msgid "Send & duplicate"
-msgstr ""
+msgstr "Пошаљи и дуплирај"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/send-correction.tsx:13
 #: scripts/apps/authoring/views/authoring-topbar.html:214
@@ -15501,7 +15501,7 @@ msgstr ""
 
 #: scripts/apps/authoring/views/authoring-topbar.html:221
 msgid "Send Kill"
-msgstr ""
+msgstr "Пошаљи уништење"
 
 #: ../superdesk-analytics/client/email_report/views/email-report-modal.html:7
 msgid "Send Report via Email"
@@ -15509,7 +15509,7 @@ msgstr ""
 
 #: scripts/apps/authoring/views/authoring-topbar.html:228
 msgid "Send Takedown"
-msgstr ""
+msgstr "Пошаљи уклањање"
 
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/send-and-duplicate.tsx:15
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/send-and-duplicate.tsx:16
@@ -15553,18 +15553,18 @@ msgstr ""
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:201
 #: scripts/core/interactive-article-actions-panel/action-tabs.tsx:9
 msgid "Send to"
-msgstr ""
+msgstr "Пошаљи у"
 
 #: scripts/apps/authoring-react/article-widgets/send-to-publish/interactive-article-actions-widget.tsx:12
 #: scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx:20
 #: scripts/apps/authoring/views/authoring-topbar.html:400
 #: scripts/apps/authoring/views/authoring-topbar.html:401
 msgid "Send to / Publish"
-msgstr ""
+msgstr "Пошаљи у / објави"
 
 #: scripts/apps/authoring/authoring/index.ts:292
 msgid "Send to Personal Space"
-msgstr ""
+msgstr "Пошаљи у лични простор"
 
 #: scripts/apps/users/components/EmailNotificationPreferences.tsx:24
 msgid "Send {{name}} notifications"
@@ -15596,7 +15596,7 @@ msgstr "Успешно послато"
 
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:16
 msgid "Sent/Queued as"
-msgstr ""
+msgstr "Послато/у реду као"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:89
 msgid "Sent/Queued as {{name}} to {{destination}} at {{date}}"
@@ -15617,7 +15617,7 @@ msgstr "Датум почетка серије"
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:128
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:143
 msgid "Service"
-msgstr ""
+msgstr "Услуга"
 
 #: scripts/apps/users/controllers/SessionsDeleteCommand.ts:13
 msgid "Sessions cleared"
@@ -15882,7 +15882,7 @@ msgstr ""
 
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:3
 msgid "Show sent/queued items"
-msgstr ""
+msgstr "Прикажи послате/ставке у реду"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:128
 msgid ""
@@ -16122,7 +16122,7 @@ msgstr "Слика мора бити најмање {{width}}x{{height}}."
 #: scripts/apps/authoring/attachments/AttachmentsWidget.tsx:38
 msgid ""
 "Sorry, but some files \"{{filenames}}\" are bigger than limit ({{limit}})"
-msgstr ""
+msgstr "Извините, али неке датотеке \"{{filenames}}\" су веће од лимита ({{limit}})"
 
 #: scripts/apps/templates/views/create-template.html:23
 msgid "Sorry, but template name must be unique."
@@ -16244,7 +16244,7 @@ msgstr ""
 
 #: scripts/apps/authoring/views/authoring-topbar.html:361
 msgid "Spell Checker"
-msgstr ""
+msgstr "Провера правописа"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:442
 #: ../superdesk-analytics/client/utils.js:164
@@ -16316,7 +16316,7 @@ msgstr "Само у корпи"
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:221
 #: scripts/apps/authoring/versioning/history/views/history.html:63
 msgid "Spiked by"
-msgstr ""
+msgstr "Преместио у корпу"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:4
 msgid "Spiked items"
@@ -16926,7 +16926,7 @@ msgstr "Сними слику"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:132
 msgid "Take created by"
-msgstr ""
+msgstr "Наставак креирао"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:418
 msgid "Take created by {{user}}"
@@ -16935,12 +16935,12 @@ msgstr ""
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:299
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:120
 msgid "Take key"
-msgstr ""
+msgstr "Кључ наставка"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:471
 #: scripts/apps/authoring/versioning/history/views/history.html:160
 msgid "Take link is removed"
-msgstr ""
+msgstr "Линк наставка је уклоњен"
 
 #: ../superdesk-analytics/client/utils.js:163
 #: scripts/apps/authoring-react/toolbar-components/angular-integration/takedown-action.tsx:10
@@ -16952,7 +16952,7 @@ msgstr "Уклањање"
 
 #: scripts/apps/authoring/authoring/index.ts:333
 msgid "Takedown item"
-msgstr ""
+msgstr "Уклони ставку"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:577
 msgid "Takedowns"
@@ -16977,7 +16977,7 @@ msgstr "Пакет наставака"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:540
 msgid "Tansa is not responding. You can continue editing or publish the story."
-msgstr ""
+msgstr "Tansa не одговара. Можете наставити уређивање или објавити причу."
 
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:105
 msgid "Target"
@@ -17320,7 +17320,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:30
 msgid "The item is read-only."
-msgstr ""
+msgstr "Ставка је само за читање."
 
 #: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:207
 #: ../superdesk-planning/client/controllers/FulfilAssignmentController.tsx:173
@@ -17536,19 +17536,19 @@ msgstr ""
 
 #: scripts/apps/authoring/metadata/views/prefered-cv-items-config.html:15
 msgid "There are no vocabularies configured."
-msgstr ""
+msgstr "Нема подешених вокабулара."
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:58
 msgid "There are some unsaved changes, do you want to save and publish it now?"
-msgstr ""
+msgstr "Постоје несачуване измене, желите ли да их сачувате и објавите сада?"
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:70
 msgid "There are some unsaved changes, do you want to save and send it now?"
-msgstr ""
+msgstr "Постоје несачуване измене, желите ли да их сачувате и пошаљете сада?"
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:45
 msgid "There are some unsaved changes, do you want to save it now?"
-msgstr ""
+msgstr "Постоје несачуване измене, желите ли да их сачувате сада?"
 
 #: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:71
 msgid "There are some unsaved changes, go to the article to save changes?"
@@ -17574,7 +17574,7 @@ msgstr "Постоје несачуване измене."
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:28
 msgid ""
 "There are unsaved changes. If you navigate away, your changes will be lost."
-msgstr ""
+msgstr "Постоје несачуване измене. Ако напустите страницу, измене ће бити изгубљене."
 
 #: ../superdesk-planning/client/actions/assignments/notifications.ts:350
 msgid "There is a {{ type }} assignment '{{ slugline }}' {{ state }}"
@@ -17692,15 +17692,15 @@ msgstr "Дошло је до грешке. Филтер садржаја не м
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:262
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:477
 msgid "There was an error. Failed to generate update."
-msgstr ""
+msgstr "Дошло је до грешке. Генерисање ажурирања није успело."
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:281
 msgid "There was an error. Failed to remove link."
-msgstr ""
+msgstr "Дошло је до грешке. Уклањање линка није успело."
 
 #: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:463
 msgid "There was an error. Failed to save the area of interest."
-msgstr ""
+msgstr "Дошло је до грешке. Чување области од интереса није успело."
 
 #: scripts/apps/content-filters/controllers/FilterConditionsController.ts:128
 msgid "There was an error. Filter condition cannot be deleted."
@@ -17770,7 +17770,7 @@ msgstr "Ово и све будуће планирање"
 msgid ""
 "This article contains unresolved comments.Click on Cancel to go back to "
 "editing toresolve those comments or OK to ignore and proceed with publishing"
-msgstr ""
+msgstr "Овај чланак садржи неразрешене коментаре. Кликните на Откажи да се вратите на уређивање и разрешите коментаре или У реду да их игноришете и наставите са објавом"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:25
 msgid "This event is a recurring event!"
@@ -17788,7 +17788,7 @@ msgstr "Само овај догађај"
 
 #: scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts:58
 msgid "This field is read-only"
-msgstr ""
+msgstr "Ово поље је само за читање"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:181
 #: ../superdesk-planning/client/validators/assignments.tsx:8
@@ -17841,7 +17841,7 @@ msgstr "Ово је понављајући догађај."
 #: scripts/apps/authoring/views/theme-select.html:38
 #: scripts/apps/authoring/views/theme-select.html:89
 msgid "This is the headline"
-msgstr ""
+msgstr "Ово је наслов"
 
 #: scripts/apps/authoring-react/fields/media/editor.tsx:175
 msgid "This item is already added"
@@ -17853,7 +17853,7 @@ msgstr "Ова ставка је већ додата као повезана."
 
 #: scripts/apps/authoring/authoring/controllers/AssociationController.ts:211
 msgid "This item is already added."
-msgstr ""
+msgstr "Ова ставка је већ додата."
 
 #: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:26
 #: ../superdesk-planning/client/planning-extension/src/extension.ts:40
@@ -17862,11 +17862,11 @@ msgstr "Ова ставка је повезана са извештавањем 
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:118
 msgid "This item was locked by {{username}}."
-msgstr ""
+msgstr "Ову ставку је закључао {{username}}."
 
 #: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:101
 msgid "This item was unlocked by {{username}}."
-msgstr ""
+msgstr "Ову ставку је откључао {{username}}."
 
 #: scripts/core/ui/components/ListPage/generic-list-page.tsx:249
 msgid "This item will be permanently deleted."
@@ -17960,7 +17960,7 @@ msgstr "Чет"
 
 #: scripts/apps/authoring/authoring/components/video-thumbnail-editor.tsx:117
 msgid "Thumbnail"
-msgstr ""
+msgstr "Сличица"
 
 #: scripts/apps/archive/views/related-items-preview.html:12
 #: scripts/apps/relations/views/related-items.html:30
@@ -18199,12 +18199,12 @@ msgstr "Прикажи/сакриј заглавље"
 
 #: scripts/apps/authoring/widgets/widgets.ts:519
 msgid "Toggle Nth widget, where 'N' is order of widget it appears"
-msgstr ""
+msgstr "Прикажи/сакриј N-ти виџет, где је 'N' редни број виџета"
 
 #: scripts/apps/authoring/views/article-edit.html:456
 #: scripts/apps/authoring/views/article-edit.html:457
 msgid "Toggle Sign-Off lock"
-msgstr ""
+msgstr "Прикажи/сакриј закључавање потписа"
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:89
 msgid "Toggle Suggestions Mode"
@@ -18295,9 +18295,9 @@ msgstr "Предугачко"
 #: scripts/apps/authoring/attachments/AttachmentsWidget.tsx:24
 msgid "Too many files selected. Only 1 file is allowed"
 msgid_plural "Too many files selected. Only {{count}} files are allowed"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Изабрано је превише датотека. Дозвољена је само 1 датотека"
+msgstr[1] "Изабрано је превише датотека. Дозвољене су само {{count}} датотеке"
+msgstr[2] "Изабрано је превише датотека. Дозвољено је само {{count}} датотека"
 
 #: ../superdesk-planning/client/validators/profile.ts:58
 #: ../superdesk-planning/client/validators/profile.ts:59
@@ -18350,18 +18350,18 @@ msgstr "Преведи"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:352
 msgid "Translate item to"
-msgstr ""
+msgstr "Преведи ставку на"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:196
 #: scripts/apps/authoring/versioning/history/views/history.html:41
 msgid "Translated by"
-msgstr ""
+msgstr "Превео"
 
 #: scripts/apps/authoring-react/article-widgets/translations/translations.tsx:63
 #: scripts/apps/authoring/translations/translationsWidget.tsx:53
 #: scripts/apps/authoring/views/authoring-header.html:81
 msgid "Translated from"
-msgstr ""
+msgstr "Преведено са"
 
 #: scripts/apps/search/components/fields/translations.tsx:58
 #: scripts/apps/search/components/fields/translations.tsx:72
@@ -18377,7 +18377,7 @@ msgstr ""
 #: scripts/extensions/ai-widget/dist/src/main-panel.js:22
 #: scripts/extensions/ai-widget/src/main-panel.tsx:45
 msgid "Translations"
-msgstr ""
+msgstr "Преводи"
 
 #: scripts/apps/publish/views/publish-queue.html:114
 msgid "Transmitted at"
@@ -18486,7 +18486,7 @@ msgstr "ВРАТИ"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:149
 msgid "UP"
-msgstr ""
+msgstr "ГОРЕ"
 
 #: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:18
 msgid "UPCOMING"
@@ -18576,7 +18576,7 @@ msgstr ""
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:405
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:197
 msgid "Unique name"
-msgstr ""
+msgstr "Јединствени назив"
 
 #: scripts/core/ui/constants.ts:5
 msgid "Unknow error occured. Try repeating the action or reloading the page."
@@ -18596,7 +18596,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:436
 msgid "Unknown Error: Item not published."
-msgstr ""
+msgstr "Непозната грешка: ставка није објављена."
 
 #: scripts/apps/desks/controllers/DeskConfigController.ts:69
 msgid "Unknown Error: There was a problem, desk was not deleted."
@@ -18643,7 +18643,7 @@ msgstr ""
 
 #: scripts/apps/authoring/versioning/history/views/history.html:148
 msgid "Unlinked by"
-msgstr ""
+msgstr "Уклонио везу"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:456
 msgid "Unlinked by {{user}}"
@@ -18666,7 +18666,7 @@ msgstr "Откључај садржај"
 
 #: scripts/apps/authoring/authoring/index.ts:468
 msgid "Unlock current item"
-msgstr ""
+msgstr "Откључај тренутну ставку"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:202
 #: scripts/apps/authoring/views/article-edit.html:461
@@ -18688,7 +18688,7 @@ msgstr ""
 
 #: scripts/apps/authoring/versioning/history/views/history.html:102
 msgid "Unmarked by"
-msgstr ""
+msgstr "Уклонио ознаку"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:336
 msgid "Unmarked from desk({{x}}) by {{user}}"
@@ -18727,7 +18727,7 @@ msgstr "Повуци објаву"
 
 #: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:69
 msgid "Unpublish related items:"
-msgstr ""
+msgstr "Повуци објаву повезаних ставки:"
 
 #: scripts/apps/search/components/fields/state.tsx:44
 msgid "Unpublished"
@@ -18735,7 +18735,7 @@ msgstr ""
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:190
 msgid "Unpublished by"
-msgstr ""
+msgstr "Повукао објаву"
 
 #: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:168
 #: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:3
@@ -18793,7 +18793,7 @@ msgstr "Враћено из корпе"
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:237
 #: scripts/apps/authoring/versioning/history/views/history.html:74
 msgid "Unspiked by"
-msgstr ""
+msgstr "Вратио из корпе"
 
 #: scripts/apps/search/views/saved-search-subscribe.html:29
 msgid "Unsubscribe"
@@ -18841,7 +18841,7 @@ msgstr "Ажурирај"
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:256
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:470
 msgid "Update Created."
-msgstr ""
+msgstr "Ажурирање креирано."
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:4
 msgid "Update Cycle:"
@@ -18946,7 +18946,7 @@ msgstr ""
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:129
 #: scripts/apps/authoring/versioning/history/views/history.html:18
 msgid "Updated by"
-msgstr ""
+msgstr "Ажурирао"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:119
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:135
@@ -18982,7 +18982,7 @@ msgstr ""
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:34
 msgid ""
 "Updates can only be created for text items. The type of this item is {{type}}"
-msgstr ""
+msgstr "Ажурирања могу бити креирана само за текстуалне ставке. Тип ове ставке је {{type}}"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:205
 #: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:136
@@ -19032,7 +19032,7 @@ msgstr "Отпреми медиј"
 
 #: scripts/apps/authoring/views/item-carousel.html:166
 msgid "Upload new"
-msgstr ""
+msgstr "Отпреми ново"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetListPanel.js:62
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetListPanel.js:62
@@ -19127,7 +19127,7 @@ msgstr "Услови коришћења"
 
 #: scripts/apps/authoring/views/confirm-media-associated.html:17
 msgid "Use Media"
-msgstr ""
+msgstr "Користи медиј"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:111
 msgid "Use Togglebox"
@@ -19314,13 +19314,13 @@ msgstr "Вредности"
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:366
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:163
 msgid "Version"
-msgstr ""
+msgstr "Верзија"
 
 #: scripts/apps/archive/views/metadata-view.html:110
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:397
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:186
 msgid "Version creator"
-msgstr ""
+msgstr "Креатор верзије"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:76
 msgid "Version: {{n}}"
@@ -19330,7 +19330,7 @@ msgstr ""
 #: scripts/apps/authoring/versioning/versioning.ts:8
 #: scripts/apps/authoring/versioning/views/versioning.html:3
 msgid "Versions"
-msgstr ""
+msgstr "Верзије"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/index.tsx:15
 msgid "Versions and item history"
@@ -19649,7 +19649,7 @@ msgstr "Без извештавања"
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:108
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:112
 msgid "Word Count"
-msgstr ""
+msgstr "Број речи"
 
 #: scripts/apps/desks/views/desk-config-modal.html:232
 msgid "Work stages"
@@ -19800,7 +19800,7 @@ msgstr "Можете изабрати подразумевани приказ с
 msgid ""
 "You can either completely block further writing after the characterlimit is "
 "reached or highlight exceeding characters in red."
-msgstr ""
+msgstr "Можете потпуно блокирати даље писање након што се достигне лимит карактера или истаћи карактере преко лимита црвеном бојом."
 
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:154
 msgid "You can't multi-edit, because these articles can't be edited"
@@ -19995,13 +19995,13 @@ msgstr ""
 
 #: scripts/apps/authoring/versioning/history/views/history.html:140
 msgid "as rewrite of"
-msgstr ""
+msgstr "као прерада"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:45
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:17
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:22
 msgid "at"
-msgstr ""
+msgstr "у"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:401
 #: scripts/apps/archive/controllers/UploadController.ts:330
@@ -20159,7 +20159,7 @@ msgstr ""
 
 #: scripts/apps/authoring/metadata/views/meta-place-directive.html:20
 msgid "country"
-msgstr ""
+msgstr "држава"
 
 #: scripts/core/lang/missing-translations-strings.ts:34
 msgid "create"
@@ -20256,7 +20256,7 @@ msgstr "онемогућио корисника {{user}}"
 
 #: scripts/apps/authoring/macros/views/macros-replace.html:9
 msgid "done"
-msgstr ""
+msgstr "завршено"
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "draft"
@@ -20268,7 +20268,7 @@ msgstr "рок"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:58
 msgid "duplicate id"
-msgstr ""
+msgstr "ИД дупликата"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:463
 msgid "e.g. @cityofsydney"
@@ -20430,11 +20430,11 @@ msgstr "за '{{ desk }}'"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:97
 msgid "for desk"
-msgstr ""
+msgstr "за деск"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:94
 msgid "for highlight"
-msgstr ""
+msgstr "за истицање"
 
 #: ../superdesk-planning/client/utils/events.tsx:1428
 msgid "for {{ repeatCount }} repeats"
@@ -20448,7 +20448,7 @@ msgstr "ознаке форматирања"
 #: scripts/apps/authoring/versioning/history/views/history.html:47
 #: scripts/apps/authoring/versioning/history/views/history.html:69
 msgid "from"
-msgstr ""
+msgstr "од"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:28
 msgid "from content"
@@ -20460,7 +20460,7 @@ msgstr "из доделе извештавања од"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:122
 msgid "from highlight"
-msgstr ""
+msgstr "из истицања"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:361
 msgid "from highlight: {{x}}"
@@ -20584,7 +20584,7 @@ msgstr ""
 #: scripts/apps/authoring-react/fields/media/editor.tsx:147
 #: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:196
 msgid "image"
-msgstr ""
+msgstr "слика"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/ImageTaggingComponent/ImageTaggingComponent.js:198
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:198
@@ -20699,14 +20699,14 @@ msgstr "последње ажурирање и последња ставка с�
 #: scripts/apps/authoring/authoring/directives/ReadingTime.ts:20
 #: scripts/apps/authoring/authoring/directives/ReadingTime.ts:54
 msgid "less than one minute read"
-msgstr ""
+msgstr "мање од минут читања"
 
 #: scripts/apps/authoring/authoring/components/line-count.tsx:21
 msgid "line"
 msgid_plural "lines"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "ред"
+msgstr[1] "реда"
+msgstr[2] "редова"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:77
 msgid "link"
@@ -20714,7 +20714,7 @@ msgstr "линк"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:143
 msgid "linked to"
-msgstr ""
+msgstr "повезано са"
 
 #: scripts/apps/contacts/views/search-results.html:4
 #: scripts/apps/content-api/views/search-results.html:4
@@ -20799,7 +20799,7 @@ msgstr ""
 
 #: scripts/apps/authoring/macros/views/macros-widget.html:31
 msgid "miscellaneous"
-msgstr ""
+msgstr "разно"
 
 #: scripts/apps/contacts/constants.ts:47
 msgid "mobile"
@@ -20892,9 +20892,9 @@ msgstr "радним данима"
 #: scripts/apps/authoring/authoring/components/text-statistics.tsx:22
 msgid "one word"
 msgid_plural "{{x}} words"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "једна реч"
+msgstr[1] "{{x}} речи"
+msgstr[2] "{{x}} речи"
 
 #: scripts/core/editor3/components/article-embed/article-embed.tsx:32
 msgid "open in a new window"
@@ -21045,7 +21045,7 @@ msgstr ""
 
 #: scripts/apps/authoring/macros/views/macros-widget.html:14
 msgid "quick list"
-msgstr ""
+msgstr "брза листа"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:75
 #: scripts/core/editor3/helpers/highlights.ts:65
@@ -21071,11 +21071,11 @@ msgstr "уклони форматирање"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:111
 msgid "removed desk"
-msgstr ""
+msgstr "уклоњен деск"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:108
 msgid "removed highlight"
-msgstr ""
+msgstr "уклоњено истицање"
 
 #: scripts/core/lang/missing-translations-strings.ts:37
 msgid "removed item {{type}} about {{subject}}"
@@ -21083,7 +21083,7 @@ msgstr "уклонио ставку типа {{type}} о {{subject}}"
 
 #: scripts/apps/authoring/macros/views/macros-replace.html:6
 msgid "replace"
-msgstr ""
+msgstr "замени"
 
 #: scripts/core/lang/missing-translations-strings.ts:43
 msgid "replaced item {{type}} about {{subject}}"
@@ -21104,7 +21104,7 @@ msgstr "поновни покушај"
 
 #: scripts/apps/authoring/versioning/versions/views/versions.html:20
 msgid "revert"
-msgstr ""
+msgstr "врати"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:72
 msgid "reverted"
@@ -21112,7 +21112,7 @@ msgstr "враћено"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:182
 msgid "rewrite id"
-msgstr ""
+msgstr "ИД прераде"
 
 #: scripts/core/lang/missing-translations-strings.ts:41
 msgid "role {{role}} is granted new privileges: Please re-login."
@@ -21227,7 +21227,7 @@ msgstr ""
 
 #: scripts/apps/authoring/metadata/views/meta-place-directive.html:19
 msgid "state, region, ..."
-msgstr ""
+msgstr "држава, регион, ..."
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:109
 #: scripts/extensions/availability-manager/dist/src/utils.js:109
@@ -21333,7 +21333,7 @@ msgstr ""
 
 #: scripts/apps/authoring/views/authoring-header.html:85
 msgid "translations"
-msgstr ""
+msgstr "преводи"
 
 #: scripts/apps/contacts/constants.ts:50
 msgid "twitter"
@@ -21381,7 +21381,7 @@ msgstr "ажуриран канал пријема {{name}}"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:25
 msgid "updated fields"
-msgstr ""
+msgstr "ажурирана поља"
 
 #: scripts/core/lang/missing-translations-strings.ts:38
 msgid "updated task {{subject}} for item {{type}}"
@@ -21672,7 +21672,7 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:384
 msgid "{{field}} cannot be earlier than now!"
-msgstr ""
+msgstr "{{field}} не може бити раније од сада!"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:109
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:94
@@ -21688,15 +21688,15 @@ msgstr ""
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:372
 msgid "{{field}} date is required!"
-msgstr ""
+msgstr "Датум {{field}} је обавезан!"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:380
 msgid "{{field}} is not a valid date!"
-msgstr ""
+msgstr "{{field}} није исправан датум!"
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:376
 msgid "{{field}} time is required!"
-msgstr ""
+msgstr "Време {{field}} је обавезно!"
 
 #: ../superdesk-analytics/client/search/directives/DateFilters.js:118
 #: ../superdesk-analytics/client/utils.js:202
@@ -21733,7 +21733,7 @@ msgstr[2] "{{multiSelectCount}} ставки изабрано"
 
 #: scripts/apps/authoring/authoring/directives/WordCount.html:1
 msgid "{{numWords}} words"
-msgstr ""
+msgstr "{{numWords}} речи"
 
 #: scripts/api/article-fetch.tsx:117
 msgid "{{n}} images can not be fetched because they are too small."
@@ -21839,4 +21839,4 @@ msgstr ""
 #: scripts/apps/authoring/authoring/directives/ReadingTime.ts:22
 #: scripts/apps/authoring/authoring/directives/ReadingTime.ts:52
 msgid "{{x}} min read"
-msgstr ""
+msgstr "{{x}} мин читања"

--- a/po/sr.po
+++ b/po/sr.po
@@ -1,0 +1,21842 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Project-Id-Version: \n"
+"PO-Revision-Date: 2026-05-06 00:00+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: scripts/core/lang/missing-translations-strings.ts:32
+msgid "\"GENRE 'null value not allowed'"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:199
+msgid "\"Name\" is a required field"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/utils.ts:16
+msgid "\"{{fieldName}}\" field is required by the system"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:204
+msgid "\"{{language}}\" translation is required"
+msgstr ""
+
+#: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:240
+msgid "\"{{x}}\" field is required"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:74
+msgid ""
+"'' is currently managing featured stories. This feature can only be accessed "
+"by one user at a time."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:23
+msgid "'ABSTRACT is a required field'"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:24
+msgid "'ANPA_CATEGORY is a required field'"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:23
+msgid "'BYLINE is a required field'"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:33
+msgid "'CATEGORY is a required field'"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:32
+msgid "'DATELINE is a required field'"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:22
+msgid "'GENRE is a required field'"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:25
+msgid "'GENRE null value not allowed'"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:24
+msgid "'HEADLINE is a required field'"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:30
+msgid "'PLACE is a required field'"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:43
+msgid "'PRIORITY is a required field'"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:24
+msgid "'SLUGLINE is a required field'"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:23
+msgid "'SUBJECT is a required field'"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:43
+msgid "'URGENCY is a required field'"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:34
+msgid "'must be of list type'\""
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:37
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:146
+msgid "'not scheduled yet'"
+msgstr ""
+
+#: scripts/apps/highlights/services/HighlightsService.ts:16
+msgid "(Global)"
+msgstr ""
+
+#: scripts/apps/contacts/components/ListTypeIcon.tsx:13
+msgid "(Private)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:269
+msgid "(advanced mode)"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-group-header.html:44
+msgid "(as defined for all groups)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:237
+msgid "(custom text field)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:238
+msgid "(custom vocabulary)"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:170
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:170
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:199
+msgid "(disabled)"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:97
+#: scripts/extensions/broadcasting/dist/src/rundowns/manage-rundown-items.js:97
+#: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:176
+msgid "(empty)"
+msgstr ""
+
+#: scripts/apps/search/MultiImageEdit.ts:290
+#: scripts/apps/search/MultiImageEdit.ts:311
+msgid "(multiple values)"
+msgstr ""
+
+#: scripts/core/ui/views/sd-timezone.html:12
+msgid "(no matches)"
+msgstr "(нема поклапања)"
+
+#: scripts/apps/authoring/compare-versions/views/compare-versions.html:17
+msgid "* choose article version from dropdown menu"
+msgstr ""
+
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:127
+msgid "* fields are required"
+msgstr ""
+
+#: scripts/apps/publish/views/email-config.html:3
+msgid "*at least one visible or hidden recipient needed"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:193
+msgid "1 day"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:199
+msgid "1 hour"
+msgstr ""
+
+#: scripts/core/ArticlesListByQueryWithFilters.tsx:316
+msgid "1 item selected"
+msgid_plural "{{number}} items selected"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../superdesk-analytics/client/utils.js:205
+msgid "1 minute"
+msgstr ""
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:22
+msgid "1 month"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/with-more-items.tsx:52
+msgid "1 more item"
+msgid_plural "{{n}} more items"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../superdesk-analytics/client/utils.js:210
+msgid "1 second"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:270
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:270
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:446
+msgid "1 tag can not be displayed"
+msgid_plural "{{n}} tags can not be displayed"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:20
+msgid "1 week"
+msgstr ""
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:24
+msgid "1 year"
+msgstr ""
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:27
+msgid "10 years"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:186
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:186
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:196
+msgid "100MB"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:97
+msgid "108h"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:183
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:183
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:193
+msgid "10MB"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:44
+#: ../superdesk-planning/client/utils/filters.ts:81
+msgid "10th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:28
+msgid "10th update"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:45
+#: ../superdesk-planning/client/utils/filters.ts:83
+msgid "11th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:28
+msgid "11th update"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:17
+msgid "12 Hours"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:204
+msgid "12:00am"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:46
+#: ../superdesk-planning/client/utils/filters.ts:85
+msgid "12th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:29
+msgid "12th update"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:47
+#: ../superdesk-planning/client/utils/filters.ts:87
+msgid "13th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:29
+msgid "13th update"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:48
+#: ../superdesk-planning/client/utils/filters.ts:89
+msgid "14th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:29
+msgid "14th update"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:49
+#: ../superdesk-planning/client/utils/filters.ts:91
+msgid "15th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:29
+msgid "15th update"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:50
+#: ../superdesk-planning/client/utils/filters.ts:93
+msgid "16th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:29
+msgid "16th update"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:51
+msgid "17th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:29
+msgid "17th update"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:52
+msgid "18th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:30
+msgid "18th update"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:53
+#: ../superdesk-planning/client/utils/filters.ts:99
+msgid "19th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:30
+msgid "19th update"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:189
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:189
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:199
+msgid "1GB"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:181
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:181
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:191
+msgid "1MB"
+msgstr ""
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:21
+msgid "2 weeks"
+msgstr ""
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:25
+msgid "2 years"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:105
+msgid "200 minimum"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:54
+#: ../superdesk-planning/client/utils/filters.ts:101
+msgid "20th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:30
+msgid "20th update"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:55
+#: ../superdesk-planning/client/utils/filters.ts:103
+msgid "21st"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:56
+#: ../superdesk-planning/client/utils/filters.ts:105
+msgid "22nd"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:57
+#: ../superdesk-planning/client/utils/filters.ts:107
+msgid "23rd"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:19
+msgid "24 Hours"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:58
+#: ../superdesk-planning/client/utils/filters.ts:109
+msgid "24th"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:187
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:187
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:197
+msgid "250MB"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:184
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:184
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:194
+msgid "25MB"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:59
+#: ../superdesk-planning/client/utils/filters.ts:111
+msgid "25th"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:60
+#: ../superdesk-planning/client/utils/filters.ts:113
+msgid "26th"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:61
+#: ../superdesk-planning/client/utils/filters.ts:115
+msgid "27th"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:62
+#: ../superdesk-planning/client/utils/filters.ts:117
+msgid "28th"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:36
+#: ../superdesk-planning/client/utils/filters.ts:65
+msgid "2nd"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:27
+msgid "2nd update"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:37
+#: ../superdesk-planning/client/utils/filters.ts:67
+msgid "3rd"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:27
+msgid "3rd update"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:25
+msgid "412: Can't publish as item state is draft"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:20
+msgid "48 Hours"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:38
+#: ../superdesk-planning/client/utils/filters.ts:69
+msgid "4th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:27
+msgid "4th update"
+msgstr ""
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:26
+msgid "5 years"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:188
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:188
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:198
+msgid "500MB"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:185
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:185
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:195
+msgid "50MB"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:182
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:182
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:192
+msgid "5MB"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:39
+#: ../superdesk-planning/client/utils/filters.ts:71
+msgid "5th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:27
+msgid "5th update"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:16
+msgid "6 Hours"
+msgstr ""
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:23
+msgid "6 months"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:40
+#: ../superdesk-planning/client/utils/filters.ts:73
+msgid "6th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:28
+msgid "6th update"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:95
+msgid "70th"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:41
+#: ../superdesk-planning/client/utils/filters.ts:75
+msgid "7th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:28
+msgid "7th update"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:42
+#: ../superdesk-planning/client/utils/filters.ts:77
+msgid "8th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:28
+msgid "8th update"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:43
+#: ../superdesk-planning/client/utils/filters.ts:79
+msgid "9th"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:28
+msgid "9th update"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:249
+msgid ": OFF"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:252
+msgid ": ON"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:206
+msgid ":00am"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:208
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:210
+msgid ":00pm"
+msgstr ""
+
+#: scripts/apps/workspace/content/views/profile-settings.html:85
+msgid ""
+"<button class=\"sd-alert__close\" ng-click=\"showInfoLabel = false\"></"
+"button>\n"
+"                    Please note that only one content profile per content "
+"type other than text is allowed. If the content type is disabled, the limit "
+"is already reached."
+msgstr ""
+
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-parameters.html:1
+msgid ""
+"<p>Generate a report showing usage of the Planning module.<br></p>\n"
+"    <p>This provides a statistics on who is and who isn't creating items in "
+"the Planning module</p>"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:6
+msgid ""
+"<sd-spinner ng-if=\"isSaving\" data-test-id=\"loading-indicator\" data-"
+"size=\"'mini'\"></sd-spinner>\n"
+"                    Save"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:183
+msgid ""
+"<sd-spinner ng-if=\"saveTopbarLoading\" data-test-id=\"loading-indicator\" "
+"data-size=\"'mini'\"></sd-spinner>\n"
+"        <span translate>Save</span>"
+msgstr ""
+
+#: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:216
+msgid "A content profile with this name already exists."
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:274
+msgid "A desk is required"
+msgstr ""
+
+#: scripts/core/auth/reset-password.html:43
+msgid ""
+"A link was sent to the specified email address. Please use it to reset your "
+"password. It is valid a limited amount of time."
+msgstr ""
+
+#: ../superdesk-planning/client/api/locations.ts:30
+msgid "A location matching this one already exists"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:107
+msgid "A new template will be created"
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:226
+msgid "A user is required"
+msgstr ""
+
+#: scripts/apps/search/views/search-parameters.html:218
+msgid "AAP Image Keyword"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:47
+msgid "ABSTRACT is too long"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:66
+msgid "ADD WORD"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:35
+msgid "AMP"
+msgstr ""
+
+#: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:88
+#: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:97
+msgid "AND"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/Categories.tsx:26
+#: ../superdesk-planning/client/components/fields/preview/index.ts:65
+#: ../superdesk-planning/client/utils/contentProfiles.ts:287
+#: scripts/apps/content-filters/views/production-test-view.html:23
+#: scripts/apps/search/services/SearchService.ts:69
+msgid "ANPA Category"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/list/Categories.tsx:19
+msgid "ANPA Category:"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:31
+msgid "ANPA Take Key"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx:109
+msgid "ASSOCIATED XMP FILE"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:242
+msgid "ATTACHED FILE {{ index }} is required"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreview.tsx:95
+msgid "ATTACHMENTS"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:107
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:88
+msgid "Abbreviation"
+msgstr ""
+
+#: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:157
+msgid "Abbreviation already exists. Do you want to overwrite it?"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/settings.html:33
+msgid "Abbreviations Dictionary"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:115
+msgid "About Superdesk"
+msgstr "О Superdesk-у"
+
+#: scripts/apps/authoring-react/field-adapters/abstract.ts:20
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-panel.tsx:164
+#: scripts/apps/authoring/views/theme-select.html:45
+#: scripts/apps/authoring/views/theme-select.html:96
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:378
+#: scripts/apps/workspace/content/constants.ts:8
+msgid "Abstract"
+msgstr ""
+
+#: scripts/apps/authoring/views/theme-select.html:47
+#: scripts/apps/authoring/views/theme-select.html:98
+msgid "Abstract example"
+msgstr ""
+
+#: scripts/apps/dashboard/views/workspace.html:9
+#: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:160
+msgid "Accept"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Accepted.tsx:15
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:173
+#: scripts/apps/authoring-react/article-widgets/suggestions.tsx:73
+#: scripts/apps/authoring/track-changes/views/suggestions-widget.html:8
+msgid "Accepted"
+msgstr ""
+
+#: scripts/apps/authoring/track-changes/views/suggestions-widget.html:37
+msgid "Accepted by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/suggestions.tsx:126
+msgid "Accepted by {{user}}"
+msgstr ""
+
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:33
+msgid "Access Key ID"
+msgstr ""
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/accreditation-deadline.tsx:24
+#: ../superdesk-planning/client/components/fields/preview/index.ts:188
+#: ../superdesk-planning/client/components/fields/resources/events.ts:108
+#: ../superdesk-planning/client/utils/contentProfiles.ts:347
+msgid "Accreditation Deadline"
+msgstr ""
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:73
+#: ../superdesk-planning/client/components/fields/preview/index.ts:284
+#: ../superdesk-planning/client/components/fields/resources/events.ts:97
+#: ../superdesk-planning/client/utils/contentProfiles.ts:345
+msgid "Accreditation Info"
+msgstr ""
+
+#: scripts/apps/monitoring/views/desk-notifications.html:28
+msgid "Acknowledge"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:16
+#: scripts/apps/publish/views/publish-queue.html:117
+msgid "Action"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/index.tsx:318
+#: ../superdesk-planning/client/components/Events/EventItem.tsx:132
+#: ../superdesk-planning/client/components/ItemActionsMenu/ActionsMenuPopup.tsx:56
+#: ../superdesk-planning/client/components/ItemActionsMenu/index.tsx:70
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:84
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:87
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:88
+#: ../superdesk-planning/client/components/Planning/PlanningItem.tsx:157
+#: ../superdesk-planning/client/constants/tooltips.ts:34
+#: scripts/apps/authoring/authoring/constants.ts:12
+#: scripts/apps/desks/views/settings.html:29
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:2
+#: scripts/apps/monitoring/views/item-actions-menu.html:16
+#: scripts/apps/search/components/actions-menu/MenuItems.tsx:272
+#: scripts/apps/templates/views/templates.html:34
+#: scripts/apps/workspace/content/views/profile-settings.html:41
+#: scripts/apps/workspace/content/views/profile-settings.html:45
+#: scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx:120
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:71
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:79
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:305
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:145
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:165
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:71
+#: scripts/extensions/broadcasting/dist/src/rundowns/manage-rundown-items.js:79
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:305
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:145
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:165
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:128
+#: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:140
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:472
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:264
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:311
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:127
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:127
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:150
+msgid "Actions"
+msgstr ""
+
+#: scripts/apps/authoring-react/subcomponents/authoring-actions-menu.tsx:42
+#: scripts/apps/authoring-react/subcomponents/authoring-actions-menu.tsx:71
+msgid "Actions menu"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:16
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:243
+#: scripts/apps/contacts/services/ContactsService.ts:61
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:22
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:138
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:23
+#: scripts/apps/publish/directives/SubscribersDirective.ts:435
+#: scripts/apps/publish/directives/SubscribersDirective.ts:65
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:44
+#: scripts/apps/users/controllers/UserListController.ts:155
+#: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:467
+#: scripts/apps/workspace/content/views/profile-settings.html:168
+#: scripts/apps/workspace/content/views/profile-settings.html:61
+msgid "Active"
+msgstr ""
+
+#: scripts/apps/workspace/content/views/profile-settings.html:22
+msgid "Active only"
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:424
+msgid "Active until {{end}}"
+msgstr ""
+
+#: scripts/apps/users/views/activity-feed.html:4
+#: scripts/core/lang/missing-translations-strings.ts:44
+msgid "Activity Stream"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:44
+msgid "Activity stream widget"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AdHocPlanning.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:41
+msgid "Ad Hoc Planning"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/date/config.tsx:109
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:239
+#: scripts/apps/authoring/metadata/views/metadata-target-publishing.html:14
+#: scripts/apps/content-filters/views/manage-filters.html:81
+#: scripts/apps/content-filters/views/manage-filters.html:93
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:27
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:75
+#: scripts/apps/templates/views/template-editor-modal.html:158
+#: scripts/core/editor3/highlightsConfig.ts:26
+#: scripts/core/interactive-article-actions-panel/subcomponents/controlled-vocabulary-select.tsx:65
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:350
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:350
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:98
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:98
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:615
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:217
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:71
+#: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:71
+#: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:153
+#: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/editor.js:35
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/editor.js:35
+#: scripts/extensions/broadcasting/src/authoring-fields/subitems/editor.tsx:79
+msgid "Add"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/confirmAddingRelatedItems.tsx:56
+msgid "Add 1 item"
+msgid_plural "Add {{n}} items"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:96
+msgid "Add Abbreviation"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/planning.ts:140
+msgid "Add As Event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Contacts/ContactEditor.tsx:88
+#: ../superdesk-planning/client/components/Contacts/ContactField.tsx:126
+msgid "Add Contact"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Editor/bookmarks/AddCoverageBookmark.tsx:56
+#: ../superdesk-planning/client/components/Editor/bookmarks/AddCoverageBookmark.tsx:92
+msgid "Add Coverage"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:323
+msgid "Add Coverage To Workflow"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:267
+msgid "Add Coverages"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:176
+msgid "Add Featuremedia"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/containers/FileUploadModal.js:232
+#: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:232
+#: scripts/extensions/sams/src/containers/FileUploadModal.tsx:288
+msgid "Add File"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:116
+msgid "Add Filter Statement"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:28
+msgid "Add Gallery"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:29
+msgid "Add Image"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-sources-list.html:1
+msgid "Add Ingest Sources"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:436
+msgid "Add Item"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:7
+#: scripts/apps/content-filters/views/manage-filters.html:6
+#: scripts/apps/desks/views/settings.html:15
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:6
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:6
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:25
+#: scripts/apps/products/views/products.html:16
+#: scripts/apps/publish/views/subscribers.html:26
+#: scripts/apps/search-providers/views/search-provider-config.html:5
+#: scripts/apps/templates/views/templates.html:21
+#: scripts/apps/users/views/settings-roles.html:6
+#: scripts/apps/vocabularies/views/vocabulary-config.html:14
+#: scripts/apps/vocabularies/views/vocabulary-config.html:19
+#: scripts/apps/vocabularies/views/vocabulary-config.html:25
+#: scripts/apps/vocabularies/views/vocabulary-config.html:31
+#: scripts/apps/vocabularies/views/vocabulary-config.html:37
+#: scripts/apps/vocabularies/views/vocabulary-config.html:43
+#: scripts/apps/vocabularies/views/vocabulary-config.html:49
+#: scripts/apps/vocabularies/views/vocabulary-config.html:8
+#: scripts/apps/workspace/content/views/profile-settings.html:26
+#: scripts/extensions/sams/dist/src/components/sets/manageSetsModal.js:103
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/manageSetsModal.js:103
+#: scripts/extensions/sams/src/components/sets/manageSetsModal.tsx:107
+msgid "Add New"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:4
+msgid "Add New Abbreviations Dictionary"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:33
+msgid "Add New Content Filter"
+msgstr ""
+
+#: scripts/apps/workspace/content/views/profile-settings.html:79
+msgid "Add New Content Profile"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:4
+msgid "Add New Desk"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:227
+msgid "Add New Destination"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:5
+msgid "Add New Dictionary"
+msgstr ""
+
+#: ../superdesk-planning/client/components/GeoLookupInput/CreateNewGeoLookup.tsx:129
+msgid "Add New Event Location"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:215
+msgid "Add New Filter"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:43
+msgid "Add New Filter Condition"
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:3
+msgid "Add New Product"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:31
+msgid "Add New Rule Set"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:31
+msgid "Add New Scheme"
+msgstr ""
+
+#: scripts/apps/search-providers/directive.ts:24
+#: scripts/apps/search-providers/views/search-provider-config.html:28
+msgid "Add New Search Provider"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:58
+msgid "Add New Source"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:69
+msgid "Add New Subscriber"
+msgstr ""
+
+#: scripts/apps/templates/views/template-editor-modal.html:4
+msgid "Add New Template"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Editor/bookmarks/AddPlanningBookmark.tsx:30
+msgid "Add Planning Item"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:84
+msgid "Add Rule"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/dashboard.html:4
+msgid "Add Sources"
+msgstr ""
+
+#: scripts/apps/dashboard/views/workspace.html:99
+msgid "Add This Widget"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/TimeInputs.tsx:95
+msgid "Add Time"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/article-url-fields.tsx:103
+msgid "Add URL"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageArrayInput.tsx:165
+#: ../superdesk-planning/client/components/fields/editor/Coverages.tsx:139
+msgid "Add a coverage"
+msgstr ""
+
+#: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:239
+msgid "Add a new location"
+msgstr ""
+
+#: scripts/apps/authoring-react/multi-edit-modal.tsx:318
+msgid "Add article"
+msgstr ""
+
+#: ../superdesk-planning/client/components/AddToPlanningModal/index.tsx:72
+msgid ""
+"Add article to Planning - select an existing Planning Item or create a new "
+"one"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningItem.tsx:317
+#: ../superdesk-planning/client/components/Planning/PlanningItem.tsx:322
+msgid "Add as coverage"
+msgstr ""
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:278
+#: ../superdesk-planning/client/utils/events.tsx:717
+msgid "Add as related event"
+msgid_plural "Add as related events"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:181
+#: ../superdesk-planning/client/utils/planning.tsx:818
+msgid "Add as related planning"
+msgid_plural "Add as related plannings"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/apps/authoring/media/views/media-metadata-editor-directive.html:122
+#: scripts/apps/authoring/views/authoring-header.html:614
+msgid "Add author"
+msgstr ""
+
+#: scripts/apps/authoring/views/item-association.html:110
+msgid "Add caption"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:55
+msgid "Add content slugline"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/planning.ts:144
+#: ../superdesk-planning/client/constants/planning.ts:147
+msgid "Add coverage"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:58
+msgid "Add description"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:50
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:50
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:74
+msgid "Add entity"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:113
+msgid "Add field after"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:69
+msgid "Add field before"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-filter.html:8
+msgid "Add filter"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldList.tsx:43
+msgid "Add first field"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupList.tsx:113
+msgid "Add first group"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupElementTemplate.tsx:80
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupList.tsx:92
+msgid "Add group after"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupElementTemplate.tsx:43
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupList.tsx:55
+msgid "Add group before"
+msgstr ""
+
+#: scripts/validate-instance-configuration.tsx:59
+msgid "Add it via Settings > Metadata"
+msgstr ""
+
+#: scripts/apps/packaging/views/search.html:10
+msgid "Add items"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventLinks.tsx:77
+#: scripts/core/editor3/highlightsConfig.ts:112
+msgid "Add link"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/meta-place-directive.html:2
+#: scripts/apps/authoring/metadata/views/metadata-tags.html:3
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:11
+#: scripts/apps/dictionaries/views/settings.html:10
+#: scripts/core/ui/components/Form/SelectMetaTermsInput/index.tsx:103
+#: scripts/core/ui/views/sd-multi-select.html:3
+msgid "Add new"
+msgstr "Додај нови"
+
+#: scripts/apps/workspace/content/components/new-field-select.tsx:34
+msgid "Add new field"
+msgstr ""
+
+#: scripts/apps/dashboard/views/workspace.html:69
+msgid "Add new widget"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Editor/bookmarks/AddPlanningBookmark.tsx:42
+msgid "Add planning item"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:65
+msgid "Add rule"
+msgstr ""
+
+#: scripts/extensions/datetimeField/dist/src/config.js:54
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:54
+#: scripts/extensions/datetimeField/src/config.tsx:109
+msgid "Add step"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:66
+msgid "Add task description"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/agenda.ts:166
+msgid "Add these  events to the planning list?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/agenda.ts:165
+msgid "Add this event to the planning list?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:251
+msgid "Add this item to all recurring events or just this one?"
+msgstr ""
+
+#: scripts/apps/authoring/views/item-association.html:100
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:56
+msgid "Add title"
+msgstr ""
+
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:268
+msgid "Add to Current Package"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningItem.tsx:111
+msgid "Add to Feature Stories"
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:129
+#: ../superdesk-planning/client/planning-extension/src/extension.ts:175
+#: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:165
+msgid "Add to Planning"
+msgstr ""
+
+#: scripts/apps/packaging/index.ts:74
+msgid "Add to current"
+msgstr ""
+
+#: scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx:67
+msgid "Add to dictionary"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/planning.ts:145
+msgid "Add to featured stories"
+msgstr ""
+
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:283
+msgid "Add to highlight"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:138
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:129
+#: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:52
+msgid "Add to workflow"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/urls/editor.tsx:85
+msgid "Add url"
+msgstr ""
+
+#: scripts/apps/dashboard/views/workspace.html:13
+#: scripts/apps/dashboard/views/workspace.html:14
+msgid "Add widget"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/attachments/difference-row.tsx:25
+msgid "Added"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:90
+msgid "Added to featured stories"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:236
+msgid "Added to workflow"
+msgstr ""
+
+#: scripts/apps/relations/services/RelationsService.ts:46
+msgid ""
+"Adding ingested items as related is not allowed due to configuration options"
+msgstr ""
+
+#: scripts/apps/relations/services/RelationsService.ts:29
+msgid ""
+"Adding published items as related is not allowed due to configuration options"
+msgstr ""
+
+#: scripts/apps/relations/services/RelationsService.ts:36
+msgid ""
+"Adding related items that are not published is not allowed due to "
+"configuration options"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:227
+#: ../superdesk-planning/client/components/Locations/LocationsList.tsx:112
+#: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:49
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:24
+msgid "Address"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:541
+msgid "Address line 1"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:553
+msgid "Address line 2"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:30
+msgid "Adjust"
+msgstr ""
+
+#: scripts/apps/authoring/views/change-image.html:239
+msgid "Adjust colours"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:95
+msgid "Admin tools"
+msgstr "Алати администратора"
+
+#: scripts/apps/users/components/UserAvatar.tsx:92
+#: scripts/apps/users/views/edit-form.html:169
+#: scripts/apps/users/views/edit-form.html:67
+msgid "Administrator"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:14
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:14
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-panel.html:14
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-panel.html:14
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-panel.html:14
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-panel.html:14
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-panel.html:14
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-panel.html:14
+msgid "Advanced"
+msgstr ""
+
+#: scripts/apps/search/views/search-panel.html:8
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:215
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:215
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:233
+msgid "Advanced Search"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentFilterPanel.tsx:104
+#: ../superdesk-planning/client/components/Main/SearchPanel.tsx:113
+#: ../superdesk-planning/client/components/Main/ToggleFiltersButton.tsx:14
+#: ../superdesk-planning/client/components/Main/ToggleFiltersButton.tsx:15
+msgid "Advanced filters"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageAddButton/CoveragesMenuPopup.tsx:66
+msgid "Advanced mode"
+msgstr ""
+
+#: scripts/apps/search/views/search-panel.html:58
+msgid "Advanced search"
+msgstr ""
+
+#: scripts/apps/search/views/search-panel.html:2
+msgid "Advanced search panel"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:10
+msgid "Africa/Abidjan"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:11
+msgid "Africa/Accra"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:12
+msgid "Africa/Cairo"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:13
+msgid "Africa/Casablanca"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:14
+msgid "Africa/Dakar"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:15
+msgid "Africa/Johannesburg"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:16
+msgid "Africa/Khartoum"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:17
+msgid "Africa/Kinshasa"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:18
+msgid "Africa/Lagos"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:19
+msgid "Africa/Nairobi"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:20
+msgid "Africa/Tunis"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:38
+msgid "After"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/createPlanningForm.tsx:46
+msgid "Agenda"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:240
+msgid "Agenda assigned to the planning item."
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/agendas.tsx:29
+msgid "Agenda:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:201
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/agendas-field.ts:27
+#: ../superdesk-planning/client/components/fields/editor/Agendas.tsx:42
+#: ../superdesk-planning/client/components/fields/preview/index.ts:50
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.js:77
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.js:77
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.tsx:106
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx:88
+#: ../superdesk-planning/client/utils/contentProfiles.ts:307
+msgid "Agendas"
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/ai-assistant.js:21
+#: scripts/extensions/ai-widget/dist/src/ai-assistant.js:90
+#: scripts/extensions/ai-widget/dist/src/extension.js:40
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/ai-assistant.js:21
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/ai-assistant.js:90
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/extension.js:40
+#: scripts/extensions/ai-widget/src/ai-assistant.tsx:159
+#: scripts/extensions/ai-widget/src/ai-assistant.tsx:66
+#: scripts/extensions/ai-widget/src/extension.ts:44
+msgid "Ai Assistant"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/airing-info-block.js:24
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/airing-info-block.js:24
+#: scripts/extensions/broadcasting/src/rundowns/components/airing-info-block.tsx:63
+msgid "Air date"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/airing-info-block.js:20
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/airing-info-block.js:20
+#: scripts/extensions/broadcasting/src/rundowns/components/airing-info-block.tsx:45
+msgid "Air time"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:89
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:97
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:37
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:89
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:97
+#: scripts/extensions/broadcasting/dist/src/rundowns/manage-rundown-items.js:37
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:191
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:217
+#: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:69
+msgid "Airtime"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:38
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:47
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/applied-filters.js:38
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/filtering-inputs.js:37
+#: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:86
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:84
+msgid "Airtime date from"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:46
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:52
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/applied-filters.js:46
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/filtering-inputs.js:42
+#: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:104
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:99
+msgid "Airtime date to"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:22
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:24
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/applied-filters.js:22
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/filtering-inputs.js:24
+#: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:50
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:43
+msgid "Airtime time from"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:30
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:34
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/applied-filters.js:30
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/filtering-inputs.js:29
+#: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:68
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:60
+msgid "Airtime time to"
+msgstr ""
+
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:18
+msgid "Alert"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/tag-popover.js:16
+#: scripts/extensions/auto-tagging-widget/dist/src/tag-popover.js:16
+#: scripts/extensions/auto-tagging-widget/src/tag-popover.tsx:26
+msgid "Aliases:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:31
+msgid "Align Center"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:32
+msgid "Align Justify"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:33
+msgid "Align Left"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:34
+msgid "Align Right"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:76
+#: scripts/apps/contacts/services/ContactsService.ts:55
+#: scripts/apps/contacts/services/ContactsService.ts:60
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:139
+#: scripts/apps/publish/directives/SubscribersDirective.ts:71
+#: scripts/apps/templates/constants.ts:8
+#: scripts/apps/users/controllers/UserListController.ts:160
+#: scripts/core/ArticlesListByQueryWithFilters.tsx:178
+msgid "All"
+msgstr ""
+
+#: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:32
+msgid "All Calendars"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:303
+msgid "All Coverage has been cancelled"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:25
+msgid "All Coverages Assigned"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:64
+#: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:12
+msgid "All Day"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:136
+msgid "All Day Toggle"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/DesksSubNavDropDown.tsx:21
+msgid "All Desks"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:283
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:368
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:114
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:253
+#: ../superdesk-planning/client/constants/events.ts:175
+msgid "All Events"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:241
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:97
+msgid "All Events & Planning"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:173
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:270
+msgid "All Planning Items"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:180
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:215
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:180
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:215
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:210
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:268
+msgid "All Sets"
+msgstr ""
+
+#: scripts/apps/search/components/fields/authors.tsx:107
+msgid "All authors"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelPlanningCoveragesForm.tsx:139
+msgid "All coverages cancelled:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventDateTime.tsx:134
+msgid "All day"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:122
+msgid "All featured planning items are currently selected"
+msgstr ""
+
+#: scripts/core/menu/notifications/views/notifications.html:12
+msgid "All good so far"
+msgstr "За сада је све у реду"
+
+#: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:72
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:72
+#: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:55
+msgid "All item types"
+msgstr ""
+
+#: scripts/core/itemList/LazyLoader.tsx:226
+msgid "All items have been loaded"
+msgstr ""
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:327
+msgid "All items were published successfully."
+msgstr ""
+
+#: ../superdesk-planning/client/components/WorkqueueContainer/index.tsx:25
+msgid "All open items"
+msgstr ""
+
+#: scripts/apps/authoring/views/opened-articles.html:2
+msgid "All opened items"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:282
+msgid "All planning"
+msgstr ""
+
+#: scripts/apps/users/views/list.html:14
+msgid "All user types"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:267
+msgid "Allow Multiple Items"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:189
+msgid "Allow Remove Ingested Items"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:78
+msgid "Allow adding items that are in progress"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:94
+msgid "Allow adding items that are published"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:68
+msgid "Allow audio"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:362
+msgid "Allow field to be toggled"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:38
+msgid "Allow picture"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/config-main.tsx:122
+msgid "Allow selecting multiple values"
+msgstr ""
+
+#: scripts/extensions/predefinedTextField/dist/src/config.js:80
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:80
+#: scripts/extensions/predefinedTextField/src/config.tsx:152
+msgid "Allow switching to free text input"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:58
+msgid "Allow video"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:258
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:156
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:258
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:156
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:355
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:164
+msgid "Allowed Desks"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:15
+msgid "Alt Text"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.ts:9
+msgid "Alt text"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-metadata.tsx:15
+#: scripts/apps/authoring/media/MediaMetadataView.tsx:30
+#: scripts/apps/authoring/views/item-carousel.html:104
+#: scripts/core/editor3/components/media/MediaBlock.tsx:204
+msgid "Alt text:"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/demo-widget.tsx:27
+msgid "Alter slugline"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:21
+msgid "America/Anchorage"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:22
+msgid "America/Argentina/Buenos Aires"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:23
+msgid "America/Bogota"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:24
+msgid "America/Caracas"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:25
+msgid "America/Chicago"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:26
+msgid "America/Edmonton"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:27
+msgid "America/Guatemala"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:28
+msgid "America/Halifax"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:29
+msgid "America/Havana"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:30
+msgid "America/La Paz"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:31
+msgid "America/Lima"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:32
+msgid "America/Los Angeles"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:33
+msgid "America/Manaus"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:34
+msgid "America/Mexico City"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:35
+msgid "America/Montevideo"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:36
+msgid "America/New York"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:37
+msgid "America/Phoenix"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:38
+msgid "America/Santiago"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:39
+msgid "America/Sao Paulo"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:40
+msgid "America/Tegucigalpa"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:41
+msgid "America/Tijuana"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:42
+msgid "America/Toronto"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:43
+msgid "America/Vancouver"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:44
+msgid "America/Winnipeg"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:395
+msgid "An Item can't have both Embargo and Publish Schedule."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/agenda.ts:47
+msgid "An agenda with this name already exists"
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:84
+msgid "An error occured when testing config."
+msgstr ""
+
+#: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:46
+msgid "An error occured, please try again."
+msgstr ""
+
+#: scripts/apps/publish-preview/previewModal.tsx:66
+msgid "An error occurred while trying to preview the item."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:230
+msgid "An update can not be created"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:52
+msgid "An update can not be created for an item which is not published yet."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:41
+msgid ""
+"An update for this version of the item already exists. To create another "
+"update, find the latest version of the item."
+msgstr ""
+
+#: ../superdesk-analytics/client/index.js:94
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:36
+msgid "Analytics"
+msgstr ""
+
+#: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:121
+#: scripts/core/editor3/components/toolbar/index.tsx:410
+#: scripts/core/editor3/highlightsConfig.ts:19
+msgid "Annotation"
+msgstr ""
+
+#: scripts/core/editor3/components/annotations/AnnotationInput.tsx:265
+msgid "Annotation Body"
+msgstr ""
+
+#: scripts/core/editor3/components/annotations/AnnotationInput.tsx:250
+msgid "Annotation Type"
+msgstr ""
+
+#: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:66
+msgid ""
+"Annotation Types information is not available. Please check your metadata "
+"configuration."
+msgstr ""
+
+#: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:124
+msgid "Annotation type"
+msgstr ""
+
+#: scripts/apps/archive/views/html-preview.html:2
+#: scripts/apps/authoring-react/article-widgets/metadata/AnnotationsPreview.tsx:20
+msgid "Annotations"
+msgstr ""
+
+#: scripts/extensions/annotationsLibrary/dist/src/extension.js:70
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/extension.js:70
+#: scripts/extensions/annotationsLibrary/src/extension.tsx:101
+msgid "Annotations Library"
+msgstr ""
+
+#: scripts/extensions/annotationsLibrary/dist/src/extension.js:59
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/extension.js:59
+#: scripts/extensions/annotationsLibrary/src/extension.tsx:89
+msgid "Annotations library"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/views/desk-stages.html:6
+msgid "Any"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:162
+msgid "Aperture"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:21
+#: scripts/apps/users/views/user-preferences.html:255
+msgid "Appearance"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:244
+msgid "Applied Global Block Filters"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:161
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:75
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:140
+#: scripts/apps/authoring/views/change-image.html:163
+#: scripts/apps/authoring/views/change-image.html:200
+#: scripts/core/helpers/generic-array-list-page-component.tsx:126
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines.js:32
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:73
+#: scripts/extensions/ai-widget/dist/src/headlines/headlines.js:32
+#: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:73
+#: scripts/extensions/ai-widget/src/headlines/headlines.tsx:70
+#: scripts/extensions/ai-widget/src/translations/translations-body.tsx:173
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:240
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:243
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:563
+msgid "Apply"
+msgstr ""
+
+#: scripts/apps/master-desk/components/FilterPanelComponent.tsx:171
+msgid "Apply Filters"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/UploadConfigModal.tsx:80
+msgid "Apply config"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:244
+msgid "Apply the changes to all recurring planning items or just this one?"
+msgstr ""
+
+#: scripts/apps/publish/views/email-config.html:38
+msgid "Apply watermark"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:37
+#: scripts/apps/production-api-keys/config.ts:23
+#: scripts/core/lang/missing-translations-strings.ts:15
+msgid "Archive"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.ts:11
+msgid "Archive description"
+msgstr ""
+
+#: scripts/apps/search/views/item-repo.html:6
+msgid "Archived"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:54
+msgid "Archived Block"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:15
+msgid "Archived Management"
+msgstr ""
+
+#: scripts/apps/archive/views/preview.html:46
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/archived-from.tsx:8
+#: scripts/apps/authoring/views/authoring-topbar.html:35
+msgid "Archived from"
+msgstr ""
+
+#: scripts/apps/search/components/ItemContainer.tsx:14
+msgid "Archived from {{desk}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ConfirmationModal.tsx:162
+msgid "Are you sure ?"
+msgstr ""
+
+#: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:214
+#: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:226
+msgid "Are you sure to remove this subscription?"
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:348
+msgid "Are you sure you want to delete Ingest Source?"
+msgstr ""
+
+#: scripts/apps/search-providers/directive.ts:87
+msgid "Are you sure you want to delete Search Provider?"
+msgstr ""
+
+#: scripts/apps/highlights/controllers/HighlightsConfig.ts:66
+msgid "Are you sure you want to delete configuration?"
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:84
+msgid "Are you sure you want to delete content filter?"
+msgstr ""
+
+#: scripts/apps/workspace/services/WorkspaceService.ts:19
+msgid "Are you sure you want to delete current workspace?"
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:120
+msgid "Are you sure you want to delete filter condition?"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:47
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:61
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:132
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:47
+#: scripts/extensions/broadcasting/dist/src/rundowns/manage-rundown-items.js:61
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:132
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:88
+#: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:118
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:245
+msgid "Are you sure you want to delete it?"
+msgstr ""
+
+#: scripts/apps/products/controllers/ProductsConfigController.ts:201
+msgid "Are you sure you want to delete product?"
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestRulesContent.ts:61
+msgid "Are you sure you want to delete rule set?"
+msgstr ""
+
+#: scripts/apps/search/directives/SavedSearches.ts:112
+msgid "Are you sure you want to delete saved search?"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/store/sets/actions.js:95
+#: scripts/extensions/sams/dist/src/store/sets/actions.js:95
+#: scripts/extensions/sams/src/store/sets/actions.ts:113
+msgid "Are you sure you want to delete the Set \"{{name}}\"?"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/store/assets/actions.js:324
+#: scripts/extensions/sams/dist/src/store/assets/actions.js:324
+#: scripts/extensions/sams/src/store/assets/actions.ts:383
+msgid "Are you sure you want to delete the asset \"{{name}}\"?"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/directives/SavedReportList.js:122
+msgid "Are you sure you want to delete the saved report?"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsList.js:204
+msgid "Are you sure you want to delete the scheduled report?"
+msgstr ""
+
+#: scripts/apps/templates/directives/TemplatesDirective.ts:363
+msgid "Are you sure you want to delete the template?"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/store/assets/actions.js:331
+#: scripts/extensions/sams/dist/src/store/assets/actions.js:331
+#: scripts/extensions/sams/src/store/assets/actions.ts:392
+msgid "Are you sure you want to delete these {{length}} assets"
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestRoutingContent.ts:239
+msgid "Are you sure you want to delete this scheme rule?"
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestRoutingContent.ts:238
+msgid "Are you sure you want to delete this scheme?"
+msgstr ""
+
+#: scripts/apps/users/directives/UserRolesDirective.ts:89
+msgid "Are you sure you want to delete user role?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:1028
+#: ../superdesk-planning/client/actions/events/ui.ts:995
+msgid "Are you sure you want to mark this event as complete?"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:498
+msgid "Are you sure you want to spike the item?"
+msgstr ""
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:188
+msgid "Are you sure you want to spike the items?"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:64
+msgid "Are you sure you want to unpublish item \"{{headline}}\"?"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:53
+msgid "Are you sure you want to unpublish item \"{{label}}\"?"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:96
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:236
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:32
+msgid "Area"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:38
+msgid "Arrow Left"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:39
+msgid "Arrow Right"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:40
+msgid "Arrow Small"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:103
+msgid "Article Defaults"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:215
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:297
+msgid "Article Template"
+msgstr ""
+
+#: scripts/apps/archive/views/preview.html:17
+msgid "Article Type"
+msgstr ""
+
+#: scripts/apps/search/components/TypeIcon.tsx:39
+#: scripts/apps/search/components/TypeIcon.tsx:50
+msgid "Article Type {{type}}"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:107
+msgid "Article Type(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/RelatedArticlesListComponent.tsx:105
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/RelatedArticlesListComponent.tsx:122
+msgid "Article Type: text"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/RelatedArticlesListComponent.tsx:100
+msgid "Article Type: {{articleType}}"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/assignments.ts:504
+#: scripts/apps/authoring/authoring/directives/AuthoringHeaderDirective.ts:70
+#: scripts/apps/search/components/ListTypeIcon.tsx:56
+#: scripts/apps/search/components/TypeIcon.tsx:49
+#: scripts/core/directives/FiletypeIconDirective.ts:39
+msgid "Article Type: {{type}}"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:577
+msgid ""
+"Article cannot be published. Please accept or reject all suggestions first."
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:16
+msgid "Article defaults"
+msgstr ""
+
+#: scripts/apps/authoring-react/packages.tsx:116
+msgid "Article is not linked to any packages"
+msgstr ""
+
+#: scripts/apps/search/components/fields/scheduledDateTime.tsx:23
+msgid "Article is scheduled for {{schedule}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:304
+msgid "Article preview"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/multiSelect.ts:236
+msgid "Article was created."
+msgstr ""
+
+#: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:49
+msgid "Article {{slug}} is already marked for this highlight"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:168
+#: ../superdesk-planning/client/components/OrderBar/OrderDirectionIcon.tsx:16
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:41
+#: scripts/apps/search/views/item-sortbar.html:20
+#: scripts/core/ui/components/SortBar/index.tsx:65
+msgid "Ascending"
+msgstr "Растуће"
+
+#: ../superdesk-analytics/client/charts/views/chart-form-options.html:50
+msgid "Ascending Order"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:45
+msgid "Asia/Almaty"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:46
+msgid "Asia/Baghdad"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:47
+msgid "Asia/Baku"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:48
+msgid "Asia/Bangkok"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:49
+msgid "Asia/Beirut"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:50
+msgid "Asia/Colombo"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:51
+msgid "Asia/Dhaka"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:52
+msgid "Asia/Dili"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:53
+msgid "Asia/Dubai"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:54
+msgid "Asia/Irkutsk"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:55
+msgid "Asia/Jakarta"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:56
+msgid "Asia/Jerusalem"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:57
+msgid "Asia/Kabul"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:58
+msgid "Asia/Karachi"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:59
+msgid "Asia/Kathmandu"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:60
+msgid "Asia/Krasnoyarsk"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:61
+msgid "Asia/Kuala Lumpur"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:62
+msgid "Asia/Manila"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:63
+msgid "Asia/Novosibirsk"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:64
+msgid "Asia/Pyongyang"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:65
+msgid "Asia/Rangoon"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:66
+msgid "Asia/Riyadh"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:67
+msgid "Asia/Seoul"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:68
+msgid "Asia/Singapore"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:69
+msgid "Asia/Tashkent"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:70
+msgid "Asia/Tehran"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:71
+msgid "Asia/Tokyo"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:72
+msgid "Asia/Vladivostok"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:73
+msgid "Asia/Yakutsk"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:74
+msgid "Asia/Yekaterinburg"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:130
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:130
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:130
+msgid "Asset Preview"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/assets.js:438
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:438
+#: scripts/extensions/sams/src/api/assets.ts:554
+msgid "Asset deleted successfully"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/assets.js:460
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:460
+#: scripts/extensions/sams/src/api/assets.ts:577
+msgid "Asset updated successfully"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/notifications/assets.js:30
+#: scripts/extensions/sams/dist/src/notifications/assets.js:30
+#: scripts/extensions/sams/src/notifications/assets.ts:43
+msgid "Asset was deleted by another user."
+msgstr ""
+
+#: scripts/apps/publish/views/http-push-config.html:10
+#: scripts/apps/publish/views/http-push-config.html:9
+msgid "Assets URL"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:216
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:42
+msgid "Assign"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:131
+msgid "Assign \"{{calendar}}\" Calendar to Series"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:134
+msgid "Assign Calendar"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-metadata.tsx:27
+#: scripts/apps/authoring/media/MediaMetadataView.tsx:21
+#: scripts/apps/authoring/views/item-carousel.html:116
+#: scripts/apps/authoring/views/item-carousel.html:47
+#: scripts/apps/authoring/views/item-carousel.html:76
+#: scripts/core/editor3/components/media/MediaBlock.tsx:216
+#: scripts/core/editor3/components/media/MediaBlock.tsx:258
+#: scripts/core/editor3/components/media/MediaBlock.tsx:298
+msgid "Assign rights:"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/planning.ts:143
+msgid "Assign to agenda"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/events.ts:168
+msgid "Assign to calendar"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/State.tsx:29
+#: ../superdesk-planning/client/utils/index.ts:385
+msgid "Assigned"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:205
+#: ../superdesk-planning/client/utils/assignments.ts:205
+msgid "Assigned Provider"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:107
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:124
+msgid "Assigned by {{name}}"
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:27
+msgid "Assigned desks"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:74
+msgid "Assigned to agenda '{{ agenda }}'"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:25
+msgid "Assigned to provider"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:195
+msgid "Assigned to:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:114
+msgid "Assigned:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/index.tsx:225
+msgid "Assigned: {{ name }}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoveragePreview/CoveragePreviewTopBar.tsx:53
+msgid "Assignee"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:254
+#: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:271
+msgid "Assignee:"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:44
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:78
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:83
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:187
+#: ../superdesk-planning/client/planning-extension/src/extension.ts:245
+#: ../superdesk-planning/client/utils/index.ts:585
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:8
+#: scripts/apps/search/views/item-preview.html:24
+msgid "Assignment"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:243
+#: ../superdesk-planning/client/components/fields/editor/AssignmentPriority.tsx:28
+msgid "Assignment Priority"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:192
+msgid "Assignment does not exist"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:50
+msgid "Assignment for"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:144
+msgid "Assignment has been cancelled, unable to reassign"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:145
+msgid "Assignment has been cancelled, unable to remove"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:141
+msgid "Assignment has been completed, unable to reassign"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:142
+msgid "Assignment has been completed, unable to remove"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:147
+msgid "Assignment is locked, unable to reassign"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:148
+msgid "Assignment is locked, unable to remove"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:123
+msgid "Assignment locked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:464
+msgid "Assignment priority has been updated."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:97
+msgid "Assignment removed"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/api.ts:362
+msgid "Assignment reverted."
+msgstr ""
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:78
+#: ../superdesk-planning/client/components/Assignments/SubNavBar.tsx:62
+#: ../superdesk-planning/client/controllers/AssignmentController.tsx:45
+#: ../superdesk-planning/client/index.ts:59
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/assignments-overview/index.js:95
+#: ../superdesk-planning/client/planning-extension/src/assignments-overview/index.tsx:132
+#: ../superdesk-planning/index.ts:21 scripts/apps/master-desk/MasterDesk.tsx:40
+#: scripts/apps/production-api-keys/config.ts:29
+msgid "Assignments"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Assignments/AssignmentsUi.tsx:14
+#: ../superdesk-planning/client/apps/Assignments/FulfilAssignmentUi.tsx:14
+msgid "Assignments Content"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/XMPFile.tsx:53
+msgid "Associate an XMP file"
+msgstr ""
+
+#: scripts/apps/search/components/Associations.tsx:40
+msgid "Associated"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:315
+msgid "Associated Event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/index.tsx:210
+#: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:233
+msgid "Associated Events"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:19
+msgid "Associated Feature Media"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoveragePreview/index.tsx:151
+msgid "Associated XMP File"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:94
+msgid "Associated an event"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:38
+msgid "Associated/featuremedia path"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:66
+msgid "At least 2 languages must be selected"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:198
+msgid "At least one of [{{list}}] is required."
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:146
+msgid ""
+"At least two versions are needed for comparison. This article has only one."
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/selectAssetModal.js:153
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/selectAssetModal.js:153
+#: scripts/extensions/sams/src/components/assets/selectAssetModal.tsx:172
+msgid "Attach Asset(s)"
+msgstr ""
+
+#: scripts/apps/authoring/attachments/AttachmentsWidgetComponent.tsx:112
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:123
+msgid "Attach files"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:212
+#: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:209
+#: ../superdesk-planning/client/components/UI/FileReadOnlyList.tsx:73
+#: ../superdesk-planning/client/components/fields/editor/EventAttachments.tsx:100
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:60
+msgid "Attached Files"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoveragePreview/index.tsx:165
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:104
+msgid "Attached files"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:43
+#: scripts/core/editor3/components/links/LinkInput.tsx:72
+msgid "Attachment"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:44
+msgid "Attachment Large"
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/planning-attachments/index.tsx:24
+#: scripts/apps/authoring-react/field-adapters/attachments.ts:16
+#: scripts/apps/authoring-react/fields/attachments/index.tsx:22
+#: scripts/apps/authoring/attachments/attachments.ts:11
+#: scripts/apps/authoring/views/article-edit.html:729
+#: scripts/apps/workspace/content/constants.ts:12
+msgid "Attachments"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/attachments/index.tsx:41
+msgid "Attachments (authoring-react)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:45
+#: ../superdesk-planning/client/utils/index.ts:597
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:239
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:241
+#: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:60
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:113
+#: scripts/extensions/sams/dist/src/utils/assets.js:113
+#: scripts/extensions/sams/src/utils/assets.ts:146
+msgid "Audio"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:75
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:75
+#: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:58
+msgid "Audio only"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:75
+msgid "Australia/Adelaide"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:76
+msgid "Australia/Melbourne"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:77
+msgid "Australia/Perth"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:78
+msgid "Australia/Sydney"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:269
+msgid "Authentication Token"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:646
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:120
+#: scripts/apps/archive/views/preview.html:50
+#: scripts/apps/users/views/edit-form.html:170
+#: scripts/apps/users/views/edit-form.html:66
+msgid "Author"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:20
+#: scripts/apps/users/views/edit-form.html:249
+msgid "Author info"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:61
+msgid "Author roles controlled vocabullary is missing."
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/version-header.tsx:43
+msgid "Author:"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:205
+#: scripts/apps/authoring/compare-versions/index.ts:27
+#: scripts/apps/authoring/multiedit/multiedit.ts:465
+#: scripts/apps/authoring/views/authoring.html:2
+msgid "Authoring"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:106
+msgid ""
+"Authoring desks are for content creation, and items within it are protected "
+"from accidental publication. Publishing is only permitted  from production "
+"desks."
+msgstr ""
+
+#: scripts/apps/authoring-react/field-adapters/authors.tsx:80
+#: scripts/apps/search/components/fields/authors.tsx:113
+#: scripts/apps/workspace/content/constants.ts:13
+msgid "Authors"
+msgstr ""
+
+#: scripts/apps/users/views/list.html:15
+msgid "Authors only"
+msgstr ""
+
+#: scripts/apps/templates/views/templates.html:61
+msgid "Automated item creation"
+msgstr ""
+
+#: scripts/apps/templates/views/template-editor-modal.html:144
+msgid "Automatically create item"
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:39
+msgid "Automatically insert items from"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extension.js:36
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/extension.js:37
+#: scripts/extensions/availability-manager/src/extension.ts:55
+msgid "Availability"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extension.js:49
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/extension.js:51
+#: scripts/extensions/availability-manager/src/extension.ts:73
+msgid "Availability Management"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extension.js:17
+#: scripts/extensions/availability-manager/dist/src/extension.js:20
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/extension.js:17
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/extension.js:20
+#: scripts/extensions/availability-manager/src/extension.ts:19
+#: scripts/extensions/availability-manager/src/extension.ts:28
+msgid ""
+"Availability manager extension could not start because vocabulary \"{{id}}\" "
+"is missing"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/availability-settings.js:189
+#: scripts/extensions/availability-manager/dist/src/settings/availability-settings.js:189
+#: scripts/extensions/availability-manager/src/settings/availability-settings.tsx:326
+msgid "Availability schedule"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:54
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:74
+#: scripts/extensions/availability-manager/dist/src/utils.js:54
+#: scripts/extensions/availability-manager/dist/src/utils.js:74
+#: scripts/extensions/availability-manager/src/utils.ts:57
+#: scripts/extensions/availability-manager/src/utils.ts:77
+msgid "Available"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:70
+#: scripts/extensions/availability-manager/dist/src/utils.js:70
+#: scripts/extensions/availability-manager/src/utils.ts:73
+msgid "Available all day"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/configuration.html:28
+msgid "Available clocks"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:209
+msgid "Available in user/desk preferences"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/translate-modal.tsx:108
+msgid "Available languages"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningList.tsx:92
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:167
+msgid "Available selections"
+msgstr ""
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:279
+#: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:30
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:24
+msgid "Average"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:33
+#: scripts/apps/dashboard/views/workspace.html:89
+#: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:70
+#: scripts/apps/search/views/saved-search-manage-subscribers.html:128
+#: scripts/core/itemList/views/relatedItem-list-widget.html:66
+#: scripts/core/ui/components/content-create-dropdown/more-templates.tsx:43
+msgid "Back"
+msgstr "Назад"
+
+#: scripts/apps/search/views/search-panel.html:5
+msgid "Back / Cancel"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/SubNavBar.tsx:51
+msgid "Back to group list view"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:10
+msgid "Back to original view"
+msgstr ""
+
+#: scripts/extensions/annotationsLibrary/dist/src/AnnotationSelectSingleItem.js:13
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.js:13
+#: scripts/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.tsx:30
+msgid "Back to results"
+msgstr ""
+
+#: scripts/apps/users/views/edit.html:3
+msgid "Back to users list"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:46
+msgid "Backward Thin"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:47
+msgid "Ban Circle"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:87
+msgid "Bar"
+msgstr ""
+
+#: scripts/apps/authoring/comments/views/comments-widget.html:24
+msgid "Be the first one..."
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:178
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:181
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:361
+msgid "Before airtime"
+msgstr ""
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:7
+msgid ""
+"Before you start using your new newsroom, please tell us a little about "
+"yourself:"
+msgstr ""
+
+#: scripts/apps/search/components/fields/state.tsx:41
+msgid "Being Corrected"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:48
+msgid "Bell"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:39
+msgid "Better"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:286
+msgid "Biography"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:46
+msgid "Black"
+msgstr ""
+
+#: scripts/apps/search/views/search-parameters.html:258
+msgid "Black&White"
+msgstr ""
+
+#: scripts/apps/authoring/packages/views/packages-widget.html:15
+#: scripts/apps/packaging/views/sd-package-item-preview.html:20
+msgid "Blank headline received"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:58
+msgid "Block API"
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:71
+msgid "Blocking"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:56
+msgid "Blue"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:57
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:166
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-panel.tsx:196
+#: scripts/apps/authoring/views/theme-select.html:105
+#: scripts/apps/authoring/views/theme-select.html:54
+msgid "Body"
+msgstr ""
+
+#: scripts/apps/authoring-react/field-adapters/body_html.ts:22
+#: scripts/apps/workspace/content/constants.ts:15
+#: scripts/core/lang/missing-translations-strings.ts:31
+msgid "Body HTML"
+msgstr ""
+
+#: scripts/apps/authoring-react/field-adapters/body_footer.ts:37
+#: scripts/apps/workspace/content/constants.ts:14
+msgid "Body footer"
+msgstr ""
+
+#: scripts/apps/authoring-react/field-adapters/body_footer.ts:36
+msgid "Body footer / Helplines / Contact Information"
+msgstr ""
+
+#: scripts/apps/authoring/views/theme-select.html:107
+#: scripts/apps/authoring/views/theme-select.html:56
+msgid "Body text example"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:49
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:32
+msgid "Bold"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:75
+msgid "Bold (Ctrl+B)"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/boolean/index.ts:23
+msgid "Boolean"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/eventsplanning.ts:23
+#: ../superdesk-planning/client/utils/eventsplanning.ts:26
+#: scripts/apps/publish/directives/SubscribersDirective.ts:66
+#: scripts/apps/publish/views/subscribers.html:149
+msgid "Both"
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:200
+msgid ""
+"Both start and end date need to be filled in (or cleared) to save the "
+"subscriber."
+msgstr ""
+
+#: scripts/apps/authoring/views/change-image.html:242
+msgid "Brightness"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:50
+#: scripts/core/lang/missing-translations-strings.ts:15
+msgid "Broadcast"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:51
+msgid "Broadcast Create"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extension.js:19
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/extension.js:19
+#: scripts/extensions/broadcasting/src/extension.ts:20
+msgid "Broadcasting"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:38
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:40
+msgid "Browse"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:546
+msgid "Building, Suite, Unit, Apartment, Floor, etc."
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:52
+msgid "Business"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:31
+msgid "By"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:143
+msgid ""
+"By selecting the categories you are interested in, the system will only "
+"display these in a menu for setting the content item's categories (along "
+"with any of its existing categories)."
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:185
+msgid ""
+"By selecting the desks as your preferred desks, they appear first in the "
+"order when sending or publishing items."
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:362
+#: scripts/apps/authoring-react/field-adapters/byline.ts:20
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:155
+#: scripts/apps/master-desk/components/FilterPanelComponent.tsx:156
+#: scripts/apps/search/views/search-parameters.html:48
+#: scripts/apps/users/views/edit-form.html:268
+#: scripts/apps/workspace/content/constants.ts:16
+msgid "Byline"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:244
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:244
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:314
+msgid "Bytes"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/correct-action.tsx:11
+#: scripts/apps/authoring/views/authoring-topbar.html:131
+msgid "C"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/close-and-continue.tsx:26
+#: scripts/apps/authoring/views/authoring-topbar.html:68
+msgid "C & C"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/cancel-authoring.tsx:12
+msgid "CANCEL"
+msgstr ""
+
+#: scripts/apps/publish/views/email-config.html:20
+msgid "CID"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/planning.ts:232
+msgid "COVERAGE SCHEDULE is required"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/planning.ts:256
+msgid "COVERAGE SCHEDULED DATE cannot be in the past"
+msgstr ""
+
+#: scripts/apps/workspace/views/workspace-dropdown.html:32
+msgid "CREATE NEW WORKSPACE"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/views/chart.html:26
+msgid "CSV File"
+msgstr ""
+
+#: scripts/apps/workspace/views/workspace-dropdown.html:20
+msgid "CUSTOM WORKSPACES"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:53
+msgid "Calendar"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:54
+msgid "Calendar List"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:922
+msgid "Calendar assigned to the event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/calendars.tsx:52
+msgid "Calendar:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:37
+msgid "Calendar: {{activeCalendarName}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:143
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/calendars.ts:36
+#: ../superdesk-planning/client/components/fields/preview/index.ts:58
+#: ../superdesk-planning/client/components/fields/resources/events.ts:133
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.js:76
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.js:82
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.tsx:94
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx:96
+#: ../superdesk-planning/client/utils/contentProfiles.ts:277
+msgid "Calendars"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:89
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:89
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:117
+msgid "Camera"
+msgstr ""
+
+#: scripts/core/itemList/views/relatedItem-list-widget.html:20
+msgid "Can be associated as a take"
+msgstr ""
+
+#: scripts/core/itemList/views/relatedItem-list-widget.html:19
+msgid "Can be associated as an update"
+msgstr ""
+
+#: scripts/apps/workspace/content/views/profile-settings.html:172
+msgid "Can be embedded"
+msgstr ""
+
+#: scripts/core/editor3/components/article-embed/can-add-article-embed.ts:35
+msgid "Can not embed to item which itself can be embedded."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:48
+msgid "Can not update a broadcast version of the story."
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:112
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:58
+#: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:31
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:205
+#: ../superdesk-planning/client/api/coverages.ts:35
+#: ../superdesk-planning/client/api/coverages.ts:56
+#: ../superdesk-planning/client/components/Assignments/EditCoverageAssignmentModal.tsx:101
+#: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:106
+#: ../superdesk-planning/client/components/ConfirmationModal.tsx:118
+#: ../superdesk-planning/client/components/Contacts/ActionBar.tsx:14
+#: ../superdesk-planning/client/components/Contacts/ContactEditor.tsx:93
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:156
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:69
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:402
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:191
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:148
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:260
+#: ../superdesk-planning/client/components/FulFilAssignmentModal/index.tsx:97
+#: ../superdesk-planning/client/components/GeoLookupInput/CreateNewGeoLookup.tsx:175
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:173
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:184
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:197
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:361
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:52
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DateInputPopup.tsx:270
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:199
+#: ../superdesk-planning/client/components/UI/SubNav/SlidingToolBar.tsx:44
+#: ../superdesk-planning/client/components/UI/SubNav/SlidingToolBar.tsx:49
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:130
+#: ../superdesk-planning/client/constants/events.ts:159
+#: ../superdesk-planning/client/utils/confirmAddingRelatedItems.tsx:54
+#: scripts/api/article-fetch.tsx:94 scripts/api/article-send.tsx:86
+#: scripts/apps/archive/show-spike-dialog.tsx:56
+#: scripts/apps/archive/views/archived-kill.html:16
+#: scripts/apps/archive/views/export.html:33
+#: scripts/apps/archive/views/resend-configuration.html:28
+#: scripts/apps/authoring-react/authoring-swtich.tsx:22
+#: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:152
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:33
+#: scripts/apps/authoring-react/toolbar/export-modal.tsx:118
+#: scripts/apps/authoring-react/toolbar/highlights-modal.tsx:96
+#: scripts/apps/authoring-react/toolbar/mark-for-desks/mark-for-desks-modal.tsx:68
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:60
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:157
+#: scripts/apps/authoring-react/toolbar/translate-modal.tsx:130
+#: scripts/apps/authoring/attachments/AttachmentsEditorModal.tsx:46
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:130
+#: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:129
+#: scripts/apps/authoring/authoring/components/publish-warning-confirm-modal.tsx:30
+#: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:46
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:594
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:49
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:61
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:73
+#: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:30
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:22
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-dropdown.html:15
+#: scripts/apps/authoring/views/authoring-topbar.html:235
+#: scripts/apps/authoring/views/change-image.html:162
+#: scripts/apps/authoring/views/change-image.html:193
+#: scripts/apps/authoring/views/change-image.html:199
+#: scripts/apps/authoring/views/change-image.html:80
+#: scripts/apps/authoring/views/confirm-media-associated.html:19
+#: scripts/apps/authoring/views/theme-select.html:118
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:258
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:104
+#: scripts/apps/content-filters/views/manage-filters.html:155
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:12
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:87
+#: scripts/apps/desks/views/desk-config-modal.html:272
+#: scripts/apps/desks/views/desk-config-modal.html:281
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:132
+#: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:96
+#: scripts/apps/highlights/views/highlights_config_modal.html:54
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:26
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:74
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:126
+#: scripts/apps/ingest/views/settings/ingest-routing-filter.html:32
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:70
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:260
+#: scripts/apps/monitoring/views/aggregate-settings.html:156
+#: scripts/apps/products/views/products-config-modal.html:93
+#: scripts/apps/publish-preview/previewModal.tsx:89
+#: scripts/apps/publish/views/publish-queue.html:144
+#: scripts/apps/publish/views/publish-queue.html:91
+#: scripts/apps/publish/views/subscribers.html:330
+#: scripts/apps/search-providers/views/search-provider-config.html:125
+#: scripts/apps/search/views/item-globalsearch.html:20
+#: scripts/apps/search/views/multi-image-edit.html:15
+#: scripts/apps/search/views/save-search.html:30
+#: scripts/apps/search/views/saved-search-subscribe.html:31
+#: scripts/apps/templates/views/create-template.html:50
+#: scripts/apps/templates/views/template-editor-modal.html:222
+#: scripts/apps/users/views/edit-form.html:400
+#: scripts/apps/users/views/edit-form.html:5
+#: scripts/apps/users/views/settings-roles.html:87
+#: scripts/apps/users/views/user-preferences.html:5
+#: scripts/apps/users/views/user-privileges.html:6
+#: scripts/apps/vocabularies/components/UploadConfigModal.tsx:75
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:92
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:322
+#: scripts/apps/workspace/content/views/profile-settings.html:130
+#: scripts/apps/workspace/content/views/profile-settings.html:188
+#: scripts/apps/workspace/views/edit-workspace-modal.html:38
+#: scripts/core/ArticlesListByQueryWithFilters.tsx:310
+#: scripts/core/activity/views/activity-chooser.html:9
+#: scripts/core/editor3/components/annotations/AnnotationInput.tsx:284
+#: scripts/core/editor3/components/comments/CommentInput.tsx:94
+#: scripts/core/editor3/components/comments/CommentPopup.tsx:221
+#: scripts/core/editor3/components/links/LinkInput.tsx:218
+#: scripts/core/editor3/components/links/LinkInput.tsx:244
+#: scripts/core/prompt-modal.tsx:35 scripts/core/services/modalService.tsx:152
+#: scripts/core/ui/components/Form/DateInput/DateInputPopup.tsx:252
+#: scripts/core/ui/components/Form/TimeInput/TimeInputPopup.tsx:147
+#: scripts/core/ui/components/IgnoreCancelSaveDialog.tsx:64
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:266
+#: scripts/core/ui/components/Modal/ModalPrompt.tsx:50
+#: scripts/core/ui/components/SubNav/SlidingToolBar.tsx:21
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:47
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:83
+#: scripts/core/ui/show-confirmation-prompt.tsx:28
+#: scripts/core/ui/views/datepicker-wrapper.html:9
+#: scripts/core/ui/views/sd-timepicker-popup.html:27
+#: scripts/extensions/annotationsLibrary/dist/src/AnnotationsSelect.js:18
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/AnnotationsSelect.js:18
+#: scripts/extensions/annotationsLibrary/src/AnnotationsSelect.tsx:38
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:260
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:260
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:72
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:72
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:415
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:179
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-workday-modal.js:107
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/manage-schedule.js:129
+#: scripts/extensions/availability-manager/dist/src/settings/edit-workday-modal.js:107
+#: scripts/extensions/availability-manager/dist/src/settings/manage-schedule.js:129
+#: scripts/extensions/availability-manager/src/settings/edit-workday-modal.tsx:165
+#: scripts/extensions/availability-manager/src/settings/manage-schedule.tsx:204
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:150
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:36
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:15
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-modal.js:52
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:150
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:36
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:15
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-modal.js:52
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:280
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:64
+#: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:34
+#: scripts/extensions/broadcasting/src/shows/create-show-modal.tsx:101
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:20
+#: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:20
+#: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:67
+#: scripts/extensions/sams/dist/src/components/assets/assetEditorPanel.js:145
+#: scripts/extensions/sams/dist/src/components/assets/selectAssetModal.js:152
+#: scripts/extensions/sams/dist/src/components/attachments/editAttachmentModal.js:131
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:220
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditorPanel.js:145
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/selectAssetModal.js:152
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/editAttachmentModal.js:131
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:220
+#: scripts/extensions/sams/src/components/assets/assetEditorPanel.tsx:125
+#: scripts/extensions/sams/src/components/assets/selectAssetModal.tsx:167
+#: scripts/extensions/sams/src/components/attachments/editAttachmentModal.tsx:125
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:237
+#: scripts/extensions/videoEditor/dist/src/VideoEditorHeader.js:10
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorHeader.js:10
+#: scripts/extensions/videoEditor/src/VideoEditorHeader.tsx:22
+msgid "Cancel"
+msgstr "Откажи"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:86
+msgid "Cancel Event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:150
+#: ../superdesk-planning/client/constants/planning.ts:138
+msgid "Cancel Planning"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:127
+msgid "Cancel Scheduled Update"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:83
+msgid "Cancel Selection"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/planning.ts:139
+msgid "Cancel all Coverage(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:152
+msgid "Cancel all recurring events or just this one?"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:326
+msgid "Cancel correction"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/index.tsx:264
+#: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:51
+msgid "Cancel coverage"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:53
+msgid "Cancel planning items with Event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:84
+msgid "Cancel {{event}}"
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:110
+msgid "Canceling failed"
+msgstr "Отказивање није успело"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/State.tsx:50
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:31
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:204
+#: ../superdesk-planning/client/utils/index.ts:374
+#: ../superdesk-planning/client/utils/index.ts:422
+msgid "Cancelled"
+msgstr ""
+
+#: scripts/apps/relations/directives/RelatedItemsDirective.ts:149
+msgid "Cannot add self as related item."
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:32
+msgid ""
+"Cannot change workflow status if the coverage is part of an expired planning "
+"item"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:35
+msgid "Cannot delete vocabulary"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:289
+msgid "Cannot end with \".\""
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:905
+msgid "Cannot load more data as filter type is not selected."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:926
+msgid "Cannot load more data. Failed to run the query."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:947
+msgid "Cannot search as filter type is not selected."
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:7
+#: scripts/core/editor3/components/media/MediaBlock.tsx:317
+msgid "Caption"
+msgstr ""
+
+#: scripts/apps/authoring/editor/views/find-replace.html:18
+msgid "Case Sensitive"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:96
+msgid "Case sensitive"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:121
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:431
+#: scripts/apps/monitoring/directives/utils.ts:32
+#: scripts/apps/users/views/user-preferences.html:17
+#: scripts/apps/workspace/content/constants.ts:17
+msgid "Categories"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:521
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:99
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:316
+#: scripts/apps/content-api/services/ContentAPISearchService.ts:33
+#: scripts/apps/legal-archive/services/LegalArchiveService.ts:27
+#: scripts/apps/legal-archive/tests/legal.spec.ts:69
+#: scripts/apps/search/directives/SearchFilters.ts:44
+msgid "Category"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:180
+msgid "Change Image"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:177
+#: ../superdesk-analytics/client/utils.js:178
+msgid "Change POI"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:235
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:235
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:323
+msgid "Change Set filter"
+msgstr ""
+
+#: scripts/apps/users/config.ts:122 scripts/apps/users/views/edit-form.html:52
+msgid "Change avatar"
+msgstr ""
+
+#: scripts/apps/authoring/views/change-image.html:203
+msgid "Change image settings"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:86
+msgid "Change password"
+msgstr "Промени лозинку"
+
+#: scripts/apps/users/views/user-preferences.html:258
+msgid "Change the appearance of Superdesk across the whole application."
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/views/table.html:23
+msgid "Change the search filters and try again!"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:167
+msgid "Change view"
+msgstr ""
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/controllers/FeaturemediaUpdatesReportController.js:143
+#: ../superdesk-analytics/client/featuremedia_updates_report/directives/FeaturemediaUpdatesReportPreview.js:21
+msgid "Changes to Featuremedia"
+msgstr ""
+
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:181
+msgid "Changes will be lost, if they are not saved."
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorTools.js:32
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorTools.js:32
+#: scripts/extensions/videoEditor/src/VideoEditorTools.tsx:76
+msgid "Changing quality is only supported for 480p and higher quality videos."
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:38
+msgid "Channel has gone strangely quiet."
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:205
+msgid "Character limit exceeded, desk can not be created/updated."
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:49
+msgid "Character limit exceeded, dictionary can not be created/updated."
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:14
+msgid "Character limit exceeded, highlight can not be created/updated."
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:290
+msgid "Character limit exceeded, stage can not be created/updated."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:124
+msgid "Character limit settings"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/editor3/editor.tsx:384
+msgid "Character {{chars}} is not allowed"
+msgid_plural "The following characters are not allowed {{chars}}"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/apps/authoring/authoring/ValidateCharacters.tsx:23
+msgid "Character {{chars}} not allowed in the {{field}}."
+msgid_plural "Characters {{chars}} not allowed in the {{field}}."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:55
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:55
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-panel.html:55
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-panel.html:48
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-panel.html:55
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-panel.html:55
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-panel.html:55
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-panel.html:55
+msgid "Chart"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:23
+msgid "Chart Colours"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/views/chart-form-options.html:26
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:24
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-preview.html:13
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-preview.html:20
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:24
+msgid "Chart Type"
+msgstr ""
+
+#: scripts/core/views/sdselect.html:13
+msgid "Check all"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/register-fields.ts:30
+#: scripts/apps/authoring/views/authoring-topbar.html:379
+#: scripts/apps/authoring/views/authoring-topbar.html:388
+msgid "Check spelling"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:55
+msgid "Chevron Down Thin"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:56
+msgid "Chevron Left Thin"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:57
+msgid "Chevron Right Thin"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:58
+msgid "Chevron Up Thin"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:36
+msgid "Choose entire category"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:92
+msgid ""
+"Choose existing labels or create new\n"
+"                                    ones by typing. The labels are only used "
+"to organize the controlled vocabularies\n"
+"                                    in the list. The CVs are grouped under "
+"each label. You can choose only one\n"
+"                                    label."
+msgstr ""
+
+#: scripts/apps/highlights/views/package_highlights_dropdown_directive.html:20
+msgid "Choose highlight list"
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:40
+#: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:40
+#: scripts/extensions/ai-widget/src/translations/translations-body.tsx:87
+msgid "Choose the language and click the translate button at the bottom"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:75
+#: scripts/apps/contacts/views/search-panel.html:61
+msgid "City"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:252
+#: ../superdesk-planning/client/components/Locations/LocationsList.tsx:118
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:48
+msgid "City/Town"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:274
+msgid "Clean Pasted HTML"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:67
+msgid "Clean pasted HTML"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentFilterPanel.tsx:126
+#: ../superdesk-planning/client/components/Main/SearchPanel.tsx:135
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:181
+#: scripts/apps/authoring/comments/views/comments-widget.html:57
+#: scripts/apps/dashboard/world-clock/configuration.html:39
+#: scripts/apps/legal-archive/views/legal_archive.html:95
+#: scripts/core/ui/components/MultiSelect.tsx:31
+#: scripts/core/ui/views/sd-timezone.html:26
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:215
+#: scripts/extensions/broadcasting/dist/src/page.js:219
+#: scripts/extensions/broadcasting/src/page.tsx:337
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:260
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:260
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:374
+msgid "Clear"
+msgstr "Очисти"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:59
+msgid "Clear All"
+msgstr ""
+
+#: scripts/apps/search/views/search-parameters.html:261
+msgid "Clear Edge"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:577
+msgid "Clear Embed"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:123
+#: ../superdesk-planning/client/components/Main/SubNavBar.tsx:32
+#: scripts/apps/master-desk/components/FilterPanelComponent.tsx:178
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:807
+msgid "Clear Filters"
+msgstr "Очисти филтере"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:60
+msgid "Clear Format"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/SearchBox.tsx:118
+msgid "Clear Search"
+msgstr ""
+
+#: scripts/apps/master-desk/components/FilterBarComponent.tsx:34
+msgid "Clear all filters"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:155
+msgid "Clear all selected"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/DateTimeInput/index.tsx:155
+#: scripts/core/ui/components/Form/DateTimeInput/index.tsx:85
+msgid "Clear date and time"
+msgstr "Очисти датум и време"
+
+#: scripts/apps/authoring-react/fields/embed/editor.tsx:78
+msgid "Clear embed"
+msgstr ""
+
+#: scripts/apps/contacts/views/search-panel.html:86
+#: scripts/apps/content-api/views/search-panel.html:22
+#: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:108
+#: scripts/apps/search/views/save-search.html:9
+msgid "Clear filters"
+msgstr ""
+
+#: scripts/apps/authoring/media/views/media-copy-metadata-directive.html:5
+msgid "Clear saved metadata"
+msgstr ""
+
+#: scripts/apps/content-filters/views/filter-search.html:43
+#: scripts/apps/monitoring/views/monitoring-view.html:86
+#: scripts/apps/publish/views/publish-queue.html:9
+#: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:356
+#: scripts/core/list/views/searchbar.html:5
+msgid "Clear search"
+msgstr ""
+
+#: scripts/apps/users/config.ts:93
+msgid "Clear sessions"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:365
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:365
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:646
+msgid "Click \"Run\" to generate"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:106
+msgid "Click on a Scheme rules on the left to view details."
+msgstr ""
+
+#: scripts/apps/dashboard/views/workspace.html:60
+msgid "Click on the \"+\" button in the top right corner to add some widgets."
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:160
+msgid "Click the Plus button to add languages"
+msgstr ""
+
+#: scripts/apps/users/views/change-avatar.html:38
+msgid ""
+"Click to capture using camera. Be sure that you allow camera accessibility."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/video-thumbnail-editor.tsx:108
+msgid "Click to replace thumbnail"
+msgstr ""
+
+#: scripts/apps/production-api-keys/config.ts:54
+msgid "Client ID"
+msgstr ""
+
+#: scripts/apps/production-api-keys/config.ts:59
+msgid "Client Secret"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/configuration.html:5
+msgid "Clock type"
+msgstr ""
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:104
+#: ../superdesk-planning/client/components/Agendas/ManageAgendasModal.tsx:72
+#: ../superdesk-planning/client/components/Assignments/AssignmentFilterPanel.tsx:100
+#: ../superdesk-planning/client/components/Assignments/EditCoverageAssignmentModal.tsx:83
+#: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:63
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:380
+#: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:218
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:271
+#: ../superdesk-planning/client/components/Events/ManageEventTemplatesModal.tsx:101
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:206
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:46
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:101
+#: ../superdesk-planning/client/components/FulFilAssignmentModal/index.tsx:78
+#: ../superdesk-planning/client/components/GeoLookupInput/CreateNewGeoLookup.tsx:133
+#: ../superdesk-planning/client/components/ItemActionsMenu/ActionsMenuPopup.tsx:59
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:196
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:339
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:361
+#: ../superdesk-planning/client/components/Main/ItemEditorModal/EditorModalPanel.tsx:175
+#: ../superdesk-planning/client/components/Main/SearchPanel.tsx:109
+#: ../superdesk-planning/client/components/ModalWithForm/index.tsx:108
+#: ../superdesk-planning/client/components/ModalWithForm/index.tsx:129
+#: ../superdesk-planning/client/components/NotificationModal.tsx:45
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:140
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:210
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModalSubnav.tsx:46
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:67
+#: ../superdesk-planning/client/components/SelectItemModal.tsx:30
+#: ../superdesk-planning/client/components/WorkqueueContainer/WorkqueueItem.tsx:49
+#: ../superdesk-planning/client/components/fields/with-more-items.tsx:65
+#: ../superdesk-planning/client/constants/tooltips.ts:25
+#: scripts/apps/authoring-react/preview-article-modal.tsx:34
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/close-button.tsx:12
+#: scripts/apps/authoring-react/toolbar/highlights-management.tsx:79
+#: scripts/apps/authoring-react/toolbar/multi-edit-toolbar-action.tsx:73
+#: scripts/apps/authoring/preview/fullPreviewMultiple.tsx:67
+#: scripts/apps/authoring/views/authoring-topbar.html:174
+#: scripts/apps/authoring/views/authoring-topbar.html:175
+#: scripts/apps/authoring/views/authoring-topbar.html:179
+#: scripts/apps/authoring/views/dashboard-articles.html:4
+#: scripts/apps/authoring/views/preview-formatted.html:29
+#: scripts/apps/content-filters/views/production-test.html:10
+#: scripts/apps/ingest/directives/authenticate-ingest-provider.tsx:24
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:235
+#: scripts/apps/search-providers/directive.ts:117
+#: scripts/apps/search/components/actions-menu/Label.tsx:24
+#: scripts/apps/search/views/multi-image-edit.html:5
+#: scripts/apps/workspace/views/edit-workspace-modal.html:5
+#: scripts/core/interactive-article-actions-panel/index-ui.tsx:72
+#: scripts/core/menu/views/about.html:37 scripts/core/menu/views/about.html:5
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/working-day-view.js:27
+#: scripts/extensions/availability-manager/dist/src/settings/working-day-view.js:27
+#: scripts/extensions/availability-manager/src/settings/working-day-view.tsx:59
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:229
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:237
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:348
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:232
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:237
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:348
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:544
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:354
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:600
+#: scripts/extensions/sams/dist/src/components/sets/manageSetsModal.js:105
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:116
+#: scripts/extensions/sams/dist/src/containers/FileUploadModal.js:231
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/manageSetsModal.js:105
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:116
+#: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:231
+#: scripts/extensions/sams/src/components/sets/manageSetsModal.tsx:127
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:107
+#: scripts/extensions/sams/src/containers/FileUploadModal.tsx:283
+msgid "Close"
+msgstr "Затвори"
+
+#: scripts/apps/authoring/views/authoring-topbar.html:67
+msgid "Close & Continue"
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines-widget.js:48
+#: scripts/extensions/ai-widget/dist/src/headlines/headlines-widget.js:48
+#: scripts/extensions/ai-widget/src/headlines/headlines-widget.tsx:71
+msgid "Close Headlines"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:61
+msgid "Close Small"
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary-widget.js:47
+#: scripts/extensions/ai-widget/dist/src/summary/summary-widget.js:47
+#: scripts/extensions/ai-widget/src/summary/summary-widget.tsx:67
+msgid "Close Summary"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:62
+msgid "Close Thick"
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-widget.js:43
+#: scripts/extensions/ai-widget/dist/src/translations/translations-widget.js:43
+#: scripts/extensions/ai-widget/src/translations/translations-widget.tsx:80
+msgid "Close Translate"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:65
+#: scripts/apps/authoring/views/authoring-topbar.html:66
+msgid "Close and Continue"
+msgstr ""
+
+#: scripts/apps/production-api-keys/utils.tsx:27
+msgid "Close anyway"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:469
+msgid "Close current item"
+msgstr ""
+
+#: scripts/apps/dashboard/closed-desk/index.ts:159
+msgid "Close desk widget"
+msgstr ""
+
+#: scripts/apps/authoring/views/change-image.html:155
+msgid "Close details"
+msgstr ""
+
+#: scripts/apps/contacts/views/search-panel.html:4
+#: scripts/apps/content-api/views/search-panel.html:11
+#: scripts/apps/legal-archive/views/legal_archive.html:44
+#: scripts/apps/search/views/search-panel.html:22
+msgid "Close panel"
+msgstr ""
+
+#: scripts/apps/search/views/item-preview.html:27
+msgid "Close preview"
+msgstr ""
+
+#: scripts/apps/production-api-keys/utils.tsx:17
+msgid "Close this panel?"
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:140
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:9
+#: scripts/apps/search-providers/views/search-provider-config.html:14
+msgid "Closed"
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:242
+msgid "Closing failed"
+msgstr "Затварање није успело"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:63
+msgid "Code"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/CollapseBox.tsx:175
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:64
+#: scripts/core/editor3/components/Editor3Component.tsx:901
+msgid "Collapse"
+msgstr ""
+
+#: scripts/apps/authoring-react/multi-edit-modal.tsx:158
+msgid "Collapse widgets"
+msgstr ""
+
+#: scripts/apps/vocabularies/services/SchemaFactory.ts:8
+msgid "Color"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:90
+msgid "Column"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:196
+msgid "Columns:"
+msgstr ""
+
+#: scripts/apps/packaging/index.ts:93
+msgid "Combine with current"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:42
+#: ../superdesk-planning/client/components/fields/editor/ItemType.tsx:18
+msgid "Combined"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:158
+msgid "Comma separated values"
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:55
+msgid "Comma separated values."
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:65
+#: scripts/core/editor3/components/comments/Comment.tsx:90
+#: scripts/core/editor3/components/toolbar/index.tsx:398
+#: scripts/core/editor3/highlightsConfig.ts:12
+msgid "Comment"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/comments/index.tsx:9
+#: scripts/apps/authoring-react/generic-widgets/comments/CommentsWidget.tsx:25
+#: scripts/apps/authoring-react/generic-widgets/comments/index.tsx:38
+#: scripts/apps/authoring/comments/comments.ts:146
+msgid "Comments"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/index.tsx:223
+msgid "Common"
+msgstr ""
+
+#: scripts/apps/monitoring/directives/utils.ts:95
+#: scripts/apps/search/views/search.html:22
+#: scripts/apps/search/views/search.html:23
+msgid "Compact View"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:102
+msgid "Compact list"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:16
+#: scripts/apps/workspace/content/constants.ts:18
+msgid "Company Codes"
+msgstr ""
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:29
+msgid "Company/Organisation"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:185
+msgid "Compare"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/compare-versions.html:2
+msgid "Compare Versions"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/compare-article-versions.tsx:129
+msgid "Compare article versions"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:148
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:132
+#: scripts/apps/authoring/views/authoring-topbar.html:286
+msgid "Compare versions"
+msgstr ""
+
+#: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:124
+msgid "Comparing \"{{x}}\"(primary) to \"{{y}}\"(secondary)"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:193
+msgid "Complete Assignment"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:28
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:66
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/State.tsx:43
+#: ../superdesk-planning/client/constants/assignments.ts:206
+#: ../superdesk-planning/client/utils/index.ts:402
+#: scripts/apps/master-desk/components/AssignmentsComponent.tsx:52
+msgid "Completed"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:66
+#: ../superdesk-planning/client/utils/index.ts:595
+msgid "Composite"
+msgstr ""
+
+#: scripts/apps/legal-archive/index.ts:38
+msgid "Confidential data"
+msgstr ""
+
+#: scripts/apps/highlights/controllers/HighlightsConfig.ts:70
+msgid "Configuration deleted."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:79
+msgid ""
+"Configuration has changed. {{message}} Would you like to save the story to "
+"your workspace?"
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:11
+#: scripts/apps/highlights/views/highlights_config_modal.html:12
+msgid "Configuration name"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:89
+#: scripts/apps/authoring/views/theme-select.html:9
+msgid "Configure Editor themes"
+msgstr ""
+
+#: scripts/extensions/predefinedTextField/dist/src/config.js:64
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:64
+#: scripts/extensions/predefinedTextField/src/config.tsx:101
+msgid "Configure predefined values"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/integration-wrapper/configure-theme-button.tsx:13
+msgid "Configure themes"
+msgstr ""
+
+#: ../superdesk-planning/client/api/coverages.ts:34
+#: ../superdesk-planning/client/api/coverages.ts:55
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:191
+#: scripts/apps/archive/index.tsx:477
+#: scripts/apps/archive/show-spike-dialog.tsx:49
+#: scripts/apps/authoring-react/authoring-swtich.tsx:28
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:46
+#: scripts/apps/authoring/authoring/components/publish-warning-confirm-modal.tsx:35
+#: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:51
+#: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:101
+#: scripts/apps/search/MultiImageEdit.ts:174
+#: scripts/core/get-superdesk-api-implementation.tsx:422
+#: scripts/core/services/modalService.tsx:150 scripts/core/ui-utils.tsx:44
+#: scripts/core/ui/components/Form/TimeInput/TimeInputPopup.tsx:140
+#: scripts/core/ui/show-confirmation-prompt.tsx:36
+#: scripts/core/ui/views/datepicker-wrapper.html:8
+#: scripts/core/ui/views/sd-timepicker-popup.html:28
+msgid "Confirm"
+msgstr "Потврди"
+
+#: ../superdesk-planning/client/constants/assignments.ts:197
+msgid "Confirm Availability"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/publish-warning-confirm-modal.tsx:24
+msgid "Confirm Publish Warnings"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:28
+#: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:41
+msgid "Confirm Unpublishing"
+msgstr ""
+
+#: scripts/apps/authoring/views/change-image.html:194
+msgid "Confirm crop"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:78
+#: scripts/core/auth/reset-password.html:51
+msgid "Confirm new password"
+msgstr "Потврди нову лозинку"
+
+#: ../superdesk-planning/client/components/ConfirmationModal.tsx:149
+msgid "Confirmation"
+msgstr ""
+
+#: scripts/apps/ingest/directives/authenticate-ingest-provider.tsx:20
+msgid "Connect an account"
+msgstr ""
+
+#: scripts/core/notification/notification.ts:222
+msgid "Connected to Notification Server!"
+msgstr "Повезано на сервер обавештења!"
+
+#: scripts/apps/publish/views/odbc-config.html:2
+#: scripts/apps/publish/views/odbc-config.html:4
+msgid "Connection string"
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/contact/index.tsx:23
+msgid "Contact"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:220
+#: scripts/apps/contacts/constants.ts:72
+#: scripts/apps/contacts/views/search-panel.html:31
+msgid "Contact Type"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:108
+msgid "Contact type \"{{ contact_type }}\" MUST have an email"
+msgstr ""
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/contacts.ts:10
+#: ../superdesk-planning/client/components/fields/editor/Contacts.tsx:19
+#: ../superdesk-planning/client/components/fields/editor/CoverageContact.tsx:22
+#: ../superdesk-planning/client/components/fields/preview/Contacts.tsx:22
+#: ../superdesk-planning/client/utils/contentProfiles.ts:285
+#: ../superdesk-planning/client/utils/contentProfiles.ts:333
+#: scripts/apps/production-api-keys/config.ts:26
+msgid "Contacts"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:52
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:91
+#: ../superdesk-planning/client/components/Main/ItemEditor/Editor.tsx:61
+#: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:84
+#: scripts/apps/archive/index.tsx:370
+#: scripts/apps/content-filters/views/production-test-view.html:52
+#: scripts/apps/legal-archive/views/legal_archive.html:118
+#: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:74
+#: scripts/apps/packaging/views/search-widget-preview.html:5
+#: scripts/apps/search/views/item-preview.html:9
+#: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/subitems-view-edit.js:52
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.js:52
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:65
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:65
+#: scripts/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.tsx:119
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:89
+msgid "Content"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:219
+msgid ""
+"Content\n"
+"                                Type"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:254
+msgid "Content API"
+msgstr ""
+
+#: scripts/apps/content-api/controllers/ContentAPIController.ts:26
+#: scripts/apps/content-api/index.ts:21
+msgid "Content API Search"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:26
+msgid "Content Expiry"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:332
+msgid "Content Fields"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:107
+#: scripts/apps/ingest/views/settings/ingest-routing-filter.html:2
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:3
+#: scripts/apps/products/views/products-config-modal.html:60
+msgid "Content Filter"
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:68
+msgid "Content Filter Type"
+msgstr ""
+
+#: scripts/apps/content-filters/index.ts:38
+#: scripts/apps/content-filters/views/filter-search-result.html:24
+#: scripts/apps/content-filters/views/settings.html:4
+msgid "Content Filters"
+msgstr ""
+
+#: scripts/apps/monitoring/directives/utils.ts:23
+#: scripts/apps/templates/views/template-editor-modal.html:28
+#: scripts/apps/templates/views/template-editor-modal.html:38
+msgid "Content Profile"
+msgstr ""
+
+#: scripts/apps/workspace/content/index.ts:43
+#: scripts/apps/workspace/content/views/profile-settings.html:4
+#: scripts/core/lang/missing-translations-strings.ts:31
+msgid "Content Profiles"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/index.js:44
+msgid "Content Publishing"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:479
+msgid "Content State"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ContentTemplate.tsx:82
+msgid "Content Template"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:321
+#: scripts/apps/publish/views/publish-queue.html:107
+#: scripts/apps/workspace/content/views/profile-settings.html:98
+msgid "Content Type"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:60
+msgid "Content Type:"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:395
+#: scripts/core/lang/missing-translations-strings.ts:15
+msgid "Content Types"
+msgstr ""
+
+#: scripts/core/activity/activity.ts:27
+msgid "Content config"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:65
+msgid "Content creation"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:75
+msgid "Content editing"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:324
+msgid "Content expiry:"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:103
+msgid "Content fields"
+msgstr ""
+
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:31
+msgid "Content filter"
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:58
+msgid "Content filter saved."
+msgstr ""
+
+#: scripts/core/activity/activity.ts:32
+msgid "Content flow"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/api.ts:265
+msgid "Content items not found!"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:75
+msgid "Content linked"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:72
+msgid "Content linked to coverage"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:122
+msgid "Content locked"
+msgstr ""
+
+#: scripts/apps/search/components/TypeIcon.tsx:26
+msgid "Content profile: {{name}}"
+msgstr ""
+
+#: scripts/apps/search/views/search-filters.html:2
+msgid "Content types"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:95
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:77
+msgid "Content unlinked"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Content.tsx:24
+msgid "Content: {{ numberOfContent }}"
+msgstr ""
+
+#: scripts/api/article-send.tsx:93
+#: scripts/apps/desks/views/desk-config-modal.html:421
+msgid "Continue"
+msgstr ""
+
+#: scripts/apps/authoring/views/change-image.html:249
+msgid "Contrast"
+msgstr ""
+
+#: scripts/apps/authoring/views/change-image.html:154
+msgid "Controls"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/index.tsx:452
+msgid "Convert text to lowercase"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/index.tsx:441
+msgid "Convert text to uppercase"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/events.ts:163
+msgid "Convert to Recurring Event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:110
+msgid "Convert to a recurring event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:80
+msgid "Converted to recurring event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:92
+msgid "Copied to clipboard"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:67
+#: scripts/apps/archive/index.tsx:268
+#: scripts/apps/products/views/products-config-modal.html:28
+#: scripts/apps/publish/views/subscribers.html:286
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines.js:42
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary.js:30
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:52
+#: scripts/extensions/ai-widget/dist/src/headlines/headlines.js:42
+#: scripts/extensions/ai-widget/dist/src/summary/summary.js:30
+#: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:52
+#: scripts/extensions/ai-widget/src/headlines/headlines.tsx:94
+#: scripts/extensions/ai-widget/src/summary/summary.tsx:62
+#: scripts/extensions/ai-widget/src/translations/translations-body.tsx:118
+msgid "Copy"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:89
+msgid "Copy assignment Id"
+msgstr ""
+
+#: scripts/apps/authoring/media/views/media-copy-metadata-directive.html:2
+msgid "Copy metadata"
+msgstr ""
+
+#: scripts/apps/production-api-keys/config.ts:64
+msgid "Copy this now, you won't be able to access it again."
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:195
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:64
+msgid "Copyright"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:32
+#: scripts/apps/archive/views/metadata-view.html:173
+#: scripts/apps/workspace/content/constants.ts:19
+msgid "Copyright holder"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-metadata.tsx:23
+#: scripts/apps/authoring/media/MediaMetadataView.tsx:20
+#: scripts/apps/authoring/views/item-carousel.html:112
+#: scripts/apps/authoring/views/item-carousel.html:43
+#: scripts/apps/authoring/views/item-carousel.html:72
+#: scripts/core/editor3/components/media/MediaBlock.tsx:212
+#: scripts/core/editor3/components/media/MediaBlock.tsx:254
+#: scripts/core/editor3/components/media/MediaBlock.tsx:294
+msgid "Copyright holder:"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:36
+#: scripts/apps/archive/views/metadata-view.html:177
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:202
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:68
+#: scripts/apps/workspace/content/constants.ts:20
+msgid "Copyright notice"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-metadata.tsx:31
+#: scripts/apps/authoring/media/MediaMetadataView.tsx:22
+#: scripts/apps/authoring/views/item-carousel.html:120
+#: scripts/apps/authoring/views/item-carousel.html:51
+#: scripts/apps/authoring/views/item-carousel.html:80
+#: scripts/core/editor3/components/media/MediaBlock.tsx:223
+#: scripts/core/editor3/components/media/MediaBlock.tsx:265
+#: scripts/core/editor3/components/media/MediaBlock.tsx:305
+msgid "Copyright notice:"
+msgstr ""
+
+#: scripts/apps/search/views/multi-image-edit.html:69
+msgid "Copyright:"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:159
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/correct-action.tsx:10
+#: scripts/apps/authoring/views/authoring-topbar.html:128
+#: scripts/apps/authoring/views/authoring-topbar.html:129
+#: scripts/apps/authoring/views/authoring-topbar.html:130
+msgid "Correct"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:357
+msgid "Correct item"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:38
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:87
+#: scripts/apps/search/components/fields/state.tsx:39
+msgid "Corrected"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/HistoryController.ts:182
+msgid "Corrected by"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/index-ui.tsx:137
+msgid "Correcting multiple items from authoring pane is not supported"
+msgstr ""
+
+#: scripts/apps/search/components/fields/state.tsx:40
+#: scripts/core/lang/missing-translations-strings.ts:16
+msgid "Correction"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:165
+msgid "Correction Cancel by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:485
+msgid "Correction cancelled by {{user}}"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:467
+msgid "Correction has been removed"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:495
+#: scripts/apps/authoring/versioning/history/views/history.html:171
+msgid "Correction link is removed"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:575
+msgid "Corrections"
+msgstr ""
+
+#: ../superdesk-planning/client/api/editor/item_planning.ts:125
+msgid "Could not link event - Please close the item and try linking again"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:42
+#: scripts/core/ui/components/Form/LinkInput.tsx:27
+msgid "Could not load title"
+msgstr "Није могуће учитати наслов"
+
+#: ../superdesk-planning/client/actions/events/ui.ts:1017
+#: ../superdesk-planning/client/actions/events/ui.ts:1039
+#: ../superdesk-planning/client/actions/events/ui.ts:895
+msgid "Could not obtain lock on the event."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:245
+msgid "Could not obtain lock on the planning item."
+msgstr ""
+
+#: ../superdesk-planning/client/components/editor-standalone/authoring-storage-event-http.ts:51
+msgid "Could not save event"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1654
+msgid "Could not save the item."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/api.ts:364
+msgid "Could not unlock the assignment."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1650
+msgid "Could not unlock the item."
+msgstr ""
+
+#: scripts/apps/highlights/services/HighlightsService.ts:126
+msgid "Couldn't mark item"
+msgstr ""
+
+#: scripts/apps/highlights/services/HighlightsService.ts:126
+msgid "Couldn't unmark item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:288
+#: ../superdesk-planning/client/components/Locations/LocationsList.tsx:136
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:84
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:635
+#: scripts/apps/contacts/constants.ts:77
+#: scripts/apps/contacts/views/search-panel.html:75
+msgid "Country"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:88
+#: scripts/apps/archive/views/assignment-icon.html:1
+#: scripts/apps/search/components/fields/assignment.tsx:17
+msgid "Coverage"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/EditCoverageAssignmentModal.tsx:81
+msgid "Coverage Assignment Details"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:37
+#: ../superdesk-planning/client/components/fields/preview/index.ts:45
+msgid "Coverage Assignment Status"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/assignments.ts:206
+msgid "Coverage Contact"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:191
+msgid "Coverage Provider"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:133
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:266
+#: ../superdesk-planning/client/components/Coverages/CoveragePreview/CoveragePreviewTopBar.tsx:60
+msgid "Coverage Provider:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/ScheduledUpdateForm.tsx:156
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:231
+#: ../superdesk-planning/client/components/fields/editor/NewsCoverageStatus.tsx:32
+#: ../superdesk-planning/client/components/fields/preview/index.ts:205
+#: ../superdesk-planning/client/utils/contentProfiles.ts:327
+msgid "Coverage Status"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageAddButton/CoveragesMenuPopup.tsx:51
+#: ../superdesk-planning/client/components/fields/editor/CoverageType.tsx:34
+#: ../superdesk-planning/client/components/fields/preview/index.ts:70
+msgid "Coverage Type"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:85
+msgid "Coverage added to workflow"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:32
+msgid "Coverage assigned"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:69
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:72
+msgid "Coverage availability"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:89
+msgid "Coverage availability confirmed"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:93
+msgid "Coverage availability reverted"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:68
+msgid "Coverage cancelled"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:105
+msgid "Coverage completed"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:64
+msgid "Coverage edited"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:293
+msgid "Coverage enabled"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:287
+msgid "Coverage has been added to workflow"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:28
+msgid "Coverage must be assigned to a desk"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:24
+msgid "Coverage must be in draft status"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:25
+msgid "Coverage of type {{ type }} created"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:81
+msgid "Coverage priority modified"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:51
+msgid "Coverage re-assigned to"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:30
+msgid "Coverage reassigned"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:52
+msgid "Coverage removed"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:20
+msgid "Coverage was cancelled"
+msgstr ""
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:77
+#: ../superdesk-planning/client/components/Coverages/CoverageArrayInput.tsx:199
+#: ../superdesk-planning/client/components/Editor/bookmarks/CoveragesBookmark.tsx:119
+#: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:252
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:121
+#: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/coverages/index.tsx:27
+#: ../superdesk-planning/client/utils/contentProfiles.ts:317
+msgid "Coverages"
+msgstr ""
+
+#: ../superdesk-planning/client/api/planning.ts:299
+msgid "Coverages added to workflow."
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:433
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:219
+#: ../superdesk-analytics/client/utils.js:150
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:74
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:201
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:158
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:143
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:127
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:203
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:410
+#: ../superdesk-planning/client/components/Main/ItemEditorModal/EditorModalPanel.tsx:168
+#: scripts/apps/monitoring/directives/MonitoringView.ts:201
+#: scripts/apps/templates/services/TemplatesService.ts:70
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:6
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:191
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:39
+#: scripts/extensions/broadcasting/dist/src/page.js:195
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:39
+#: scripts/extensions/broadcasting/src/page.tsx:286
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:71
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:223
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:223
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:245
+msgid "Create"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:420
+msgid "Create & Post"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:246
+msgid "Create Broadcast"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:175
+msgid "Create Highlight"
+msgstr ""
+
+#: ../superdesk-planning/client/components/GeoLookupInput/CreateNewGeoLookup.tsx:180
+msgid "Create Location"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:189
+msgid "Create New Location"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:45
+msgid "Create New Task"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:128
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:257
+msgid "Create Package"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Editor/EditorBookmarksBar.tsx:64
+msgid "Create Planning"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/events.ts:157
+msgid "Create Planning Item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:105
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:179
+msgid "Create Scheduled Export"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:126
+msgid "Create a broadcast"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:49
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:50
+msgid "Create a new location"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/events.ts:158
+msgid "Create and Open Planning Item"
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary.js:50
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:63
+#: scripts/extensions/ai-widget/dist/src/summary/summary.js:50
+#: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:63
+#: scripts/extensions/ai-widget/src/summary/summary.tsx:91
+#: scripts/extensions/ai-widget/src/translations/translations-body.tsx:148
+msgid "Create article"
+msgstr ""
+
+#: scripts/apps/highlights/views/settings.html:11
+msgid "Create configuration"
+msgstr ""
+
+#: scripts/apps/contacts/views/list.html:10
+msgid "Create contact"
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:3
+msgid "Create highlight configuration"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:45
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:55
+#: scripts/apps/authoring/workqueue/work-queue-create-new-button.tsx:10
+#: scripts/apps/relations/directives/related-items-create-new-button.tsx:11
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:166
+#: scripts/extensions/broadcasting/dist/src/page.js:170
+#: scripts/extensions/broadcasting/src/page.tsx:252
+msgid "Create new"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:183
+#: scripts/extensions/broadcasting/dist/src/page.js:187
+#: scripts/extensions/broadcasting/src/page.tsx:275
+msgid "Create new Show"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:292
+msgid "Create new Stage"
+msgstr ""
+
+#: scripts/apps/workspace/views/edit-workspace-modal.html:3
+msgid "Create new Workspace"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:110
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:114
+#: scripts/apps/monitoring/views/monitoring-view.html:126
+#: scripts/apps/workspace/content/index.ts:54
+msgid "Create new item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ListPanel.tsx:344
+msgid "Create new items or change your search filters"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:109
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:113
+msgid "Create new planning item"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:18
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:18
+#: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:44
+msgid "Create new rundown template"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:55
+msgid "Create new schedule"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-modal.js:48
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-modal.js:48
+#: scripts/extensions/broadcasting/src/shows/create-show-modal.tsx:85
+msgid "Create new show"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:141
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:141
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:135
+msgid "Create new tag: \"{{ tag }}\""
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:134
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:134
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:261
+msgid "Create new template"
+msgstr ""
+
+#: scripts/apps/packaging/index.ts:50 scripts/apps/packaging/index.ts:59
+#: scripts/core/ui/components/content-create-dropdown/initial-view.tsx:199
+msgid "Create package"
+msgstr "Креирај пакет"
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:239
+msgid "Create planning"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:259
+msgid "Create planning for all events or just this one?"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:57
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:57
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:103
+msgid "Create rundown"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:14
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:14
+#: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:28
+msgid "Create rundown template"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:161
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:161
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:317
+msgid "Create rundowns automatically"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:219
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:219
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:415
+msgid "Create template"
+msgstr ""
+
+#: scripts/apps/users/views/list.html:3
+msgid "Create user"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:129
+#: ../superdesk-planning/client/components/AuditInformation/index.tsx:110
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:23
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:33
+#: scripts/apps/archive/views/metadata-view.html:89
+#: scripts/apps/archive/views/preview.html:6
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:370
+#: scripts/apps/authoring/authoring/created-info.tsx:49
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:167
+#: scripts/apps/authoring/suggest/SuggestView.html:21
+#: scripts/apps/authoring/suggest/SuggestView.html:69
+#: scripts/apps/contacts/services/ContactsService.ts:40
+#: scripts/apps/content-api/services/ContentAPISearchService.ts:29
+#: scripts/apps/legal-archive/services/LegalArchiveService.ts:25
+#: scripts/apps/legal-archive/tests/legal.spec.ts:67
+#: scripts/apps/production-api-keys/ProductionApiItem.tsx:36
+#: scripts/apps/search/services/SearchService.ts:67
+#: scripts/apps/users/views/list.html:37
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:146
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:146
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:112
+#: scripts/extensions/sams/dist/src/utils/ui.js:112
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:171
+#: scripts/extensions/sams/src/utils/ui.tsx:105
+msgid "Created"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/List/CreatedUpdatedColumn.tsx:28
+msgid "Created : {{ datetime }}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:154
+msgid "Created From"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:39
+msgid "Created Ingest Channel {{name}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:158
+msgid "Created To"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:105
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:105
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:187
+msgid "Created at {{date}}"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:88
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:88
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:165
+msgid "Created at {{time}} by {{user}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:96
+#: scripts/apps/authoring/versioning/history/views/history.html:6
+msgid "Created by"
+msgstr ""
+
+#: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:111
+msgid "Created by this user"
+msgstr ""
+
+#: scripts/apps/search/directives/DateFilters.ts:77
+msgid "Created from"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:92
+msgid "Created from 'update repetitions'"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:104
+msgid "Created from a planning item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:37
+msgid "Created from content"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:32
+msgid "Created from event"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:127
+msgid "Created from highlight"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:380
+msgid "Created from highlight({{x}}) by {{user}}"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:2
+msgid "Created on"
+msgstr ""
+
+#: scripts/apps/search/directives/DateFilters.ts:78
+msgid "Created to"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/common/versionUserDateLines.js:95
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/versionUserDateLines.js:66
+#: scripts/extensions/sams/src/components/common/versionUserDateLines.tsx:36
+msgid "Created {{ datetime }}"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/common/versionUserDateLines.js:96
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/versionUserDateLines.js:67
+#: scripts/extensions/sams/src/components/common/versionUserDateLines.tsx:41
+msgid "Created {{ datetime }} by"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:129
+msgid "Creation Date"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/DatesGroup.tsx:80
+msgid "Creation date"
+msgstr ""
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:17
+#: scripts/apps/search/constants.ts:11
+#: scripts/apps/search/views/search-parameters.html:131
+msgid "Creator"
+msgstr ""
+
+#: scripts/apps/production-api-keys/config.ts:49
+msgid "Credentials"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:209
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:72
+msgid "Credit"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-metadata.tsx:19
+#: scripts/apps/authoring/media/MediaMetadataView.tsx:19
+#: scripts/apps/authoring/views/item-carousel.html:108
+#: scripts/apps/authoring/views/item-carousel.html:39
+#: scripts/apps/authoring/views/item-carousel.html:68
+#: scripts/core/editor3/components/media/MediaBlock.tsx:208
+#: scripts/core/editor3/components/media/MediaBlock.tsx:250
+#: scripts/core/editor3/components/media/MediaBlock.tsx:290
+msgid "Credit:"
+msgstr ""
+
+#: scripts/apps/search/views/search-filters.html:57
+msgid "Credits"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:248
+#: scripts/apps/publish/views/subscribers.html:234
+msgid "Critical Errors"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:68
+#: scripts/apps/authoring/views/change-image.html:205
+msgid "Crop"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:181
+msgid "Crop coordinates are not defined for {{cropName}} picture crop."
+msgstr ""
+
+#: scripts/apps/profiling/views/profiling.html:35
+msgid "Cumulative time"
+msgstr ""
+
+#: scripts/apps/profiling/views/profiling.html:36
+msgid "Cumulative time per call"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:209
+msgid "Current Assignments"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:78
+msgid "Current Date"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:82
+msgid "Current Date (Based on Event timezone)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/RepeatEventSummary/index.tsx:14
+msgid "Current Repeat Summary"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:181
+msgid "Currently Selected"
+msgstr ""
+
+#: scripts/apps/search/views/multi-image-edit.html:93
+msgid "Currently editing: {{getSelectedItemsLength()}} items"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningSelectedList.tsx:23
+msgid "Currently selected"
+msgstr ""
+
+#: scripts/core/upload/image-crop-directive.ts:254
+msgid "Currently the image size is {{width}}x{{height}})."
+msgstr "Тренутна величина слике је {{width}}x{{height}})."
+
+#: scripts/apps/authoring/views/dashboard-articles.html:5
+msgid "Currently working on"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:221
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:316
+msgid "Custom Layout"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/index.tsx:358
+msgid "Custom block"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/settings.html:22
+msgid "Custom blocks"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/settings.html:25
+msgid "Custom date fields"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/settings.html:28
+msgid "Custom embed fields"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/settings.html:19
+msgid "Custom text fields"
+msgstr ""
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:76
+msgid "Customer Installation No.:"
+msgstr ""
+
+#: scripts/apps/dashboard/index.ts:54
+msgid "Customize your widgets and views"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:69
+msgid "Cut"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/CalendarNavigation.tsx:46
+msgid "D"
+msgstr ""
+
+#: scripts/apps/workspace/views/workspace-dropdown.html:11
+msgid "DESKS"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:32
+msgid "DONE"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:130
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:216
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-parameters.html:25
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-preview.html:11
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:34
+msgid "Daily"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:45
+msgid "Daily @ {{ time }} to {{ desk }}"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:67
+msgid "Daily at {{hour}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:58
+msgid "Dark Blue"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:47
+msgid "Dark Gray"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:69
+msgid "Dark Magenta"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:66
+msgid "Dark Orange"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:70
+msgid "Dark Violet"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:48
+msgid "Darker Gray"
+msgstr ""
+
+#: scripts/apps/dashboard/controllers/DashboardController.ts:38
+#: scripts/apps/dashboard/index.ts:70
+#: scripts/apps/dashboard/views/workspace.html:2
+msgid "Dashboard"
+msgstr ""
+
+#: scripts/apps/dashboard/views/workspace.html:59
+msgid "Dashboard is empty"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:419
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:16
+#: ../superdesk-analytics/client/search/views/date-filters.html:62
+#: ../superdesk-planning/client/components/UI/Form/DateInput/index.tsx:218
+#: ../superdesk-planning/client/components/fields/editor/DateOnly.tsx:26
+#: scripts/core/lang/missing-translations-strings.ts:31
+#: scripts/extensions/datetimeField/dist/src/editor.js:41
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:41
+#: scripts/extensions/datetimeField/src/editor.tsx:64
+msgid "Date"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/date/index.tsx:17
+msgid "Date (authoring-react)"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:177
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:91
+msgid "Date Created"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:2
+#: ../superdesk-planning/client/components/fields/preview/index.ts:142
+msgid "Date Filter"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:3
+msgid "Date Filter:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:108
+#: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:16
+msgid "Date Filters"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:180
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:94
+msgid "Date Updated"
+msgstr ""
+
+#: scripts/apps/search/directives/DateFilters.ts:76
+msgid "Date created"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:183
+msgid "Date field is required"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/planning.ts:253
+msgid "Date is in the past"
+msgstr ""
+
+#: scripts/apps/search/directives/DateFilters.ts:84
+msgid "Date modified"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/SubNavDatePicker.tsx:71
+#: ../superdesk-planning/client/components/UI/Form/DateInput/index.tsx:209
+msgid "Date picker"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:21
+#: scripts/apps/search/directives/DateFilters.ts:92
+msgid "Date published"
+msgstr ""
+
+#: scripts/apps/search/directives/DateFilters.ts:100
+msgid "Date scheduled"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/datetime/preview.tsx:16
+msgid "Date time (AUTHORING-REACT)"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:415
+msgid "Date/Time"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:113
+#: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:88
+msgid "Date:"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:352
+#: scripts/apps/authoring-react/field-adapters/dateline.ts:12
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:151
+#: scripts/apps/users/views/user-preferences.html:106
+#: scripts/apps/workspace/content/constants.ts:21
+msgid "Dateline"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dateline/index.tsx:27
+msgid "Dateline (authoring-react)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/DatesGroup.tsx:40
+#: ../superdesk-planning/client/components/fields/index.tsx:232
+#: ../superdesk-planning/client/utils/contentProfiles.ts:265
+msgid "Dates"
+msgstr ""
+
+#: scripts/extensions/datetimeField/dist/src/extension.js:20
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/extension.js:20
+#: scripts/extensions/datetimeField/src/extension.tsx:27
+msgid "Datetime"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/datetime/index.tsx:24
+msgid "Datetime (authoring-react)"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:157
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:77
+#: scripts/extensions/availability-manager/dist/src/constants.js:34
+#: scripts/extensions/availability-manager/dist/src/correspondent-availability/filters.js:84
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/constants.js:34
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/correspondent-availability/filters.js:84
+#: scripts/extensions/availability-manager/src/constants.ts:42
+#: scripts/extensions/availability-manager/src/correspondent-availability/filters.tsx:128
+msgid "Day"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:29
+msgid "Day of the Month"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:30
+msgid "Day(s)"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:4
+msgid "Days"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:68
+msgid "Deep Pink"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-group-header.html:31
+#: scripts/apps/monitoring/views/monitoring-group-header.html:43
+#: scripts/apps/search-providers/directive.ts:118
+msgid "Default"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:219
+msgid "Default Agenda"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:206
+msgid "Default Calendar"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:176
+msgid "Default Content Profile"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:153
+msgid "Default Content Template"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:220
+msgid "Default Desk"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:147
+msgid "Default Duration"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:232
+msgid "Default Events & Planning Filter"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:72
+msgid "Default Template"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:96
+#: scripts/apps/authoring/views/theme-select.html:15
+msgid "Default Theme"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:236
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:208
+msgid "Default Value"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:54
+msgid "Default author roles"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:18
+#: scripts/apps/users/views/edit-form.html:215
+msgid "Default desk"
+msgstr ""
+
+#: scripts/core/ui/components/content-create-dropdown/initial-view.tsx:131
+msgid "Default desk template"
+msgstr "Подразумевани шаблон деска"
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:189
+msgid "Default language"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:69
+msgid "Default language is a required field"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:131
+msgid "Default monitoring view"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/manage-schedule.js:128
+#: scripts/extensions/availability-manager/dist/src/settings/manage-schedule.js:128
+#: scripts/extensions/availability-manager/src/settings/manage-schedule.tsx:199
+msgid "Default schedule"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:53
+msgid "Default view"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:106
+msgid ""
+"Defines the width of the pop-up in the\n"
+"                                    article header. A minimal value of 200 "
+"is required."
+msgstr ""
+
+#: scripts/extensions/annotationsLibrary/dist/src/GetFields.js:23
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/GetFields.js:23
+#: scripts/extensions/annotationsLibrary/src/GetFields.ts:24
+#: scripts/extensions/predefinedTextField/dist/src/config.js:21
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:21
+#: scripts/extensions/predefinedTextField/src/config.tsx:30
+msgid "Definition"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:204
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:305
+#: ../superdesk-planning/client/components/Events/ManageEventTemplatesModal.tsx:51
+#: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:100
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:71
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:86
+#: ../superdesk-planning/client/components/UI/Form/InputArray/index.tsx:86
+#: ../superdesk-planning/client/components/fields/common/PreviewFilterSchedule.tsx:69
+#: ../superdesk-planning/client/constants/tooltips.ts:27
+#: scripts/apps/production-api-keys/ProductionApiItem.tsx:63
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:97
+#: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:187
+#: scripts/core/editor3/components/annotations/AnnotationInput.tsx:280
+#: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:97
+#: scripts/core/editor3/components/comments/Comment.tsx:61
+#: scripts/core/editor3/components/links/LinkToolbar.tsx:59
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:250
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:59
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:130
+#: scripts/extensions/broadcasting/dist/src/rundowns/manage-rundown-items.js:59
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:130
+#: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:116
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:242
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:124
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:124
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:51
+#: scripts/extensions/sams/dist/src/utils/assets.js:51
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:116
+#: scripts/extensions/sams/src/utils/assets.ts:63
+msgid "Delete"
+msgstr "Обриши"
+
+#: ../superdesk-planning/client/constants/tooltips.ts:26
+msgid "Delete Agenda"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/store/assets/actions.js:324
+#: scripts/extensions/sams/dist/src/extensions/sams/src/store/assets/actions.js:331
+#: scripts/extensions/sams/dist/src/store/assets/actions.js:324
+#: scripts/extensions/sams/dist/src/store/assets/actions.js:331
+#: scripts/extensions/sams/src/store/assets/actions.ts:384
+#: scripts/extensions/sams/src/store/assets/actions.ts:393
+msgid "Delete Asset?"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/tooltips.ts:36
+msgid "Delete Filter"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:203
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:304
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:70
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:85
+msgid "Delete Item?"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:70
+msgid "Delete Rule"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:33
+msgid "Delete Saved Report"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:114
+msgid "Delete Scheduled Export"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/store/sets/actions.js:95
+#: scripts/extensions/sams/dist/src/store/sets/actions.js:95
+#: scripts/extensions/sams/src/store/sets/actions.ts:114
+msgid "Delete Set?"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:102
+msgid "Delete empty paragraphs"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:101
+msgid "Delete failed! Field is required by the system"
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:248
+msgid "Delete item?"
+msgstr "Обрисати ставку?"
+
+#: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:226
+#: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:230
+msgid "Delete link"
+msgstr ""
+
+#: scripts/apps/search/views/saved-searches.html:16
+#: scripts/apps/search/views/saved-searches.html:45
+msgid "Delete search"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:35
+msgid "Delete this Schedule"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:87
+msgid "Delete vocabulary?"
+msgstr ""
+
+#: scripts/apps/dashboard/views/workspace.html:35
+#: scripts/apps/monitoring/views/monitoring-view.html:220
+msgid "Delete workspace"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:40
+msgid "Deleted Ingest Channel {{name}}"
+msgstr ""
+
+#: scripts/apps/publish/views/destination.html:22
+msgid "Delivery type"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/demo-widget.tsx:10
+msgid "Demo widget"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:169
+#: ../superdesk-planning/client/components/OrderBar/OrderDirectionIcon.tsx:20
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:70
+#: scripts/apps/search/views/item-sortbar.html:21
+#: scripts/core/ui/components/SortBar/index.tsx:77
+msgid "Descending"
+msgstr "Опадајуће"
+
+#: ../superdesk-analytics/client/charts/views/chart-form-options.html:49
+msgid "Descending Order"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:437
+#: ../superdesk-analytics/client/utils.js:156
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/deschedule.tsx:9
+#: scripts/apps/authoring/views/authoring-topbar.html:110
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:316
+msgid "Deschedule"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:113
+#: scripts/apps/authoring/versioning/history/views/history.html:17
+msgid "Descheduled by"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:48
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:53
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:65
+#: ../superdesk-planning/client/components/fields/preview/index.ts:232
+#: ../superdesk-planning/client/components/fields/preview/index.ts:264
+#: ../superdesk-planning/client/components/fields/resources/events.ts:31
+#: ../superdesk-planning/client/components/fields/resources/planning.ts:12
+#: scripts/apps/archive/views/metadata-associateditem-view.html:11
+#: scripts/apps/archive/views/metadata-view.html:215
+#: scripts/apps/authoring-react/field-adapters/description_text.ts:22
+#: scripts/apps/authoring-react/fields/embed/editor.tsx:121
+#: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:216
+#: scripts/apps/authoring-react/fields/urls/editor.tsx:59
+#: scripts/apps/authoring/attachments/AttachmentsEditorModal.tsx:71
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:189
+#: scripts/apps/authoring/authoring/article-url-fields.tsx:89
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:209
+#: scripts/apps/authoring/views/article-edit.html:611
+#: scripts/apps/search/views/save-search-dialog.html:10
+#: scripts/apps/search/views/search-parameters.html:207
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:78
+#: scripts/apps/workspace/content/constants.ts:22
+#: scripts/apps/workspace/content/views/profile-settings.html:122
+#: scripts/apps/workspace/content/views/profile-settings.html:158
+#: scripts/core/editor3/components/embeds/EmbedBlock.tsx:174
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:67
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:67
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:158
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show.js:69
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:25
+#: scripts/extensions/broadcasting/dist/src/shows/create-show.js:69
+#: scripts/extensions/broadcasting/dist/src/shows/manage-shows.js:25
+#: scripts/extensions/broadcasting/src/shows/create-show.tsx:107
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:37
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:183
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:227
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:114
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:146
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:238
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:144
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:183
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:227
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:114
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:146
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:238
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:144
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:205
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:264
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:131
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:163
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:291
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:144
+msgid "Description"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:291
+msgid "Description Long"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:273
+msgid "Description Short"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:305
+msgid "Description Text"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:135
+msgid "Description:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:328
+#: scripts/apps/search/views/multi-image-edit.html:33
+msgid "Deselect All"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:495
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-parameters.html:9
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-preview.html:2
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:111
+#: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:171
+#: ../superdesk-planning/client/components/Coverages/CoveragePreview/CoveragePreviewTopBar.tsx:45
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:280
+#: ../superdesk-planning/client/components/fields/editor/DeskId.tsx:39
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:64
+#: scripts/apps/desks/views/actionpicker.html:4
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:39
+#: scripts/apps/templates/views/create-template.html:39
+#: scripts/apps/templates/views/template-editor-modal.html:80
+#: scripts/apps/workspace/content/constants.ts:23
+msgid "Desk"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:231
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:383
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:500
+#: ../superdesk-analytics/client/desk_activity_report/index.js:45
+msgid "Desk Activity"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:64
+msgid "Desk Assignments"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:68
+msgid "Desk Email"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:16
+msgid "Desk Management"
+msgstr ""
+
+#: scripts/apps/monitoring/directives/AggregateSettings.ts:56
+#: scripts/apps/workspace/content/constants.ts:66
+msgid "Desk Output"
+msgstr ""
+
+#: scripts/apps/dashboard/closed-desk/index.ts:152
+msgid "Desk Router"
+msgstr ""
+
+#: scripts/apps/monitoring/directives/AggregateSettings.ts:50
+msgid "Desk Schedule Output"
+msgstr ""
+
+#: scripts/apps/monitoring/directives/AggregateSettings.ts:62
+msgid "Desk Sent Output"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:79
+msgid "Desk Templates"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:367
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:371
+msgid "Desk Transitions"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:93
+#: scripts/apps/desks/views/settings.html:82
+msgid "Desk Type"
+msgstr ""
+
+#: scripts/apps/desks/controllers/DeskConfigController.ts:63
+msgid "Desk deleted."
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:32
+msgid "Desk description"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:70
+msgid "Desk email address."
+msgstr ""
+
+#: scripts/apps/desks/services/DesksFactory.ts:425
+msgid "Desk has been modified elsewhere. Please reload the desks."
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:114
+msgid "Desk language"
+msgstr ""
+
+#: scripts/apps/desks/views/settings.html:4
+msgid "Desk management"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:16
+msgid "Desk name"
+msgstr ""
+
+#: scripts/apps/dashboard/closed-desk/index.ts:26
+msgid "Desk status is outdated, please refresh."
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-manage-subscribers.html:167
+#: scripts/apps/search/views/saved-search-manage-subscribers.html:88
+msgid "Desk subscription"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:126
+msgid "Desk template"
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskeditBasic.ts:65
+msgid "Desk with name {{name}} already exists."
+msgstr ""
+
+#: scripts/apps/templates/views/templates.html:52
+msgid "Desk(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Archive/ArchivePreview/ArchivePreviewMetadataList.tsx:24
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Desk.tsx:12
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:98
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:242
+#: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:218
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:94
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateAssignmentForm.tsx:157
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx:166
+msgid "Desk:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:111
+msgid "Desk: {{ desk }}"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:109
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:383
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:137
+#: scripts/apps/desks/index.ts:50
+#: scripts/apps/monitoring/views/aggregate-settings.html:8
+#: scripts/apps/production-api-keys/config.ts:24
+#: scripts/apps/search/views/search-filters.html:31
+#: scripts/apps/templates/views/template-editor-modal.html:91
+#: scripts/apps/users/views/user-preferences.html:18
+#: scripts/extensions/sams/dist/src/components/common/DesksSelectInput.js:130
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/DesksSelectInput.js:130
+#: scripts/extensions/sams/src/components/common/DesksSelectInput.tsx:109
+msgid "Desks"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:196
+#: scripts/apps/publish/views/publish-queue.html:111
+#: scripts/core/interactive-article-actions-panel/actions/duplicate-to-action.tsx:62
+#: scripts/core/interactive-article-actions-panel/actions/fetch-to-action.tsx:83
+#: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:118
+#: scripts/core/interactive-article-actions-panel/actions/unspike-action.tsx:61
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:250
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:250
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:325
+msgid "Destination"
+msgstr ""
+
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:14
+msgid "Destination name"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:216
+msgid "Destinations"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:151
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:64
+#: ../superdesk-planning/client/components/fields/index.tsx:241
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:541
+#: scripts/apps/authoring/authoring/index.ts:418
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:253
+msgid "Details"
+msgstr "Детаљи"
+
+#: scripts/apps/authoring/views/change-image.html:7
+msgid "Details / Metadata"
+msgstr ""
+
+#: scripts/apps/dictionaries/index.ts:33
+msgid "Dictionaries"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:16
+msgid "Dictionaries List Management"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/settings.html:23
+msgid "Dictionary"
+msgstr ""
+
+#: scripts/apps/dictionaries/controllers/DictionaryConfigController.ts:93
+msgid "Dictionary deleted."
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:36
+msgid "Dictionary file"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/settings.html:4
+msgid "Dictionary management"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:25
+msgid "Dictionary name"
+msgstr ""
+
+#: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:14
+msgid "Dictionary saved successfully"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:28
+msgid "Dictionary with name {{dictionary.name}} already exists."
+msgstr ""
+
+#: scripts/apps/authoring-react/compare-articles/view-difference.tsx:74
+msgid ""
+"Difference view for \"{{type}}\" fields is not implemented. Latter version "
+"is being displayed."
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:72
+msgid "Digital/Internet"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:45
+#: scripts/apps/archive/views/metadata-view.html:211
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:205
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:133
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:133
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:159
+msgid "Dimensions"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:192
+msgid "Disable Item Updates"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:169
+msgid "Disable selection of an entire category"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:487
+msgid "Disable spellchecker"
+msgstr ""
+
+#: scripts/apps/users/config.ts:76
+msgid "Disable user"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Agendas/AgendaListItem.tsx:41
+#: ../superdesk-planning/client/utils/planning.tsx:1368
+#: scripts/apps/users/controllers/UserListController.ts:159
+msgid "Disabled"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:216
+msgid "Disabled Agendas"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:158
+msgid "Disabled Calendars"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:77
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:77
+#: scripts/extensions/sams/src/components/sets/setListPanel.tsx:83
+msgid "Disabled Sets"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:197
+msgid "Disallow sending items to this desk"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:76
+msgid "Disallowed characters"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:379
+#: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:217
+msgid "Discard All"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:104
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:116
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:124
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:104
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:116
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:124
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:206
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:231
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:199
+msgid "Discard unsaved changes?"
+msgstr ""
+
+#: scripts/core/notification/notification.ts:215
+msgid "Disconnected from Notification Server!"
+msgstr "Прекинута веза са сервером обавештења!"
+
+#: scripts/core/lang/missing-translations-strings.ts:45
+msgid ""
+"Displaying news ingest statistics. You can switch color themes or graph "
+"sources."
+msgstr ""
+
+#: scripts/core/keyboard/keyboard.ts:401 scripts/core/keyboard/keyboard.ts:410
+msgid "Displays active keyboard shortcuts"
+msgstr "Приказује активне пречице на тастатури"
+
+#: ../superdesk-planning/client/components/fields/editor/NoContentLinking.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/Flags.tsx:30
+msgid "Do not link content updates"
+msgstr ""
+
+#: scripts/apps/vocabularies/constants.ts:56
+msgid "Do not show"
+msgstr ""
+
+#: scripts/apps/settings/index.ts:20
+msgid "Do some admin chores"
+msgstr ""
+
+#: scripts/apps/authoring/views/confirm-media-associated.html:3
+msgid "Do you want to add an image to this update?"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:26
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:26
+#: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:74
+msgid "Do you want to create a rundown template for this show right away?"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:477
+msgid "Do you want to delete the item permanently?"
+msgstr ""
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:167
+msgid "Do you want to delete the items permanently?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/locations.ts:66
+msgid "Do you want to delete the location \"{{ name }}\"?"
+msgstr ""
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:391
+msgid "Do you want to deschedule articles?"
+msgstr ""
+
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:264
+msgid "Do you want to link it to that assignment ?"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:50
+msgid "Do you want to publish the article?"
+msgid_plural "Do you want to publish {{number}} articles?"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:148
+msgid "Do you want to remove Abbreviation?"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:360
+msgid "Do you want to reset the password for user {{user.full_name}} ?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/multiSelect.ts:128
+msgid "Do you want to spike  item(s) ?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/multiSelect.ts:148
+msgid "Do you want to unspike  item(s) ?"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:122
+#: scripts/extensions/sams/dist/src/utils/assets.js:122
+#: scripts/extensions/sams/src/utils/assets.ts:152
+msgid "Document"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:76
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:76
+#: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:59
+msgid "Documents only"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:147
+msgid "Does match"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:148
+msgid "Doesn't match"
+msgstr ""
+
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:326
+msgid "Don't Fulfil Assignment"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:273
+msgid "Don't Save"
+msgstr ""
+
+#: ../superdesk-planning/client/components/AddToPlanningModal/index.tsx:77
+msgid "Don't add"
+msgstr ""
+
+#: scripts/core/auth/reset-password.html:70
+msgid "Don't have token? Get it."
+msgstr "Немате токен? Преузмите га."
+
+#: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:28
+#: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:49
+msgid "Don't save"
+msgstr "Не чувати"
+
+#: scripts/apps/authoring/editor/views/find-replace.html:35
+#: scripts/apps/authoring/views/change-image.html:13
+#: scripts/apps/dashboard/views/workspace.html:83
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:11
+#: scripts/apps/desks/views/desk-config-modal.html:216
+#: scripts/apps/desks/views/desk-config-modal.html:422
+#: scripts/apps/desks/views/desk-config-modal.html:452
+#: scripts/apps/desks/views/desk-config-modal.html:477
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:129
+#: scripts/apps/monitoring/views/aggregate-settings.html:157
+#: scripts/apps/users/views/change-avatar.html:79
+#: scripts/extensions/videoEditor/dist/src/VideoEditorHeader.js:11
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorHeader.js:11
+#: scripts/extensions/videoEditor/src/VideoEditorHeader.tsx:30
+msgid "Done"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:71
+msgid "Dots"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:72
+msgid "Dots Vertical"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:269
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:67
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:229
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:73
+#: scripts/apps/authoring/attachments/AttachmentsListItem.tsx:50
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:45
+#: scripts/extensions/sams/dist/src/utils/assets.js:45
+#: scripts/extensions/sams/src/utils/assets.ts:57
+msgid "Download"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:74
+msgid "Download Alternate"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config.html:84
+msgid "Download config"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/State.tsx:21
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:19
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:196
+#: ../superdesk-planning/client/utils/index.ts:341
+#: scripts/apps/search/components/fields/state.tsx:30
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:187
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:242
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:187
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:242
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:95
+#: scripts/extensions/sams/dist/src/utils/ui.js:95
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:225
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:306
+#: scripts/extensions/sams/src/utils/ui.tsx:76
+msgid "Draft"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:75
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:75
+#: scripts/extensions/sams/src/components/sets/setListPanel.tsx:61
+msgid "Draft Sets"
+msgstr ""
+
+#: scripts/apps/archive/views/upload.html:37
+msgid "Drag Your Files Here"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/FileInput.tsx:200
+#: scripts/core/ui/components/Form/FileInput.tsx:136
+#: scripts/extensions/sams/dist/src/apps/samsAttachmentsWidget.js:194
+#: scripts/extensions/sams/dist/src/apps/samsAttachmentsWidget.js:204
+#: scripts/extensions/sams/dist/src/extensions/sams/src/apps/samsAttachmentsWidget.js:194
+#: scripts/extensions/sams/dist/src/extensions/sams/src/apps/samsAttachmentsWidget.js:204
+#: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:192
+#: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:216
+msgid "Drag files here or"
+msgstr "Превуците датотеке овде или"
+
+#: scripts/apps/vocabularies/components/UploadConfigModal.tsx:60
+msgid ""
+"Drag one or more files here to upload them,\n"
+"                or select files by clicking the button below"
+msgstr ""
+
+#: scripts/apps/authoring/attachments/AttachmentsWidgetComponent.tsx:126
+msgid "Drag one or more files here to upload them, or just click here."
+msgstr ""
+
+#: scripts/apps/authoring/attachments/AttachmentsWidgetComponent.tsx:104
+msgid ""
+"Drag one or more files here to upload them, or just click the button below."
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:101
+msgid "Drop events here"
+msgstr ""
+
+#: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:87
+msgid "Drop files here to upload"
+msgstr ""
+
+#: scripts/apps/users/views/change-avatar.html:29
+msgid "Drop it here"
+msgstr ""
+
+#: scripts/apps/relations/views/related-items.html:11
+#: scripts/core/ui/components/drop-zone-3.tsx:128
+msgid "Drop items here"
+msgstr "Пустите ставке овде"
+
+#: scripts/apps/authoring/views/item-association.html:11
+#: scripts/apps/authoring/views/item-carousel.html:10
+#: scripts/core/ui/components/drop-zone-3.tsx:127
+msgid "Drop items here or click to upload"
+msgstr "Пустите ставке овде или кликните за отпремање"
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:184
+msgid "Drop planning items here"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/index.ts:21
+msgid "Dropdown (authoring-react)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:174
+msgid "Dropped item is not a planning item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:164
+msgid "Dropped item is not an event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/ScheduledUpdateForm.tsx:169
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:235
+#: ../superdesk-planning/client/components/fields/editor/CoverageSchedule.tsx:27
+#: ../superdesk-planning/client/components/fields/preview/index.ts:197
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:75
+msgid "Due"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:26
+msgid "Due Date"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:34
+msgid "Due date"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:38
+msgid "Due time"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:142
+#: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:172
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:119
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateAssignmentForm.tsx:128
+msgid "Due:"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:435
+#: ../superdesk-analytics/client/utils.js:169
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:372
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/index.tsx:217
+#: ../superdesk-planning/client/constants/events.ts:156
+#: ../superdesk-planning/client/constants/planning.ts:137
+#: scripts/apps/archive/index.tsx:168 scripts/apps/archive/index.tsx:196
+#: scripts/apps/archive/index.tsx:214
+#: scripts/apps/authoring/authoring/constants.ts:13
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:228
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:242
+#: scripts/core/interactive-article-actions-panel/actions/duplicate-to-action.tsx:92
+msgid "Duplicate"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/index.tsx:230
+msgid "Duplicate As"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:16
+msgid "Duplicate Content within a Desk"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:55
+msgid "Duplicate ID: {{x}}"
+msgstr ""
+
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:239
+msgid "Duplicate In Place"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:172
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:225
+msgid "Duplicate To"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:125
+msgid "Duplicate an item"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/actions/duplicate-to-action.tsx:80
+msgid "Duplicate and open"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:96
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:78
+msgid "Duplicate created"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:171
+#: scripts/apps/authoring/versioning/history/views/history.html:52
+msgid "Duplicate created by"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:151
+msgid "Duplicate in place"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/action-tabs.tsx:13
+msgid "Duplicate to"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:200
+msgid "Duplicate to personal"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:100
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:82
+msgid "Duplicated"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:152
+msgid "Duplicated From"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:146
+#: scripts/apps/authoring/versioning/history/views/history.html:30
+msgid "Duplicated by"
+msgstr ""
+
+#: scripts/apps/search/views/item-preview.html:15
+msgid "Duplicates"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:63
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:95
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/duration-label.js:11
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:95
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/duration-label.js:11
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:124
+#: scripts/extensions/broadcasting/src/rundowns/components/duration-label.tsx:21
+msgid "Duration"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/duration/index.tsx:20
+msgid "Duration (authoring-react)"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:54
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:60
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/applied-filters.js:54
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/filtering-inputs.js:50
+#: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:122
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:119
+msgid "Duration from"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:62
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:65
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/applied-filters.js:62
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/filtering-inputs.js:55
+#: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:140
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:132
+msgid "Duration to"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:87
+msgid "END DATE cannot be in the past"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:20
+msgid "END DATE is a required field"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:60
+msgid "END DATE should be after START DATE"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:41
+msgid "END TIME is a required field"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:57
+msgid "END TIME should be after START TIME"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:290
+msgid "EXTERNAL LINK {{ index }} cannot end with \".\""
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:284
+msgid ""
+"EXTERNAL LINK {{ index }} must start with \"http://\", \"https://\" or \"www."
+"\""
+msgstr ""
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:35
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:16
+#: scripts/apps/archive/views/metadata-associateditem-view.html:19
+msgid "Ed Note"
+msgstr ""
+
+#: scripts/apps/authoring-react/field-adapters/ednote.ts:20
+#: scripts/apps/workspace/content/constants.ts:24
+msgid "Ed. Note"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Agendas/AgendaListItem.tsx:57
+#: ../superdesk-planning/client/components/Events/ManageEventTemplatesModal.tsx:42
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:42
+#: ../superdesk-planning/client/components/ExportTemplates/ExportTemplateItem.tsx:31
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:428
+#: ../superdesk-planning/client/components/Main/ItemEditorModal/EditorModalPanel.tsx:168
+#: ../superdesk-planning/client/components/fields/common/PreviewFilterSchedule.tsx:58
+#: ../superdesk-planning/client/constants/events.ts:166
+#: ../superdesk-planning/client/constants/planning.ts:141
+#: ../superdesk-planning/client/constants/tooltips.ts:24
+#: scripts/apps/authoring-react/fields/linked-items/editor.tsx:48
+#: scripts/apps/authoring-react/fields/package-items/editor.tsx:45
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/edit-button.tsx:11
+#: scripts/apps/authoring/attachments/AttachmentsListItem.tsx:60
+#: scripts/apps/authoring/authoring/index.ts:222
+#: scripts/apps/authoring/views/authoring-topbar.html:105
+#: scripts/apps/desks/views/settings.html:37
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:104
+#: scripts/apps/production-api-keys/ProductionApiItem.tsx:50
+#: scripts/apps/search/components/WidgetItem.tsx:107
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:115
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:116
+#: scripts/apps/templates/views/templates.html:36
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:4
+#: scripts/apps/vocabularies/views/vocabulary-config.html:92
+#: scripts/apps/workspace/content/views/profile-settings.html:47
+#: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:92
+#: scripts/core/editor3/components/comments/Comment.tsx:56
+#: scripts/core/editor3/components/links/LinkToolbar.tsx:58
+#: scripts/extensions/annotationsLibrary/dist/src/annotations-library-page.js:35
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/annotations-library-page.js:35
+#: scripts/extensions/annotationsLibrary/src/annotations-library-page.tsx:69
+#: scripts/extensions/annotationsLibrary/src/annotations-library-page.tsx:70
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/working-day-view.js:18
+#: scripts/extensions/availability-manager/dist/src/settings/working-day-view.js:18
+#: scripts/extensions/availability-manager/src/settings/working-day-view.tsx:36
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:32
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:146
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:250
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:45
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:124
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:159
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:62
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:32
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:146
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:253
+#: scripts/extensions/broadcasting/dist/src/rundowns/manage-rundown-items.js:45
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:124
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:159
+#: scripts/extensions/broadcasting/dist/src/shows/manage-shows.js:62
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:72
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:269
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:579
+#: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:98
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:236
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:296
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:88
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:89
+#: scripts/extensions/predefinedTextField/dist/src/config.js:37
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:37
+#: scripts/extensions/predefinedTextField/src/config.tsx:55
+#: scripts/extensions/predefinedTextField/src/config.tsx:56
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:111
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:111
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:57
+#: scripts/extensions/sams/dist/src/utils/assets.js:57
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:102
+#: scripts/extensions/sams/src/utils/assets.ts:69
+msgid "Edit"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:8
+msgid "Edit \"' + schedule.name + '\" Schedule"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:5
+msgid "Edit \"{{name}}\" Desk"
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:4
+msgid "Edit \"{{name}}\" Product"
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:4
+msgid "Edit \"{{name}}\" highlight"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:7
+msgid "Edit Abbreviations Dictionary"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/tooltips.ts:23
+msgid "Edit Agenda"
+msgstr ""
+
+#: scripts/apps/authoring/attachments/AttachmentsEditorModal.tsx:41
+#: scripts/extensions/sams/dist/src/components/attachments/editAttachmentModal.js:122
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/editAttachmentModal.js:122
+#: scripts/extensions/sams/src/components/attachments/editAttachmentModal.tsx:102
+msgid "Edit Attachment"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:76
+#: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:77
+msgid "Edit Contact"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:20
+#: scripts/apps/content-filters/views/manage-filters.html:32
+msgid "Edit Content Filter"
+msgstr ""
+
+#: scripts/apps/workspace/content/views/profile-settings.html:47
+msgid "Edit Content Profile"
+msgstr ""
+
+#: scripts/apps/authoring/views/change-image.html:4
+msgid "Edit Crops"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:8
+msgid "Edit Dictionary"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:114
+msgid "Edit Event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:96
+#: ../superdesk-planning/client/constants/tooltips.ts:35
+msgid "Edit Filter"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:23
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:42
+msgid "Edit Filter Condition"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:109
+msgid "Edit Ingest Source"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-sources-list.html:6
+msgid "Edit Ingest Sources"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:75
+msgid "Edit Line"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:190
+msgid "Edit Location"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:254
+msgid "Edit Media Metadata"
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:148
+msgid "Edit Planning"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:194
+msgid "Edit Priority"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:29
+msgid "Edit Role"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:67
+msgid "Edit Rule"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:30
+msgid "Edit Rule set"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:262
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:262
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:404
+msgid "Edit Rundown"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:106
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:180
+msgid "Edit Scheduled Export"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:30
+msgid "Edit Scheme"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:16
+#: scripts/apps/search-providers/views/search-provider-config.html:27
+msgid "Edit Search Provider"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:57
+msgid "Edit Source"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:50
+#: scripts/apps/publish/views/subscribers.html:68
+msgid "Edit Subscriber"
+msgstr ""
+
+#: scripts/apps/templates/views/templates.html:36
+msgid "Edit Template"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:17
+msgid "Edit Unique Name"
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditor.js:486
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditor.js:486
+#: scripts/extensions/videoEditor/src/VideoEditor.tsx:680
+msgid "Edit Video"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:121
+msgid "Edit an item"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:124
+msgid "Edit an item in a new Window"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-workday-modal.js:106
+#: scripts/extensions/availability-manager/dist/src/settings/edit-workday-modal.js:106
+#: scripts/extensions/availability-manager/src/settings/edit-workday-modal.tsx:161
+msgid "Edit availability"
+msgstr ""
+
+#: scripts/apps/highlights/views/settings.html:19
+msgid "Edit configuration"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-carousel/image.tsx:104
+#: scripts/apps/authoring/views/article-edit.html:301
+#: scripts/apps/authoring/views/change-image.html:9
+#: scripts/apps/authoring/views/item-association.html:77
+#: scripts/apps/authoring/views/item-carousel.html:100
+#: scripts/core/editor3/components/media/MediaBlock.tsx:192
+msgid "Edit crops"
+msgstr ""
+
+#: scripts/apps/desks/views/settings.html:34
+msgid "Edit desk"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/settings.html:54
+msgid "Edit dictionary"
+msgstr ""
+
+#: scripts/core/editor3/components/embeds/EmbedBlock.tsx:83
+msgid "Edit embed"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-carousel/image.tsx:94
+#: scripts/apps/authoring/views/article-edit.html:300
+#: scripts/apps/authoring/views/change-image.html:3
+#: scripts/apps/authoring/views/change-image.html:8
+#: scripts/apps/authoring/views/item-association.html:76
+#: scripts/apps/authoring/views/item-carousel.html:99
+#: scripts/core/editor3/components/media/MediaBlock.tsx:182
+msgid "Edit image"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:241
+msgid "Edit in new Window"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/linked-items/editor.tsx:54
+#: scripts/apps/authoring-react/fields/package-items/editor.tsx:51
+msgid "Edit in new window"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:492
+#: ../superdesk-planning/client/constants/events.ts:167
+#: ../superdesk-planning/client/constants/planning.ts:142
+#: ../superdesk-planning/client/constants/tooltips.ts:32
+msgid "Edit in popup"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:374
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:374
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:649
+msgid "Edit item"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:124
+msgid "Edit link"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-carousel/audio.tsx:85
+#: scripts/apps/authoring-react/fields/media/media-carousel/image.tsx:84
+#: scripts/apps/authoring-react/fields/media/media-carousel/video.tsx:84
+#: scripts/apps/authoring/views/article-edit.html:299
+#: scripts/apps/authoring/views/article-edit.html:327
+#: scripts/apps/authoring/views/article-edit.html:348
+#: scripts/apps/authoring/views/item-association.html:42
+#: scripts/apps/authoring/views/item-association.html:62
+#: scripts/apps/authoring/views/item-association.html:75
+#: scripts/apps/authoring/views/item-carousel.html:56
+#: scripts/apps/authoring/views/item-carousel.html:85
+#: scripts/apps/authoring/views/item-carousel.html:98
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:101
+#: scripts/apps/search/views/multi-image-edit.html:2
+#: scripts/core/editor3/components/media/MediaBlock.tsx:172
+#: scripts/core/editor3/components/media/MediaBlock.tsx:332
+msgid "Edit metadata"
+msgstr ""
+
+#: scripts/apps/products/views/product-test.html:35
+#: scripts/apps/products/views/products.html:31
+msgid "Edit product"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:17
+msgid "Edit role"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:19
+msgid "Edit rule set"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:19
+msgid "Edit scheme"
+msgstr ""
+
+#: scripts/apps/search/views/saved-searches.html:15
+#: scripts/apps/search/views/saved-searches.html:44
+msgid "Edit search"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:46
+msgid "Edit source"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:28
+msgid "Edit this Schedule"
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/extension.js:15
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/extension.js:15
+#: scripts/extensions/videoEditor/src/extension.tsx:22
+msgid "Edit video"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:27
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:41
+msgid "Edited"
+msgstr ""
+
+#: scripts/apps/workspace/content/views/profile-settings.html:138
+msgid "Editing"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:124
+msgid "Editor 3"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/editor3/index.tsx:57
+msgid "Editor3 (authoring-react)"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:295
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:147
+msgid "Editorial Note"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Archive/ArchivePreview/ArchivePreviewMetadataList.tsx:33
+msgid "Editorial Note:"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:348
+msgid "Editorial note"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:253
+msgid "Ednote"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:70
+#: scripts/apps/contacts/views/search-panel.html:47
+#: scripts/apps/users/views/list.html:36
+#: scripts/core/auth/reset-password.html:13
+msgid "Email"
+msgstr "Имејл"
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:14
+msgid "Email Address"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:21
+msgid "Email this report"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:405
+#: scripts/apps/search/components/fields/embargo.tsx:46
+#: scripts/apps/workspace/content/constants.ts:25
+#: scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx:75
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx:126
+msgid "Embargo"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:132
+msgid "Embargo Timestamp"
+msgstr ""
+
+#: scripts/apps/search/components/fields/embargo.tsx:23
+msgid "Embargo until {{date}}"
+msgstr ""
+
+#: scripts/apps/search/components/fields/embargo.tsx:30
+msgid "Embargo: {{text}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/embed/index.tsx:18
+msgid "Embed (authoring-react)"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/embed/editor.tsx:106
+msgid "Embed code"
+msgstr ""
+
+#: scripts/core/editor3/components/BaseUnstyledComponent.tsx:103
+msgid "Embedding articles is not configured for this content profile field"
+msgstr ""
+
+#: scripts/core/editor3/components/article-embed/article-embed.tsx:24
+msgid "Embedding from:"
+msgstr ""
+
+#: scripts/core/editor3/actions/editor3.tsx:75
+msgid "Embedding is not allowed for this editor"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:14
+msgid "Enable Feature Preview"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:204
+msgid "Enable if config can't be tested on REST server."
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:488
+msgid "Enable spellchecker"
+msgstr ""
+
+#: scripts/apps/users/config.ts:108
+msgid "Enable user"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Agendas/ManageAgendasModal.tsx:31
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/availability-settings.js:129
+#: scripts/extensions/availability-manager/dist/src/settings/availability-settings.js:129
+#: scripts/extensions/availability-manager/src/settings/availability-settings.tsx:200
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:232
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:232
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:268
+msgid "Enabled"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:96
+msgid "End Date"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:23
+msgid "End Time (exclusive)"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:177
+msgid "End date cannot be greater than today"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:84
+msgid "End date is in the past"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:162
+msgid "End date is required"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/profile.ts:49
+#: ../superdesk-planning/client/validators/profile.ts:50
+msgid "End date must be set"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:59
+msgid "End date should be after start date"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:56
+msgid "End time should be after start time"
+msgstr ""
+
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:3
+msgid "Endpoint URL"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:133
+msgid "Ends"
+msgstr ""
+
+#: scripts/apps/publish-preview/previewModal.tsx:67
+msgid ""
+"Ensure correct preview endpoint is configured or contact endpoint "
+"maintainers."
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:163
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:535
+msgid "Enter Desk Actions"
+msgstr ""
+
+#: scripts/core/editor3/components/embeds/EmbedInput.tsx:164
+msgid "Enter URL or code to embed"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:75
+#: scripts/core/auth/reset-password.html:48
+msgid "Enter new password"
+msgstr "Унесите нову лозинку"
+
+#: scripts/apps/users/views/change-avatar.html:44
+msgid "Enter web url"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:36
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:36
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:58
+msgid "Entity"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:60
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:60
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:135
+msgid "Entity type"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:83
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:83
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:195
+msgid "Entity type is required."
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:76
+msgid "Envelope"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:243
+msgid "Error"
+msgstr ""
+
+#: scripts/api/highlights.ts:44 scripts/api/highlights.ts:48
+msgid "Error creating highlight."
+msgstr ""
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:339
+#: scripts/apps/search/controllers/get-multi-actions.tsx:381
+msgid "Error on item:"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:21
+msgid "Error sending as"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:74
+msgid "Error sending as {{name}} to {{destination}} at {{date}}"
+msgstr ""
+
+#: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:28
+msgid "Error. Dictionary not saved."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:626
+msgid "Error. Item not published."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:322
+msgid "Error. Item not updated."
+msgstr ""
+
+#: scripts/apps/search/directives/SavedSearches.ts:119
+msgid "Error. Saved search not deleted."
+msgstr ""
+
+#: scripts/apps/search/directives/SaveSearch.ts:83
+msgid "Error. Search could not be saved."
+msgstr ""
+
+#: scripts/apps/users/controllers/SessionsDeleteCommand.ts:15
+msgid "Error. Sessions could not be cleared."
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:315
+#: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:270
+msgid "Error. The Desk Activity report could not be generated!"
+msgstr ""
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:223
+msgid "Error. The Planning Usage Report could not be generated!"
+msgstr ""
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:240
+msgid "Error. The Production Time report could not be generated!"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/controllers/ContentPublishingReportController.js:275
+#: ../superdesk-analytics/client/featuremedia_updates_report/controllers/FeaturemediaUpdatesReportController.js:216
+#: ../superdesk-analytics/client/publishing_performance_report/controllers/PublishingPerformanceReportController.ts:280
+#: ../superdesk-analytics/client/update_time_report/controllers/UpdateTimeReportController.js:243
+msgid "Error. The Publishing Report could not be generated!"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/controller.js:246
+msgid "Error. The report could not be generated."
+msgstr ""
+
+#: scripts/apps/users/controllers/UserDeleteCommand.ts:24
+msgid "Error. User Profile cannot be disabled."
+msgstr ""
+
+#: scripts/apps/users/controllers/UserEnableCommand.ts:21
+msgid "Error. User Profile cannot be enabled."
+msgstr ""
+
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:120
+msgid "Error. Vocabulary not saved."
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:199
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:107
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:110
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:126
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:145
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:148
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:64
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:69
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:72
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:90
+#: scripts/apps/content-filters/controllers/ProductionTestController.ts:107
+#: scripts/apps/content-filters/controllers/ProductionTestController.ts:109
+#: scripts/apps/desks/controllers/DeskConfigController.ts:104
+#: scripts/apps/desks/controllers/DeskConfigController.ts:67
+#: scripts/apps/desks/directives/DeskeditPeople.ts:64
+#: scripts/apps/desks/directives/DeskeditStages.ts:239
+#: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:22
+#: scripts/apps/ingest/directives/IngestRoutingContent.ts:54
+#: scripts/apps/ingest/directives/IngestRulesContent.ts:52
+#: scripts/apps/products/controllers/ProductsConfigController.ts:180
+#: scripts/apps/products/controllers/ProductsConfigController.ts:185
+#: scripts/apps/products/controllers/ProductsConfigController.ts:187
+#: scripts/apps/products/controllers/ProductsConfigController.ts:206
+#: scripts/apps/products/controllers/ProductsConfigController.ts:257
+#: scripts/apps/publish/controllers/PublishQueueController.ts:180
+#: scripts/apps/publish/directives/SubscribersDirective.ts:219
+#: scripts/apps/search-providers/directive.ts:59
+#: scripts/apps/templates/directives/TemplatesDirective.ts:369
+#: scripts/apps/templates/helpers.ts:6 scripts/apps/templates/helpers.ts:9
+#: scripts/apps/users/controllers/UserDeleteCommand.ts:20
+#: scripts/apps/users/controllers/UserDeleteCommand.ts:22
+#: scripts/apps/users/controllers/UserEnableCommand.ts:17
+#: scripts/apps/users/controllers/UserEnableCommand.ts:19
+#: scripts/apps/users/directives/UserRolesDirective.ts:66
+msgid "Error:"
+msgstr ""
+
+#: scripts/apps/search-providers/directive.ts:62
+msgid "Error: A Search Provider with type  already exists."
+msgstr ""
+
+#: scripts/apps/products/controllers/ProductsConfigController.ts:208
+msgid "Error: Failed to delete product."
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/ProductionTestController.ts:111
+msgid "Error: Failed to fetch production test results."
+msgstr ""
+
+#: scripts/apps/publish/controllers/PublishQueueController.ts:183
+msgid "Error: Failed to re-schedule"
+msgstr ""
+
+#: scripts/apps/search-providers/directive.ts:66
+msgid "Error: Failed to save Search Provider."
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:228
+msgid "Error: Failed to save Subscriber."
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:151
+msgid "Error: Failed to save content filter."
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:112
+msgid "Error: Failed to save filter condition."
+msgstr ""
+
+#: scripts/apps/templates/helpers.ts:13
+msgid "Error: Failed to save template."
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:76
+msgid "Error: Failed to test content filter."
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:74
+msgid "Error: Internal error in Filter testing"
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:105
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:67
+#: scripts/apps/products/controllers/ProductsConfigController.ts:183
+msgid "Error: Name needs to be unique"
+msgstr ""
+
+#: scripts/core/itemList/itemList.ts:110
+msgid "Error: Slugline required."
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:225
+msgid "Error: Subscriber must have at least one destination."
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:222
+msgid "Error: Subscriber with Name  already exists."
+msgstr ""
+
+#: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:24
+msgid "Error: The dictionary already exists."
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:359
+msgid "Error: Unable to delete Ingest Source"
+msgstr ""
+
+#: scripts/apps/search-providers/directive.ts:98
+msgid "Error: Unable to delete Search Provider."
+msgstr ""
+
+#: scripts/api/article.ts:422
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:100
+msgid "Error: Unique Name is not unique."
+msgstr ""
+
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:111
+msgid "Error: {{ message }}"
+msgstr ""
+
+#: scripts/apps/users/directives/UserEditDirective.ts:272
+msgid "Error: {{error}}"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:316
+#: scripts/apps/authoring/authoring/services/LockService.ts:20
+#: scripts/extensions/sams/dist/src/api/assets.js:446
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:446
+#: scripts/extensions/sams/src/api/assets.ts:562
+msgid "Error: {{message}}"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/api.js:25
+#: scripts/extensions/sams/dist/src/utils/api.js:25
+#: scripts/extensions/sams/src/utils/api.ts:25
+msgid "Error[04002]: Invalid search query"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/api.js:46
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/api.js:56
+#: scripts/extensions/sams/dist/src/utils/api.js:46
+#: scripts/extensions/sams/dist/src/utils/api.js:56
+#: scripts/extensions/sams/src/utils/api.ts:42
+#: scripts/extensions/sams/src/utils/api.ts:53
+msgid "Error[{{number}}]: {{description}}"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/api.js:33
+#: scripts/extensions/sams/dist/src/utils/api.js:33
+#: scripts/extensions/sams/src/utils/api.ts:30
+msgid "Error[{{number}}]: {{error}} not unique"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/api.js:39
+#: scripts/extensions/sams/dist/src/utils/api.js:39
+#: scripts/extensions/sams/src/utils/api.ts:35
+msgid "Error[{{number}}]: {{error}} requried"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/validation-errors.js:14
+#: scripts/extensions/availability-manager/dist/src/validation-errors.js:14
+#: scripts/extensions/availability-manager/src/validation-errors.tsx:19
+msgid "Errors"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:79
+msgid "Europe/Athens"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:80
+msgid "Europe/Belgrade"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:81
+msgid "Europe/Berlin"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:82
+msgid "Europe/Brussels"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:83
+msgid "Europe/Bucharest"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:84
+msgid "Europe/Dublin"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:85
+msgid "Europe/Helsinki"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:86
+msgid "Europe/Istanbul"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:87
+msgid "Europe/Kiev"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:88
+msgid "Europe/Lisbon"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:89
+msgid "Europe/London"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:90
+msgid "Europe/Madrid"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:91
+msgid "Europe/Minsk"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:92
+msgid "Europe/Moscow"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:93
+msgid "Europe/Paris"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:94
+msgid "Europe/Prague"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:95
+msgid "Europe/Rome"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:96
+msgid "Europe/Sofia"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:97
+msgid "Europe/Stockholm"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:40
+#: ../superdesk-planning/client/components/ItemIcon.tsx:23
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:53
+#: ../superdesk-planning/client/components/Main/ItemEditorModal/EditorModalPanel.tsx:169
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:77
+#: ../superdesk-planning/client/utils/history.tsx:75
+#: ../superdesk-planning/client/utils/index.ts:581
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:17
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:17
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:25
+msgid "Event"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:479
+msgid "Event \"{{name}}\" is already added as related"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:43
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:57
+msgid "Event Cancelled"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:59
+msgid "Event Cancelled:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningEditor/PlanningEditorHeader.tsx:61
+#: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:187
+#: ../superdesk-planning/client/components/StateLabel/index.tsx:61
+#: ../superdesk-planning/client/components/fields/state.tsx:45
+msgid "Event Completed"
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/event-dates/index.tsx:23
+msgid "Event Date"
+msgstr ""
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/event-dates.ts:18
+msgid "Event Dates"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/Editor.tsx:187
+#: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:126
+msgid "Event Details"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:225
+msgid "Event Ends"
+msgstr ""
+
+#: ../superdesk-planning/client/api/contentProfiles.ts:212
+msgid "Event Fields"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventEditor/index.tsx:182
+msgid "Event Name"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:47
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:65
+msgid "Event Postponed"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:41
+msgid "Event Postponed:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:39
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:53
+msgid "Event Rescheduled"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:51
+msgid "Event Rescheduled from"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:206
+msgid "Event Starts"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:60
+msgid "Event cancelled"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:154
+msgid "Event duration is greater than {{maxDuration}} days."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:136
+msgid "Event has been cancelled"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:151
+msgid "Event has been postponed"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:324
+msgid "Event has been rescheduled"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:77
+msgid "Event has to be created before adding related plannings"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:84
+msgid "Event repetitions modified"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:522
+msgid "Event repetitions updated"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:31
+msgid "Event spiked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:507
+msgid "Event time has been updated"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:76
+msgid "Event time modified"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:35
+msgid "Event unspiked"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:234
+msgid "Event will be changed to a multi-day event!"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/DatesGroup.tsx:44
+msgid "Event/Planning date"
+msgstr ""
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:75
+#: ../superdesk-planning/client/components/fields/editor/ItemType.tsx:21
+#: ../superdesk-planning/client/components/fields/index.tsx:235
+#: ../superdesk-planning/client/utils/eventsplanning.ts:17
+#: ../superdesk-planning/client/utils/eventsplanning.ts:19
+#: scripts/apps/production-api-keys/config.ts:28
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:18
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:18
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:26
+msgid "Events"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FiltersBox.tsx:39
+msgid "Events & Planning"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/AddToPlanningUi.tsx:34
+#: ../superdesk-planning/client/apps/Planning/PlanningUi.tsx:21
+msgid "Events and Planning content"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FiltersBox.tsx:45
+msgid "Events only"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:101
+msgid "Every"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:163
+#: ../superdesk-planning/client/utils/filters.ts:180
+msgid "Every Hour"
+msgstr ""
+
+#: scripts/apps/search/views/edit-time-interval.html:4
+msgid "Every day"
+msgstr ""
+
+#: scripts/apps/search/views/edit-time-interval.html:18
+msgid "Every hour"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1402
+msgid "Every {{interval}} day(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1395
+msgid "Every {{interval}} month(s) on day {{day}}"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1405
+msgid "Every {{interval}} week(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1388
+msgid "Every {{interval}} year(s) on {{date}}"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:6
+msgid "Exact"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:78
+msgid "Exclamation Sign"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/preview-source-filter.html:6
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:102
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:131
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:15
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:160
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:189
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:218
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:247
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:276
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:318
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:347
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:44
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:73
+msgid "Exclude"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ExcludeRescheduledAndCancelled.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:79
+msgid "Exclude Rescheduled And Cancelled"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:304
+msgid "Exclude Rewrites"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:173
+msgid "Exclude Spike"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:359
+msgid "Exclude all locked items"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:67
+msgid "Exclude rewrites"
+msgstr ""
+
+#: scripts/apps/search/views/search-parameters.html:151
+msgid "Exclude spiked content"
+msgstr ""
+
+#: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:151
+msgid "Existing Locations"
+msgstr ""
+
+#: scripts/apps/authoring/multiedit/views/multiedit.html:3
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:87
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:39
+msgid "Exit"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:173
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:556
+msgid "Exit Desk Actions"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:79
+#: scripts/core/editor3/components/Editor3Component.tsx:901
+msgid "Expand"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:80
+msgid "Expand Thin"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:108
+msgid "Expandable"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:304
+msgid "Expire in:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/state.tsx:55
+#: ../superdesk-planning/client/utils/index.ts:430
+msgid "Expired"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:98
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:277
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:92
+msgid "Expiry"
+msgstr ""
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:82
+msgid "Expiry Date:"
+msgstr ""
+
+#: scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx:64
+msgid "Explanation"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:266
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:142
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:222
+#: scripts/apps/archive/index.tsx:342 scripts/apps/archive/views/export.html:32
+#: scripts/apps/archive/views/export.html:4
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:183
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/export-highlight.tsx:18
+#: scripts/apps/authoring-react/toolbar/export-modal.tsx:112
+#: scripts/apps/authoring-react/toolbar/export-modal.tsx:82
+#: scripts/apps/authoring/views/authoring-topbar.html:208
+#: scripts/apps/authoring/views/authoring-topbar.html:307
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:113
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:287
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:287
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:452
+msgid "Export"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/views/chart.html:23
+msgid "Export Chart As..."
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:174
+msgid "Export Highlight"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ExportTemplate.tsx:48
+msgid "Export Template"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:255
+msgid "Export as article"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:353
+#: scripts/apps/authoring/versioning/history/views/history.html:116
+msgid "Exported by"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:163
+msgid "Exposure time"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:81
+msgid "External"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:237
+#: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:116
+msgid "External Links"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventEditor/index.tsx:172
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:61
+msgid "External Reference"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:82
+msgid "Eye Open"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:107
+msgid "FR"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:27
+msgid "FTP File Extension"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:22
+msgid "FTP Server Path"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:39
+msgid "FTP Server Path for Associated media items"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:4
+msgid "FTP Server URL"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:83
+#: scripts/apps/users/views/edit-form.html:295
+msgid "Facebook"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:84
+msgid "Facebook Circle"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:923
+msgid "Failed to add Calendar to the Event"
+msgstr ""
+
+#: ../superdesk-planning/client/api/planning.ts:306
+msgid "Failed to add coverages to workflow"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:328
+#: ../superdesk-planning/client/actions/planning/ui.ts:369
+msgid "Failed to add planning item added as featured story"
+msgstr ""
+
+#: scripts/apps/archive/directives/ArchivedItemKill.ts:33
+#: scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.ts:97
+msgid "Failed to apply kill template to the item."
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem.ts:188
+msgid "Failed to associate update: {{message}}"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:307
+msgid "Failed to cancel all coverage!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:140
+msgid "Failed to cancel the Event!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:289
+msgid "Failed to cancel the Planning Item!"
+msgstr ""
+
+#: scripts/core/auth/login-modal-directive.ts:80
+msgid "Failed to change the password."
+msgstr "Промена лозинке није успела."
+
+#: scripts/apps/authoring/authoring/services/MultiEditUnsavedChangesService.ts:78
+msgid "Failed to check for unsaved changes"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:710
+msgid "Failed to create an archive item."
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsModal.js:102
+msgid "Failed to create the Report Schedule!"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/sets.js:46
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:46
+#: scripts/extensions/sams/src/api/sets.ts:59
+msgid "Failed to create the Set"
+msgstr ""
+
+#: ../superdesk-planning/client/api/locations.ts:33
+msgid "Failed to create the location"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:197
+msgid "Failed to create/update Events and Planning view filter"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/assets.js:449
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:449
+#: scripts/extensions/sams/src/api/assets.ts:564
+msgid "Failed to delete the Asset"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/sets.js:84
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:84
+#: scripts/extensions/sams/src/api/sets.ts:104
+msgid "Failed to delete the Set"
+msgstr ""
+
+#: ../superdesk-planning/client/api/locations.ts:91
+msgid "Failed to delete the location"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:194
+msgid "Failed to delete the saved report"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/MultiEditUnsavedChangesService.ts:60
+msgid "Failed to discard some changes"
+msgstr ""
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:258
+msgid "Failed to duplicate the item"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:61
+#: ../superdesk-analytics/client/charts/services/ChartManager.js:30
+msgid "Failed to export the chart;"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:239
+msgid "Failed to fetch all filters"
+msgstr ""
+
+#: ../superdesk-planning/client/controllers/AssignmentPreviewController.tsx:107
+#: ../superdesk-planning/client/controllers/AssignmentPreviewController.tsx:73
+msgid "Failed to fetch assignment information."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:242
+msgid "Failed to fetch featured stories!"
+msgstr ""
+
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:72
+msgid "Failed to fetch item from archive"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:633
+msgid "Failed to fetch planning item."
+msgstr ""
+
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:115
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:65
+msgid "Failed to find an Assignment to link to!"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:407
+msgid "Failed to generate picture crops."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:260
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:474
+msgid "Failed to generate update: {{message}}"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/assets.js:348
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:348
+#: scripts/extensions/sams/src/api/assets.ts:437
+msgid "Failed to get Assets"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/LockService.ts:21
+msgid "Failed to get a lock on the item!"
+msgstr ""
+
+#: scripts/extensions/sams/src/api/assets.ts:406
+msgid "Failed to get asset \"\""
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/assets.js:305
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:305
+#: scripts/extensions/sams/src/api/assets.ts:389
+msgid "Failed to get assets counts for sets"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/assets.js:408
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:408
+#: scripts/extensions/sams/src/api/assets.ts:519
+msgid "Failed to get binary for asset"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/assets.js:427
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:427
+#: scripts/extensions/sams/src/api/assets.ts:541
+msgid "Failed to get compressed binaries for assets"
+msgstr ""
+
+#: scripts/apps/ingest/controllers/ExternalSourceController.ts:29
+msgid "Failed to get item."
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/assets.js:527
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:527
+#: scripts/extensions/sams/src/api/assets.ts:648
+msgid "Failed to get tags"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/autosave.ts:76
+msgid "Failed to get the autosave entry"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1528
+msgid "Failed to get the queue item"
+msgstr ""
+
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:254
+msgid "Failed to link to requested assignment!"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/sets.js:23
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:23
+#: scripts/extensions/sams/src/api/sets.ts:30
+msgid "Failed to load all sets"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/storageDestinations.js:23
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/storageDestinations.js:23
+#: scripts/extensions/sams/src/api/storageDestinations.ts:34
+msgid "Failed to load all storage destinations"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:352
+msgid "Failed to load duplicated Event."
+msgstr ""
+
+#: ../superdesk-planning/client/api/locks.ts:80
+msgid "Failed to load item locks"
+msgstr ""
+
+#: ../superdesk-planning/client/api/locks.ts:73
+msgid "Failed to load locked items"
+msgstr ""
+
+#: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:229
+#: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:286
+msgid "Failed to load the item."
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:241
+msgid "Failed to load the saved report!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/autosave.ts:32
+msgid "Failed to load {{ itemType }} autosaves."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:277
+#: ../superdesk-planning/client/actions/planning/ui.ts:330
+msgid "Failed to lock featured story action!"
+msgstr ""
+
+#: ../superdesk-planning/client/api/locks.ts:226
+msgid "Failed to lock item"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/assets.js:486
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:486
+#: scripts/extensions/sams/src/api/assets.ts:604
+msgid "Failed to lock the Asset"
+msgstr ""
+
+#: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:273
+msgid "Failed to lock the item."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:485
+msgid "Failed to post the {{ itemType }}"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:447
+msgid "Failed to post, could not find the item type!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:155
+msgid "Failed to postpone the Event!"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/publish-and-continue.tsx:25
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:671
+msgid "Failed to publish and continue."
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/assets.js:249
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:249
+#: scripts/extensions/sams/src/api/assets.ts:330
+msgid "Failed to query Assets"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/autosave.ts:199
+msgid "Failed to remove autosave. Not found"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:279
+msgid "Failed to remove link: {{message}}"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:327
+#: ../superdesk-planning/client/actions/planning/ui.ts:368
+msgid "Failed to remove planning item as featured story"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/api.ts:762
+msgid "Failed to remove the file from event."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/api.ts:728
+msgid "Failed to remove the file from planning."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:365
+msgid "Failed to reschedule the Event!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:544
+msgid "Failed to revert the assignment."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:896
+msgid "Failed to run the query"
+msgstr ""
+
+#: scripts/apps/contacts/directives/ContactsSearchResultsDirective.ts:80
+#: scripts/apps/content-api/directives/ContentAPISearchResultsDirective.ts:77
+#: scripts/apps/search/directives/SearchResults.ts:293
+msgid "Failed to run the query!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:986
+msgid "Failed to run the query.."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/autosave.ts:141
+msgid "Failed to save autosave item."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:357
+msgid "Failed to save featured story record!"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:169
+msgid "Failed to save report"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/MultiEditUnsavedChangesService.ts:72
+msgid "Failed to save some articles"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsModal.js:103
+msgid "Failed to save the Report Schedule!"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:461
+msgid "Failed to save the area of interest:"
+msgstr ""
+
+#: scripts/apps/authoring/tests/changeImage.spec.ts:94
+msgid "Failed to save the area of interest: Failed to call picture_crop."
+msgstr ""
+
+#: scripts/apps/authoring/tests/changeImage.spec.ts:128
+msgid "Failed to save the area of interest: Failed to call picture_renditions."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:469
+msgid "Failed to save the assignment."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/api.ts:833
+msgid "Failed to save the event template"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:190
+#: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:135
+msgid "Failed to save the profile!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:351
+msgid "Failed to save the {{itemType}}!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:293
+msgid "Failed to save, could not find the item {{itemType}}!"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/services/EmailReportService.js:69
+msgid "Failed to send report email!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:69
+#: ../superdesk-planning/client/actions/events/ui.ts:86
+msgid "Failed to spike the event(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/api/locks.ts:354
+#: ../superdesk-planning/client/api/locks.ts:396
+msgid "Failed to unlock item"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/assets.js:504
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:504
+#: scripts/extensions/sams/src/api/assets.ts:623
+msgid "Failed to unlock the Asset"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:408
+msgid "Failed to unpost the {{ itemType }}"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:385
+msgid "Failed to unpost, could not find the item type!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:526
+msgid "Failed to update Event repetitions"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/assets.js:365
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:365
+#: scripts/extensions/sams/src/api/assets.ts:464
+msgid "Failed to update asset."
+msgstr ""
+
+#: ../superdesk-planning/client/api/locations.ts:69
+msgid "Failed to update location"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/assets.js:468
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:468
+#: scripts/extensions/sams/src/api/assets.ts:585
+msgid "Failed to update the Asset"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:511
+msgid "Failed to update the Event time!"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/sets.js:66
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:66
+#: scripts/extensions/sams/src/api/sets.ts:85
+msgid "Failed to update the Set"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/assets.js:43
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:43
+#: scripts/extensions/sams/src/api/assets.ts:61
+msgid "Failed to upload file."
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventAttachments.tsx:62
+#: scripts/extensions/sams/dist/src/containers/FileUploadModal.js:208
+#: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:208
+#: scripts/extensions/sams/src/containers/FileUploadModal.tsx:240
+msgid "Failed to upload files"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:34
+#: ../superdesk-planning/client/components/fields/preview/base/utils.ts:17
+msgid "False"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:85
+msgid "Fast Forward"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:86
+msgid "Fast Rewind"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.ts:26
+msgid "Feature Image"
+msgstr ""
+
+#: scripts/apps/search/views/search-parameters.html:175
+#: scripts/apps/workspace/content/constants.ts:27
+msgid "Feature Media"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:17
+msgid "Feature Preview"
+msgstr ""
+
+#: scripts/apps/authoring-react/field-adapters/feature_media.ts:21
+msgid "Feature media"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:13
+#: scripts/apps/users/views/user-preferences.html:27
+msgid "Feature preview"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeatureLabel.tsx:9
+#: ../superdesk-planning/client/components/fields/editor/Featured.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:83
+msgid "Featured"
+msgstr ""
+
+#: scripts/apps/authoring/views/confirm-media-associated.html:8
+msgid "Featured Media"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:75
+msgid "Featured Stories"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:66
+msgid "Featured Stories Locked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/notifications.ts:383
+msgid "Featured Stories Unlocked"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:133
+msgid "Featured Stories based on timezone: {{tz}}"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/notifications.ts:384
+msgid "Featured stories you were managing was unlocked by"
+msgstr ""
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:20
+msgid "Featuremedia History"
+msgstr ""
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/index.js:50
+msgid "Featuremedia Updates"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:99
+msgid "Feed Parser"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:105
+msgid "Feedback"
+msgstr "Повратне информације"
+
+#: scripts/core/menu/views/menu.html:107
+msgid "Feedback/Suggestions"
+msgstr "Повратне информације/Предлози"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:92
+msgid "Feeding Service"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:64
+msgid "Fern Green"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:434
+#: ../superdesk-analytics/client/utils.js:151 scripts/apps/ingest/index.ts:129
+#: scripts/apps/ingest/index.ts:166
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:4
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:25
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:39
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:70
+#: scripts/core/interactive-article-actions-panel/actions/fetch-to-action.tsx:116
+msgid "Fetch"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:87
+msgid "Fetch As"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:17
+msgid "Fetch Content To a Desk"
+msgstr ""
+
+#: scripts/apps/ingest/index.ts:115 scripts/apps/ingest/index.ts:146
+msgid "Fetch To"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:122
+msgid "Fetch an item"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/actions/fetch-to-action.tsx:101
+msgid "Fetch and open"
+msgstr ""
+
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:48
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:78
+#: scripts/core/interactive-article-actions-panel/action-tabs.tsx:11
+msgid "Fetch to"
+msgstr ""
+
+#: scripts/api/article-fetch.tsx:104
+msgid "Fetch valid({{count}})"
+msgstr ""
+
+#: scripts/apps/search/components/fields/state.tsx:33
+msgid "Fetched"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:269
+#: scripts/apps/authoring/versioning/history/views/history.html:76
+msgid "Fetched by"
+msgstr ""
+
+#: scripts/apps/content-filters/views/filter-search.html:9
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:59
+msgid "Field"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:66
+msgid ""
+"Field\n"
+"                                    type"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:200
+msgid "Field \"{{field}}\" will be permanently deleted."
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:88
+msgid "Field ID to prefill from"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/planning.ts:108
+#: scripts/apps/authoring-react/authoring-react.tsx:1007
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:168
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:203
+msgid "Field is required"
+msgstr "Поље је обавезно"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:88
+msgid "File"
+msgstr ""
+
+#: scripts/apps/publish/views/file-config.html:11
+#: scripts/apps/publish/views/file-config.html:9
+#: scripts/apps/publish/views/ftp-config.html:25
+msgid "File Extension"
+msgstr ""
+
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:201
+msgid "File Name"
+msgstr ""
+
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:211
+msgid "File Size"
+msgstr ""
+
+#: scripts/apps/profiling/views/profiling.html:37
+msgid "File name/line"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:161
+msgid "File types"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/containers/FileUploadModal.js:203
+#: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:203
+#: scripts/extensions/sams/src/containers/FileUploadModal.tsx:230
+msgid "File uploaded successfully"
+msgid_plural "{{count}} files uploaded successfully"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:224
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:117
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:149
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:143
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:224
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:117
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:149
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:143
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:108
+#: scripts/extensions/sams/dist/src/utils/ui.js:108
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:254
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:136
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:168
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:168
+#: scripts/extensions/sams/src/utils/ui.tsx:101
+msgid "Filename"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:169
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:169
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:169
+msgid "Filename:"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:297
+msgid "Files"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/SubNav/Dropdown.tsx:227
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:815
+#: scripts/core/views/sdselect.html:10
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:221
+#: scripts/extensions/broadcasting/dist/src/page.js:225
+#: scripts/extensions/broadcasting/src/page.tsx:348
+msgid "Filter"
+msgstr "Филтер"
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:69
+msgid "Filter \"{{ name }}\" will be permanently deleted."
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:102
+msgid "Filter Condition"
+msgstr ""
+
+#: scripts/apps/content-filters/views/filter-search-result.html:7
+#: scripts/apps/content-filters/views/settings.html:14
+msgid "Filter Conditions"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:183
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:36
+msgid "Filter Details"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:89
+msgid "Filter Large"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:225
+msgid "Filter Name"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:140
+msgid "Filter Schedule"
+msgstr ""
+
+#: scripts/apps/content-filters/views/settings.html:19
+msgid "Filter Search"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:66
+msgid "Filter Statement"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:133
+msgid "Filter Test"
+msgstr ""
+
+#: scripts/apps/content-filters/views/production-test.html:4
+msgid "Filter Test Results"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:111
+msgid "Filter by day:"
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:99
+msgid "Filter condition saved."
+msgstr ""
+
+#: scripts/apps/contacts/views/search-panel.html:3
+msgid "Filter contacts"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:158
+msgid "Filter file types"
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:50
+msgid "Filter statement {{id}} does not have a filter condition."
+msgstr ""
+
+#: scripts/apps/templates/views/templates.html:8
+msgid "Filter:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:76
+msgid "Filtered By"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:48
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:48
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-panel.html:48
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-panel.html:48
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-panel.html:48
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-panel.html:48
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-panel.html:48
+#: scripts/apps/archive/views/list.html:14
+#: scripts/apps/contacts/views/list.html:19
+#: scripts/apps/contacts/views/list.html:20
+#: scripts/apps/content-api/views/list.html:4
+#: scripts/apps/content-api/views/list.html:5
+#: scripts/apps/content-api/views/search-panel.html:8
+#: scripts/apps/content-filters/views/settings.html:9
+#: scripts/apps/legal-archive/views/legal_archive.html:3
+#: scripts/apps/legal-archive/views/legal_archive.html:4
+#: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:49
+#: scripts/apps/search/views/search-panel.html:64
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:292
+msgid "Filters"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:78
+#: scripts/apps/authoring/editor/views/find-replace.html:5
+msgid "Find"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:12
+#: scripts/apps/authoring/editor/find-replace.ts:95
+msgid "Find and Replace"
+msgstr ""
+
+#: scripts/apps/search/index.ts:108
+msgid "Find live and archived content"
+msgstr ""
+
+#: scripts/apps/users/config.ts:39
+msgid "Find your colleagues"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:67
+msgid "Fire Brick"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:63
+msgid "First"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:35
+msgid "First Day"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:224
+msgid "First Event Ends"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:205
+msgid "First Event Starts"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:68
+#: scripts/apps/contacts/views/search-panel.html:14
+#: scripts/core/directives/views/phone-home-modal-directive.html:19
+msgid "First Name"
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:1058
+msgid "First created"
+msgstr "Прво креирано"
+
+#: scripts/apps/search/views/search-filters.html:118
+msgid "Flags"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:166
+msgid "Flash"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:90
+msgid "Flip Horizontal"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:91
+msgid "Flip Vertical"
+msgstr ""
+
+#: scripts/apps/authoring/views/change-image.html:208
+msgid "Flip horizontal"
+msgstr ""
+
+#: scripts/apps/authoring/views/change-image.html:209
+msgid "Flip vertical"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:164
+msgid "Focal length"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:92
+msgid "Folder Close"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:93
+msgid "Folder Open"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:94
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-panel.tsx:94
+#: scripts/apps/authoring/views/theme-select.html:18
+#: scripts/apps/authoring/views/theme-select.html:69
+msgid "Font"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.ts:28
+msgid "Footer"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.ts:29
+msgid "Footers"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:218
+msgid "For Content API only subscriber destinations are not required."
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:21
+msgid "For Publication"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:63
+#: scripts/extensions/sams/dist/src/utils/assets.js:63
+#: scripts/extensions/sams/src/utils/assets.ts:75
+msgid "Force Unlock"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:32
+msgid "Forgot password?"
+msgstr "Заборавили лозинку?"
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:74
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:54
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:177
+#: scripts/apps/authoring/views/preview-formatted.html:18
+#: scripts/apps/publish/views/destination.html:9
+msgid "Format"
+msgstr ""
+
+#: scripts/apps/archive/views/export.html:10
+#: scripts/apps/authoring-react/toolbar/export-modal.tsx:88
+#: scripts/apps/authoring/views/preview-formatted.html:13
+msgid "Formatters"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:34
+msgid "Formatting Marks"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:69
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:75
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:177
+msgid "Formatting Options"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:17
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:316
+#: scripts/apps/workspace/content/views/FormattingOptionsMultiSelect.tsx:34
+msgid "Formatting options"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/OverrideAutoAssignToWorkflow.tsx:15
+msgid "Forward Planning"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:95
+msgid "Forward Thin"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:145
+msgid "Fr"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:16
+msgid "Frequency"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:112
+msgid "Fri"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1458
+#: scripts/core/datetime/datetime.ts:294
+msgid "Friday"
+msgstr "Петак"
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:43
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:241
+#: ../superdesk-planning/client/components/fields/editor/CreationDate.tsx:42
+#: ../superdesk-planning/client/components/fields/editor/StartDateTime.tsx:33
+#: ../superdesk-planning/client/components/fields/preview/index.ts:150
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:67
+#: scripts/core/interactive-article-actions-panel/actions/publish-action.tsx:181
+msgid "From"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:12
+#: scripts/apps/search/views/search-parameters.html:102
+msgid "From Desk"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:73
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:84
+msgid "From template"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:30
+msgid "From:"
+msgstr ""
+
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:327
+msgid "Fulfil Assignment with this item?"
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:152
+msgid "Fulfil assignment"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:160
+msgid "Full"
+msgstr ""
+
+#: scripts/apps/users/views/list.html:33
+msgid "Full name"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/toggleFullWithEditor.tsx:20
+msgid "Full width mode"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:69
+#: scripts/extensions/sams/dist/src/utils/assets.js:69
+#: scripts/extensions/sams/src/utils/assets.ts:81
+msgid "Full-screen preview"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:96
+msgid "Fullscreen"
+msgstr ""
+
+#: scripts/apps/profiling/views/profiling.html:38
+msgid "Function"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:215
+msgid "Future Assignments"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:247
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:247
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:317
+msgid "GB"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:199
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:191
+#: scripts/apps/legal-archive/views/legal_archive.html:52
+msgid "GUID"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:10
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:70
+#: scripts/apps/publish/views/subscribers.html:75
+#: scripts/apps/users/views/edit-form.html:16
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:12
+#: scripts/core/keyboard/keyboard.ts:400 scripts/core/keyboard/keyboard.ts:409
+msgid "General"
+msgstr "Опште"
+
+#: scripts/apps/authoring/views/article-edit.html:580
+msgid "Generate From URL"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-parameters.html:1
+msgid "Generate a report showing activity on a desk."
+msgstr ""
+
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:1
+msgid ""
+"Generate a report showing average and maximum time it took to produce "
+"content per desk."
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-parameters.html:1
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-parameters.html:1
+msgid "Generate a report showing statistics for published content."
+msgstr ""
+
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-parameters.html:1
+msgid ""
+"Generate a report showing the time between original publish and update "
+"publish."
+msgstr ""
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-parameters.html:1
+msgid ""
+"Generate a report showing updates to featuremedia items after initial "
+"publish."
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-parameters.html:1
+msgid "Generate a report showing user activity."
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/embed/editor.tsx:40
+msgid "Generate from URL"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:318
+msgid "Generate token"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:188
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:191
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:399
+msgid "Generated name for created rundowns"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:534
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:127
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:443
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:102
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/ScheduledUpdateForm.tsx:132
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:221
+#: ../superdesk-planning/client/components/fields/editor/Genre.tsx:26
+#: ../superdesk-planning/client/components/fields/preview/index.ts:192
+#: ../superdesk-planning/client/utils/contentProfiles.ts:325
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:336
+#: scripts/apps/authoring-react/field-adapters/genre.ts:26
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:139
+#: scripts/apps/search/directives/SearchFilters.ts:45
+#: scripts/apps/search/services/SearchService.ts:72
+#: scripts/apps/workspace/content/constants.ts:30
+msgid "Genre"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:102
+#: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:78
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Genre.tsx:18
+msgid "Genre:"
+msgstr ""
+
+#: scripts/core/auth/reset-password.html:17
+msgid "Get token"
+msgstr "Преузми токен"
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:15
+msgid "Global"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:51
+msgid "Global Block"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:249
+#: scripts/apps/desks/views/desk-config-modal.html:350
+msgid "Global Read"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:310
+msgid "Global Read:"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-list.html:28
+msgid "Global Saved Reports"
+msgstr ""
+
+#: scripts/apps/search/views/saved-searches.html:36
+msgid "Global Saved Searches"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:66
+msgid "Global saved searches"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:97
+msgid "Globe"
+msgstr ""
+
+#: scripts/apps/legal-archive/views/legal_archive.html:94
+#: scripts/apps/search/views/item-globalsearch.html:19
+msgid "Go"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:268
+msgid "Go Back"
+msgstr ""
+
+#: scripts/apps/master-desk/components/HeaderComponent.tsx:208
+msgid "Go To Desk"
+msgstr ""
+
+#: scripts/apps/production-api-keys/utils.tsx:36
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:46
+#: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:36
+#: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:44
+msgid "Go back"
+msgstr "Иди назад"
+
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:41
+msgid "Go to content profiles"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:45
+msgid "Go to items"
+msgstr ""
+
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:133
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:92
+msgid "Go-To"
+msgstr "Иди на"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:98
+#: ../superdesk-planning/client/utils/index.ts:593
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:253
+msgid "Graphic"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:50
+msgid "Gray"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:52
+msgid "Gray Text"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:59
+msgid "Green"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:99
+msgid "Grid View"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:100
+msgid "Grid View Large"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:298
+msgid "Group \"{{group}}\" and all its fields will be permanently deleted."
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:301
+msgid "Group \"{{group}}\" will be permanently deleted."
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:2
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:2
+msgid "Group By"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-parameters.html:7
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-parameters.html:7
+msgid "Group By:"
+msgstr ""
+
+#: scripts/apps/authoring-react/macros/macros.tsx:359
+#: scripts/apps/authoring/macros/views/macros-widget.html:3
+msgid "Group Macros"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:155
+msgid "Group by day"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:326
+msgid "Groups"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:22
+msgid "Groups Management"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:402
+msgid "Guid"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:20
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:79
+msgid "H1"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:21
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:80
+msgid "H2"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:22
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:81
+msgid "H3"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:23
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:82
+msgid "H4"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:24
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:83
+msgid "H5"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:25
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:84
+msgid "H6"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:47
+msgid "HEADLINE is too long"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/TimeInputs.tsx:45
+msgid "HOUR"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:161
+msgid "Half"
+msgstr ""
+
+#: scripts/core/auth/reset-password.html:69
+msgid "Have password? Sign in."
+msgstr "Имате лозинку? Пријавите се."
+
+#: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:101
+msgid "Header fields"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:101
+msgid "Heading 1"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:102
+msgid "Heading 2"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:103
+msgid "Heading 3"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:104
+msgid "Heading 4"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:105
+msgid "Heading 5"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:106
+msgid "Heading 6"
+msgstr ""
+
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:67
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:57
+#: ../superdesk-planning/client/components/fields/preview/index.ts:259
+#: ../superdesk-planning/client/components/fields/resources/planning.ts:22
+#: ../superdesk-planning/client/utils/contentProfiles.ts:319
+#: scripts/apps/authoring-react/data-layer.ts:204
+#: scripts/apps/authoring-react/field-adapters/headline.ts:20
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-panel.tsx:134
+#: scripts/apps/authoring/views/theme-select.html:36
+#: scripts/apps/authoring/views/theme-select.html:87
+#: scripts/apps/content-filters/views/production-test-view.html:20
+#: scripts/apps/legal-archive/views/legal_archive.html:64
+#: scripts/apps/master-desk/components/FilterPanelComponent.tsx:141
+#: scripts/apps/packaging/views/sd-package-edit.html:4
+#: scripts/apps/publish/views/publish-queue.html:106
+#: scripts/apps/search/views/search-parameters.html:13
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:379
+#: scripts/apps/workspace/content/constants.ts:31
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:311
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:311
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:501
+msgid "Headline"
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-tooltip.html:3
+msgid "Headline:"
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines-widget.js:49
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/main-panel.js:14
+#: scripts/extensions/ai-widget/dist/src/headlines/headlines-widget.js:49
+#: scripts/extensions/ai-widget/dist/src/main-panel.js:14
+#: scripts/extensions/ai-widget/src/headlines/headlines-widget.tsx:74
+#: scripts/extensions/ai-widget/src/main-panel.tsx:25
+msgid "Headlines"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:107
+msgid "Heart"
+msgstr ""
+
+#: scripts/extensions/helloWorld/dist/src/extension.js:5
+#: scripts/extensions/helloWorld/dist/src/extensions/helloWorld/src/extension.js:5
+#: scripts/extensions/helloWorld/src/extension.ts:6
+msgid "Hello world"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:108
+msgid "Help Large"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:238
+msgid "Help us translate Superdesk"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:115
+msgid ""
+"Helper\n"
+"                                    text"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:395
+msgid "Helplines/Contact Information"
+msgstr ""
+
+#: scripts/apps/publish/views/email-config.html:11
+msgid "Hidden recipients (blind carbon copy)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/related_events.tsx:40
+msgid "Hide 1 event"
+msgid_plural "Hide {{n}} events"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../superdesk-planning/client/components/fields/related_plannings.tsx:30
+msgid "Hide 1 planning item"
+msgid_plural "Hide {{n}} planning items"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:250
+msgid "Hide Date"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:586
+msgid "Hide Preview"
+msgstr ""
+
+#: scripts/apps/authoring/preview/fullPreviewMultiple.tsx:46
+msgid "Hide media"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/embed/editor.tsx:55
+msgid "Hide preview"
+msgstr ""
+
+#: scripts/apps/search/components/fields/nested-link.tsx:27
+msgid "Hide previous items"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:6
+msgid "Hide sent/queued items"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:209
+msgid "High priority"
+msgstr ""
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:35
+msgid "Highcharts {{licenseType}} License"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:109
+msgid "Highlight Package"
+msgstr ""
+
+#: scripts/apps/packaging/views/sd-package-items-edit.html:21
+msgid "Highlight Preview"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:159
+msgid "Highlight characters"
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:15
+msgid "Highlight with name"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:219
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/manage-highlights.tsx:21
+#: scripts/apps/authoring-react/toolbar/highlights-modal.tsx:74
+#: scripts/apps/authoring/views/authoring-topbar.html:331
+#: scripts/apps/highlights/index.ts:61 scripts/apps/highlights/index.ts:83
+#: scripts/apps/highlights/views/package_highlights_dropdown_directive.html:2
+#: scripts/apps/templates/services/TemplatesService.ts:71
+msgid "Highlights"
+msgstr ""
+
+#: scripts/apps/highlights/index.ts:70
+msgid "Highlights View"
+msgstr ""
+
+#: scripts/apps/highlights/views/settings.html:4
+msgid "Highlights configurations"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:17
+msgid "Highlights/Summary List Management"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/Editor.tsx:63
+#: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:92
+#: scripts/apps/authoring/versioning/versioning.ts:8
+msgid "History"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:18
+msgid "Hold"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:110
+msgid "Home"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:2
+msgid "Host"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleHour.tsx:41
+msgid "Hour"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:127
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:213
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-parameters.html:24
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-preview.html:10
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:31
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:62
+#: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:20
+msgid "Hourly"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:42
+msgid "Hourly to {{ desk }}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:148
+#: scripts/core/ui/views/sd-timepicker-popup.html:9
+msgid "Hours"
+msgstr "Сати"
+
+#: scripts/apps/users/directives/UserRolesDirective.ts:46
+msgid "I'm sorry but a role with that name already exists."
+msgstr ""
+
+#: scripts/apps/users/directives/UserRolesDirective.ts:50
+msgid "I'm sorry but there was an error when saving the role."
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestRoutingContent.ts:188
+msgid "I'm sorry but there was an error when saving the routing scheme."
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestRulesContent.ts:37
+msgid "I'm sorry but there was an error when saving the rule set."
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:110
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:29
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:39
+msgid "ID"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:45
+msgid ""
+"ID\n"
+"                                must contain only letters, digits and "
+"characters -, _."
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:43
+msgid ""
+"ID conflicts\n"
+"                                with system field."
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:41
+msgid "ID must be unique."
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:93
+msgid "Icon"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:85
+msgid "Id: {{id}}"
+msgstr ""
+
+#: scripts/apps/publish/views/email-config.html:26
+msgid "Identifier for the media in the email template"
+msgstr ""
+
+#: scripts/apps/publish/views/email-config.html:21
+msgid "Identifier for the media within the email html template"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:53
+msgid "Identifiers have to be specified for all items."
+msgstr ""
+
+#: scripts/apps/workspace/content/views/profile-settings.html:173
+msgid ""
+"If enabled, it will be possible to embed articles using this content profile "
+"into other articles that accept embeds (configurable in content profile "
+"field settings)"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx:134
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx:194
+#: scripts/core/ui/views/sd-timezone.html:17
+msgid "If not set, the UTC+0 time zone is assumed."
+msgstr "Ако није подешено, претпоставља се временска зона UTC+0."
+
+#: scripts/apps/desks/views/desk-config-modal.html:84
+msgid "If selected, content published from this desk will be not be expired"
+msgstr ""
+
+#: scripts/core/editor3/components/embeds/EmbedInput.tsx:153
+msgid "If you paste an embed code, it will be used \"as is\"."
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:55
+msgid ""
+"If you select a default role for content creation or editing,\n"
+"                        Superdesk will prefill the Authors field with user's "
+"name and the role.\n"
+"                        The roles are managed in <b>Author roles</b> "
+"controlled vocabulary in the Metadata section."
+msgstr ""
+
+#: ../superdesk-planning/client/components/ConfirmationModal.tsx:137
+#: ../superdesk-planning/client/components/FulFilAssignmentModal/index.tsx:104
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:176
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:48
+#: scripts/apps/desks/controllers/DeskConfigController.ts:96
+#: scripts/core/ui/components/IgnoreCancelSaveDialog.tsx:57
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:38
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:74
+msgid "Ignore"
+msgstr "Игнориши"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:111
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:155
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:168
+msgid "Ignore changes?"
+msgstr ""
+
+#: scripts/core/editor3/components/spellchecker/default-spellcheckers.tsx:74
+msgid "Ignore word"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:233
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:235
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:107
+#: scripts/extensions/sams/dist/src/utils/assets.js:107
+#: scripts/extensions/sams/src/utils/assets.ts:142
+msgid "Image"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:103
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:103
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:114
+msgid "Image Preview"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:82
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:185
+msgid "Image Width"
+msgstr ""
+
+#: scripts/core/upload/crop-directive.ts:41
+msgid ""
+"Image is bigger than {{maxFileSize}}MB, upload file size may be limited!"
+msgstr "Слика је већа од {{maxFileSize}}MB, величина отпремљене датотеке може бити ограничена!"
+
+#: scripts/apps/authoring/views/change-image.html:217
+msgid "Image size"
+msgstr ""
+
+#: scripts/api/article-fetch.tsx:111
+msgid "Image size validation failed"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/ImageTaggingComponent/ImageTaggingComponent.js:199
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:199
+#: scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.tsx:297
+msgid ""
+"Image suggestions are based on generated tags and can be added to article "
+"content by dragging."
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:73
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:73
+#: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:56
+msgid "Images only"
+msgstr ""
+
+#: scripts/apps/users/import/views/import-user.html:44
+msgid "Import"
+msgstr ""
+
+#: scripts/apps/users/import/import.ts:50
+msgid "Import user"
+msgstr ""
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/field-components/time-header-common.tsx:35
+msgid "In 1 hr"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:104
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DateInputPopup.tsx:217
+#: scripts/core/ui/components/Form/DateInput/DateInputPopup.tsx:199
+msgid "In 2 days"
+msgstr "За 2 дана"
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/field-components/time-header-common.tsx:46
+msgid "In 2 hr"
+msgstr ""
+
+#: scripts/apps/vocabularies/services/VocabularyService.ts:136
+msgid "In 3 days"
+msgstr ""
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/field-components/time-header-common.tsx:24
+msgid "In 30 min"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:32
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/State.tsx:36
+#: ../superdesk-planning/client/constants/assignments.ts:203
+#: ../superdesk-planning/client/utils/index.ts:390
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:10
+#: scripts/apps/master-desk/components/AssignmentsComponent.tsx:46
+#: scripts/apps/search/components/fields/state.tsx:35
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:298
+msgid "In Progress"
+msgstr ""
+
+#: scripts/apps/authoring-react/data-layer.ts:428
+#: scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.ts:72
+msgid ""
+"In the story {{slugline}} sent at: {{date}}.{{lineBreak}}This is a corrected "
+"repeat."
+msgstr ""
+
+#: ../superdesk-planning/client/utils/index.ts:335
+#: scripts/apps/contacts/components/ContactInfo.tsx:64
+#: scripts/apps/contacts/services/ContactsService.ts:62
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:92
+#: scripts/apps/publish/directives/SubscribersDirective.ts:67
+#: scripts/apps/users/controllers/UserListController.ts:158
+#: scripts/apps/workspace/content/views/profile-settings.html:62
+msgid "Inactive"
+msgstr ""
+
+#: scripts/apps/publish/views/email-config.html:17
+msgid "Include Feature Media"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/IncludeKilled.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:91
+msgid "Include Killed"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:303
+msgid "Include Rewrites"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/IncludeScheduledUpdates.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:95
+msgid "Include Scheduled Updates"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:175
+msgid "Include Spike"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SpikeState.tsx:31
+msgid "Include Spiked"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:358
+msgid "Include all locked items"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:64
+msgid "Include rewrites"
+msgstr ""
+
+#: scripts/apps/search/views/search-parameters.html:152
+msgid "Include spiked content"
+msgstr ""
+
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:15
+msgid "Included Statistics"
+msgstr ""
+
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-preview.html:13
+msgid "Included Stats"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:372
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:425
+msgid "Incoming"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:386
+msgid "Incoming Rule"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:334
+msgid "Incoming Rule:"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:307
+#: scripts/apps/desks/views/desk-config-modal.html:362
+#: scripts/apps/workspace/content/constants.ts:57
+msgid "Incoming Stage"
+msgstr ""
+
+#: scripts/core/editor3/components/media/MediaBlock.tsx:17
+msgid "Indefinite Usage"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:111
+msgid "Indent Left"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:112
+msgid "Indent Right"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/metadata.ts:1420
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:21
+msgid "Info"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:113
+msgid "Info Large"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:114
+msgid "Info Sign"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/ImageTaggingComponent/ImageTaggingComponent.js:199
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:199
+#: scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.tsx:293
+msgid "Information"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:115
+#: scripts/apps/ingest/index.ts:182 scripts/apps/ingest/index.ts:83
+#: scripts/apps/ingest/views/settings/settings.html:4
+#: scripts/apps/search/views/item-repo.html:3
+msgid "Ingest"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:18
+msgid "Ingest Channels"
+msgstr ""
+
+#: scripts/apps/ingest/index.ts:92
+#: scripts/apps/ingest/views/dashboard/dashboard.html:2
+msgid "Ingest Dashboard"
+msgstr ""
+
+#: scripts/apps/ingest/controllers/IngestDashboardController.ts:36
+msgid "Ingest Dashboard preferences could not be saved."
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:26
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:263
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:84
+#: scripts/apps/publish/views/publish-queue.html:110
+#: scripts/apps/workspace/content/constants.ts:32
+msgid "Ingest Provider"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:30
+msgid "Ingest Provider:"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:596
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:151
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:493
+msgid "Ingest Providers"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/settings.html:15
+msgid "Ingest Routing"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/settings.html:12
+msgid "Ingest Rule sets"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:99
+msgid "Ingest Source"
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:353
+msgid "Ingest Source deleted."
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/settings.html:9
+msgid "Ingest Sources"
+msgstr ""
+
+#: scripts/apps/ingest/ingest-stats-widget/stats.ts:9
+#: scripts/core/lang/missing-translations-strings.ts:44
+msgid "Ingest Stats"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:128
+msgid "Ingest provider sequence"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:270
+msgid "Ingest sequence"
+msgstr ""
+
+#: ../superdesk-planning/client/components/AuditInformation/index.tsx:49
+msgid "Ingest: {{ name }}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:19
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:28
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:22
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:198
+#: ../superdesk-planning/client/utils/index.ts:351
+#: scripts/apps/search/components/fields/state.tsx:31
+msgid "Ingested"
+msgstr ""
+
+#: scripts/extensions/datetimeField/dist/src/config.js:24
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:24
+#: scripts/extensions/datetimeField/src/config.tsx:32
+msgid "Initial time offset"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/inline-comments.tsx:9
+#: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:19
+#: scripts/apps/authoring/track-changes/inline-comments.ts:137
+msgid "Inline comments"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:119
+msgid "Input Type"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/tag-input/editor.tsx:23
+msgid "Input tags here"
+msgstr ""
+
+#: scripts/core/editor3/components/links/LinkInput.tsx:221
+#: scripts/core/editor3/components/links/LinkInput.tsx:253
+msgid "Insert"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:116
+#: scripts/apps/users/views/edit-form.html:312
+msgid "Instagram"
+msgstr ""
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:87
+msgid "Installed Version:"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:474
+msgid "Instant Spellchecking, when automatic spellchecking turned off"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:181
+msgid "Insufficient privileges to view the assignment"
+msgstr ""
+
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:166
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:188
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:243
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:188
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:243
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:93
+#: scripts/extensions/sams/dist/src/utils/ui.js:93
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:230
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:309
+#: scripts/extensions/sams/src/utils/ui.tsx:68
+msgid "Internal"
+msgstr ""
+
+#: scripts/apps/internal-destinations/index.ts:13
+#: scripts/apps/internal-destinations/views/settings.html:5
+msgid "Internal Destinations"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/ScheduledUpdateForm.tsx:145
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:225
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:40
+#: ../superdesk-planning/client/components/fields/preview/index.ts:246
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:27
+#: ../superdesk-planning/client/utils/contentProfiles.ts:293
+msgid "Internal Note"
+msgstr ""
+
+#: ../superdesk-planning/client/components/InternalNoteLabel/index.tsx:83
+msgid "Internal Note:"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-parameters.html:22
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-preview.html:9
+msgid "Interval"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/index.tsx:191
+msgid "Invalid Date"
+msgstr ""
+
+#: scripts/apps/archive/controllers/file-upload-error-modal.tsx:73
+msgid "Invalid File : {{name}}"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:258
+msgid "Invalid format. Only Alphanumerics are allowed."
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:315
+msgid "Invalid time"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:146
+msgid "Invalid value for latitude"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:148
+msgid "Invalid value for longitude"
+msgstr ""
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:69
+#: ../superdesk-planning/client/components/fields/preview/index.ts:278
+#: ../superdesk-planning/client/components/fields/resources/events.ts:86
+#: ../superdesk-planning/client/utils/contentProfiles.ts:343
+msgid "Invitation Details"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:41
+msgid "Is Default"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:165
+msgid "Iso"
+msgstr ""
+
+#: scripts/validate-instance-configuration.tsx:85
+msgid "Issue with extension \"{{id}}\":"
+msgid_plural "Issues with extension \"{{id}}\":"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../superdesk-planning/client/utils/confirmAddingRelatedItems.tsx:29
+msgid "Issues detected:"
+msgstr ""
+
+#: scripts/apps/templates/views/create-template.html:26
+msgid "It will create a new template."
+msgstr ""
+
+#: scripts/apps/templates/views/create-template.html:25
+msgid "It will update existing template."
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:117
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:31
+msgid "Italic"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:76
+msgid "Italic (Ctrl+I)"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/index.ts:599
+msgid "Item"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/planning.tsx:523
+msgid "Item \"{{name}}\" is already added as related"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/planning.tsx:511
+msgid "Item \"{{name}}\" is locked and can not be added as related"
+msgstr ""
+
+#: scripts/apps/archive/controllers/DuplicateController.ts:20
+#: scripts/apps/search/controllers/get-multi-actions.tsx:256
+msgid "Item Duplicated"
+msgstr ""
+
+#: scripts/apps/ingest/controllers/ExternalSourceController.ts:25
+msgid "Item Fetched."
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:56
+msgid "Item History"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/translate-modal.tsx:80
+#: scripts/extensions/ai-widget/dist/src/extension.js:32
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/extension.js:32
+#: scripts/extensions/ai-widget/src/extension.ts:35
+msgid "Item Translated"
+msgstr ""
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:73
+#: ../superdesk-planning/client/components/fields/editor/ItemType.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:104
+msgid "Item Type"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1466
+#: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:206
+#: ../superdesk-planning/client/controllers/FulfilAssignmentController.tsx:172
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:106
+msgid "Item Unlocked"
+msgstr ""
+
+#: scripts/apps/search/components/Item.tsx:44
+#: scripts/core/ui/components/article-item-concise.tsx:78
+msgid "Item actions"
+msgstr "Радње над ставком"
+
+#: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:242
+#: ../superdesk-planning/client/controllers/FulfilAssignmentController.tsx:186
+msgid "Item already linked to a Planning item"
+msgstr ""
+
+#: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:258
+#: ../superdesk-planning/client/controllers/FulfilAssignmentController.tsx:192
+#: ../superdesk-planning/client/controllers/UnlinkAssignmentController.tsx:38
+msgid "Item already locked."
+msgstr ""
+
+#: scripts/core/editor3/components/article-embed/can-add-article-embed.ts:30
+msgid "Item content profile is not configured to allow embedding."
+msgstr ""
+
+#: scripts/api/article-duplicate.tsx:42
+msgid "Item duplicated"
+msgid_plural "Items duplicated"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/apps/archive/directives/ArchivedItemKill.ts:47
+msgid "Item has been killed."
+msgstr ""
+
+#: scripts/apps/archive/directives/ResendItem.ts:39
+msgid "Item has been resent."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1663 scripts/api/article.ts:294
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:445
+msgid ""
+"Item has changed since it was opened. Please close and reopen the item to "
+"continue. Regrettably, your changes cannot be saved."
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:60
+msgid "Item has not been transmitted to any subscriber"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/index.tsx:41
+#: scripts/apps/authoring/versioning/views/versioning.html:6
+#: scripts/apps/legal-archive/views/legal_archive.html:127
+#: scripts/apps/search/views/item-preview.html:18
+msgid "Item history"
+msgstr ""
+
+#: scripts/apps/packaging/directives/PackageItemsEdit.ts:21
+msgid "Item is already in this package."
+msgstr ""
+
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:55
+#: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:55
+#: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:151
+msgid "Item is locked and marked user can not be changed."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/controllers/AssociationController.ts:299
+msgid "Item is locked. Cannot associate media item."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:120
+msgid "Item locked"
+msgstr ""
+
+#: scripts/apps/highlights/services/HighlightsService.ts:125
+msgid "Item marked"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/editor.tsx:134
+msgid "Item not added. Maximum limit of {{n}} items exceeded."
+msgstr ""
+
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:65
+msgid "Item not found!"
+msgstr ""
+
+#: scripts/apps/search/directives/ItemGlobalSearch.ts:49
+msgid "Item not found..."
+msgstr ""
+
+#: ../superdesk-planning/client/controllers/UnlinkAssignmentController.tsx:27
+msgid "Item not linked to a Planning item."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:205
+#: scripts/apps/search/views/item-preview.html:2
+msgid "Item preview"
+msgstr ""
+
+#: scripts/api/article.ts:380
+msgid "Item published."
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:190
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:257
+msgid "Item saved."
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:114
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:29
+msgid "Item sent to Subscriber"
+msgstr ""
+
+#: scripts/apps/ingest/ingest-stats-widget/configuration.html:11
+msgid "Item type stats"
+msgstr ""
+
+#: scripts/apps/highlights/services/HighlightsService.ts:125
+msgid "Item unmarked"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:299
+#: scripts/apps/authoring/multiedit/multiedit.ts:375
+msgid "Item updated."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/controllers/AssociationController.ts:200
+msgid "Item was not added. Only 1 item is allowed for this field."
+msgid_plural ""
+"Item was not added. Only {{number}} items are allowed in this field."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:490
+msgid "Item was unpublished successfully."
+msgstr ""
+
+#: scripts/apps/search/MultiImageEdit.ts:198
+msgid "Item {{headline}} unlocked by another user."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:96
+msgid "Item {{headline}} was unlocked by {{username}}."
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:15
+#: scripts/core/views/sdSearchList.html:36
+msgid "Items"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:128
+msgid "Items Count"
+msgstr ""
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:241
+msgid "Items Created"
+msgstr ""
+
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions-bulk.js:21
+#: scripts/extensions/markForUser/dist/src/get-article-actions-bulk.js:21
+#: scripts/extensions/markForUser/src/get-article-actions-bulk.tsx:26
+msgid "Items are marked for different users"
+msgstr ""
+
+#: scripts/apps/dashboard/user-activity/user-activity.ts:22
+msgid "Items created by the user"
+msgstr ""
+
+#: scripts/apps/dashboard/user-activity/user-activity.ts:25
+msgid "Items locked by the user"
+msgstr ""
+
+#: scripts/apps/dashboard/user-activity/user-activity.ts:28
+msgid "Items marked for the user"
+msgstr ""
+
+#: scripts/apps/dashboard/user-activity/user-activity.ts:31
+msgid "Items moved to a working stage by the user"
+msgstr ""
+
+#: scripts/api/article-fetch.tsx:131
+msgid "Items that can not be fetched"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/directives/EmailReportModal.js:91
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsList.js:101
+msgid "JPEG Image"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:186
+msgid "Jabber Identifier (JID)"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:73
+#: scripts/apps/contacts/views/search-panel.html:39
+#: scripts/apps/users/views/edit-form.html:277
+msgid "Job Title"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/JumpToDropdown.tsx:61
+#: ../superdesk-planning/client/components/Main/JumpToDropdown.tsx:67
+msgid "Jump to specific date"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/kill-action.tsx:9
+#: scripts/apps/authoring/views/authoring-topbar.html:158
+msgid "K"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:245
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:245
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:315
+msgid "KB"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:118
+msgid "Kanban View"
+msgstr ""
+
+#: scripts/core/keyboard/views/keyboard-modal.html:3
+msgid "Keyboard Shortcuts"
+msgstr "Пречице на тастатури"
+
+#: ../superdesk-planning/client/components/fields/editor/Keywords.tsx:25
+#: ../superdesk-planning/client/components/fields/preview/index.ts:184
+#: ../superdesk-planning/client/utils/contentProfiles.ts:335
+#: scripts/apps/archive/views/preview.html:54
+#: scripts/apps/authoring-react/field-adapters/keywords.ts:25
+#: scripts/apps/authoring-react/field-adapters/keywords.ts:47
+#: scripts/apps/content-filters/views/production-test-view.html:21
+#: scripts/apps/search/views/search-parameters.html:229
+#: scripts/apps/workspace/content/constants.ts:33
+msgid "Keywords"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:162
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:119
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/kill-action.tsx:10
+#: scripts/apps/authoring/views/authoring-topbar.html:155
+#: scripts/apps/authoring/views/authoring-topbar.html:156
+#: scripts/apps/authoring/views/authoring-topbar.html:157
+#: scripts/apps/templates/services/TemplatesService.ts:69
+msgid "Kill"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:309
+msgid "Kill item"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:32
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:84
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:28
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:202
+#: ../superdesk-planning/client/utils/index.ts:363
+#: scripts/apps/search/components/fields/state.tsx:42
+msgid "Killed"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/HistoryController.ts:184
+msgid "Killed by"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:574
+msgid "Kills"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:58
+#: scripts/apps/authoring-react/fields/date/config.tsx:37
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:143
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:87
+#: scripts/apps/workspace/content/views/profile-settings.html:115
+#: scripts/apps/workspace/content/views/profile-settings.html:150
+msgid "Label"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:126
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/language.ts:36
+#: ../superdesk-planning/client/components/fields/editor/Language.tsx:75
+#: ../superdesk-planning/client/components/fields/preview/index.ts:108
+#: ../superdesk-planning/client/utils/contentProfiles.ts:267
+#: scripts/apps/archive/views/metadata-view.html:118
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:161
+#: scripts/apps/authoring-react/field-adapters/language.ts:14
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:44
+#: scripts/apps/desks/views/settings.html:90
+#: scripts/apps/templates/views/template-editor-modal.html:119
+#: scripts/apps/users/views/edit-form.html:19
+#: scripts/apps/users/views/edit-form.html:229
+#: scripts/apps/users/views/edit-form.html:234
+#: scripts/apps/workspace/content/constants.ts:34
+#: scripts/extensions/annotationsLibrary/dist/src/GetFields.js:14
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/GetFields.js:14
+#: scripts/extensions/annotationsLibrary/src/GetFields.ts:15
+msgid "Language"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:31
+msgid "Language code"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Language.tsx:17
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx:209
+msgid "Language:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:158
+#: scripts/apps/search/views/search-filters.html:18
+msgid "Languages"
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-footer.js:32
+#: scripts/extensions/ai-widget/dist/src/translations/translations-footer.js:32
+#: scripts/extensions/ai-widget/src/translations/translations-footer.tsx:50
+msgid "Languages are not available."
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:76
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:11
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:17
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:23
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:5
+#: ../superdesk-planning/client/utils/filters.ts:119
+#: scripts/apps/highlights/views/highlights_config_modal.html:45
+msgid "Last"
+msgstr ""
+
+#: scripts/apps/search/directives/DateFilters.ts:47
+msgid "Last 24 Hours"
+msgstr ""
+
+#: scripts/apps/search/directives/DateFilters.ts:31
+msgid "Last 30 Days"
+msgstr ""
+
+#: scripts/apps/search/directives/DateFilters.ts:39
+msgid "Last 7 Days"
+msgstr ""
+
+#: scripts/apps/search/directives/DateFilters.ts:55
+msgid "Last 8 Hours"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:63
+#: scripts/core/lang/missing-translations-strings.ts:20
+msgid "Last Day"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:34
+msgid "Last Item Arrived"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:27
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:20
+#: scripts/core/lang/missing-translations-strings.ts:21
+msgid "Last Month"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:69
+#: scripts/apps/contacts/views/search-panel.html:22
+#: scripts/core/directives/views/phone-home-modal-directive.html:24
+msgid "Last Name"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:30
+msgid "Last Time Updated"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:14
+msgid "Last Updated"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:22
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:14
+#: scripts/core/lang/missing-translations-strings.ts:26
+msgid "Last Week"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:31
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:26
+msgid "Last Year"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/PreviewArticle.tsx:83
+#: scripts/apps/authoring/preview/fullPreview.tsx:77
+msgid "Last modified"
+msgstr ""
+
+#: scripts/apps/profiling/views/profiling.html:24
+#: scripts/apps/publish/views/publish-queue.html:78
+msgid "Last refreshed at"
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-subscribe.html:21
+msgid "Last report sent on:"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:93
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:381
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:171
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:38
+#: scripts/apps/production-api-keys/ProductionApiItem.tsx:33
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:1054
+msgid "Last updated"
+msgstr "Последње ажурирано"
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:735
+msgid "Last {{days}} days"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:728
+msgid "Last {{hours}} hours"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:780
+msgid "Last {{months}} months"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:751
+msgid "Last {{weeks}} weeks"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:301
+msgid "Latitude"
+msgstr ""
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:50
+msgid ""
+"Learn more about Superdesk at <a href=\"https://www.superdesk.org/\" "
+"title=\"Superdesk\" target=\"_blank\">www.superdesk.org</a>. For help and "
+"support, join the discussion on <a href=\"https://forum.sourcefabric.org/"
+"categories/superdesk-dev\" title=\"Superdesk forum\" "
+"target=\"_blank\">Superdesk forums</a>."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/toggleFullWithEditor.tsx:20
+msgid "Leave full width mode"
+msgstr ""
+
+#: scripts/apps/archive/views/item-preview.html:10
+#: scripts/apps/archive/views/metadata-view.html:193
+#: scripts/apps/archive/views/preview.html:41
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:128
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:237
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:26
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:31
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:79
+#: scripts/apps/authoring/views/authoring-header.html:62
+#: scripts/apps/search/components/MediaInfo.tsx:61
+#: scripts/apps/search/components/fields/flags.tsx:23
+#: scripts/apps/search/components/fields/flags.tsx:25
+#: scripts/apps/search/views/search-filters.html:122
+#: scripts/apps/templates/views/template-editor-modal.html:108
+#: scripts/core/itemList/views/relatedItem-list-widget.html:33
+msgid "Legal"
+msgstr ""
+
+#: scripts/apps/legal-archive/index.ts:37
+msgid "Legal Archive"
+msgstr ""
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:70
+msgid "License ID:"
+msgstr ""
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:45
+msgid "License Type"
+msgstr ""
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:56
+msgid "Licensee Contact:"
+msgstr ""
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:50
+msgid "Licensee:"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:53
+msgid "Light Gray"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:54
+msgid "Lighter Gray"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:163
+msgid "Limit further typing"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:99
+msgid "Line"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:160
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:120
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:29
+#: scripts/core/editor3/components/toolbar/TableControls.tsx:118
+msgid "Link"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/index.tsx:287
+msgid "Link (Ctrl+K)"
+msgstr ""
+
+#: scripts/core/editor3/components/links/LinkToolbar.tsx:52
+msgid "Link controls:"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:276
+msgid "Link has been removed"
+msgstr ""
+
+#: scripts/core/auth/auth.ts:103
+msgid "Link sent. Please check your email inbox."
+msgstr "Линк је послат. Проверите своје сандуче е-поште."
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/index.tsx:186
+#: ../superdesk-planning/client/planning-extension/src/extension.ts:204
+#: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:172
+msgid "Link to Assignment"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:131
+msgid "Linked by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:398
+msgid "Linked by {{user}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/linked-items/index.tsx:28
+msgid "Linked items (authoring-react)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:121
+msgid "LinkedIn"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:122
+msgid "LinkedIn Circle"
+msgstr ""
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/link-field.ts:14
+#: ../superdesk-planning/client/components/fields/editor/EventLinks.tsx:62
+#: ../superdesk-planning/client/components/fields/resources/events.ts:53
+#: ../superdesk-planning/client/utils/contentProfiles.ts:299
+msgid "Links"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:78
+msgid "List"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:123
+msgid "List Alternate"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:124
+msgid "List Menu"
+msgstr ""
+
+#: scripts/apps/vocabularies/services/SchemaFactory.ts:9
+msgid "List Name"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:125
+msgid "List Plus"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:126
+#: scripts/apps/desks/directives/DeskConfigModal.ts:34
+#: scripts/apps/search-providers/directive.ts:16
+#: scripts/apps/search/views/search.html:17
+#: scripts/apps/search/views/search.html:18
+#: scripts/apps/users/directives/UserPreferencesDirective.ts:28
+#: scripts/apps/users/directives/UserPreferencesDirective.ts:30
+msgid "List View"
+msgstr ""
+
+#: scripts/apps/monitoring/directives/utils.ts:88
+msgid "List view"
+msgstr ""
+
+#: scripts/apps/authoring/suggest/SuggestView.html:4
+msgid "Live Suggestions"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:278
+msgid "Live suggestions"
+msgstr ""
+
+#: scripts/apps/stream/views/activity-stream.html:30
+msgid "Load more"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ListPanel.tsx:338
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModalSubnav.tsx:52
+#: scripts/core/menu/notifications/views/notifications.html:17
+msgid "Loading"
+msgstr "Учитавање"
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentGroupList.tsx:350
+msgid "Loading more..."
+msgstr ""
+
+#: scripts/apps/publish-preview/previewModal.tsx:45
+msgid "Loading preview"
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditor.js:78
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditor.js:78
+#: scripts/extensions/videoEditor/src/VideoEditor.tsx:132
+msgid "Loading video..."
+msgstr ""
+
+#: scripts/apps/dashboard/views/workspace.html:63
+#: scripts/apps/search/components/ItemList.tsx:511
+#: scripts/apps/users/views/user-list-item.html:36
+#: scripts/core/list/views/list-view.html:2
+#: scripts/core/ui/components/select2.tsx:192
+msgid "Loading..."
+msgstr "Учитавање..."
+
+#: scripts/apps/desks/views/desk-config-modal.html:354
+msgid "Local Read Only"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:315
+msgid "Local Read Only:"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:252
+msgid "Local Readonly"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:260
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:56
+msgid "Locality"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:14
+#: scripts/core/lang/missing-translations-strings.ts:31
+msgid "Located"
+msgstr ""
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/locations-field.ts:19
+#: ../superdesk-planning/client/components/fields/editor/Location.tsx:49
+#: ../superdesk-planning/client/components/fields/preview/Location.tsx:19
+#: ../superdesk-planning/client/components/fields/preview/index.ts:113
+#: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/location/index.tsx:25
+#: ../superdesk-planning/client/utils/contentProfiles.ts:283
+msgid "Location"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/Location.tsx:62
+msgid "Location Details"
+msgstr ""
+
+#: ../superdesk-planning/client/api/locations.ts:86
+msgid "Location deleted"
+msgstr ""
+
+#: ../superdesk-planning/client/controllers/LocationsController.tsx:27
+msgid "Locations"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/LocationsApp.tsx:13
+msgid "Locations Content"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:170
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:127
+msgid "Lock"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/LockState.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:117
+msgid "Lock State"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/LockState.tsx:18
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:147
+#: scripts/apps/authoring/views/article-edit.html:460
+msgid "Locked"
+msgstr ""
+
+#: scripts/apps/archive/views/item-lock.html:7
+#: scripts/apps/authoring-react/subcomponents/lock-info-generic.tsx:47
+#: scripts/apps/authoring-react/subcomponents/lock-info.tsx:48
+#: scripts/apps/authoring/views/authoring-topbar.html:20
+msgid "Locked by"
+msgstr ""
+
+#: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:91
+msgid "Locked by this user"
+msgstr ""
+
+#: scripts/apps/archive/views/item-lock.html:19
+msgid "Locked by you in another browser"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:21
+msgid "Log In"
+msgstr "Пријави се"
+
+#: scripts/core/auth/login-modal.html:57
+msgid "Log In with Google"
+msgstr "Пријави се преко Google-а"
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:41
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:87
+msgid "Log Messages"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:239
+#: ../superdesk-planning/client/components/fields/resources/events.ts:20
+msgid "Long Description"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:310
+msgid "Longitude"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:19
+msgid "Lowercase"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/CalendarNavigation.tsx:66
+msgid "M"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:72
+msgid "MASTER"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:246
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:246
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:316
+msgid "MB"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:75
+msgid "MO"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:411
+msgid "MORE"
+msgstr ""
+
+#: scripts/apps/desks/views/actionpicker.html:26
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:59
+msgid "Macro"
+msgstr ""
+
+#: scripts/apps/authoring/macros/macros.ts:399
+#: scripts/apps/desks/views/desk-config-modal.html:465
+msgid "Macros"
+msgstr ""
+
+#: scripts/apps/authoring-react/macros/macros.tsx:37
+msgid "Macros widget"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:85
+msgid "Main menu"
+msgstr "Главни мени"
+
+#: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:26
+msgid "Make Global"
+msgstr ""
+
+#: scripts/apps/templates/views/template-editor-modal.html:59
+msgid "Make Public"
+msgstr ""
+
+#: scripts/apps/search/views/save-search-dialog.html:14
+msgid "Make global"
+msgstr ""
+
+#: scripts/apps/users/views/change-avatar.html:53
+msgid "Make sure you're looking the best"
+msgstr ""
+
+#: scripts/apps/production-api-keys/utils.tsx:45
+msgid ""
+"Make sure you've saved your Client Secret.You won't be able to access it "
+"again after closing"
+msgstr ""
+
+#: scripts/apps/search/views/search-panel.html:45
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/availability-settings.js:190
+#: scripts/extensions/availability-manager/dist/src/settings/availability-settings.js:190
+#: scripts/extensions/availability-manager/src/settings/availability-settings.tsx:330
+msgid "Manage"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Agendas/ManageAgendasModal.tsx:67
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:22
+msgid "Manage Agendas"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:211
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:34
+msgid "Manage Coverage Profiles"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:96
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:66
+msgid "Manage Custom Layouts"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:59
+msgid "Manage Event & Planning Filters"
+msgstr ""
+
+#: ../superdesk-planning/client/api/contentProfiles.ts:210
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:43
+msgid "Manage Event Profile"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/ManageEventTemplatesModal.tsx:96
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:50
+msgid "Manage Event Templates"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:202
+msgid "Manage Events & Planning Filters"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:18
+msgid "Manage Global Saved Searches"
+msgstr ""
+
+#: ../superdesk-planning/index.ts:28 ../superdesk-planning/index.ts:29
+msgid "Manage Locations"
+msgstr ""
+
+#: ../superdesk-planning/client/api/contentProfiles.ts:183
+#: ../superdesk-planning/client/components/Main/ActionsSubnavDropdown.tsx:29
+msgid "Manage Planning Profile"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:144
+#: scripts/extensions/broadcasting/dist/src/page.js:148
+#: scripts/extensions/broadcasting/src/page.tsx:209
+msgid "Manage Rundown Templates"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:243
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:243
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:349
+msgid "Manage SAMS"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:18
+msgid "Manage Search Providers"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/manageSetsModal.js:99
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:118
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/manageSetsModal.js:99
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:118
+#: scripts/extensions/sams/src/components/sets/manageSetsModal.tsx:94
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:140
+msgid "Manage Sets"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:151
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:153
+#: scripts/extensions/broadcasting/dist/src/page.js:155
+#: scripts/extensions/broadcasting/dist/src/page.js:157
+#: scripts/extensions/broadcasting/src/page.tsx:223
+#: scripts/extensions/broadcasting/src/page.tsx:228
+msgid "Manage Shows"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:72
+msgid "Manage profile"
+msgstr "Управљање профилом"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:146
+#: scripts/extensions/broadcasting/dist/src/page.js:150
+#: scripts/extensions/broadcasting/src/page.tsx:214
+msgid "Manage rundown templates"
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-subscribe.html:5
+#: scripts/apps/search/views/saved-searches.html:27
+#: scripts/apps/search/views/saved-searches.html:56
+msgid "Manage subscription"
+msgstr ""
+
+#: scripts/apps/users/config.ts:145
+msgid "Manage user roles"
+msgstr ""
+
+#: scripts/apps/users/config.ts:135
+msgid "Manage users"
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-manage-subscribers.html:5
+msgid "Manage:"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/config-main.tsx:86
+msgid "Manual entry"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:128
+msgid "Map Marker"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:172
+msgid "Mark"
+msgstr ""
+
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:38
+#: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:38
+#: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:111
+msgid "Mark and send"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/events.ts:162
+msgid "Mark as Postponed"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/events.ts:170
+#: ../superdesk-planning/client/utils/assignments.ts:263
+msgid "Mark as completed"
+msgstr ""
+
+#: scripts/extensions/markForUser/dist/src/extension.js:44
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/extension.js:44
+#: scripts/extensions/markForUser/src/extension.tsx:51
+msgid "Mark for User"
+msgstr ""
+
+#: scripts/apps/desks/index.ts:60 scripts/apps/monitoring/index.ts:130
+msgid "Mark for desk"
+msgstr ""
+
+#: scripts/apps/highlights/index.ts:46 scripts/apps/monitoring/index.ts:129
+msgid "Mark for highlight"
+msgstr ""
+
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions.js:29
+#: scripts/extensions/markForUser/dist/src/get-article-actions.js:29
+#: scripts/extensions/markForUser/src/get-article-actions.tsx:32
+msgid "Mark for other user"
+msgstr ""
+
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions-bulk.js:24
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions.js:13
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:19
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:27
+#: scripts/extensions/markForUser/dist/src/get-article-actions-bulk.js:24
+#: scripts/extensions/markForUser/dist/src/get-article-actions.js:13
+#: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:19
+#: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:27
+#: scripts/extensions/markForUser/src/get-article-actions-bulk.tsx:30
+#: scripts/extensions/markForUser/src/get-article-actions.tsx:14
+#: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:61
+#: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:91
+msgid "Mark for user"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:19
+msgid "Mark items for Highlights/Summary Lists"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:17
+#: scripts/apps/search/views/search-parameters.html:71
+msgid "Marked Desks"
+msgstr ""
+
+#: scripts/apps/archive/views/marked_item_title.html:13
+#: scripts/apps/search/components/HighlightsList.tsx:74
+#: scripts/apps/search/components/MarkedDesksList.tsx:86
+msgid "Marked For"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:311
+msgid "Marked For Not Publication"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:88
+msgid "Marked by"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/marked-desks.tsx:11
+#: scripts/apps/authoring-react/toolbar/highlights-management.tsx:74
+msgid "Marked for"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:319
+msgid "Marked for desk {{x}} by {{user}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:256
+#: scripts/apps/authoring-react/toolbar/mark-for-desks/mark-for-desks-modal.tsx:37
+#: scripts/apps/authoring/views/authoring-topbar.html:337
+msgid "Marked for desks"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:285
+msgid "Marked for highlight {{x}} by {{user}}"
+msgstr ""
+
+#: scripts/extensions/markForUser/dist/src/extension.js:19
+#: scripts/extensions/markForUser/dist/src/extension.js:64
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/extension.js:19
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/extension.js:64
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-marked-for-me-component.js:101
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-marked-for-me-component.js:99
+#: scripts/extensions/markForUser/dist/src/get-marked-for-me-component.js:101
+#: scripts/extensions/markForUser/dist/src/get-marked-for-me-component.js:99
+#: scripts/extensions/markForUser/src/extension.tsx:26
+#: scripts/extensions/markForUser/src/extension.tsx:71
+#: scripts/extensions/markForUser/src/get-marked-for-me-component.tsx:140
+#: scripts/extensions/markForUser/src/get-marked-for-me-component.tsx:148
+msgid "Marked for me"
+msgstr ""
+
+#: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:99
+msgid "Marked for this user"
+msgstr ""
+
+#: scripts/apps/master-desk/index.ts:12 scripts/apps/master-desk/index.ts:23
+msgid "Master Desk"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:7
+msgid "Match Any"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:8
+msgid "Match Prefix"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:97
+msgid "Max"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:147
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:147
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:149
+msgid "Max Asset Size"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:272
+msgid "Max. number of items"
+msgstr ""
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:280
+#: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:31
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:28
+#: scripts/apps/publish/views/subscribers.html:193
+msgid "Maximum"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:44
+msgid "Maximum 80 characters."
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:241
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:241
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:301
+msgid "Maximum Asset Size"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:25
+msgid "Maximum items allowed"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:44
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:216
+msgid "Maximum length"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:226
+msgid "Maximum soft length"
+msgstr ""
+
+#: scripts/apps/authoring-react/field-adapters/_media_self.ts:29
+#: scripts/apps/publish/views/subscribers.html:147
+#: scripts/apps/workspace/content/constants.ts:35
+#: scripts/core/editor3/components/toolbar/index.tsx:302
+msgid "Media"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/index.tsx:21
+msgid "Media (authoring-react)"
+msgstr ""
+
+#: scripts/apps/contacts/index.ts:22
+msgid "Media Contacts"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:143
+msgid "Media Type"
+msgstr ""
+
+#: scripts/apps/vocabularies/constants.ts:18
+msgid "Media gallery"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:57
+msgid "Medium Blue"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:49
+msgid "Medium Gray"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:61
+msgid "Member since"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:92
+msgid "Merge paragraphs"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:116
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:69
+msgid "Message"
+msgstr ""
+
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:82
+msgid "Message Group ID"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:66
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:19
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:3
+#: scripts/apps/authoring/views/change-image.html:153
+#: scripts/apps/content-filters/views/production-test-view.html:55
+#: scripts/apps/legal-archive/views/legal_archive.html:123
+#: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:77
+#: scripts/apps/packaging/views/search-widget-preview.html:8
+#: scripts/apps/search/views/item-preview.html:12
+#: scripts/apps/search/views/multi-image-edit.html:88
+#: scripts/apps/templates/views/template-editor-modal.html:102
+#: scripts/apps/vocabularies/index.ts:43
+msgid "Metadata"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/settings.html:4
+msgid "Metadata management"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:86
+msgid "Min"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:485
+#: ../superdesk-planning/client/constants/tooltips.ts:33
+msgid "Minimise"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/minimize-button.tsx:12
+#: scripts/apps/authoring/views/authoring-topbar.html:248
+#: scripts/apps/authoring/views/authoring-topbar.html:249
+msgid "Minimize"
+msgstr ""
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:277
+#: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:28
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:20
+#: scripts/apps/publish/views/subscribers.html:184
+msgid "Minimum"
+msgstr ""
+
+#: scripts/api/article-fetch.tsx:122
+#: scripts/apps/archive/controllers/file-upload-error-modal.tsx:44
+msgid "Minimum allowed image size is {{minWidth}}x{{minHeight}}"
+msgstr ""
+
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:213
+msgid "Minimum height and width should be greater than or equal to 200"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:32
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:206
+msgid "Minimum length"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:129
+msgid "Minus Sign"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:130
+msgid "Minus Small"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:162
+#: scripts/core/ui/views/sd-timepicker-popup.html:15
+msgid "Minutes"
+msgstr "Минути"
+
+#: scripts/apps/authoring-react/macros/macros.tsx:71
+msgid "Miscellaneous"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:61
+msgid "Missing Link"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:133
+msgid "Mo"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:131
+msgid "Mobile"
+msgstr ""
+
+#: scripts/apps/archive/views/preview.html:9
+#: scripts/apps/authoring-react/fields/attachments/difference-row.tsx:30
+#: scripts/apps/authoring/authoring/modified-info.tsx:20
+msgid "Modified"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:96
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:96
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:182
+msgid "Modified at {{time}} by {{user}}"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:139
+#: scripts/extensions/availability-manager/dist/src/utils.js:139
+#: scripts/extensions/availability-manager/src/utils.ts:159
+msgid "Modified by {{user}} at {{date}}"
+msgstr ""
+
+#: scripts/apps/search/directives/DateFilters.ts:85
+msgid "Modified from"
+msgstr ""
+
+#: scripts/apps/search/directives/DateFilters.ts:86
+msgid "Modified to"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/List/CreatedUpdatedColumn.tsx:29
+msgid "Modified: {{ datetime }}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:108
+msgid "Mon"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1454
+#: scripts/core/datetime/datetime.ts:290
+msgid "Monday"
+msgstr "Понедељак"
+
+#: scripts/apps/monitoring/aggregate-widget/aggregate.ts:6
+msgid "Monitor"
+msgstr ""
+
+#: scripts/apps/monitoring/config.ts:19 scripts/apps/monitoring/config.ts:7
+#: scripts/apps/monitoring/views/monitoring-view.html:21
+#: scripts/apps/monitoring/views/monitoring-view.html:3
+#: scripts/core/lang/missing-translations-strings.ts:44
+msgid "Monitoring"
+msgstr ""
+
+#: scripts/apps/desks/views/settings.html:43
+#: scripts/apps/desks/views/settings.html:47
+#: scripts/apps/monitoring/views/aggregate-settings.html:2
+#: scripts/apps/monitoring/views/monitoring-view.html:107
+msgid "Monitoring settings"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:163
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:83
+msgid "Month"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:32
+msgid "Month(s)"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:40
+#: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:26
+msgid "Monthly"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:51
+msgid "Monthly on the {{ day }} day @ {{ time }} to {{ desk }}"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:78
+msgid "Monthly on the {{day}} day at {{hour}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionsMenu/index.tsx:71
+#: scripts/apps/authoring/views/authoring-topbar.html:260
+#: scripts/apps/authoring/views/authoring-topbar.html:261
+#: scripts/apps/monitoring/views/item-actions-menu.html:10
+#: scripts/apps/monitoring/views/monitoring-view.html:159
+#: scripts/apps/monitoring/views/monitoring-view.html:201
+msgid "More actions"
+msgstr ""
+
+#: scripts/core/ui/components/content-create-dropdown/more-templates.tsx:49
+msgid "More templates"
+msgstr "Више шаблона"
+
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:82
+#: scripts/core/ui/components/content-create-dropdown/initial-view.tsx:181
+msgid "More templates..."
+msgstr "Више шаблона..."
+
+#: ../superdesk-analytics/client/utils.js:166
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:132
+msgid "Move"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:19
+msgid "Move Content to another desk"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:167
+msgid "Move From"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:168
+msgid "Move To"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:209
+msgid "Move down"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:113
+msgid "Move focus to next stage or group"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:115
+msgid "Move focus to previous stage or group"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:197
+msgid "Move up"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:253
+#: scripts/apps/authoring/versioning/history/views/history.html:75
+msgid "Moved by"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:397
+msgid "Moved onto stage Rule"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:338
+msgid "Moved onto stage Rule:"
+msgstr ""
+
+#: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:154
+msgid "Moved to a working stage by this user"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:134
+#: scripts/apps/authoring-react/multi-edit-modal.tsx:240
+msgid "Multi Edit"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:123
+msgid "Multi Line"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:133
+msgid "Multi Start"
+msgstr ""
+
+#: scripts/apps/vocabularies/constants.ts:52
+msgid "Multi selection"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:167
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:124
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:157
+msgid "Multi-edit"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/index.tsx:320
+msgid "Multi-line quote"
+msgstr ""
+
+#: scripts/apps/workspace/index.ts:39
+msgid "Multi-select (or deselect) an item"
+msgstr ""
+
+#: scripts/apps/authoring/multiedit/views/multiedit.html:2
+#: scripts/apps/authoring/views/authoring-topbar.html:296
+#: scripts/apps/authoring/views/opened-articles.html:22
+msgid "Multiedit"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:178
+msgid "Multilingual"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/planning.ts:33
+#: ../superdesk-planning/client/utils/contentProfiles.ts:353
+msgid "Multiple Content"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:129
+msgid "Must be greater than 1"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:102
+msgid "Must be greater than starting date"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:126
+msgid "Must be less than {{ maximum }}"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:46
+msgid ""
+"Must be {{MIN_LENGTH}} characters long and contain {{MIN_STRENGTH}} out of 4 "
+"of the following:"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:165
+msgid "Must select at least one day"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:283
+msgid "Must start with \"http://\", \"https://\" or \"www.\""
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/DesksSubNavDropDown.tsx:20
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:75
+msgid "My Assignments"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:115
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:254
+msgid "My Events"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:242
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:98
+msgid "My Events & Planning"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:174
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:271
+msgid "My Planning"
+msgstr ""
+
+#: scripts/apps/users/index.ts:89
+msgid "My Profile"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-list.html:12
+msgid "My Saved Reports"
+msgstr ""
+
+#: scripts/apps/search/views/saved-searches.html:7
+msgid "My Saved Searches"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:92
+msgid "My Templates"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:17
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-dropdown.html:10
+msgid "NO SUGGESTIONS."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:33
+msgid "NTB Currency Macro"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:31
+#: ../superdesk-planning/client/components/Agendas/ManageAgendasModal.tsx:15
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:98
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:20
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/assignCalendarForm.tsx:77
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:122
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/convertToRecurringEventForm.tsx:137
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:97
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:96
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:199
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:85
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikePlanningForm.tsx:42
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikeEventForm.tsx:80
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikePlanningForm.tsx:41
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateEventRepetitionsForm.tsx:104
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:216
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:218
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:44
+#: ../superdesk-planning/client/components/fields/preview/index.ts:214
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:38
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:16
+#: ../superdesk-planning/client/utils/contentProfiles.ts:271
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:51
+#: scripts/apps/content-filters/views/manage-filters.html:42
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:6
+#: scripts/apps/production-api-keys/ProductionApiKeys.tsx:12
+#: scripts/apps/production-api-keys/config.ts:12
+#: scripts/apps/publish/views/destination.html:4
+#: scripts/apps/publish/views/subscribers.html:112
+#: scripts/apps/search-providers/views/search-provider-config.html:82
+#: scripts/apps/search/views/save-search-dialog.html:7
+#: scripts/apps/templates/views/create-template.html:12
+#: scripts/apps/vocabularies/services/SchemaFactory.ts:6
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:52
+#: scripts/extensions/annotationsLibrary/dist/src/GetFields.js:8
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/GetFields.js:8
+#: scripts/extensions/annotationsLibrary/src/GetFields.ts:9
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:55
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:55
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:89
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:180
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:221
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:111
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:143
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:235
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:141
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:140
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:180
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:221
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:111
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:143
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:235
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:141
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:140
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:106
+#: scripts/extensions/sams/dist/src/utils/ui.js:106
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:191
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:244
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:126
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:158
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:279
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:139
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:165
+#: scripts/extensions/sams/src/utils/ui.tsx:99
+msgid "Name"
+msgstr ""
+
+#: scripts/apps/vocabularies/ManageVocabularyItemTranslations.tsx:28
+msgid "Name ({{language}})"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:131
+msgid "Name Translations"
+msgstr ""
+
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:218
+msgid ""
+"Name field should only have alphanumeric characters, dashes and underscores"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:79
+msgid "Name is not unique."
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:153
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:77
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:77
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:187
+msgid "Name is required."
+msgstr ""
+
+#: scripts/apps/publish/views/email-config.html:30
+msgid "Name of the rendition to attach to the email"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:71
+msgid "Navy"
+msgstr ""
+
+#: scripts/apps/search/views/search-filters.html:11
+#: scripts/apps/search/views/search-filters.html:111
+#: scripts/apps/search/views/search-filters.html:124
+#: scripts/apps/search/views/search-filters.html:132
+#: scripts/apps/search/views/search-filters.html:24
+#: scripts/apps/search/views/search-filters.html:37
+#: scripts/apps/search/views/search-filters.html:50
+#: scripts/apps/search/views/search-filters.html:72
+#: scripts/apps/search/views/search-filters.html:85
+#: scripts/apps/search/views/search-filters.html:98
+msgid "Negate"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:51
+msgid "Neutral Gray"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:278
+msgid "Never"
+msgstr ""
+
+#: scripts/apps/publish/controllers/SubscriberTokenController.ts:28
+msgid "Never expire"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:573
+msgid "New"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:135
+msgid "New Document"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:30
+msgid "New Role"
+msgstr ""
+
+#: scripts/core/editor3/components/annotations/AnnotationInput.tsx:310
+msgid "New annotation"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:237
+msgid "New stage"
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-subscribe.html:6
+msgid "New subscription"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:133
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:133
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:256
+msgid "New template"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:185
+#: scripts/apps/monitoring/views/aggregate-settings.html:158
+#: scripts/extensions/availability-manager/dist/src/correspondent-availability/filters.js:81
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/correspondent-availability/filters.js:81
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/availability-settings.js:183
+#: scripts/extensions/availability-manager/dist/src/settings/availability-settings.js:183
+#: scripts/extensions/availability-manager/src/correspondent-availability/filters.tsx:115
+#: scripts/extensions/availability-manager/src/settings/availability-settings.tsx:313
+msgid "Next"
+msgstr ""
+
+#: scripts/apps/search/directives/DateFilters.ts:23
+msgid "Next 3 Months"
+msgstr ""
+
+#: scripts/apps/search/directives/DateFilters.ts:15
+msgid "Next Month"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:29
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:162
+msgid "Next Week"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:115
+#: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:114
+msgid "Next match"
+msgstr ""
+
+#: scripts/apps/users/config.ts:158
+msgid "Next user"
+msgstr ""
+
+#: scripts/core/ui/components/generic-form/input-types/checkbox.tsx:10
+#: scripts/core/ui/components/generic-form/input-types/yes-no.tsx:7
+msgid "No"
+msgstr "Не"
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:182
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:267
+#: ../superdesk-planning/client/components/fields/editor/NoAgendaAssigned.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:121
+msgid "No Agenda Assigned"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Agendas/AgendaNameList.tsx:14
+msgid "No Agenda Assigned."
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetListPanel.js:62
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetListPanel.js:62
+#: scripts/extensions/sams/src/components/assets/assetListPanel.tsx:35
+msgid "No Assets found"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:123
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:248
+#: ../superdesk-planning/client/components/fields/editor/NoCalendarAssigned.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:125
+msgid "No Calendar Assigned"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:337
+msgid "No Content Linking"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:23
+msgid "No Coverage Assigned"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/InputArray/index.tsx:190
+msgid "No Coverages Yet"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:129
+msgid "No Coverge"
+msgstr ""
+
+#: scripts/apps/templates/constants.ts:11
+msgid "No Desk"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ListPanel.tsx:343
+msgid "No Event or Planning items found"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:7
+msgid "No Fetch actions defined"
+msgstr ""
+
+#: scripts/apps/highlights/views/search_highlights_dropdown_directive.html:6
+msgid "No Filter"
+msgstr ""
+
+#: scripts/apps/products/views/products.html:39
+msgid "No Products Found"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:39
+msgid "No Publish actions defined"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:57
+msgid "No Subscribers Found"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ContentTemplate.tsx:70
+#: ../superdesk-planning/client/components/fields/editor/ExportTemplate.tsx:38
+msgid "No Templates Available"
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:39
+#: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:39
+#: scripts/extensions/ai-widget/src/translations/translations-body.tsx:84
+msgid "No Translations yet"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:51
+msgid "No agendas assigned."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:233
+#: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:227
+#: ../superdesk-planning/client/components/UI/FileReadOnlyList.tsx:65
+msgid "No attached files added."
+msgstr ""
+
+#: scripts/apps/desks/directives/MarkDesksDropdown.ts:25
+#: scripts/apps/desks/views/mark_desks_dropdown_directive.html:8
+#: scripts/apps/search/components/actions-menu/Item.tsx:168
+msgid "No available desks"
+msgstr ""
+
+#: scripts/apps/desks/directives/MarkDesksDropdown.ts:24
+#: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:113
+#: scripts/apps/highlights/views/mark_highlights_dropdown_directive.html:8
+#: scripts/apps/highlights/views/package_highlights_dropdown_directive.html:26
+#: scripts/apps/search/components/actions-menu/Item.tsx:167
+msgid "No available highlights"
+msgstr ""
+
+#: scripts/apps/archive/views/package_item_labels_dropdown_directive.html:13
+msgid "No available labels"
+msgstr ""
+
+#: scripts/apps/translations/views/TranslationDropdown.html:8
+msgid "No available languages"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:123
+msgid "No available selections"
+msgstr ""
+
+#: scripts/apps/desks/directives/MarkDesksDropdown.ts:26
+#: scripts/apps/search/components/actions-menu/Item.tsx:169
+msgid "No available translations"
+msgstr ""
+
+#: ../superdesk-planning/client/components/PlanningTemplatesModal/TemplatesListView.tsx:38
+msgid "No calendar"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/calendars.tsx:80
+msgid "No calendars assigned"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:59
+msgid "No calendars assigned."
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/configuration.html:20
+msgid "No clock here!"
+msgstr ""
+
+#: scripts/apps/authoring-react/generic-widgets/comments/CommentsWidget.tsx:170
+#: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:216
+#: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:48
+msgid "No comments have been posted"
+msgstr ""
+
+#: scripts/apps/authoring/comments/views/comments-widget.html:23
+msgid "No comments so far."
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-filter.html:5
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:11
+msgid "No content filter defined"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/correspondent-availability/with-availability-records.js:54
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/correspondent-availability/with-availability-records.js:54
+#: scripts/extensions/availability-manager/src/correspondent-availability/with-availability-records.tsx:98
+msgid "No data available"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/views/table.html:22
+msgid "No data found"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:222
+msgid "No desk selected"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx:174
+#: scripts/core/interactive-article-actions-panel/actions/send-to-tab.tsx:40
+msgid "No destinations are available."
+msgstr ""
+
+#: scripts/core/spellcheck/spellcheck.ts:527
+msgid "No dictionary available for spell checking."
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:77
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:77
+#: scripts/extensions/sams/src/components/sets/setListPanel.tsx:84
+msgid "No disabled sets configured"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:75
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:75
+#: scripts/extensions/sams/src/components/sets/setListPanel.tsx:62
+msgid "No draft sets configured"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:99
+msgid "No events yet, drop some here, or click the plus button"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:251
+#: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:129
+msgid "No external links added."
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:20
+msgid "No fetch or publish actions defined"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:1080
+msgid ""
+"No formatters found for {{formats}} while publishing item having unique name."
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:206
+msgid "No highlights have been created yet."
+msgstr ""
+
+#: scripts/apps/users/views/change-avatar.html:15
+msgid "No image"
+msgstr ""
+
+#: scripts/core/ui/components/generic-form/input-types/select_single_value.tsx:88
+#: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/editor.js:34
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/editor.js:34
+#: scripts/extensions/broadcasting/src/authoring-fields/subitems/editor.tsx:70
+msgid "No items available"
+msgstr "Нема доступних ставки"
+
+#: ../superdesk-planning/client/components/UI/Form/SelectMetaTermsInput/SelectFieldPopup.tsx:379
+#: ../superdesk-planning/client/components/UI/Form/SelectMetaTermsInput/SelectFieldPopup.tsx:471
+msgid "No items found"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:176
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:176
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:339
+msgid "No items found matching search criteria"
+msgstr ""
+
+#: scripts/core/ui/components/select2.tsx:194
+msgid "No items found."
+msgstr "Ниједна ставка није пронађена."
+
+#: scripts/apps/search/components/WidgetItemList.tsx:38
+msgid "No items in this stage"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/multiSelect.ts:208
+msgid "No items selected."
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:11
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-inner-dropdown.html:10
+msgid "No items to add!"
+msgstr ""
+
+#: scripts/apps/desks/views/task-status-items.html:3
+msgid "No items with this status"
+msgstr ""
+
+#: scripts/core/ui/components/virtual-lists/select.tsx:149
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:146
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:146
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:294
+msgid "No items yet"
+msgstr "Још нема ставки"
+
+#: scripts/apps/archive/views/package_item_labels_dropdown_directive.html:4
+msgid "No label"
+msgstr ""
+
+#: scripts/apps/authoring-react/macros/macros.tsx:317
+msgid "No macros configured."
+msgstr ""
+
+#: scripts/extensions/annotationsLibrary/dist/src/AnnotationsSelect.js:24
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/AnnotationsSelect.js:24
+#: scripts/extensions/annotationsLibrary/src/AnnotationsSelect.tsx:50
+msgid "No matches found in the library."
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-replace.html:2
+msgid "No matches found."
+msgstr ""
+
+#: scripts/apps/profiling/views/profiling.html:32
+msgid "No of calls"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:179
+msgid "No options available for this field"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:101
+msgid "No planning items have been added"
+msgstr ""
+
+#: scripts/apps/users/directives/UserPreferencesDirective.ts:442
+msgid ""
+"No preferred categories selected. Should you choose to proceed with your "
+"choice. A default set of categories will be selected for you."
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EditorFieldEventRelatedItems.tsx:85
+msgid "No related articles yet"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:149
+msgid "No related planning items."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsList.tsx:79
+msgid "No result"
+msgstr ""
+
+#: scripts/apps/dashboard/user-activity/components/Group.tsx:55
+msgid "No results for this user"
+msgstr ""
+
+#: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:205
+#: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:230
+msgid "No results found"
+msgstr ""
+
+#: scripts/core/ui/components/SelectUser.tsx:102
+msgid "No results found."
+msgstr "Нема резултата."
+
+#: scripts/apps/master-desk/components/UserListComponent.tsx:38
+msgid "No role"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:22
+msgid "No roles created yet."
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:63
+msgid "No rules defined in a set."
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:58
+msgid "No rules defined yet"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:180
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningSelectedList.tsx:25
+msgid "No selected featured stories"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:43
+#: scripts/core/auth/reset-password.html:33
+#: scripts/core/auth/reset-password.html:80
+#: scripts/core/auth/secure-login.html:34
+msgid "No server response so far.<br>Let me try again."
+msgstr "Још увек нема одговора сервера.<br>Покушаћу поново."
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:123
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:123
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:239
+msgid "No show selected"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/subitems-view-edit.js:58
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.js:58
+#: scripts/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.tsx:142
+msgid "No subitems"
+msgstr ""
+
+#: scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx:91
+msgid "No suggestions available"
+msgstr ""
+
+#: scripts/apps/authoring/track-changes/views/suggestions-widget.html:46
+msgid "No suggestions have been resolved"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:363
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:363
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:642
+msgid "No tags yet"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:149
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:149
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:316
+msgid "No template selected"
+msgstr ""
+
+#: ../superdesk-planning/client/components/PlanningTemplatesModal/TemplatesListView.tsx:73
+msgid "No templates available in this calendar group."
+msgstr ""
+
+#: ../superdesk-planning/client/components/PlanningTemplatesModal/TemplatesListView.tsx:83
+msgid "No templates found."
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:251
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:251
+#: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:371
+msgid "No thumbnail"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/assets.js:382
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/assets.js:382
+#: scripts/extensions/sams/src/api/assets.ts:483
+msgid "No usable Sets found. Enable one first"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:76
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:76
+#: scripts/extensions/sams/src/components/sets/setListPanel.tsx:73
+msgid "No usable sets configured"
+msgstr ""
+
+#: scripts/apps/users/views/list.html:28
+msgid "No user roles defined!"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/assignCalendarForm.tsx:87
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:136
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:107
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:95
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikeEventForm.tsx:90
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:338
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:231
+msgid "No. of Events"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:148
+msgid "Non-media"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/ColouredValueInput/ColouredValuePopup.tsx:129
+#: ../superdesk-planning/client/components/UI/Form/ColouredValueInput/index.tsx:146
+#: ../superdesk-planning/client/components/UI/Form/ColouredValueInput/index.tsx:165
+#: ../superdesk-planning/client/components/fields/editor/base/numberSelect.tsx:78
+#: scripts/apps/archive/views/marked_item_title.html:22
+#: scripts/apps/archive/views/metadata-view.html:54
+#: scripts/apps/authoring/metadata/views/metadata-dropdown.html:34
+#: scripts/apps/desks/directives/DeskConfigModal.ts:33
+#: scripts/apps/publish/views/publish-queue.html:23
+#: scripts/apps/publish/views/publish-queue.html:39
+#: scripts/apps/publish/views/publish-queue.html:54
+#: scripts/apps/publish/views/publish-queue.html:68
+#: scripts/apps/search-providers/directive.ts:15
+#: scripts/apps/templates/views/template-editor-modal.html:178
+#: scripts/apps/templates/views/template-editor-modal.html:84
+#: scripts/apps/users/views/settings-roles.html:69
+#: scripts/apps/users/views/settings-roles.html:79
+#: scripts/core/ui/components/Form/ColouredValueInput/ColouredValuePopup.tsx:123
+#: scripts/core/ui/components/Form/ColouredValueInput/index.tsx:101
+#: scripts/core/ui/components/Form/ColouredValueInput/index.tsx:87
+#: scripts/core/views/sdSearchList.html:32
+msgid "None"
+msgstr "Ниједан"
+
+#: scripts/apps/authoring/metadata/views/metadata-target-publishing.html:3
+#: scripts/apps/ingest/directives/IngestRoutingAction.ts:67
+#: scripts/core/interactive-article-actions-panel/subcomponents/controlled-vocabulary-select.tsx:46
+msgid "Not"
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:432
+msgid "Not Active"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:35
+msgid "Not Category"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:32
+msgid "Not Desk"
+msgstr ""
+
+#: scripts/apps/desks/views/settings.html:87
+msgid "Not Expired"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/NotForPublication.tsx:15
+#: ../superdesk-planning/client/constants/tooltips.ts:31
+#: scripts/apps/archive/views/item-preview.html:9
+#: scripts/apps/archive/views/metadata-view.html:192
+#: scripts/apps/archive/views/preview.html:40
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:107
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:230
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:15
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:20
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:78
+#: scripts/apps/authoring/views/authoring-header.html:64
+#: scripts/apps/search/components/fields/flags.tsx:15
+#: scripts/apps/search/components/fields/flags.tsx:17
+#: scripts/apps/templates/views/template-editor-modal.html:104
+msgid "Not For Publication"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:34
+msgid "Not Genre"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:41
+msgid "Not Language"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:39
+msgid "Not Legal"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/LockState.tsx:21
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:148
+msgid "Not Locked"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:38
+msgid "Not Priority"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:40
+msgid "Not Sms"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:37
+msgid "Not Source"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:33
+msgid "Not Type"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:36
+msgid "Not Urgency"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:10
+msgid "Not been transmitted to any subscriber"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/profile.ts:100
+msgid "Not enough"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/profile.ts:101
+msgid "Not enough {{ name }}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/Flags.tsx:23
+msgid "Not for Publication"
+msgstr ""
+
+#: scripts/core/ui/components/List/PubStatus.tsx:22
+msgid "Not for publication"
+msgstr "Не за објаву"
+
+#: ../superdesk-planning/client/components/UI/List/PubStatus.tsx:38
+msgid "Not posted"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:134
+msgid "Not scheduled"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:152
+#: ../superdesk-planning/client/components/fields/preview/index.ts:200
+#: ../superdesk-planning/client/utils/planning.tsx:1816
+msgid "Not scheduled yet"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/components/status-select.js:20
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/components/status-select.js:20
+#: scripts/extensions/availability-manager/src/components/status-select.tsx:41
+msgid "Not set"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:319
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:96
+msgid "Notes"
+msgstr ""
+
+#: ../superdesk-planning/client/components/NotificationModal.tsx:44
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:227
+msgid "Notification"
+msgstr ""
+
+#: scripts/apps/monitoring/views/desk-notifications.html:15
+msgid "Notification list"
+msgstr ""
+
+#: scripts/apps/monitoring/views/desk-notifications.html:4
+#: scripts/apps/users/views/user-preferences.html:15
+#: scripts/apps/users/views/user-preferences.html:70
+#: scripts/core/menu/notifications/views/notifications.html:3
+msgid "Notifications"
+msgstr "Обавештења"
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:150
+msgid "Notify when idle for more than"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:84
+#: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:67
+msgid "Number"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentGroupList.tsx:306
+msgid "Number of Assignments:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:83
+msgid "Number of assignments in TO DO"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:71
+#: scripts/apps/users/activity-widget/configuration.html:7
+msgid "Number of items"
+msgstr ""
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:27
+msgid "OEM"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:312
+#: scripts/apps/desks/views/desk-config-modal.html:317
+msgid "OFF"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/EditCoverageAssignmentModal.tsx:106
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:106
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:120
+#: scripts/apps/authoring/macros/views/macros-replace.html:3
+#: scripts/core/auth/auth.ts:242
+#: scripts/core/directives/PasswordStrengthDirective.ts:40
+#: scripts/core/services/modalService.tsx:151
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:391
+msgid "OK"
+msgstr "У реду"
+
+#: scripts/apps/desks/views/desk-config-modal.html:311
+#: scripts/apps/desks/views/desk-config-modal.html:316
+msgid "ON"
+msgstr ""
+
+#: scripts/apps/monitoring/directives/ActiveFilterTags.tsx:87
+msgid "OR"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:25
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:25
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:35
+msgid "Object"
+msgstr ""
+
+#: scripts/apps/search/views/search-parameters.html:196
+msgid "Object Name (Slugline)"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:26
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:26
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:36
+msgid "Objects"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:281
+msgid "Occur Status"
+msgstr ""
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/occurrence-status.ts:34
+#: ../superdesk-planning/client/components/fields/editor/EventOccurenceStatus.tsx:30
+#: ../superdesk-planning/client/components/fields/preview/index.ts:175
+msgid "Occurrence Status"
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.js:74
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx:82
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:41
+msgid "Off"
+msgstr ""
+
+#: scripts/apps/users/components/UserAvatar.tsx:100
+msgid "Offline"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ConfirmationModal.tsx:127
+#: scripts/apps/archive/controllers/file-upload-error-modal.tsx:38
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:593
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:21
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-dropdown.html:14
+#: scripts/apps/search/views/save-search.html:31
+#: scripts/apps/users/views/settings-roles.html:88
+#: scripts/core/prompt-modal.tsx:40 scripts/core/services/modalService.tsx:115
+msgid "Ok"
+msgstr "У реду"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:136
+msgid "Okay"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:65
+msgid "Old Gold"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:37
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.js:73
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx:81
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:40
+#: scripts/apps/templates/views/template-editor-modal.html:151
+msgid "On"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:175
+msgid "On Days"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:341
+msgid ""
+"One of the items that was selected is locked. By default locked items are "
+"not included in the export."
+msgid_plural ""
+"{{ count }} items that were selected are locked. By default locked items are "
+"not included in the export."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/apps/users/components/UserAvatar.tsx:99
+#: scripts/apps/users/controllers/UserListController.ts:156
+msgid "Online"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:86
+msgid "Only 1 image is allowed in this field"
+msgid_plural "Only {{number}} images are allowed in this field"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../superdesk-planning/client/utils/planning.tsx:541
+msgid "Only 1 item can be linked. Adding this would exceed the limit"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/OnlyPosted.tsx:15
+msgid "Only Posted"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:293
+msgid ""
+"Only allow content with the\n"
+"                                following status:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageForm.tsx:247
+msgid "Only one XMP files are accepted"
+msgstr ""
+
+#: scripts/apps/archive/controllers/UploadController.ts:229
+msgid "Only one file can be uploaded"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:269
+msgid "Only the following content item types are allowed:"
+msgstr ""
+
+#: scripts/apps/archive/controllers/UploadController.ts:333
+msgid "Only the following files are allowed: {{fileTypes}}"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:89
+msgid "Only the following media item types are allowed:"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/editor.tsx:159
+msgid "Only the following media types are allowed: {{types}}"
+msgstr ""
+
+#: scripts/core/auth/secure-login.html:28
+msgid "Oops! Authentication has been denied."
+msgstr "Упс! Аутентификација је одбијена."
+
+#: scripts/core/auth/login-modal.html:36
+msgid "Oops! Invalid Username or Password.<br>Please try again."
+msgstr "Упс! Неисправно корисничко име или лозинка.<br>Покушајте поново."
+
+#: scripts/core/auth/reset-password.html:27
+msgid "Oops! Invalid user Email.<br>Please try again."
+msgstr "Упс! Неисправан имејл корисника.<br>Покушајте поново."
+
+#: scripts/apps/users/views/user-list-item.html:37
+#: scripts/core/list/views/list-view.html:3
+msgid "Oops! There are no items."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/multiSelect.ts:238
+#: scripts/apps/authoring/authoring/index.ts:380
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:239
+#: scripts/apps/search-providers/directive.ts:117
+#: scripts/core/editor3/components/links/LinkToolbar.tsx:55
+msgid "Open"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:43
+#: ../superdesk-planning/client/constants/assignments.ts:196
+msgid "Open Coverage"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:47
+msgid "Open advanced search panel by default"
+msgstr ""
+
+#: scripts/apps/workspace/index.ts:34
+msgid "Open highlights"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:401
+msgid "Open in new Window"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/notifications.js:10
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/notifications.js:14
+#: scripts/extensions/broadcasting/dist/src/notifications.js:10
+#: scripts/extensions/broadcasting/dist/src/notifications.js:14
+#: scripts/extensions/broadcasting/src/notifications.ts:22
+#: scripts/extensions/broadcasting/src/notifications.ts:26
+msgid "Open item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:215
+#: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:218
+msgid "Open link"
+msgstr ""
+
+#: scripts/apps/authoring/views/change-image.html:26
+msgid "Open metadata"
+msgstr ""
+
+#: scripts/apps/workspace/index.ts:33
+msgid "Open monitoring"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/multi-edit-toolbar-action.tsx:58
+msgid "Open multi edit"
+msgstr ""
+
+#: scripts/apps/authoring-react/packages.tsx:106
+msgid "Open package"
+msgstr ""
+
+#: scripts/apps/workspace/index.ts:37
+msgid "Open personal"
+msgstr ""
+
+#: scripts/apps/workspace/index.ts:38
+msgid "Open search"
+msgstr ""
+
+#: scripts/apps/workspace/index.ts:36
+msgid "Open spike"
+msgstr ""
+
+#: scripts/apps/workspace/index.ts:35
+msgid "Open tasks"
+msgstr ""
+
+#: scripts/apps/workspace/index.ts:32
+msgid "Open workspace / dashboard"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:40
+msgid "OpenStreetMap Details"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:18
+msgid "Opened"
+msgstr ""
+
+#: scripts/apps/monitoring/views/desk-notifications.html:35
+msgid "Opened by"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:637
+msgid "Operation"
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/views/item-timeline-tooltip.html:4
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-tooltip.html:5
+msgid "Operations:"
+msgstr ""
+
+#: scripts/apps/content-filters/views/filter-search.html:18
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:68
+msgid "Operator"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:105
+msgid "Options:"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/apps/samsAttachmentsWidget.js:199
+#: scripts/extensions/sams/dist/src/apps/samsAttachmentsWidget.js:209
+#: scripts/extensions/sams/dist/src/extensions/sams/src/apps/samsAttachmentsWidget.js:199
+#: scripts/extensions/sams/dist/src/extensions/sams/src/apps/samsAttachmentsWidget.js:209
+#: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:199
+#: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:224
+msgid "Or select an existing asset"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:62
+msgid "Orange"
+msgstr ""
+
+#: ../superdesk-planning/client/components/OrderBar/OrderFieldInput.tsx:21
+msgid "Order By: {{ name }}"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/views/chart-form-options.html:44
+msgid "Order Data In:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:137
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:26
+msgid "Ordered List"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:87
+msgid "Ordered list"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:337
+#: scripts/apps/contacts/directives/ContactsSearchPanelDirective.tsx:87
+#: scripts/apps/contacts/services/ContactsService.ts:39
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:9
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:9
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:15
+msgid "Organisation"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:249
+#: scripts/apps/contacts/components/ListTypeIcon.tsx:7
+msgid "Organisation Contact"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:10
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:10
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:16
+msgid "Organisations"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Archive/ArchivePreview/index.tsx:63
+#: scripts/apps/archive/views/item-preview.html:24
+#: scripts/apps/archive/views/preview.html:122
+#: scripts/apps/authoring-react/article-widgets/translations/translations.tsx:58
+#: scripts/apps/authoring/translations/translationsWidget.tsx:48
+#: scripts/apps/authoring/views/authoring-header.html:84
+#: scripts/apps/authoring/views/change-image.html:125
+#: scripts/apps/authoring/views/change-image.html:232
+#: scripts/apps/authoring/views/change-image.html:92
+msgid "Original"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:306
+msgid ""
+"Original ({{item.renditions.original.width}} x "
+"{{item.renditions.original.height}} px)"
+msgstr ""
+
+#: ../superdesk-analytics/client/views/renditions-preview.html:33
+msgid ""
+"Original ({{preview.item.update.update.renditions.original.width}} x "
+"{{preview.item.update.update.renditions.original.height}} px)"
+msgstr ""
+
+#: scripts/apps/search/components/fields/translations.tsx:26
+msgid "Original Article"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:102
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:176
+msgid "Original ID"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:386
+msgid "Original Id"
+msgstr ""
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:19
+msgid "Original Image"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:27
+#: scripts/apps/archive/views/metadata-view.html:31
+msgid "Original Source"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:106
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:390
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:182
+msgid "Original creator"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-metadata.tsx:43
+msgid "Original size"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:432
+#: scripts/apps/authoring/tests/changeImage.spec.ts:56
+msgid "Original size cannot be less than the required crop sizes."
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:188
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:60
+msgid "Original source"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/SelectInputWithFreeText.tsx:70
+#: ../superdesk-planning/client/components/fields/editor/base/selectWithFreeText.tsx:171
+#: ../superdesk-planning/client/components/fields/editor/base/selectWithFreeText.tsx:174
+#: scripts/apps/vocabularies/controllers/VocabularyConfigController.ts:12
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:125
+#: scripts/extensions/sams/dist/src/utils/assets.js:125
+#: scripts/extensions/sams/src/utils/assets.ts:154
+msgid "Other"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:264
+msgid "Other Coverages"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:100
+msgid "Other Names"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/settings.html:37
+msgid "Other fields"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:373
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:426
+msgid "Outgoing"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:408
+msgid "Outgoing Rule"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:342
+msgid "Outgoing Rule:"
+msgstr ""
+
+#: scripts/apps/publish/views/file-config.html:2
+#: scripts/apps/publish/views/file-config.html:4
+msgid "Output file path"
+msgstr ""
+
+#: scripts/apps/monitoring/directives/AggregateSettings.ts:55
+msgid "Output/Published"
+msgstr ""
+
+#: scripts/apps/monitoring/directives/AggregateSettings.ts:49
+msgid "Output/Scheduled"
+msgstr ""
+
+#: scripts/apps/monitoring/directives/AggregateSettings.ts:61
+msgid "Output/Sent"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:313
+msgid "Override Auto Assign to Workflow"
+msgstr ""
+
+#: scripts/apps/master-desk/MasterDesk.tsx:36
+#: scripts/apps/users/controllers/UserEditController.ts:14
+msgid "Overview"
+msgstr ""
+
+#: scripts/apps/templates/views/templates.html:48
+msgid "Owner"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:79
+msgid "P"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/publish-and-continue.tsx:29
+#: scripts/apps/authoring/views/authoring-topbar.html:100
+msgid "P & C"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:116
+#: scripts/extensions/sams/dist/src/utils/assets.js:116
+#: scripts/extensions/sams/src/utils/assets.ts:148
+msgid "PDF"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/directives/EmailReportModal.js:95
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsList.js:105
+msgid "PDF File"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/planning.ts:29
+msgid "PLANNING DATE cannot be in the past"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/directives/EmailReportModal.js:92
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsList.js:102
+msgid "PNG Image"
+msgstr ""
+
+#: scripts/apps/authoring-react/subcomponents/content-profile-dropdown.tsx:32
+#: scripts/apps/authoring/views/authoring-header.html:24
+#: scripts/apps/authoring/views/authoring-header.html:28
+msgid "PROFILE"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/publish-correction.tsx:13
+msgid "PUBLISH"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:98
+msgid "Pacific/Auckland"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:99
+msgid "Pacific/Honolulu"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:100
+msgid "Pacific/Noumea"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/timezones-all-labels.ts:101
+msgid "Pacific/Port Moresby"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:256
+msgid "Package"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:138
+msgid "Package Create"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:139
+msgid "Package Plus"
+msgstr ""
+
+#: scripts/apps/publish/views/http-push-config.html:2
+msgid "Package individual items"
+msgstr ""
+
+#: scripts/apps/authoring-react/data-layer.ts:212
+#: scripts/apps/authoring-react/field-adapters/package_items.ts:9
+msgid "Package items"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/package-items/index.tsx:36
+msgid "Package items (authoring-react)"
+msgstr ""
+
+#: scripts/apps/archive/views/item-preview.html:5
+msgid "Package preview"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.ts:7
+msgid "Package story labels"
+msgstr ""
+
+#: scripts/apps/authoring-react/packages.tsx:22
+#: scripts/apps/authoring/packages/packages.ts:47
+msgid "Packages"
+msgstr ""
+
+#: scripts/apps/authoring-react/data-layer.ts:223
+msgid "Packages profile"
+msgstr ""
+
+#: scripts/core/list/views/sdPaginationAlt.html:2
+msgid "Page"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/views/chart-form-options.html:57
+msgid "Page Size"
+msgstr ""
+
+#: scripts/core/list/views/sdPagination.html:2
+msgid "Page Size:"
+msgstr ""
+
+#: scripts/apps/legal-archive/views/legal_archive.html:24
+msgid "Pagination"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:140
+msgid "Paragraph"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:203
+msgid "Parallel publishing"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:41
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:41
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-panel.html:41
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-panel.html:41
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-panel.html:41
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-panel.html:41
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-panel.html:41
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-panel.html:41
+#: scripts/apps/content-api/views/search-panel.html:5
+#: scripts/apps/search/views/search-panel.html:63
+msgid "Parameters"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:642
+msgid "Parent coverage not linked to a news item yet."
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:58
+#: scripts/extensions/availability-manager/dist/src/utils.js:58
+#: scripts/extensions/availability-manager/src/utils.ts:61
+msgid "Partially available"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:15
+msgid "Passive mode"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/searchConfig.html:6
+#: scripts/apps/publish/views/ftp-config.html:11
+#: scripts/apps/search-providers/views/search-provider-config.html:117
+#: scripts/apps/users/views/edit-form.html:17
+#: scripts/apps/users/views/edit-form.html:205
+msgid "Password"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:75
+msgid "Password is too weak."
+msgstr ""
+
+#: scripts/core/auth/auth.ts:114
+msgid "Password was changed. You can login using your new password."
+msgstr "Лозинка је промењена. Можете се пријавити новом лозинком."
+
+#: ../superdesk-planning/client/utils/events.tsx:871
+#: ../superdesk-planning/client/utils/events.tsx:885
+msgid "Past Events"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:141
+msgid "Paste"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/LinkInput.tsx:191
+msgid "Paste link"
+msgstr ""
+
+#: scripts/apps/authoring/media/views/media-copy-metadata-directive.html:3
+msgid "Paste metadata"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:21
+msgid "Path"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:142
+msgid "Pause"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:143
+msgid "Paywall"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:144
+msgid "Pencil"
+msgstr ""
+
+#: scripts/apps/users/controllers/UserListController.ts:157
+msgid "Pending"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:426
+#: scripts/apps/desks/views/settings.html:71
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:14
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:14
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:21
+msgid "People"
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:70
+msgid "Permitting"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:13
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:13
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:20
+msgid "Person"
+msgstr ""
+
+#: scripts/apps/contacts/services/ContactsService.ts:38
+msgid "Person (Last Name)"
+msgstr ""
+
+#: scripts/apps/contacts/components/ListTypeIcon.tsx:7
+msgid "Person Contact"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/settings.html:48
+#: scripts/apps/monitoring/controllers/AggregateCtrl.ts:568
+#: scripts/apps/monitoring/views/aggregate-settings.html:122
+#: scripts/apps/monitoring/views/aggregate-settings.html:143
+#: scripts/apps/monitoring/views/aggregate-settings.html:55
+#: scripts/apps/templates/constants.ts:10
+msgid "Personal"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/settings.html:28
+msgid "Personal Dictionary"
+msgstr ""
+
+#: scripts/apps/monitoring/controllers/AggregateCtrl.ts:40
+msgid "Personal Items"
+msgstr ""
+
+#: scripts/apps/monitoring/config.ts:54
+msgid "Personal Space"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/index.ts:170
+msgid "Personal Workspace"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:33
+msgid ""
+"Personal dictionary for language \"{{dictionary.language_id}}\" already "
+"exists."
+msgstr ""
+
+#: scripts/apps/users/controllers/UserEditController.ts:23
+msgid "Personal preferences"
+msgstr ""
+
+#: scripts/apps/monitoring/config.ts:64
+#: scripts/core/interactive-article-actions-panel/subcomponents/destination-select.tsx:28
+msgid "Personal space"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:145
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:394
+msgid "Phone"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:146
+msgid "Photo"
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskConfigModal.ts:40
+#: scripts/apps/monitoring/directives/utils.ts:110
+#: scripts/apps/search-providers/directive.ts:17
+#: scripts/apps/search/views/search.html:27
+#: scripts/apps/search/views/search.html:28
+#: scripts/apps/users/directives/UserPreferencesDirective.ts:29
+msgid "Photo Grid View"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:110
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:92
+msgid "Phrase"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:147
+msgid "Pick"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:385
+msgid "Pick task"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:148
+#: ../superdesk-planning/client/utils/index.ts:589
+#: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:58
+msgid "Picture"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:102
+msgid "Pie"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:149
+#: scripts/apps/authoring-react/widget-header-component.tsx:24
+msgid "Pin"
+msgstr ""
+
+#: scripts/apps/authoring/widgets/WidgetHeaderComponent.tsx:24
+msgid "Pin/Unpin"
+msgstr ""
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/place-field.ts:37
+#: ../superdesk-planning/client/components/fields/editor/Place.tsx:25
+#: ../superdesk-planning/client/utils/contentProfiles.ts:279
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:343
+#: scripts/apps/authoring-react/field-adapters/place.ts:52
+#: scripts/apps/authoring-react/field-adapters/place.ts:82
+#: scripts/apps/workspace/content/constants.ts:36
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:21
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:21
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:30
+msgid "Place"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:137
+#: scripts/core/lang/missing-translations-strings.ts:12
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:22
+#: scripts/extensions/auto-tagging-widget/dist/src/groups.js:22
+#: scripts/extensions/auto-tagging-widget/src/groups.ts:31
+msgid "Places"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/list/Places.tsx:20
+msgid "Places:"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/rundown-items.js:40
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/rundown-items.js:40
+#: scripts/extensions/broadcasting/src/rundowns/components/rundown-items.tsx:128
+msgid "Planned"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:103
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/airing-info-block.js:16
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/planned-duration-label.js:12
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show.js:72
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:34
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:103
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/airing-info-block.js:16
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/planned-duration-label.js:12
+#: scripts/extensions/broadcasting/dist/src/shows/create-show.js:72
+#: scripts/extensions/broadcasting/dist/src/shows/manage-shows.js:34
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:133
+#: scripts/extensions/broadcasting/src/rundowns/components/airing-info-block.tsx:29
+#: scripts/extensions/broadcasting/src/rundowns/components/planned-duration-label.tsx:22
+#: scripts/extensions/broadcasting/src/shows/create-show.tsx:119
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:46
+msgid "Planned duration"
+msgstr ""
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:76
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/index.tsx:245
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:41
+#: ../superdesk-planning/client/components/ItemIcon.tsx:30
+#: ../superdesk-planning/client/components/ItemIcon.tsx:37
+#: ../superdesk-planning/client/components/Main/ItemEditorModal/EditorModalPanel.tsx:169
+#: ../superdesk-planning/client/components/fields/editor/ItemType.tsx:24
+#: ../superdesk-planning/client/components/fields/index.tsx:238
+#: ../superdesk-planning/client/controllers/PlanningController.tsx:45
+#: ../superdesk-planning/client/index.ts:68
+#: ../superdesk-planning/client/index.ts:69
+#: ../superdesk-planning/client/utils/eventsplanning.ts:21
+#: ../superdesk-planning/client/utils/history.tsx:75
+#: ../superdesk-planning/index.ts:13 ../superdesk-planning/index.ts:14
+#: scripts/apps/authoring/authoring/constants.ts:17
+#: scripts/apps/authoring/views/authoring-topbar.html:315
+#: scripts/apps/production-api-keys/config.ts:27
+#: scripts/apps/users/views/user-preferences.html:19
+#: scripts/apps/users/views/user-preferences.html:203
+msgid "Planning"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:61
+msgid "Planning Cancelled"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikePlanningForm.tsx:49
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikePlanningForm.tsx:48
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/planning-date.tsx:25
+#: ../superdesk-planning/client/components/fields/editor/PlanningDateTime.tsx:64
+#: ../superdesk-planning/client/components/fields/preview/index.ts:180
+#: ../superdesk-planning/client/utils/contentProfiles.ts:303
+msgid "Planning Date"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/Editor.tsx:188
+#: ../superdesk-planning/client/components/Main/ItemPreview/PreviewPanel.tsx:127
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/planning-details-widget.js:25
+#: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:11
+msgid "Planning Details"
+msgstr ""
+
+#: ../superdesk-planning/client/api/contentProfiles.ts:185
+msgid "Planning Fields"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/CreateNewSubnavDropdown.tsx:43
+#: ../superdesk-planning/client/utils/index.ts:583
+msgid "Planning Item"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:283
+msgid "Planning Item has been cancelled"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:143
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:111
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:214
+msgid "Planning Items"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:19
+msgid "Planning Management"
+msgstr ""
+
+#: ../superdesk-analytics/client/planning_usage_report/controllers/PlanningUsageReportController.js:150
+msgid "Planning Module (Items created per user)"
+msgstr ""
+
+#: ../superdesk-analytics/client/planning_usage_report/directives/PlanningUsageReportPreview.js:21
+#: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:21
+msgid "Planning Module Usage"
+msgstr ""
+
+#: ../superdesk-analytics/client/planning_usage_report/index.js:45
+msgid "Planning Usage"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:56
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:69
+msgid "Planning cancelled"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelPlanningCoveragesForm.tsx:142
+msgid "Planning cancelled:"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/planning.ts:26
+msgid "Planning date is in the past"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:256
+msgid "Planning duplicated"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:321
+#: ../superdesk-planning/client/actions/planning/ui.ts:365
+msgid "Planning item added as featured story"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:501
+msgid "Planning item already has one related event. Can not add more."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:72
+msgid "Planning item created"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:97
+msgid "Planning item has to be created before adding related events"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:320
+#: ../superdesk-planning/client/actions/planning/ui.ts:364
+msgid "Planning item removed as featured story"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FiltersBox.tsx:51
+msgid "Planning only"
+msgstr ""
+
+#: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:66
+msgid "Planning templates"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Editor/bookmarks/AssociatedPlanningsBookmark.tsx:55
+msgid "Planning: {{ name }}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:150
+msgid "Play"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/UploadConfigModal.tsx:58
+msgid ""
+"Please be aware that uploading external config files\n"
+"                will overwrite your existing configuration."
+msgstr ""
+
+#: scripts/apps/templates/directives/TemplatesDirective.ts:359
+msgid "Please change the default templates first."
+msgstr ""
+
+#: scripts/core/auth/secure-login.html:14
+msgid "Please check that the following id is the same as on your device:"
+msgstr "Проверите да ли је следећи ИД исти као на вашем уређају:"
+
+#: scripts/apps/users/config.ts:95
+msgid "Please confirm that you want to delete all the sessions for this user."
+msgstr ""
+
+#: scripts/apps/users/config.ts:78
+msgid "Please confirm that you want to disable a user."
+msgstr ""
+
+#: scripts/apps/desks/controllers/DeskConfigController.ts:57
+msgid "Please confirm you want to delete desk."
+msgstr ""
+
+#: scripts/apps/dictionaries/controllers/DictionaryConfigController.ts:89
+msgid "Please confirm you want to delete dictionary."
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-subscribe.html:12
+msgid "Please define the frequency and time of your email notifications below."
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:4
+msgid "Please log in again."
+msgstr "Пријавите се поново."
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:86
+msgid "Please provide a valid email address"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:94
+#: scripts/apps/users/views/edit-form.html:340
+msgid "Please provide a valid twitter account"
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:129
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:130
+msgid "Please provide an article GUID"
+msgstr ""
+
+#: scripts/apps/products/controllers/ProductsConfigController.ts:234
+msgid "Please provide an article id"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:208
+msgid ""
+"Please specify 'first name, last name' or  'organisation' or both, and at "
+"least one of [{{list}}] fields."
+msgstr ""
+
+#: scripts/apps/templates/views/create-template.html:27
+#: scripts/apps/templates/views/template-editor-modal.html:22
+#: scripts/apps/workspace/content/views/profile-settings.html:117
+#: scripts/apps/workspace/content/views/profile-settings.html:152
+msgid "Please use less than 40 characters"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:45
+msgid "Please use less than 80 characters"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:53
+msgid "Please use less than 80 characters."
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:151
+msgid "Plus Large"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:152
+msgid "Plus Sign"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:153
+msgid "Plus Small"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:194
+msgid "Point of contact"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:171
+msgid "Point of interest is not defined."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:188
+msgid "Point of interest outside the crop {{cropName}} limits"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:33
+msgid "Populate Abstract"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/FloatingCharacterCount.tsx:45
+msgid "Position"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:119
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:122
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:372
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:217
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:154
+#: ../superdesk-planning/client/constants/events.ts:165
+#: scripts/apps/authoring/comments/views/comments-widget.html:46
+msgid "Post"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:280
+#: ../superdesk-planning/client/components/Locations/LocationsList.tsx:130
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:76
+#: scripts/apps/contacts/constants.ts:74
+#: scripts/apps/contacts/views/search-panel.html:54
+msgid "Post Code"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:66
+msgid "Post Event"
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.js:75
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.js:70
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRuleEditor.tsx:86
+#: ../superdesk-planning/client/planning-extension/src/ingest_rule_autopost/AutopostIngestRulePreview.tsx:77
+msgid "Post Items"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:77
+msgid "Post all recurring events or just this one?"
+msgstr ""
+
+#: scripts/apps/authoring/comments/views/comments-widget.html:45
+msgid "Post on 'Enter'"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:64
+msgid "Post planning items with Event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/AuditInformation/index.tsx:132
+#: ../superdesk-planning/client/components/fields/preview/index.ts:133
+#: ../superdesk-planning/client/constants/tooltips.ts:28
+#: ../superdesk-planning/client/utils/index.ts:415
+#: scripts/core/ui/components/List/PubStatus.tsx:19
+msgid "Posted"
+msgstr "Послато"
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:346
+msgid "Posted Featured Stories record"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:104
+msgid "Postpone"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:102
+msgid "Postpone {{event}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:37
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:208
+#: ../superdesk-planning/client/utils/index.ts:379
+msgid "Postponed"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:113
+msgid "Powered by Superdesk technology"
+msgstr "Покреће технологија Superdesk-а"
+
+#: scripts/extensions/predefinedTextField/dist/src/extension.js:10
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/extension.js:10
+#: scripts/extensions/predefinedTextField/src/extension.tsx:12
+msgid "Predefined text field"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:15
+msgid "Preferred Categories"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:200
+msgid "Preferred values for vocabularies"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:374
+msgid "Prefill the field with text from:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:155
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:37
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:250
+msgid "Preformatted"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:91
+msgid "Preformatted text"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:92
+msgid "Preserve Desk"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:86
+msgid "Preserve Published Content"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/events.ts:171
+#: ../superdesk-planning/client/constants/planning.ts:148
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:254
+#: scripts/apps/authoring-react/fields/embed/editor.tsx:65
+#: scripts/apps/authoring/views/article-edit.html:583
+#: scripts/apps/authoring/views/authoring-topbar.html:197
+#: scripts/apps/authoring/views/authoring.html:23
+#: scripts/apps/search/components/WidgetItem.tsx:94
+#: scripts/core/interactive-article-actions-panel/actions/publish-action.tsx:278
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:52
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:153
+#: scripts/extensions/broadcasting/dist/src/rundowns/manage-rundown-items.js:52
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:153
+#: scripts/extensions/broadcasting/src/rundowns/manage-rundown-items.tsx:107
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:289
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:39
+#: scripts/extensions/sams/dist/src/utils/assets.js:39
+#: scripts/extensions/sams/src/utils/assets.ts:51
+msgid "Preview"
+msgstr ""
+
+#: scripts/apps/authoring/views/preview-formatted.html:6
+msgid "Preview Formatted Story"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:156
+msgid "Preview Mode"
+msgstr ""
+
+#: scripts/apps/publish/views/destination.html:17
+msgid "Preview endpoint URL"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:472
+msgid "Preview formatted article, when previewFormats feature configured"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:74
+msgid "Preview master story"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:171
+#: scripts/apps/monitoring/views/aggregate-settings.html:155
+#: scripts/extensions/availability-manager/dist/src/correspondent-availability/filters.js:78
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/correspondent-availability/filters.js:78
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/availability-settings.js:178
+#: scripts/extensions/availability-manager/dist/src/settings/availability-settings.js:178
+#: scripts/extensions/availability-manager/src/correspondent-availability/filters.tsx:104
+#: scripts/extensions/availability-manager/src/settings/availability-settings.tsx:301
+msgid "Previous"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:107
+#: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:122
+msgid "Previous match"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:661
+msgid "Previous scheduled update is not linked to a news item yet."
+msgstr ""
+
+#: scripts/apps/users/config.ts:157
+msgid "Previous user"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:157
+#: scripts/apps/authoring-react/preview-article-modal.tsx:24
+#: scripts/apps/authoring/preview/fullPreviewMultiple.tsx:57
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:296
+msgid "Print"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/integration-wrapper/print-preview-button.tsx:13
+msgid "Print preview"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:131
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:129
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateAssignmentForm.tsx:138
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/priority-field.ts:50
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:71
+#: ../superdesk-planning/client/utils/contentProfiles.ts:349
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:286
+#: scripts/apps/authoring-react/field-adapters/priority.ts:38
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:104
+#: scripts/apps/content-api/services/ContentAPISearchService.ts:31
+#: scripts/apps/legal-archive/services/LegalArchiveService.ts:29
+#: scripts/apps/legal-archive/tests/legal.spec.ts:71
+#: scripts/apps/search/components/ItemPriority.tsx:25
+#: scripts/apps/search/components/ItemPriority.tsx:36
+#: scripts/apps/search/directives/SearchFilters.ts:46
+#: scripts/apps/search/services/SearchService.ts:71
+#: scripts/apps/workspace/content/constants.ts:37
+msgid "Priority"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:63
+msgid "Priority modified to"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:288
+#: ../superdesk-planning/client/components/fields/priority.tsx:30
+msgid "Priority:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/PriorityLabel/index.tsx:51
+msgid "Priority: {{ name }}"
+msgstr ""
+
+#: scripts/apps/contacts/views/list.html:27
+msgid "Privacy Level:"
+msgstr ""
+
+#: scripts/apps/contacts/services/ContactsService.ts:57
+#: scripts/apps/templates/constants.ts:9
+#: scripts/apps/users/views/edit-form.html:171
+#: scripts/core/ui/components/content-create-dropdown/dropdown-option.tsx:34
+msgid "Private"
+msgstr "Приватно"
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:89
+msgid "Private saved searches"
+msgstr ""
+
+#: scripts/apps/users/controllers/UserEditController.ts:32
+msgid "Privileges"
+msgstr ""
+
+#: scripts/apps/users/directives/UserPrivilegesDirective.ts:43
+msgid "Privileges not found."
+msgstr ""
+
+#: scripts/apps/users/directives/RolesPrivilegesDirective.ts:34
+#: scripts/apps/users/directives/UserPrivilegesDirective.ts:77
+msgid "Privileges updated."
+msgstr ""
+
+#: scripts/apps/packaging/views/sd-package-item-preview.html:37
+#: scripts/apps/packaging/views/sd-package-item-preview.html:8
+msgid "Problems occurred while fetching data."
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:12
+msgid "Product Details"
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:26
+msgid "Product ID"
+msgstr ""
+
+#: scripts/apps/products/views/settings.html:12
+msgid "Product Test"
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:44
+msgid "Product Type"
+msgstr ""
+
+#: scripts/apps/products/controllers/ProductsConfigController.ts:185
+msgid "Product Type is required"
+msgstr ""
+
+#: scripts/apps/products/views/products.html:5
+msgid "Product Type:"
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:53
+msgid "Product codes"
+msgstr ""
+
+#: scripts/apps/products/controllers/ProductsConfigController.ts:203
+msgid "Product deleted."
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:40
+msgid "Product description"
+msgstr ""
+
+#: scripts/apps/products/controllers/ProductsConfigController.ts:175
+msgid "Product is saved."
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:36
+msgid "Product name"
+msgstr ""
+
+#: scripts/apps/search/views/item-repo.html:4
+msgid "Production"
+msgstr ""
+
+#: scripts/apps/production-api-keys/index.ts:13
+#: scripts/apps/production-api-keys/views/settings.html:5
+msgid "Production API"
+msgstr ""
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:276
+msgid "Production Stats"
+msgstr ""
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:293
+#: ../superdesk-analytics/client/production_time_report/index.js:45
+msgid "Production Time"
+msgstr ""
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:173
+msgid "Production Times"
+msgstr ""
+
+#: scripts/apps/products/index.ts:20
+#: scripts/apps/products/views/settings.html:9
+#: scripts/apps/publish/views/subscribers.html:168
+#: scripts/apps/publish/views/subscribers.html:257
+msgid "Products"
+msgstr ""
+
+#: scripts/apps/products/views/settings.html:4
+msgid "Products management"
+msgstr ""
+
+#: scripts/apps/profiling/views/profiling.html:6
+msgid "Profile:"
+msgstr ""
+
+#: scripts/apps/profiling/index.ts:26
+msgid "Profiling Data"
+msgstr ""
+
+#: scripts/apps/authoring/views/theme-select.html:66
+msgid "Proofread Theme"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:104
+msgid "Proofreading Theme"
+msgstr ""
+
+#: scripts/core/auth/reset-password.html:11
+msgid ""
+"Provide your email in order to get 'Reset Token'. Once you get it, use it to "
+"reset your password."
+msgstr ""
+
+#: scripts/apps/users/views/change-avatar.html:47
+msgid "Provided image URL is not valid."
+msgstr ""
+
+#: scripts/apps/search/constants.ts:18
+#: scripts/apps/search/views/search-parameters.html:161
+msgid "Provider"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:77
+msgid "Provider Name"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:72
+msgid "Provider Type"
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:563
+msgid "Provider saved!"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:88
+msgid "Provider sequence"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:39
+msgid ""
+"Provider {{name}} has gone strangely quiet. Last activity was on {{last}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:279
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:110
+msgid "Provider:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/index.tsx:218
+msgid "Provider: {{ name }}"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:123
+msgid "PubStatus"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:95
+#: scripts/apps/contacts/services/ContactsService.ts:56
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:189
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:244
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:189
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:244
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:97
+#: scripts/extensions/sams/dist/src/utils/ui.js:97
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:235
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:312
+#: scripts/extensions/sams/src/utils/ui.tsx:84
+msgid "Public"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:441
+#: ../superdesk-analytics/client/utils.js:154
+#: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:35
+#: scripts/apps/authoring/views/authoring-topbar.html:76
+#: scripts/apps/authoring/views/authoring-topbar.html:77
+#: scripts/apps/authoring/views/authoring-topbar.html:78
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:37
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:32
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:212
+#: scripts/core/interactive-article-actions-panel/action-tabs.tsx:17
+#: scripts/core/interactive-article-actions-panel/action-tabs.tsx:24
+#: scripts/core/interactive-article-actions-panel/actions/publish-action.tsx:304
+msgid "Publish"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:99
+msgid "Publish & Continue"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:445
+#: ../superdesk-analytics/client/utils.js:157
+msgid "Publish Embargo"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:577
+msgid "Publish Pars"
+msgstr ""
+
+#: scripts/apps/publish/index.ts:51
+msgid "Publish Queue"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:137
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:416
+msgid "Publish Schedule"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:444
+#: ../superdesk-analytics/client/utils.js:155
+msgid "Publish Scheduled"
+msgstr ""
+
+#: scripts/apps/authoring/views/confirm-media-associated.html:18
+msgid "Publish Without Media"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:97
+#: scripts/apps/authoring/views/authoring-topbar.html:98
+msgid "Publish and Continue"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/actions/publish-action.tsx:290
+msgid "Publish from"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx:153
+msgid "Publish schedule"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:26
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:81
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:65
+#: scripts/apps/dashboard/workspace-tasks/views/desk-stages.html:22
+#: scripts/apps/search/components/fields/state.tsx:37
+#: scripts/apps/search/views/item-repo.html:5
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:301
+msgid "Published"
+msgstr ""
+
+#: scripts/apps/desks/views/settings.html:86
+msgid "Published Content"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/controllers/PublishingPerformanceReportController.ts:383
+msgid "Published Content for {{group}}: {{data}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/controllers/PublishingPerformanceReportController.ts:389
+msgid "Published Content per {{group}}"
+msgstr ""
+
+#: scripts/apps/legal-archive/views/legal_archive.html:84
+msgid "Published From"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:234
+msgid "Published Stories"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/controllers/ContentPublishingReportController.js:377
+msgid "Published Stories per {{group}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/controllers/ContentPublishingReportController.js:371
+msgid "Published Stories per {{group}} with {{subgroup}} breakdown"
+msgstr ""
+
+#: scripts/apps/legal-archive/views/legal_archive.html:88
+msgid "Published Until"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/HistoryController.ts:180
+msgid "Published by"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:22
+#: scripts/apps/search/directives/DateFilters.ts:93
+msgid "Published from"
+msgstr ""
+
+#: scripts/apps/search/constants.ts:23
+#: scripts/apps/search/directives/DateFilters.ts:94
+msgid "Published to"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:25
+msgid "Publishing"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:108
+msgid "Publishing Action"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/index.js:47
+msgid "Publishing Actions"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/index.js:48
+msgid "Publishing Actions Widget"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/index.js:48
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/controller.js:81
+msgid "Publishing Performance"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/constants.ts:16
+msgid "Publishing actions"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/index-ui.tsx:104
+msgid "Publishing multiple items from authoring pane is not supported"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:181
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:56
+msgid "Pubstatus"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:63
+msgid "Purple"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:30
+msgid "Push associated/feature media items"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:34
+msgid "Push the original rendition"
+msgstr ""
+
+#: scripts/apps/vocabularies/services/SchemaFactory.ts:7
+msgid "QCode"
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorTools.js:30
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorTools.js:30
+#: scripts/extensions/videoEditor/src/VideoEditorTools.tsx:68
+msgid "Quality:"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:163
+msgid "Quarter"
+msgstr ""
+
+#: scripts/apps/search/views/save-search-dialog.html:4
+msgid "Query"
+msgstr ""
+
+#: scripts/apps/search/views/raw-search.html:4
+msgid "Query Text"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:158
+msgid "Question Sign"
+msgstr ""
+
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:67
+msgid "Queue Name"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:112
+msgid "Queued at"
+msgstr ""
+
+#: scripts/apps/authoring-react/macros/macros.tsx:57
+msgid "Quick List"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:159
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:28
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:85
+msgid "Quote"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:103
+msgid "RECURRING ENDS ON must be greater than START DATE"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:119
+msgid "RECURRING REPEAT COUNT is a required field"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:130
+msgid "RECURRING REPEAT COUNT must be greater than 1"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:127
+msgid "RECURRING REPEAT COUNT must be less than {{ maximum }}"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:108
+msgid "RECURRING REPEAT ON is a required field"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:113
+msgid "RECURRING REPEAT UNTIL is a required field"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:53
+msgid "RELATED"
+msgstr ""
+
+#: scripts/apps/search/components/HighlightsList.tsx:98
+#: scripts/apps/search/components/MarkedDesksList.tsx:110
+msgid "REMOVE"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:160
+msgid "Random"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:9
+msgid "Range"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:168
+msgid "Range cannot be greater than {{max}} days"
+msgstr ""
+
+#: scripts/apps/search/views/search-panel.html:15
+msgid "Raw"
+msgstr ""
+
+#: scripts/apps/search/views/raw-search.html:1
+msgid "Raw search"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:42
+msgid "Read Only"
+msgstr ""
+
+#: scripts/apps/users/config.ts:150
+msgid "Read user roles"
+msgstr ""
+
+#: scripts/apps/users/config.ts:140
+msgid "Read users"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/common-field-configuration.tsx:29
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/read-only-label.tsx:7
+#: scripts/apps/authoring/views/authoring-topbar.html:41
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:179
+msgid "Read-only"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:206
+msgid "Rearrange Groups"
+msgstr ""
+
+#: scripts/apps/dashboard/views/workspace.html:5
+msgid "Rearrange widgets"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:161
+msgid "Reason for Event cancellation:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:82
+msgid "Reason for Event postponement:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelPlanningCoveragesForm.tsx:97
+msgid "Reason for cancelling all coverage:"
+msgstr ""
+
+#: ../superdesk-planning/client/api/coverages.ts:33
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelCoverageForm.tsx:81
+msgid "Reason for cancelling the coverage"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelPlanningCoveragesForm.tsx:98
+msgid "Reason for cancelling the planning item:"
+msgstr ""
+
+#: ../superdesk-planning/client/api/coverages.ts:54
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelCoverageForm.tsx:80
+msgid "Reason for cancelling the scheduled update"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:179
+msgid "Reason for rescheduling this event:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:155
+#: ../superdesk-planning/client/constants/assignments.ts:192
+msgid "Reassign"
+msgstr ""
+
+#: scripts/apps/search/components/fields/state.tsx:43
+msgid "Recalled"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/HistoryController.ts:186
+msgid "Recalled by"
+msgstr ""
+
+#: scripts/core/ui/components/content-create-dropdown/initial-view.tsx:151
+msgid "Recent templates"
+msgstr "Недавни шаблони"
+
+#: scripts/apps/users/views/list.html:42
+msgid "Recently added"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:62
+#: scripts/apps/publish/views/email-config.html:2
+msgid "Recipients"
+msgstr ""
+
+#: scripts/apps/publish/views/email-config.html:10
+msgid "Recipients (Bcc, hidden)"
+msgstr ""
+
+#: scripts/apps/publish/views/email-config.html:4
+msgid "Recipients (visible to everybody)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:161
+msgid "Recurring"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemIcon.tsx:26
+msgid "Recurring Event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:120
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:73
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:79
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:85
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:91
+msgid "Recurring Event(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:263
+msgid "Recurring Rules"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:60
+msgid "Red"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:162
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:44
+#: scripts/core/editor3/components/toolbar/index.tsx:473
+msgid "Redo"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:220
+#: ../superdesk-planning/client/components/fields/resources/events.ts:42
+#: ../superdesk-planning/client/utils/contentProfiles.ts:275
+msgid "Reference"
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:770
+msgid "Refine search"
+msgstr "Прецизирај претрагу"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:163
+#: scripts/apps/monitoring/views/monitoring-group-header.html:24
+#: scripts/apps/monitoring/views/monitoring-group-header.html:87
+#: scripts/apps/monitoring/views/monitoring-view.html:99
+#: scripts/apps/profiling/views/profiling.html:23
+#: scripts/apps/publish/views/publish-queue.html:79
+#: scripts/apps/search/views/search-tags.html:24
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:415
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:415
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:794
+msgid "Refresh"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:99
+msgid "Refresh content"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/metadata-tags.html:9
+msgid "Refresh suggestions"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/metadata-tags.html:10
+msgid "Refreshing..."
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines-widget.js:54
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines.js:22
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary-widget.js:55
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary.js:21
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:31
+#: scripts/extensions/ai-widget/dist/src/headlines/headlines-widget.js:54
+#: scripts/extensions/ai-widget/dist/src/headlines/headlines.js:22
+#: scripts/extensions/ai-widget/dist/src/summary/summary-widget.js:55
+#: scripts/extensions/ai-widget/dist/src/summary/summary.js:21
+#: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:31
+#: scripts/extensions/ai-widget/src/headlines/headlines-widget.tsx:100
+#: scripts/extensions/ai-widget/src/headlines/headlines.tsx:46
+#: scripts/extensions/ai-widget/src/summary/summary-widget.tsx:101
+#: scripts/extensions/ai-widget/src/summary/summary.tsx:42
+#: scripts/extensions/ai-widget/src/translations/translations-body.tsx:67
+msgid "Regenerate"
+msgstr ""
+
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:18
+msgid "Region"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/events.ts:75
+msgid "Registration"
+msgstr ""
+
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:77
+#: ../superdesk-planning/client/components/fields/preview/index.ts:271
+#: ../superdesk-planning/client/components/fields/resources/events.ts:64
+#: ../superdesk-planning/client/utils/contentProfiles.ts:341
+msgid "Registration Details"
+msgstr ""
+
+#: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:163
+msgid "Reject"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/suggestions.tsx:74
+#: scripts/apps/authoring/track-changes/views/suggestions-widget.html:9
+msgid "Rejected"
+msgstr ""
+
+#: scripts/apps/authoring/track-changes/views/suggestions-widget.html:38
+msgid "Rejected by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/suggestions.tsx:127
+msgid "Rejected by {{user}}"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem.ts:114
+msgid "Relate an item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EditorFieldEventRelatedItems.tsx:54
+#: ../superdesk-planning/client/components/fields/preview/RelatedArticles.tsx:34
+#: ../superdesk-planning/client/components/fields/resources/events.ts:120
+#: ../superdesk-planning/client/utils/contentProfiles.ts:351
+msgid "Related Articles"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:109
+msgid "Related Events"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem.ts:109
+#: scripts/apps/archive/related-item-widget/relatedItem.ts:13
+#: scripts/apps/workspace/content/constants.ts:39
+msgid "Related Items"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:134
+msgid "Related Planning Items"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:220
+msgid "Related Planning(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Editor/bookmarks/AssociatedPlanningsBookmark.tsx:95
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EventRelatedPlannings.tsx:111
+#: ../superdesk-planning/client/utils/contentProfiles.ts:301
+msgid "Related Plannings"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/settings.html:31
+msgid "Related content"
+msgstr ""
+
+#: scripts/apps/relations/directives/RelatedItemsDirective.ts:237
+msgid "Related item is not available."
+msgstr ""
+
+#: scripts/apps/relations/directives/RelatedItemsDirective.ts:160
+msgid ""
+"Related item was not added, because the field reached the limit of related "
+"items allowed."
+msgstr ""
+
+#: scripts/apps/vocabularies/constants.ts:22
+msgid "Related items"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:16
+msgid "Relative Days"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:13
+msgid "Relative Hours"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:26
+msgid "Relative Months"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:21
+msgid "Relative Weeks"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:181
+msgid "Relative value is required"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Agendas/AgendaListItem.tsx:68
+#: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:58
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:166
+#: ../superdesk-planning/client/components/EventsPlanningFilters/TimeInputs.tsx:84
+#: ../superdesk-planning/client/components/ExportTemplates/ExportTemplateItem.tsx:44
+#: ../superdesk-planning/client/components/UI/Form/FileInput.tsx:117
+#: ../superdesk-planning/client/components/UI/Form/FileInput.tsx:154
+#: ../superdesk-planning/client/components/UI/TermsList.tsx:48
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/RelatedArticlesListComponent.tsx:197
+#: scripts/apps/archive/views/marked_item_title.html:20
+#: scripts/apps/authoring-react/fields/date/config.tsx:93
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:184
+#: scripts/apps/authoring-react/fields/linked-items/editor.tsx:68
+#: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:149
+#: scripts/apps/authoring-react/fields/package-items/editor.tsx:65
+#: scripts/apps/authoring-react/fields/urls/editor.tsx:70
+#: scripts/apps/authoring-react/toolbar/highlights-management.tsx:90
+#: scripts/apps/authoring-react/toolbar/mark-for-desks/mark-for-desks-popover.tsx:48
+#: scripts/apps/authoring/attachments/AttachmentsListItem.tsx:72
+#: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:106
+#: scripts/apps/desks/views/settings.html:57 scripts/apps/ingest/index.ts:102
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:115
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:59
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:126
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:127
+#: scripts/apps/templates/views/templates.html:37
+#: scripts/apps/workspace/content/views/profile-settings.html:48
+#: scripts/core/editor3/highlightsConfig.ts:34
+#: scripts/core/ui/components/select2.tsx:301
+#: scripts/core/ui/components/select2.tsx:302
+#: scripts/extensions/annotationsLibrary/dist/src/annotations-library-page.js:40
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/annotations-library-page.js:40
+#: scripts/extensions/annotationsLibrary/src/annotations-library-page.tsx:80
+#: scripts/extensions/annotationsLibrary/src/annotations-library-page.tsx:81
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:77
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/working-day-view.js:21
+#: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:77
+#: scripts/extensions/availability-manager/dist/src/settings/working-day-view.js:21
+#: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:165
+#: scripts/extensions/availability-manager/src/settings/working-day-view.tsx:44
+#: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/subitems-view-edit.js:39
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.js:39
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:67
+#: scripts/extensions/broadcasting/dist/src/shows/manage-shows.js:67
+#: scripts/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.tsx:81
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:100
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:99
+#: scripts/extensions/datetimeField/dist/src/config.js:36
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:36
+#: scripts/extensions/datetimeField/src/config.tsx:67
+#: scripts/extensions/predefinedTextField/dist/src/config.js:42
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:42
+#: scripts/extensions/predefinedTextField/src/config.tsx:66
+#: scripts/extensions/predefinedTextField/src/config.tsx:67
+msgid "Remove"
+msgstr "Уклони"
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:36
+msgid "Remove All Format"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:195
+msgid "Remove Assignment"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:83
+#: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:85
+msgid "Remove Contact"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:21
+msgid "Remove Content Filter"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/InputArray/index.tsx:84
+msgid "Remove Coverage"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:127
+msgid "Remove Event"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:179
+msgid "Remove Featuremedia"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:30
+msgid "Remove Filter Condition"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:35
+msgid "Remove Format"
+msgstr ""
+
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-article.html:4
+msgid "Remove Item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/GeoLookupInput/LocationItem.tsx:49
+msgid "Remove Location"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:154
+msgid "Remove Scheduled Update"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:17
+msgid "Remove Search Provider"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:164
+msgid "Remove Sign"
+msgstr ""
+
+#: scripts/apps/templates/views/templates.html:37
+msgid "Remove Template"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/index.tsx:386
+msgid "Remove all formatting"
+msgstr ""
+
+#: scripts/apps/authoring-react/multi-edit-modal.tsx:131
+msgid "Remove article"
+msgstr ""
+
+#: scripts/apps/highlights/views/settings.html:20
+msgid "Remove configuration"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/index.tsx:277
+msgid "Remove coverage"
+msgstr ""
+
+#: scripts/apps/desks/views/settings.html:53
+msgid "Remove desk"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/settings.html:55
+msgid "Remove dictionary"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:14
+msgid "Remove fetch action"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:98
+msgid "Remove field"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-filter.html:16
+msgid "Remove filter"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/index.tsx:377
+msgid "Remove formatting"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningItem.tsx:83
+msgid "Remove from Feature Stories"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/planning.ts:146
+msgid "Remove from featured stories"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupElementTemplate.tsx:71
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupList.tsx:83
+msgid "Remove group"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/meta-place-directive.html:33
+#: scripts/apps/authoring/metadata/views/metadata-target-publishing.html:20
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:125
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:128
+#: scripts/apps/search/views/multi-image-edit.html:56
+#: scripts/apps/templates/views/template-editor-modal.html:164
+#: scripts/core/ui/views/sd-multi-select.html:28
+msgid "Remove item"
+msgstr "Уклони ставку"
+
+#: scripts/core/editor3/highlightsConfig.ts:119
+msgid "Remove link"
+msgstr ""
+
+#: scripts/apps/authoring/multiedit/views/multiedit.html:17
+msgid "Remove panel"
+msgstr ""
+
+#: scripts/apps/products/views/products.html:32
+msgid "Remove product"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:46
+msgid "Remove publish action"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:18
+msgid "Remove role"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:20
+msgid "Remove rule set"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:20
+msgid "Remove scheme"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:47
+msgid "Remove source"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/attachments/difference-row.tsx:35
+msgid "Removed"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:86
+msgid "Removed from featured stories"
+msgstr ""
+
+#: scripts/apps/workspace/views/edit-workspace-modal.html:4
+msgid "Rename Workspace"
+msgstr ""
+
+#: scripts/apps/dashboard/views/workspace.html:29
+#: scripts/apps/monitoring/views/monitoring-view.html:213
+msgid "Rename workspace"
+msgstr ""
+
+#: scripts/apps/publish/views/email-config.html:29
+msgid "Rendition"
+msgstr ""
+
+#: ../superdesk-analytics/client/views/renditions-preview.html:11
+msgid "Renditions"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:133
+msgid "Reopened by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:443
+msgid "Reopened by {{user}}"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:105
+msgid "Reorder Sections"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:108
+msgid "Reorder stages and saved searches for monitoring view"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:165
+msgid "Repeat"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/DaysOfWeekInput.tsx:98
+msgid "Repeat On"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:99
+#: ../superdesk-planning/client/components/Events/RepeatEventSummary/index.tsx:15
+msgid "Repeat Summary"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/profile.ts:44
+#: ../superdesk-planning/client/validators/profile.ts:45
+msgid "Repeat must be set"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventScheduleInput/index.tsx:100
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:160
+#: ../superdesk-planning/client/components/fields/editor/EventRecurringRules.tsx:60
+#: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/recurring-rules/index.tsx:23
+msgid "Repeats"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:88
+msgid "Repetitions updated"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:125
+#: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:161
+#: scripts/apps/authoring/editor/views/find-replace.html:28
+#: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:91
+msgid "Replace"
+msgstr ""
+
+#: scripts/apps/authoring/editor/views/find-replace.html:29
+msgid "Replace All"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:141
+msgid "Replace all"
+msgstr ""
+
+#: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:106
+msgid "Replace link"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:88
+#: scripts/apps/authoring/editor/views/find-replace.html:13
+msgid "Replace with"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/suggestions.tsx:87
+msgid "Replace {{x}} with {{y}}"
+msgstr ""
+
+#: scripts/apps/authoring/track-changes/views/suggestions-widget.html:25
+msgid "Replace:"
+msgstr ""
+
+#: scripts/core/editor3/components/comments/CommentPopup.tsx:218
+msgid "Reply"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsModal.js:94
+msgid "Report Schedule created!"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsModal.js:95
+msgid "Report Schedule saved!"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:67
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:63
+msgid "Report Type"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/services/EmailReportService.js:66
+msgid "Report chart emailed!"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:185
+msgid "Report deleted!"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:151
+msgid "Report saved!"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:27
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:46
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:63
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:138
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:156
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:38
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:99
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:196
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/ListElementTemplate.tsx:88
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:19
+#: ../superdesk-planning/client/validators/events.ts:107
+#: ../superdesk-planning/client/validators/events.ts:112
+#: ../superdesk-planning/client/validators/events.ts:118
+#: ../superdesk-planning/client/validators/events.ts:241
+#: ../superdesk-planning/client/validators/planning.ts:231
+#: ../superdesk-planning/client/validators/planning.ts:288
+#: ../superdesk-planning/client/validators/planning.ts:292
+#: scripts/apps/authoring-react/authoring-section/get-field-container.tsx:25
+#: scripts/apps/authoring-react/fields/common-field-configuration.tsx:19
+#: scripts/apps/authoring/authoring/article-url-fields.tsx:68
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:172
+#: scripts/core/editor3/directive.tsx:427 scripts/core/ui/ui.ts:1129
+msgid "Required"
+msgstr "Обавезно"
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:24
+msgid "Required field {{key}} is missing. ..."
+msgstr ""
+
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:116
+msgid "Required {{field}} in item {{item}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:98
+#: ../superdesk-planning/client/constants/events.ts:161
+msgid "Reschedule"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:96
+msgid "Reschedule {{event}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:34
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:206
+#: ../superdesk-planning/client/utils/index.ts:369
+msgid "Rescheduled"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/state.tsx:30
+msgid "Rescheduled Event"
+msgstr ""
+
+#: scripts/apps/archive/views/resend-configuration.html:25
+#: scripts/apps/publish/views/publish-queue.html:147
+#: scripts/apps/publish/views/publish-queue.html:90
+msgid "Resend"
+msgstr ""
+
+#: scripts/apps/archive/views/resend-configuration.html:4
+msgid "Resend To"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:280
+msgid "Resend item"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/HistoryController.ts:188
+msgid "Resent by"
+msgstr ""
+
+#: scripts/apps/profiling/views/profiling.html:22
+msgid "Reset"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:13
+msgid "Reset Filters"
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:247
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:247
+#: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:359
+msgid "Reset change"
+msgstr ""
+
+#: scripts/core/auth/reset-password.html:59
+msgid "Reset password"
+msgstr "Ресетуј лозинку"
+
+#: scripts/core/editor3/components/comments/CommentPopup.tsx:173
+msgid "Resolve"
+msgstr ""
+
+#: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:176
+#: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:4
+msgid "Resolved"
+msgstr ""
+
+#: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:39
+msgid "Resolved by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/suggestions.tsx:18
+msgid "Resolved suggestions"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:592
+msgid "Resolving comments"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:576
+msgid "Resolving suggestions"
+msgstr ""
+
+#: scripts/apps/publish/views/http-push-config.html:5
+#: scripts/apps/publish/views/http-push-config.html:6
+msgid "Resource URL"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:20
+msgid "Restore"
+msgstr ""
+
+#: scripts/apps/products/views/product-test.html:15
+msgid "Result Type"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:166
+msgid "Retweet"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:167
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:272
+msgid "Revert"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:198
+msgid "Revert Availability"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:283
+msgid "Revoke"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:158
+msgid "Rewrite"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:467
+#: scripts/apps/authoring/versioning/history/views/history.html:154
+msgid "Rewrite link is removed"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/preview-source-filter.html:13
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:299
+msgid "Rewrites"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/source-fitlers.html:305
+msgid "Rewrites Only"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:70
+msgid "Rewrites only"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:176
+msgid "Rewritten by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:504
+msgid "Rewritten by {{user}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:469
+#: scripts/apps/authoring/versioning/history/views/history.html:157
+msgid "Rewritten link is removed"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:194
+#: scripts/apps/users/views/edit-form.html:155
+#: scripts/apps/users/views/list.html:35
+#: scripts/apps/users/views/user-privileges.html:19
+msgid "Role"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:45
+msgid "Role Description"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:38
+msgid "Role Name"
+msgstr ""
+
+#: scripts/apps/users/views/settings.html:9
+msgid "Roles"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:20
+msgid "Roles Management"
+msgstr ""
+
+#: scripts/apps/users/views/settings.html:12
+msgid "Roles privileges"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:168
+msgid "Rotate Left"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:169
+msgid "Rotate Right"
+msgstr ""
+
+#: scripts/apps/authoring/views/change-image.html:206
+msgid "Rotate left"
+msgstr ""
+
+#: scripts/apps/authoring/views/change-image.html:207
+msgid "Rotate right"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:253
+msgid "Round corners for dropdown items"
+msgstr ""
+
+#: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:22
+msgid "Route incoming content to"
+msgstr ""
+
+#: scripts/apps/search/components/fields/state.tsx:32
+msgid "Routed"
+msgstr ""
+
+#: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:3
+msgid "Routed from"
+msgstr ""
+
+#: scripts/apps/dashboard/closed-desk/views/top-menu-info.html:8
+msgid "Routed from other desks"
+msgstr ""
+
+#: scripts/apps/dashboard/closed-desk/views/top-menu-info.html:9
+msgid "Routed from:"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:20
+msgid "Routing Rules Management"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:219
+msgid "Routing Scheme"
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestRoutingContent.ts:182
+msgid "Routing scheme saved."
+msgstr ""
+
+#: scripts/apps/dashboard/closed-desk/views/top-menu-info.html:12
+msgid "Routing to:"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:53
+msgid "Rule name"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:38
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:39
+msgid "Rule set name"
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestRulesContent.ts:34
+msgid "Rule set saved."
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:210
+msgid "Ruleset"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:410
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:410
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:782
+msgid "Run"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:18
+msgid "Run Report"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:370
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:297
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:297
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:497
+msgid "Run automatically"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:170
+#: scripts/extensions/broadcasting/dist/src/page.js:174
+#: scripts/extensions/broadcasting/src/page.tsx:256
+msgid "Rundown"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:53
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:53
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:89
+msgid "Rundown created"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:86
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:86
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:174
+msgid "Rundown name"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/send-and-duplicate.tsx:17
+#: scripts/apps/authoring/views/authoring-topbar.html:90
+msgid "S & D"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:115
+msgid "SA"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extension.js:13
+#: scripts/extensions/sams/dist/src/extensions/sams/src/extension.js:13
+#: scripts/extensions/sams/src/extension.ts:17
+msgid "SAMS"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoveragePreview/index.tsx:178
+msgid "SCHEDULED UPDATES"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:45
+msgid "SIGNAL"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:47
+msgid "SLUGLINE is too long"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.ts:42
+msgid "SMS"
+msgstr ""
+
+#: scripts/apps/authoring-react/field-adapters/sms_message.ts:21
+#: scripts/apps/workspace/content/constants.ts:43
+msgid "SMS Message"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:49
+msgid "SOURCE"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:79
+msgid "START DATE cannot be in the past"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:15
+msgid "START DATE is a required field"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:36
+msgid "START TIME is a required field"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:30
+msgid "START TIME is required when END TIME is set"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:123
+msgid "SU"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:148
+msgid "Sa"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:188
+msgid "Sample content"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:113
+msgid "Sat"
+msgstr ""
+
+#: scripts/apps/authoring/views/change-image.html:256
+msgid "Saturation"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1459
+#: scripts/core/datetime/datetime.ts:295
+msgid "Saturday"
+msgstr "Субота"
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:61
+#: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:40
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:211
+#: ../superdesk-analytics/client/utils.js:153
+#: ../superdesk-planning/client/components/Contacts/ActionBar.tsx:25
+#: ../superdesk-planning/client/components/Contacts/ContactEditor.tsx:99
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:407
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:202
+#: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilterSchedule.tsx:159
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:278
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:140
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:145
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:53
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:204
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:391
+#: ../superdesk-planning/client/components/ModalWithForm/index.tsx:135
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:231
+#: ../superdesk-planning/client/components/editor-standalone/base-editor-standalone.tsx:127
+#: scripts/apps/authoring-react/multi-edit-modal.tsx:85
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/save-button.tsx:12
+#: scripts/apps/authoring-react/toolbar/highlights-modal.tsx:101
+#: scripts/apps/authoring-react/toolbar/mark-for-desks/mark-for-desks-modal.tsx:62
+#: scripts/apps/authoring-react/toolbar/proofreading-theme-modal.tsx:64
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:162
+#: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:134
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:47
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-article.html:8
+#: scripts/apps/authoring/views/authoring-topbar.html:194
+#: scripts/apps/authoring/views/change-image.html:81
+#: scripts/apps/authoring/views/theme-select.html:119
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:265
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:105
+#: scripts/apps/content-filters/views/manage-filters.html:156
+#: scripts/apps/dashboard/views/configuration.html:9
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:11
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:88
+#: scripts/apps/desks/controllers/DeskConfigController.ts:95
+#: scripts/apps/desks/views/desk-config-modal.html:275
+#: scripts/apps/desks/views/desk-config-modal.html:283
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:133
+#: scripts/apps/highlights/views/highlights_config_modal.html:55
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:127
+#: scripts/apps/ingest/views/settings/ingest-rules-content.html:71
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:261
+#: scripts/apps/products/views/products-config-modal.html:94
+#: scripts/apps/publish/views/subscribers.html:331
+#: scripts/apps/search-providers/views/search-provider-config.html:126
+#: scripts/apps/search/views/multi-image-edit.html:6
+#: scripts/apps/templates/views/create-template.html:53
+#: scripts/apps/templates/views/template-editor-modal.html:223
+#: scripts/apps/users/views/settings-privileges.html:4
+#: scripts/apps/users/views/user-preferences.html:6
+#: scripts/apps/users/views/user-privileges.html:10
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:332
+#: scripts/apps/workspace/content/views/profile-settings.html:189
+#: scripts/apps/workspace/views/edit-workspace-modal.html:39
+#: scripts/core/ui/components/IgnoreCancelSaveDialog.tsx:71
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:578
+#: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:57
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:56
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:259
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:259
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:409
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-workday-modal.js:108
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/manage-schedule.js:130
+#: scripts/extensions/availability-manager/dist/src/settings/edit-workday-modal.js:108
+#: scripts/extensions/availability-manager/dist/src/settings/manage-schedule.js:130
+#: scripts/extensions/availability-manager/src/settings/edit-workday-modal.tsx:172
+#: scripts/extensions/availability-manager/src/settings/manage-schedule.tsx:211
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-modal.js:53
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-modal.js:53
+#: scripts/extensions/broadcasting/src/shows/create-show-modal.tsx:106
+#: scripts/extensions/sams/dist/src/components/assets/assetEditorPanel.js:146
+#: scripts/extensions/sams/dist/src/components/attachments/editAttachmentModal.js:132
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:222
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditorPanel.js:146
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/editAttachmentModal.js:132
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:222
+#: scripts/extensions/sams/src/components/assets/assetEditorPanel.tsx:131
+#: scripts/extensions/sams/src/components/attachments/editAttachmentModal.tsx:130
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:244
+#: scripts/extensions/videoEditor/dist/src/VideoEditorHeader.js:11
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorHeader.js:11
+#: scripts/extensions/videoEditor/src/VideoEditorHeader.tsx:25
+msgid "Save"
+msgstr "Сачувај"
+
+#: scripts/apps/search/views/multi-image-edit.html:7
+msgid "Save & Close"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:214
+#: scripts/apps/desks/views/desk-config-modal.html:451
+msgid "Save & Continue"
+msgstr ""
+
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:137
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:372
+msgid "Save & Post"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:64
+msgid "Save & Post Event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:382
+msgid "Save & Unpost"
+msgstr ""
+
+#: scripts/apps/workspace/content/views/profile-settings.html:131
+msgid "Save &amp; Continue"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:388
+#: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:225
+msgid "Save All"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:35
+#: scripts/apps/search/views/save-search.html:15
+msgid "Save As"
+msgstr ""
+
+#: scripts/apps/search/views/save-search.html:16
+#: scripts/apps/search/views/save-search.html:17
+msgid "Save Changes"
+msgstr ""
+
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:179
+msgid "Save Changes?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:67
+msgid "Save Event"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:33
+#: ../superdesk-analytics/client/saved_reports/views/save-report-form.html:3
+msgid "Save Report"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:276
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:276
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:426
+msgid "Save Rundown"
+msgstr ""
+
+#: scripts/apps/search/views/save-search.html:10
+msgid "Save Search"
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:713
+msgid "Save all other changes before performing this action."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:60
+msgid "Save and publish"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:72
+msgid "Save and send"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:230
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:65
+#: scripts/apps/authoring/views/authoring-topbar.html:270
+#: scripts/apps/templates/views/create-template.html:5
+msgid "Save as template"
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:245
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:245
+#: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:352
+msgid "Save change"
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-manage-subscribers.html:129
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:220
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:220
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:416
+msgid "Save changes"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:340
+msgid "Save changes before adding to top stories ?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:289
+msgid "Save changes before adding to top stories?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:225
+msgid "Save changes before cancelling the Event?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:956
+msgid "Save changes before creating a planning item ?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorItemActions.tsx:106
+msgid "Save changes before creating a template?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:988
+msgid "Save changes before marking event as complete ?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:249
+msgid "Save changes before postponing the Event?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:272
+msgid "Save changes before rescheduling the Event?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1578
+msgid "Save changes before spiking ?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:307
+msgid "Save changes before updating Event Repetitions?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:202
+msgid "Save changes before updating the Event's time?"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:402
+msgid "Save changes without re-posting?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:112
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:169
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:264
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:46
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:59
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:71
+#: scripts/apps/desks/controllers/DeskConfigController.ts:94
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:34
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:70
+msgid "Save changes?"
+msgstr "Сачувати измене?"
+
+#: scripts/apps/authoring/authoring/index.ts:470
+msgid "Save current item"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/events.ts:169
+msgid "Save event as a template"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:364
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:364
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:630
+msgid "Save item"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:401
+msgid "Save password"
+msgstr ""
+
+#: scripts/apps/search/views/save-search.html:23
+msgid "Save search"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:22
+#: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:22
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-panel.html:22
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-panel.html:22
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-panel.html:22
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-panel.html:22
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-panel.html:22
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-panel.html:22
+#: scripts/apps/search/views/search-panel.html:9
+#: scripts/apps/users/directives/UserEditDirective.ts:240
+msgid "Saved"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:348
+msgid "Saved Featured Stories record"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:71
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:83
+msgid "Saved Report"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:166
+msgid ""
+"Saved Report has changed since it was opened. Please re-select the Saved "
+"Report to continue. Regrettably, your changes cannot be saved."
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:62
+msgid "Saved Searches"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:238
+msgid "Saved report not found!"
+msgstr ""
+
+#: scripts/apps/search/directives/SavedSearches.ts:116
+msgid "Saved search removed"
+msgstr ""
+
+#: scripts/apps/search/views/saved-searches.html:1
+msgid "Saved searches"
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:117
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:117
+#: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:181
+msgid "Saving capture thumbnail..."
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:131
+#: scripts/apps/desks/directives/DeskeditBasic.ts:31
+#: scripts/apps/desks/directives/DeskeditPeople.ts:50
+#: scripts/apps/desks/directives/DeskeditStages.ts:163
+#: scripts/core/notify/notify.tsx:59
+msgid "Saving..."
+msgstr "Чување..."
+
+#: scripts/apps/search/views/search-parameters.html:249
+msgid "Scanpix ID(s)"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:105
+msgid "Scatter"
+msgstr ""
+
+#: scripts/apps/templates/views/templates.html:56
+msgid "Sched. Desk / Stage"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:27
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:49
+#: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:2
+#: scripts/apps/search/views/edit-time-interval.html:1
+msgid "Schedule"
+msgstr ""
+
+#: scripts/apps/templates/views/template-editor-modal.html:175
+msgid "Schedule Desk"
+msgstr ""
+
+#: scripts/apps/templates/views/template-editor-modal.html:197
+msgid "Schedule Macro"
+msgstr ""
+
+#: scripts/apps/templates/views/template-editor-modal.html:187
+msgid "Schedule Stage"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduledUpdates.tsx:98
+msgid "Schedule an update"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:84
+msgid "Schedule will be permanently deleted."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:132
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:25
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:200
+#: ../superdesk-planning/client/constants/tooltips.ts:30
+#: ../superdesk-planning/client/utils/contentProfiles.ts:329
+#: ../superdesk-planning/client/utils/index.ts:356
+#: ../superdesk-planning/client/utils/index.ts:357
+#: scripts/apps/search/components/fields/state.tsx:38
+msgid "Scheduled"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:174
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:88
+msgid "Scheduled Date"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.ts:70
+msgid "Scheduled Desk Output"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:151
+msgid "Scheduled Export"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.ts:38
+msgid "Scheduled Time"
+msgstr ""
+
+#: scripts/apps/templates/views/templates.html:68
+msgid "Scheduled Time(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/ScheduledUpdates.tsx:64
+#: ../superdesk-planning/client/utils/contentProfiles.ts:331
+msgid "Scheduled Updates"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:113
+#: scripts/apps/templates/views/template-editor-modal.html:156
+msgid "Scheduled at"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/HistoryController.ts:180
+msgid "Scheduled by"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/common/PreviewFilterSchedule.tsx:46
+msgid "Scheduled export: {{ description }}"
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:426
+msgid "Scheduled from {{start}} to {{end}}"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/planning.ts:320
+msgid "Scheduled updates have to be after the previous updates."
+msgstr ""
+
+#: ../superdesk-planning/client/validators/planning.ts:324
+msgid "Scheduled updates should have a date/time."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/quick-publish-modal.tsx:73
+msgid "Scheduled:"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:51
+msgid "Scheduling"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:103
+msgid "Scheme details"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:41
+msgid "Scheme name"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-content.html:49
+msgid "Scheme rules"
+msgstr ""
+
+#: scripts/apps/production-api-keys/config.ts:18
+msgid "Scopes"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentFilterPanel.tsx:131
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:38
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:39
+#: ../superdesk-planning/client/components/Main/SearchPanel.tsx:140
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:170
+#: ../superdesk-planning/client/components/UI/SearchBar/index.tsx:84
+#: ../superdesk-planning/client/components/UI/SearchBox.tsx:126
+#: ../superdesk-planning/client/components/UI/SearchField/index.tsx:87
+#: scripts/apps/contacts/views/search-panel.html:87
+#: scripts/apps/content-api/views/search-panel.html:23
+#: scripts/apps/content-filters/views/filter-search.html:44
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:55
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:6
+#: scripts/apps/legal-archive/views/legal_archive.html:42
+#: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:11
+#: scripts/apps/monitoring/views/monitoring-view.html:84
+#: scripts/apps/packaging/views/search.html:4
+#: scripts/apps/publish/views/publish-queue.html:8
+#: scripts/apps/search/directives/SearchContainer.ts:21
+#: scripts/apps/search/index.ts:110 scripts/apps/search/index.ts:120
+#: scripts/apps/search/index.ts:129
+#: scripts/apps/search/views/item-searchbar.html:9
+#: scripts/apps/search/views/menu-providers.html:3
+#: scripts/apps/search/views/menu-providers.html:4
+#: scripts/apps/search/views/menu.html:3 scripts/apps/search/views/menu.html:4
+#: scripts/apps/search/views/save-search.html:13
+#: scripts/apps/search/views/save-search.html:5
+#: scripts/apps/search/views/saved-search-manage-subscribers.html:34
+#: scripts/apps/search/views/search-parameters.html:241
+#: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:351
+#: scripts/core/itemList/views/relatedItem-list-widget.html:5
+#: scripts/core/itemList/views/relatedItem-list-widget.html:7
+#: scripts/core/lang/missing-translations-strings.ts:26
+#: scripts/core/list/views/searchbar.html:4
+#: scripts/core/ui/components/SearchBar/index.tsx:139
+#: scripts/core/ui/components/select2.tsx:224
+#: scripts/core/views/sdSearchList.html:43
+#: scripts/core/views/sdTypeahead.html:4
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:127
+#: scripts/extensions/broadcasting/dist/src/page.js:131
+#: scripts/extensions/broadcasting/src/page.tsx:186
+msgid "Search"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:238
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:238
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:336
+msgid "Search Assets"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/SubNavBar.tsx:72
+msgid "Search Assignments"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:432
+msgid "Search Categories"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:480
+msgid "Search Content State"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:396
+msgid "Search Content Type"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:384
+msgid "Search Desks"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:536
+msgid "Search Enter Desk Actions"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:557
+msgid "Search Exit Desk Actions"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:86
+msgid "Search Filters"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:444
+msgid "Search Genre"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:494
+msgid "Search Ingest Providers"
+msgstr ""
+
+#: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:160
+msgid "Search OpenStreetMap"
+msgstr ""
+
+#: scripts/apps/search-providers/directive.ts:92
+msgid "Search Provider deleted."
+msgstr ""
+
+#: scripts/apps/search-providers/directive.ts:53
+msgid "Search Provider saved."
+msgstr ""
+
+#: scripts/apps/search-providers/index.ts:37
+#: scripts/apps/search-providers/views/settings.html:4
+msgid "Search Providers"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:118
+msgid "Search Related Articles"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:456
+msgid "Search Source"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:509
+msgid "Search Stages"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/FullText.tsx:15
+#: ../superdesk-planning/client/components/fields/preview/index.ts:87
+msgid "Search Text"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:468
+msgid "Search Urgency"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:414
+#: ../superdesk-analytics/client/search/views/user-select.html:17
+msgid "Search Users"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-recipients-input.html:9
+msgid "Search emails"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Contacts/SelectSearchContactsField/SelectListPopup.tsx:226
+msgid "Search for a contact"
+msgstr ""
+
+#: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupInput.tsx:289
+msgid "Search for a location"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/configuration.html:34
+msgid "Search for clock"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:91
+msgid "Search icons...."
+msgstr ""
+
+#: scripts/apps/content-api/index.ts:22
+msgid "Search items is content API"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:116
+#: ../superdesk-planning/client/components/Main/SubNavBar.tsx:29
+msgid "Search planning"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:217
+msgid "Search provider contacts"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-list.html:6
+msgid "Search saved reports"
+msgstr ""
+
+#: scripts/apps/search/views/saved-searches.html:3
+msgid "Search saved searches"
+msgstr ""
+
+#: scripts/apps/search/views/save-search-dialog.html:18
+msgid "Search shortcut"
+msgstr ""
+
+#: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:81
+msgid "Search templates"
+msgstr ""
+
+#: scripts/apps/search/directives/SaveSearch.ts:72
+msgid "Search was saved successfully"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EventsRelatedArticlesModal.tsx:157
+#: scripts/core/ui/components/SearchBar/manual.tsx:37
+#: scripts/core/ui/components/SelectUser.tsx:101
+msgid "Search..."
+msgstr "Претрага..."
+
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:31
+msgid "Search/Browse Locations"
+msgstr ""
+
+#: scripts/core/ui/views/sd-timepicker-popup.html:21
+msgid "Seconds"
+msgstr "Секунде"
+
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:50
+msgid "Secret Access Key"
+msgstr ""
+
+#: scripts/apps/publish/views/http-push-config.html:13
+msgid "Secret Token"
+msgstr ""
+
+#: scripts/core/auth/secure-login.html:18
+msgid "Secure Log In"
+msgstr "Безбедна пријава"
+
+#: scripts/apps/products/views/products.html:10
+#: scripts/apps/publish/views/subscribers.html:10
+#: scripts/core/views/sdSearchList.html:3
+msgid "Select"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:277
+msgid "Select Agenda"
+msgstr ""
+
+#: scripts/apps/search/views/multi-image-edit.html:25
+msgid "Select All"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/selectAssetModal.js:150
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/selectAssetModal.js:150
+#: scripts/extensions/sams/src/components/assets/selectAssetModal.tsx:162
+msgid "Select Asset(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/DesksSubNavDropDown.tsx:49
+msgid "Select Assignments From:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:260
+msgid "Select Calendar"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/drop-zone.tsx:76
+msgid "Select Files"
+msgstr ""
+
+#: scripts/apps/archive/views/resend-configuration.html:10
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:55
+msgid "Select Subscribers"
+msgstr ""
+
+#: scripts/apps/workspace/views/workspace-dropdown.html:5
+msgid "Select Workspace"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:179
+msgid ""
+"Select a default content profile which is used for articles fetched from "
+"ingest. If you don't see any, create one\n"
+"                                   <a href=\"#/settings/content-"
+"profiles\">here</a>"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:156
+msgid ""
+"Select a default template for new articles. If you don't see any, first make "
+"sure that there is at least one content profile. Each time a profile is "
+"created, Superdesk creates a template with the same name."
+msgstr ""
+
+#: scripts/core/ui/components/generic-form/input-types/desk_single_value.tsx:40
+msgid "Select a desk"
+msgstr "Изаберите деск"
+
+#: scripts/core/ui/components/generic-form/input-types/macro_single_value.tsx:27
+#: scripts/core/ui/components/generic-form/input-types/stage_single_value.tsx:42
+msgid "Select a desk first"
+msgstr "Прво изаберите деск"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:123
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:123
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:240
+msgid "Select a show from the dropdown above."
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:149
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/manage-rundown-templates.js:149
+#: scripts/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.tsx:317
+msgid "Select a template from the sidebar."
+msgstr ""
+
+#: scripts/core/ui/components/SelectUser.tsx:100
+#: scripts/core/ui/components/SelectUser.tsx:51
+msgid "Select a user"
+msgstr "Изаберите корисника"
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-vocabulary/config.tsx:27
+msgid "Select a vocabulary"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:110
+msgid "Select a vocabulary for predefined snippets"
+msgstr ""
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:332
+msgid "Select all"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:149
+msgid "Select all categories"
+msgstr ""
+
+#: ../superdesk-planning/client/components/FulFilAssignmentModal/index.tsx:76
+msgid "Select an Assignment"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/multi-edit-toolbar-action.tsx:35
+msgid "Select articles"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:70
+msgid "Select at most 1 file to upload."
+msgstr ""
+
+#: scripts/apps/archive/controllers/UploadController.ts:233
+#: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:207
+msgid "Select at most {{maxUploads}} files to upload."
+msgstr ""
+
+#: scripts/apps/ingest/ingest-stats-widget/configuration.html:20
+msgid "Select color"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/compare-versions.html:12
+msgid "Select current version."
+msgstr ""
+
+#: scripts/apps/search/views/edit-time-interval.html:5
+msgid "Select days"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:161
+msgid "Select default categories only"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/mark-for-desks/mark-for-desks-modal.tsx:43
+#: scripts/apps/master-desk/components/HeaderComponent.tsx:224
+msgid "Select desks"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:18
+msgid "Select desks for view"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsSubNav.tsx:41
+msgid "Select either Search or Browse the locations"
+msgstr ""
+
+#: scripts/extensions/predefinedTextField/dist/src/editor.js:34
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/editor.js:34
+#: scripts/extensions/predefinedTextField/src/editor.tsx:53
+msgid "Select from a predefined value"
+msgstr ""
+
+#: scripts/apps/search/views/edit-time-interval.html:19
+msgid "Select hours"
+msgstr ""
+
+#: ../superdesk-planning/client/components/SelectItemModal.tsx:29
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-inner-dropdown.html:2
+msgid "Select item"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:117
+msgid "Select next item on focused stage or group"
+msgstr ""
+
+#: scripts/apps/publish-preview/previewModal.tsx:87
+msgid "Select preview target"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:119
+msgid "Select previous item on focused stage or group"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:65
+msgid "Select saved searches for view"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/select-show.js:21
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/select-show.js:21
+#: scripts/extensions/broadcasting/src/rundowns/components/select-show.tsx:53
+msgid "Select show"
+msgstr ""
+
+#: scripts/apps/ingest/ingest-stats-widget/configuration.html:7
+msgid "Select source"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/SelectDeskTemplate.tsx:62
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:85
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:85
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:157
+msgid "Select template"
+msgstr ""
+
+#: scripts/apps/archive/views/upload.html:39
+msgid "Select them from folder"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/video-thumbnail-editor.tsx:122
+msgid "Select thumbnail"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:63
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:63
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:141
+msgid "Select type"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/version-header.tsx:29
+msgid "Select version"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventMetadata/RelatedEventListItem.tsx:93
+#: ../superdesk-planning/client/components/RelatedPlannings/PlanningMetaData/RelatedPlanningListItem.tsx:101
+#: scripts/core/editor3/components/toolbar/FloatingCharacterCount.tsx:46
+msgid "Selected"
+msgstr ""
+
+#: scripts/core/views/sdSearchList.html:21
+msgid "Selected item"
+msgstr ""
+
+#: scripts/core/views/sdSearchList.html:14
+msgid "Selected items"
+msgstr ""
+
+#: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:77
+#: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:33
+msgid "Selected text:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:200
+msgid "Selections automatically removed"
+msgstr ""
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:39
+#: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:170
+msgid "Send"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:89
+msgid "Send & duplicate"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/send-correction.tsx:13
+#: scripts/apps/authoring/views/authoring-topbar.html:214
+msgid "Send Correction"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:117
+msgid "Send Email"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:221
+msgid "Send Kill"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:7
+msgid "Send Report via Email"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:228
+msgid "Send Takedown"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/send-and-duplicate.tsx:15
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/send-and-duplicate.tsx:16
+#: scripts/apps/authoring/views/authoring-topbar.html:86
+#: scripts/apps/authoring/views/authoring-topbar.html:87
+msgid "Send and duplicate"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:157
+msgid "Send and open"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx:144
+msgid "Send correction"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/send-kill-action.tsx:13
+msgid "Send kill"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:14
+msgid "Send notifications via email"
+msgstr ""
+
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:70
+msgid "Send only after publish schedule"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/actions/send-to-action.tsx:183
+msgid "Send package and items"
+msgid_plural "Send packages and items"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/apps/packaging/index.ts:110
+msgid "Send package to"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:277
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:201
+#: scripts/core/interactive-article-actions-panel/action-tabs.tsx:9
+msgid "Send to"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/send-to-publish/interactive-article-actions-widget.tsx:12
+#: scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx:20
+#: scripts/apps/authoring/views/authoring-topbar.html:400
+#: scripts/apps/authoring/views/authoring-topbar.html:401
+msgid "Send to / Publish"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:292
+msgid "Send to Personal Space"
+msgstr ""
+
+#: scripts/apps/users/components/EmailNotificationPreferences.tsx:24
+msgid "Send {{name}} notifications"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:22
+msgid "Sending"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.ts:68
+msgid "Sent Desk Output"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:443
+msgid "Sent From"
+msgstr ""
+
+#: scripts/apps/monitoring/controllers/AggregateCtrl.ts:41
+msgid "Sent Items"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:436
+msgid "Sent To"
+msgstr ""
+
+#: scripts/api/article-send.tsx:257
+msgid "Sent successfully"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:16
+msgid "Sent/Queued as"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:89
+msgid "Sent/Queued as {{name}} to {{destination}} at {{date}}"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:104
+msgid "Sequence No"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:181
+msgid "Sequence Number Settings"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateEventRepetitionsForm.tsx:111
+msgid "Series Start Date"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:128
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:143
+msgid "Service"
+msgstr ""
+
+#: scripts/apps/users/controllers/SessionsDeleteCommand.ts:13
+msgid "Sessions cleared"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:192
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:136
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:165
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:192
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:136
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:165
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:246
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:166
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:191
+msgid "Set"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:132
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:132
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:127
+msgid "Set Details"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/attachments/samsAttachmentsList.js:116
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/samsAttachmentsList.js:116
+#: scripts/extensions/sams/src/components/attachments/samsAttachmentsList.tsx:129
+msgid "Set Disabled"
+msgstr ""
+
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:42
+#: scripts/apps/publish/views/amazon-sqs-fifo-config.html:59
+#: scripts/apps/publish/views/ftp-config.html:12
+#: scripts/apps/publish/views/http-push-config.html:14
+msgid "Set and hidden thereafter"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:50
+msgid "Set as default"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/sets.js:34
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:34
+#: scripts/extensions/sams/src/api/sets.ts:46
+msgid "Set created successfully"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/sets.js:77
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:77
+#: scripts/extensions/sams/src/api/sets.ts:98
+msgid "Set deleted successfully"
+msgstr ""
+
+#: scripts/apps/highlights/components/SetHighlightsForMultipleArticlesModal.tsx:90
+msgid "Set highlights"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:219
+msgid "Set label in current package"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:131
+msgid "Set maximum items per stages and saved searches for view"
+msgstr ""
+
+#: scripts/apps/monitoring/aggregate-widget/aggregate.ts:17
+msgid ""
+"Set up different monitors to follow any topics from ingest or production, "
+"desk outputs or any part of the workflow. All you need is to give it a "
+"sensible name, select a saved search or desk or its workflow stages. Monitor "
+"anything, anywhere, anytime. You can have as many Monitor widgets as you "
+"wish."
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/api/sets.js:57
+#: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:57
+#: scripts/extensions/sams/src/api/sets.ts:76
+msgid "Set updated successfully"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/notifications/sets.js:45
+#: scripts/extensions/sams/dist/src/notifications/sets.js:45
+#: scripts/extensions/sams/src/notifications/sets.ts:50
+msgid "Set was deleted by another user."
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/notifications/sets.js:25
+#: scripts/extensions/sams/dist/src/notifications/sets.js:25
+#: scripts/extensions/sams/src/notifications/sets.ts:28
+msgid "Set was updated by another user."
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:176
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:176
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:206
+msgid "Sets"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:171
+#: scripts/apps/settings/index.ts:19 scripts/apps/settings/settings.tsx:32
+#: scripts/core/menu/views/menu.html:30
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:139
+#: scripts/extensions/broadcasting/dist/src/page.js:143
+#: scripts/extensions/broadcasting/src/page.tsx:204
+msgid "Settings"
+msgstr "Подешавања"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:172
+msgid "Share Alternate"
+msgstr ""
+
+#: scripts/apps/search/views/item-preview.html:3
+msgid "Shift preview"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:37
+msgid "Short"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:138
+msgid "Shortcuts"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/planning.ts:305
+#: ../superdesk-planning/client/validators/planning.ts:307
+msgid "Should be after the previous scheduled update/coverage"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:56
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/applied-filters.js:16
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/select-show.js:10
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/applied-filters.js:16
+#: scripts/extensions/broadcasting/dist/src/rundowns/components/select-show.js:10
+#: scripts/extensions/broadcasting/src/rundowns/components/applied-filters.tsx:31
+#: scripts/extensions/broadcasting/src/rundowns/components/select-show.tsx:35
+msgid "Show"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/related_events.tsx:46
+msgid "Show 1 event"
+msgid_plural "Show {{n}} events"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../superdesk-planning/client/components/fields/related_plannings.tsx:35
+msgid "Show 1 planning item"
+msgid_plural "Show {{n}} planning items"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/apps/archive/views/provider-menu.html:9
+msgid "Show All"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:121
+msgid "Show Bookmark"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:332
+msgid "Show Crops"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:186
+msgid "Show Floating Character Count"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:352
+msgid "Show Image Title"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Preview/ExpandableText.tsx:47
+#: scripts/apps/master-desk/components/HeaderComponent.tsx:226
+#: scripts/apps/master-desk/components/HeaderComponent.tsx:229
+msgid "Show all"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/Language.tsx:96
+msgid "Show all language fields"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:93
+msgid "Show all messages"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:19
+#: scripts/extensions/broadcasting/dist/src/shows/manage-shows.js:19
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:31
+msgid "Show code"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:48
+msgid "Show crops for pictures"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:101
+msgid "Show error messages"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:302
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:302
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:509
+msgid "Show image suggestions"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:30
+msgid "Show in embedded form"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:263
+msgid "Show in preview"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:120
+msgid "Show input for editing description"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/config.tsx:110
+msgid "Show input for editing title"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Archive/ArchivePreview/index.tsx:42
+#: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:93
+#: ../superdesk-planning/client/components/UI/Preview/ExpandableText.tsx:46
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEventItem.tsx:94
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx:109
+msgid "Show less"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Archive/ArchivePreview/index.tsx:42
+#: ../superdesk-planning/client/components/Contacts/ContactMetaData.tsx:93
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEventItem.tsx:94
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx:109
+msgid "Show more"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show.js:66
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/manage-shows.js:13
+#: scripts/extensions/broadcasting/dist/src/shows/create-show.js:66
+#: scripts/extensions/broadcasting/dist/src/shows/manage-shows.js:13
+#: scripts/extensions/broadcasting/src/shows/create-show.tsx:95
+#: scripts/extensions/broadcasting/src/shows/manage-shows.tsx:25
+msgid "Show name"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Location/index.tsx:54
+#: ../superdesk-planning/client/components/Locations/LocationsList.tsx:93
+msgid "Show on map"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/WidgetsConfig.tsx:57
+msgid "Show or hide the widgets in the right toolbar in the editor workspace."
+msgstr ""
+
+#: scripts/apps/search/components/fields/nested-link.tsx:28
+msgid "Show previous items"
+msgstr ""
+
+#: scripts/apps/search/index.ts:138
+msgid "Show search modal"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:3
+msgid "Show sent/queued items"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:128
+msgid ""
+"Show to users\n"
+"                                as"
+msgstr ""
+
+#: scripts/apps/archive/views/item-crops.html:1
+#: scripts/apps/authoring-react/fields/media/media-carousel/image-crops.tsx:22
+msgid "Show/hide crops"
+msgstr ""
+
+#: scripts/apps/users/views/change-avatar.html:17
+msgid "Shows your initials instead"
+msgstr ""
+
+#: scripts/apps/authoring-react/field-adapters/sign_off.tsx:118
+#: scripts/apps/workspace/content/constants.ts:40
+#: scripts/core/lang/missing-translations-strings.ts:18
+msgid "Sign Off"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:31
+msgid "Sign in as a different user."
+msgstr "Пријавите се као други корисник."
+
+#: scripts/core/menu/views/menu.html:73
+msgid "Sign out"
+msgstr "Одјави се"
+
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:159
+#: scripts/apps/users/views/edit-form.html:254
+msgid "Sign-Off"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:364
+#: scripts/apps/search/views/search-parameters.html:22
+msgid "Sign-off"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:173
+#: scripts/apps/archive/views/metadata-view.html:45
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:303
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:124
+msgid "Signal"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:10
+msgid "Single Day"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/resources/profiles.ts:122
+msgid "Single Line"
+msgstr ""
+
+#: scripts/core/editor3/components/media/MediaBlock.tsx:13
+msgid "Single Usage"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:57
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:214
+msgid "Single line"
+msgstr ""
+
+#: scripts/apps/vocabularies/constants.ts:48
+msgid "Single selection"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:120
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:152
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:152
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:120
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:152
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:152
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:110
+#: scripts/extensions/sams/dist/src/utils/ui.js:110
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:141
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:173
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:177
+#: scripts/extensions/sams/src/utils/ui.tsx:103
+msgid "Size"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:247
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:247
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:320
+msgid "Size From:"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:251
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:251
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:334
+msgid "Size To:"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:176
+#: scripts/extensions/sams/dist/src/components/assets/assetGridItem.js:125
+#: scripts/extensions/sams/dist/src/components/assets/assetListItem.js:120
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:176
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetGridItem.js:125
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetListItem.js:120
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:179
+#: scripts/extensions/sams/src/components/assets/assetGridItem.tsx:155
+#: scripts/extensions/sams/src/components/assets/assetListItem.tsx:137
+msgid "Size:"
+msgstr ""
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:41
+msgid "Skip"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:174
+msgid "Skip Next"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:175
+msgid "Skip Previous"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:203
+msgid "Skip config test"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:59
+msgid "Slack Channel Name"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:176
+msgid "Slideshow"
+msgstr ""
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:18
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:66
+#: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:429
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:78
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/assignCalendarForm.tsx:70
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/cancelEventForm.tsx:115
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/convertToRecurringEventForm.tsx:130
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:90
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:89
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:192
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:78
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikePlanningForm.tsx:34
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikeEventForm.tsx:73
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikePlanningForm.tsx:33
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateEventRepetitionsForm.tsx:97
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:209
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:48
+#: ../superdesk-planning/client/components/fields/preview/index.ts:225
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:49
+#: ../superdesk-planning/client/utils/contentProfiles.ts:269
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:282
+#: scripts/apps/authoring-react/field-adapters/slugline.ts:21
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:96
+#: scripts/apps/content-api/services/ContentAPISearchService.ts:32
+#: scripts/apps/legal-archive/services/LegalArchiveService.ts:28
+#: scripts/apps/legal-archive/tests/legal.spec.ts:70
+#: scripts/apps/legal-archive/views/legal_archive.html:71
+#: scripts/apps/master-desk/components/FilterPanelComponent.tsx:126
+#: scripts/apps/search/services/SearchService.ts:70
+#: scripts/apps/search/views/search-parameters.html:6
+#: scripts/apps/workspace/content/constants.ts:41
+msgid "Slugline"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:4
+msgid "Slugline Match"
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-tooltip.html:2
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:85
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateAssignmentForm.tsx:118
+msgid "Slugline:"
+msgstr ""
+
+#: scripts/apps/archive/views/item-preview.html:11
+#: scripts/apps/archive/views/metadata-view.html:194
+#: scripts/apps/archive/views/preview.html:42
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:244
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:80
+#: scripts/apps/authoring/views/authoring-header.html:63
+#: scripts/apps/search/components/fields/flags.tsx:32
+#: scripts/apps/search/views/search-filters.html:130
+#: scripts/core/itemList/views/relatedItem-list-widget.html:34
+msgid "Sms"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AssignedCoverage.tsx:24
+msgid "Some Coverages Assigned"
+msgstr ""
+
+#: scripts/apps/authoring/multiedit/multiedit.ts:85
+msgid "Some articles failed to unlock"
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:42
+#: ../superdesk-planning/client/planning-extension/src/extension.ts:57
+msgid "Some items are linked to in-progress planning coverage."
+msgstr ""
+
+#: scripts/api/article-send.tsx:135
+msgid ""
+"Some packages contain the following published items that can not be sent:"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:477
+msgid "Some related planning item post validation failed"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:458
+msgid ""
+"Some selected items have not yet been posted. All selections must be visible "
+"to subscribers."
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:53
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:53
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:124
+msgid "Some tags can not be displayed"
+msgstr ""
+
+#: scripts/core/upload/crop-directive.ts:57
+msgid "Sorry, but avatar must be at least 200x200 pixels big."
+msgstr "Аватар мора бити најмање величине 200x200 пиксела."
+
+#: scripts/core/auth/login-modal.html:39
+#: scripts/core/auth/reset-password.html:29
+#: scripts/core/auth/reset-password.html:76
+#: scripts/core/auth/secure-login.html:30
+msgid "Sorry, but can't reach the server now.<br>Please try again later."
+msgstr "Тренутно није могуће доћи до сервера.<br>Покушајте касније."
+
+#: scripts/core/upload/image-crop-directive.ts:251
+msgid "Sorry, but image must be at least {{width}}x{{height}}."
+msgstr "Слика мора бити најмање {{width}}x{{height}}."
+
+#: scripts/apps/authoring/attachments/AttachmentsWidget.tsx:38
+msgid ""
+"Sorry, but some files \"{{filenames}}\" are bigger than limit ({{limit}})"
+msgstr ""
+
+#: scripts/apps/templates/views/create-template.html:23
+msgid "Sorry, but template name must be unique."
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:37
+#: scripts/core/auth/reset-password.html:28
+#: scripts/core/auth/reset-password.html:75
+#: scripts/core/auth/secure-login.html:29
+msgid "Sorry, but your account has been suspended."
+msgstr "Ваш налог је суспендован."
+
+#: scripts/apps/workspace/views/edit-workspace-modal.html:23
+msgid "Sorry, given workspace name is in use"
+msgstr ""
+
+#: scripts/apps/users/views/settings-roles.html:40
+msgid "Sorry, this role name already exists."
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:38
+msgid "Sorry, user not found."
+msgstr "Корисник није пронађен."
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:138
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:138
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:163
+msgid "Sort By"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:28
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-preview.html:15
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-preview.html:17
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-preview.html:24
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:28
+msgid "Sort Order"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-group-header.html:37
+#: scripts/apps/search/views/item-sortbar.html:12
+#: scripts/apps/search/views/item-sortbar.html:6
+msgid "Sort by"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:239
+msgid "Sort by:"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:262
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:262
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:410
+msgid "Sort by: {{ field }}"
+msgstr ""
+
+#: scripts/apps/search/views/item-sortbar.html:19
+msgid "Sort order"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:266
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:266
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:424
+msgid "Sort order: Ascending"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:267
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:267
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:425
+msgid "Sort order: Descending"
+msgstr ""
+
+#: scripts/apps/legal-archive/views/legal_archive.html:29
+msgid "Sorting"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-group-header.html:28
+msgid "Sorting:"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:586
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:455
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:105
+#: ../superdesk-planning/client/components/fields/editor/IngestSource.tsx:25
+#: scripts/apps/archive/views/metadata-associateditem-view.html:23
+#: scripts/apps/archive/views/metadata-view.html:36
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:297
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:116
+#: scripts/apps/content-filters/views/production-test-view.html:22
+#: scripts/apps/search-providers/views/search-provider-config.html:89
+#: scripts/apps/workspace/content/constants.ts:44
+msgid "Source"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:85
+msgid "Source Name"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:3
+msgid "Source Type:"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:44
+msgid "Source for User Created Articles"
+msgstr ""
+
+#: scripts/apps/ingest/ingest-stats-widget/configuration.html:9
+msgid "Source stats"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/tag-popover.js:20
+#: scripts/extensions/auto-tagging-widget/dist/src/tag-popover.js:20
+#: scripts/extensions/auto-tagging-widget/src/tag-popover.tsx:29
+msgid "Source:"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:133
+#: scripts/apps/search/views/search-filters.html:44
+msgid "Sources"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:361
+msgid "Spell Checker"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:442
+#: ../superdesk-analytics/client/utils.js:164
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:139
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:74
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:153
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:250
+#: ../superdesk-planning/client/constants/events.ts:154
+#: scripts/apps/archive/show-spike-dialog.tsx:61
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:189
+msgid "Spike"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:120
+msgid "Spike Item"
+msgstr ""
+
+#: scripts/apps/monitoring/config.ts:29
+msgid "Spike Monitoring"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:138
+msgid "Spike Planning Item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:146
+msgid "Spike State"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:104
+msgid "Spike all recurring events or just this one?"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:127
+msgid "Spike item(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/planning.ts:135
+msgid "Spike planning"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:72
+msgid "Spike {{event}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:45
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:40
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:210
+#: ../superdesk-planning/client/utils/index.ts:346
+#: scripts/apps/dashboard/workspace-tasks/views/desk-stages.html:17
+#: scripts/apps/search/components/fields/state.tsx:36
+#: scripts/apps/search/constants.ts:14
+msgid "Spiked"
+msgstr ""
+
+#: scripts/apps/search/views/search-parameters.html:145
+msgid "Spiked Content"
+msgstr ""
+
+#: scripts/apps/monitoring/config.ts:40
+#: scripts/apps/monitoring/views/monitoring-view.html:257
+msgid "Spiked Items"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:177
+msgid "Spiked Only"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:221
+#: scripts/apps/authoring/versioning/history/views/history.html:63
+msgid "Spiked by"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:4
+msgid "Spiked items"
+msgstr ""
+
+#: scripts/apps/search/views/search-parameters.html:153
+msgid "Spiked only content"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:108
+msgid "Spline"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:83
+msgid "Split paragraph"
+msgstr ""
+
+#: scripts/apps/desks/views/actionpicker.html:15
+#: scripts/apps/internal-destinations/InternalDestinations.tsx:48
+#: scripts/apps/workspace/content/constants.ts:45
+#: scripts/core/interactive-article-actions-panel/subcomponents/destination-select.tsx:87
+msgid "Stage"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:299
+msgid "Stage Details"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:369
+msgid "Stage description"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:320
+msgid "Stage description:"
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskeditStages.ts:190
+msgid "Stage has been modified elsewhere. Please reload the desks"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:289
+msgid "Stage with name"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:624
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:157
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:508
+#: scripts/apps/desks/views/desk-config-modal.html:228
+#: scripts/apps/desks/views/settings.html:67
+#: scripts/apps/monitoring/views/monitoring-view.html:23
+#: scripts/apps/monitoring/views/monitoring-view.html:66
+msgid "Stages"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:177
+msgid "Star"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:178
+msgid "Star Empty"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:87
+msgid "Start Date"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:18
+msgid "Start Time (inclusive)"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:191
+msgid "Start Working"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:174
+msgid "Start date cannot be greater than today"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:76
+msgid "Start date is in the past"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:160
+msgid "Start date is required"
+msgstr ""
+
+#: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:31
+msgid "Start routing"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:87
+#: scripts/apps/search/views/item-searchbar.html:19
+msgid "Start search"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:571
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:123
+#: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:53
+#: scripts/apps/archive/views/metadata-view.html:188
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:217
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:76
+#: scripts/apps/contacts/constants.ts:76
+#: scripts/apps/contacts/views/search-panel.html:68
+#: scripts/apps/content-filters/views/production-test-view.html:18
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:186
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:240
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:130
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:162
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:186
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:240
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:130
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:162
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:217
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:300
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:154
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:186
+msgid "State"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:598
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:611
+msgid "State/Province or Region"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:268
+#: ../superdesk-planning/client/components/Locations/LocationsList.tsx:124
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:64
+msgid "State/Province/Region"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:145
+msgid "States"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:64
+#: scripts/apps/publish/views/publish-queue.html:115
+#: scripts/apps/publish/views/subscribers.html:79
+#: scripts/apps/search-providers/views/search-provider-config.html:35
+#: scripts/apps/workspace/content/views/profile-settings.html:60
+#: scripts/extensions/availability-manager/dist/src/correspondent-availability/filters.js:114
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/correspondent-availability/filters.js:114
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/manage-schedule.js:168
+#: scripts/extensions/availability-manager/dist/src/settings/manage-schedule.js:168
+#: scripts/extensions/availability-manager/src/correspondent-availability/filters.tsx:199
+#: scripts/extensions/availability-manager/src/settings/manage-schedule.tsx:286
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:124
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:124
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:158
+msgid "Status"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx:233
+#: scripts/apps/contacts/views/list.html:38
+#: scripts/apps/publish/views/publish-queue.html:46
+#: scripts/apps/publish/views/subscribers.html:15
+msgid "Status:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:112
+msgid "Status: Unassigned"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:143
+msgid "Status: {{ state }}"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:11
+msgid "Status: {{filter}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:179
+msgid "Stop"
+msgstr ""
+
+#: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:37
+msgid "Stop routing"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:254
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:150
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:254
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:150
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:342
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:154
+msgid "Storage Destination"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:256
+#: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:153
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:256
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setPreviewPanel.js:153
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:348
+#: scripts/extensions/sams/src/components/sets/setPreviewPanel.tsx:159
+msgid "Storage Provider"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:243
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:243
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:311
+msgid "Storage Unit"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setListItem.js:97
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListItem.js:97
+#: scripts/extensions/sams/src/components/sets/setListItem.tsx:85
+msgid "Storage:"
+msgstr ""
+
+#: scripts/apps/publish/views/odbc-config.html:11
+#: scripts/apps/publish/views/odbc-config.html:9
+msgid "Stored Procedure"
+msgstr ""
+
+#: scripts/apps/products/views/product-test.html:9
+msgid "Story GUID"
+msgstr ""
+
+#: scripts/apps/legal-archive/views/legal_archive.html:78
+#: scripts/apps/search/views/search-parameters.html:31
+msgid "Story Text"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem.ts:183
+msgid "Story is associated as update."
+msgstr ""
+
+#: ../superdesk-planning/client/reducers/featuredPlanning.ts:177
+msgid "Story with slugline \"{{ slugline }}\" is added to the list"
+msgstr ""
+
+#: ../superdesk-planning/client/reducers/featuredPlanning.ts:195
+#: ../superdesk-planning/client/reducers/featuredPlanning.ts:215
+msgid "Story with slugline \"{{ slugline }}\" is removed from the list"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:180
+msgid "Stream"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:534
+msgid "Street Address"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:533
+msgid "Street Address, PO Box, Company Name"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:65
+msgid "Strength"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:181
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:40
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:78
+msgid "Strikethrough"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:41
+msgid "Strong"
+msgstr ""
+
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:49
+msgid "Style"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:130
+msgid "Su"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:6
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:6
+msgid "Subgroup By"
+msgstr ""
+
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-parameters.html:23
+msgid "Subgroup By:"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:112
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:112
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:144
+msgid "Subitem attachments"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/index.js:13
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/index.js:13
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:130
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:130
+#: scripts/extensions/broadcasting/src/authoring-fields/subitems/index.tsx:30
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:165
+msgid "Subitems"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:547
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:117
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/subject.ts:45
+#: ../superdesk-planning/client/components/fields/editor/Subjects.tsx:26
+#: ../superdesk-planning/client/utils/contentProfiles.ts:289
+#: scripts/apps/authoring-react/field-adapters/subject.tsx:26
+#: scripts/apps/search/constants.ts:15
+#: scripts/apps/workspace/content/constants.ts:46
+msgid "Subject"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/planning.ts:109
+msgid "Subject is a required field"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:39
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:150
+msgid "Subject:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:162
+#: scripts/core/lang/missing-translations-strings.ts:12
+msgid "Subjects"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/list/Subject.tsx:20
+msgid "Subjects:"
+msgstr ""
+
+#: scripts/core/editor3/components/annotations/AnnotationInput.tsx:287
+#: scripts/core/editor3/components/comments/CommentInput.tsx:97
+#: scripts/core/ui/components/Modal/ModalPrompt.tsx:55
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:261
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:261
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:379
+msgid "Submit"
+msgstr "Пошаљи"
+
+#: ../superdesk-planning/client/utils/index.ts:396
+#: scripts/apps/search/components/fields/state.tsx:34
+msgid "Submitted"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:109
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:202
+msgid "Submitting...."
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-subscribe.html:34
+#: scripts/apps/search/views/saved-searches.html:21
+#: scripts/apps/search/views/saved-searches.html:50
+msgid "Subscribe"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:109
+#: scripts/apps/search/constants.ts:20
+#: scripts/apps/search/views/search-parameters.html:181
+msgid "Subscriber"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:84
+msgid "Subscriber Schedule Settings"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:156
+msgid "Subscriber codes"
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:284
+msgid "Subscriber could not be initialized!"
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:213
+msgid "Subscriber saved."
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:14
+msgid "Subscriber:"
+msgstr ""
+
+#: scripts/apps/content-filters/views/filter-search-result.html:42
+#: scripts/apps/products/views/products-config-modal.html:16
+#: scripts/apps/publish/index.ts:41 scripts/apps/publish/views/settings.html:4
+msgid "Subscribers"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:182
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:39
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:92
+msgid "Subscript"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/views/chart-form-options.html:15
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:15
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-preview.html:6
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-preview.html:6
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-preview.html:6
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:15
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-preview.html:6
+msgid "Subtitle"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:244
+#: ../superdesk-planning/client/components/fields/resources/locations.ts:40
+msgid "Suburb"
+msgstr ""
+
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:27
+msgid "Success"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:183
+msgid "Suggestion"
+msgstr ""
+
+#: scripts/apps/authoring/track-changes/suggestions.ts:91
+#: scripts/core/editor3/components/spellchecker/SpellcheckerContextMenu.tsx:84
+msgid "Suggestions"
+msgstr ""
+
+#: scripts/apps/authoring/suggest/SuggestView.html:8
+msgid "Suggestions will appear here once the article's body starts changing..."
+msgstr ""
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:278
+#: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:29
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:32
+msgid "Sum"
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/main-panel.js:18
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary-widget.js:48
+#: scripts/extensions/ai-widget/dist/src/main-panel.js:18
+#: scripts/extensions/ai-widget/dist/src/summary/summary-widget.js:48
+#: scripts/extensions/ai-widget/src/main-panel.tsx:35
+#: scripts/extensions/ai-widget/src/summary/summary-widget.tsx:70
+msgid "Summary"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:106
+msgid "Sun"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1460
+#: scripts/core/datetime/datetime.ts:296
+msgid "Sunday"
+msgstr "Недеља"
+
+#: scripts/apps/contacts/controllers/ContactsController.ts:33
+msgid "Superdesk Contacts Management"
+msgstr ""
+
+#: scripts/core/menu/views/superdesk-view.html:50
+msgid "Superdesk is experiencing network connection issues:/"
+msgstr "Superdesk има проблема са мрежном везом :/"
+
+#: scripts/core/menu/views/menu.html:114
+msgid "Superdesk logo"
+msgstr "Superdesk лого"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:184
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:38
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:93
+msgid "Superscript"
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskConfigModal.ts:37
+#: scripts/apps/monitoring/directives/utils.ts:103
+#: scripts/apps/users/directives/UserPreferencesDirective.ts:31
+msgid "Swimlane View"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/Language.tsx:111
+msgid "Switch Metadata Language"
+msgstr ""
+
+#: scripts/apps/authoring-react/multi-edit-modal.tsx:115
+msgid "Switch article"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-swtich.tsx:16
+msgid "Switch authoring"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-swtich.tsx:18
+msgid "Switch authoring?"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:111
+msgid "Switch between grouped/single desk view"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:109
+msgid "Switch between grouped/single stage view"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:38
+msgid "Switch to feature preview"
+msgstr "Пређи на преглед нових функција"
+
+#: scripts/apps/archive/views/list.html:20
+#: scripts/apps/contacts/views/list.html:6
+#: scripts/apps/content-api/views/list.html:12
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:270
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:270
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:439
+msgid "Switch to grid view"
+msgstr ""
+
+#: scripts/apps/archive/views/list.html:21
+#: scripts/apps/contacts/views/list.html:7
+#: scripts/apps/content-api/views/list.html:13
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:271
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:271
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:440
+msgid "Switch to list view"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:185
+msgid "Switches"
+msgstr ""
+
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:148
+#: scripts/apps/system-messages/index.ts:34
+msgid "System Message"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:140
+msgid "T"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/to-desk.tsx:14
+#: scripts/apps/authoring/views/authoring-topbar.html:58
+msgid "T D"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:119
+#: ../superdesk-planning/client/components/UI/DateTime.tsx:49
+#: ../superdesk-planning/client/constants/index.ts:166
+#: ../superdesk-planning/client/utils/index.ts:962
+#: ../superdesk-planning/client/utils/planning.tsx:1380
+#: ../superdesk-planning/client/utils/planning.tsx:1795
+msgid "TBC"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:99
+msgid "TH"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/events.ts:25
+msgid "TIMEZONE is a required field"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:83
+msgid "TU"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:41
+msgid "Tab"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:42
+msgid "Tab As Spaces"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:93
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:186
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:33
+#: scripts/core/editor3/components/toolbar/index.tsx:310
+msgid "Table"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:191
+msgid "Table Header"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:192
+msgid "Table Header Large"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:193
+msgid "Table Header List"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/tag-input/index.tsx:26
+msgid "Tag-input (authoring-react)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:83
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:40
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:195
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:230
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:139
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:168
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:195
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:230
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:139
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:168
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:266
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:274
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:171
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:196
+msgid "Tags"
+msgstr ""
+
+#: scripts/apps/authoring-react/field-adapters/anpa_take_key.ts:20
+#: scripts/apps/workspace/content/constants.ts:10
+msgid "Take Key"
+msgstr ""
+
+#: scripts/apps/users/controllers/ChangeAvatarController.ts:7
+msgid "Take a picture"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:132
+msgid "Take created by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:418
+msgid "Take created by {{user}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:299
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:120
+msgid "Take key"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:471
+#: scripts/apps/authoring/versioning/history/views/history.html:160
+msgid "Take link is removed"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:163
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/takedown-action.tsx:10
+#: scripts/apps/authoring/views/authoring-topbar.html:137
+#: scripts/apps/authoring/views/authoring-topbar.html:138
+#: scripts/apps/authoring/views/authoring-topbar.html:139
+msgid "Takedown"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:333
+msgid "Takedown item"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:577
+msgid "Takedowns"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:50
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:90
+msgid "Taken Down"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:427
+msgid "Taken as a rewrite of"
+msgstr ""
+
+#: scripts/core/itemList/views/relatedItem-list-widget.html:31
+msgid "Takes"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:187
+msgid "Takes Package"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:540
+msgid "Tansa is not responding. You can continue editing or publish the story."
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:105
+msgid "Target"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:151
+#: scripts/apps/products/views/products-config-modal.html:76
+msgid "Target Regions"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:156
+msgid "Target Subscriber Types"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:146
+#: scripts/apps/templates/views/template-editor-modal.html:135
+msgid "Target Subscribers"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:130
+msgid "Target Type"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:5
+msgid "Target Type:"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-routing-action.html:67
+msgid "Target Types"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:131
+msgid "Target regions"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:106
+msgid "Target subscribers"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-target-select.tsx:148
+msgid "Target types"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:163
+msgid "Targetable by users"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:188
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:405
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:2
+msgid "Tasks"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:20
+msgid "Tasks Management"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:58
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:58
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:74
+msgid "Tech. title"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/authoring-fields/subitems/subitems-view-edit.js:46
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.js:46
+#: scripts/extensions/broadcasting/src/authoring-fields/subitems/subitems-view-edit.tsx:101
+msgid "Technical information"
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:19
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:72
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:111
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:72
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:111
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:136
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:210
+msgid "Template"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:49
+msgid "Template Content"
+msgstr ""
+
+#: scripts/apps/templates/views/template-editor-modal.html:46
+msgid "Template Type"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/api.ts:842
+msgid "Template already exists. Do you want to overwrite it?"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/create-rundown-from-template.js:93
+#: scripts/extensions/broadcasting/dist/src/rundowns/create-rundown-from-template.js:93
+#: scripts/extensions/broadcasting/src/rundowns/create-rundown-from-template.tsx:206
+msgid "Template based settings"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/api.ts:796
+#: ../superdesk-planning/client/components/Events/ManageEventTemplatesModal.tsx:72
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:70
+#: scripts/apps/templates/views/template-editor-modal.html:21
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:184
+#: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:187
+#: scripts/extensions/broadcasting/src/rundown-templates/template-edit.tsx:384
+msgid "Template name"
+msgstr ""
+
+#: scripts/apps/templates/directives/TemplatesDirective.ts:248
+msgid "Template saved."
+msgstr ""
+
+#: scripts/apps/templates/views/templates.html:45
+msgid "Template type"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar/template-modal.tsx:117
+msgid "Template will be updated"
+msgstr ""
+
+#: scripts/apps/templates/index.ts:46
+#: scripts/apps/templates/views/templates.html:3
+msgid "Templates"
+msgstr ""
+
+#: scripts/apps/authoring-react/field-adapters/usageterms.ts:20
+msgid "Terms of use"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:138
+msgid "Test"
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:19
+msgid "Test Filter Against Content"
+msgstr ""
+
+#: scripts/apps/products/views/product-test.html:24
+msgid "Test Products"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:189
+#: ../superdesk-planning/client/utils/index.ts:587
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:83
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:247
+#: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:56
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:119
+#: scripts/extensions/sams/dist/src/utils/assets.js:119
+#: scripts/extensions/sams/src/utils/assets.ts:150
+msgid "Text"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:190
+msgid "Text Format"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:142
+msgid "Th"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/agenda.ts:407
+msgid "The Agenda you were viewing was deleted!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/notifications.ts:22
+msgid "The Assignment you were viewing was removed."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/notifications.ts:39
+msgid "The Event and Planning filter you were viewing is deleted!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/notifications.ts:16
+msgid "The Event and Planning filter you were viewing is modified!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/notifications.ts:123
+msgid "The Event was spiked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/notifications.ts:152
+msgid "The Event was unspiked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1410
+msgid "The Event you were editing was unlocked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1405
+msgid "The Event you were editing was unlocked by \"{{ userName }}\""
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1399
+msgid "The Event you were editing was updated via ingest"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:214
+msgid "The Events and Planning view filter is deleted."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:187
+msgid "The Events and Planning view filter is {{action}}."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:196
+msgid "The Events and Planning view filter with this name already exists"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:37
+msgid "The Planning Item(s) has been spiked."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:59
+msgid "The Planning Item(s) has been unspiked."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/notifications.ts:218
+msgid "The Planning item was spiked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/notifications.ts:251
+msgid "The Planning item was unspiked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1411
+msgid "The Planning item you were editing was unlocked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1406
+msgid "The Planning item you were editing was unlocked by \"{{ userName }}\""
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:1400
+msgid "The Planning item you were editing was updated via ingest"
+msgstr ""
+
+#: scripts/apps/products/views/products-config-modal.html:31
+msgid ""
+"The Product ID can be copied and used as Superdesk Newshub product query."
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:278
+msgid "The Saved Report you are using was deleted!"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:270
+msgid ""
+"The Saved Report you are using was updated! Please re-select the Saved Report"
+msgstr ""
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:52
+msgid ""
+"The Superdesk project is developed and maintained on <a href=\"https://"
+"github.com/superdesk\" title=\"Superdesk GitHub\" target=\"_blank\">GitHub</"
+"a> by <a href=\"https://www.sourcefabric.org/\" title=\"Sourcefabric\" "
+"target=\"_blank\">Sourcefabric</a>."
+msgstr ""
+
+#: scripts/core/auth/reset-password.html:74
+msgid "The activation token is not valid."
+msgstr "Токен за активацију није исправан."
+
+#: scripts/core/editor3/components/annotations/AnnotationInput.tsx:220
+#: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:85
+msgid "The annotation will be deleted. Are you sure?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:107
+msgid "The assignment has been accepted"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:105
+msgid "The assignment has been accepted by"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:541
+msgid "The assignment has been reverted."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:463
+msgid "The assignment was reassigned."
+msgstr ""
+
+#: scripts/core/editor3/components/comments/CommentPopup.tsx:151
+msgid "The comment will be deleted. Are you sure?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/InputArray/index.tsx:94
+msgid "The coverage has been removed"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/tooltips.ts:29
+msgid "The event has been killed"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:64
+msgid "The event(s) have been spiked"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/events/ui.ts:81
+msgid "The event(s) have been unspiked"
+msgstr ""
+
+#: scripts/apps/archive/controllers/file-upload-error-modal.tsx:31
+msgid "The file was not uploaded"
+msgid_plural "Some files were not uploaded"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/spikeEventForm.tsx:112
+msgid "The following Events are in use and will not be spiked:"
+msgstr ""
+
+#: scripts/extensions/predefinedTextField/dist/src/config.js:66
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:66
+#: scripts/extensions/predefinedTextField/src/config.tsx:106
+msgid "The following placeholders are available to be used in definitions:"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:246
+#: scripts/apps/relations/directives/RelatedItemsDirective.ts:141
+msgid "The following status is not allowed in this field: {{status}}"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:121
+msgid "The helper text must not exceed 120 characters."
+msgstr ""
+
+#: scripts/core/helpers/crud-manager-http.tsx:52
+msgid "The item has been created."
+msgstr ""
+
+#: scripts/core/helpers/crud-manager-http.tsx:97
+msgid "The item has been deleted."
+msgstr ""
+
+#: scripts/core/helpers/crud-manager-http.tsx:86
+msgid "The item has been updated."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:30
+msgid "The item is read-only."
+msgstr ""
+
+#: ../superdesk-planning/client/controllers/AddToPlanningController.tsx:207
+#: ../superdesk-planning/client/controllers/FulfilAssignmentController.tsx:173
+msgid "The item was unlocked by \"{{ username }}\""
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:396
+msgid "The item with unsaved changes must be closed before you can filter."
+msgstr "Ставка са несачуваним изменама мора бити затворена пре филтрирања."
+
+#: ../superdesk-planning/client/api/locations.ts:24
+msgid "The location has been created"
+msgstr ""
+
+#: ../superdesk-planning/client/api/locations.ts:62
+msgid "The location has been updated"
+msgstr ""
+
+#: scripts/apps/users/views/change-avatar.html:33
+msgid "The minimum image resolution is 200x200 pixels."
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:61
+msgid ""
+"The name of a Slack channel associated with this desk, the # is not required"
+msgstr ""
+
+#: scripts/api/article-send.tsx:113
+msgid ""
+"The package \"{{name}}\" contains the following published items that can not "
+"be sent:"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-swtich.tsx:19
+msgid "The page needs to be reloaded in order to do that."
+msgstr ""
+
+#: scripts/apps/users/directives/ChangePasswordDirective.ts:21
+#: scripts/core/auth/login-modal-directive.ts:75
+msgid "The password has been changed."
+msgstr "Лозинка је промењена."
+
+#: scripts/apps/users/directives/ResetPasswordDirective.ts:18
+msgid "The password has been reset."
+msgstr ""
+
+#: scripts/apps/publish/views/email-config.html:35
+msgid "The rendition to attach to the email"
+msgstr ""
+
+#: scripts/core/editor3/components/comments/CommentPopup.tsx:155
+msgid "The reply will be deleted. Are you sure?"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:23
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:23
+#: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:64
+msgid "The show {{name}} has been successfully created"
+msgstr ""
+
+#: scripts/apps/archive/controllers/file-upload-error-modal.tsx:61
+msgid "The size of {{filename}} is {{width}}x{{height}}"
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:401
+msgid ""
+"The subscriber is currently inactive, but the schedule from {{start}} to "
+"{{end}} is valid. The subscriber will be activated on save."
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:383
+msgid ""
+"The subscriber is set to start on {{date}}, but the Active switch will "
+"override this and activate the subscriber on save."
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:391
+msgid ""
+"The subscriber schedule ended on {{date}}, but the Active switch will keep "
+"the subscriber active on save."
+msgstr ""
+
+#: ../superdesk-analytics/client/components/HighchartsLicense.tsx:39
+msgid ""
+"The use of Highcharts is provided under a license with the following details:"
+msgstr ""
+
+#: scripts/apps/dashboard/user-activity/user-activity.ts:14
+msgid ""
+"The user activity widget provides information about user activity. Using the "
+"widget, editors can search and select a user. Upon selection a list of "
+"content items is shown categorized as follows:"
+msgstr ""
+
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:226
+msgid "The values should be unique for {{uniqueField}}"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:55
+msgid ""
+"The vocabulary {{name}} can't be deleted because it is currently used in the "
+"following Content Profile:"
+msgid_plural ""
+"The vocabulary {{name}} can't be deleted because it is currently used in the "
+"following Content Profiles:"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../superdesk-planning/client/actions/main.ts:468
+msgid "The {{ itemType }} has been posted"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:318
+msgid "The {{ itemType }} has been saved"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:396
+msgid "The {{ itemType }} has been unposted"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:257
+msgid "Themes"
+msgstr ""
+
+#: scripts/apps/contacts/components/ItemList.tsx:180
+#: scripts/apps/master-desk/components/ListItemsComponent.tsx:45
+#: scripts/apps/search/components/ItemList.tsx:523
+#: scripts/core/itemList/LazyLoader.tsx:216
+msgid "There are currently no items"
+msgstr ""
+
+#: scripts/validate-instance-configuration.tsx:108
+msgid "There are issues with instance configuration"
+msgstr ""
+
+#: scripts/api/highlights.ts:37
+msgid "There are items locked or not published. Do you want to continue?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionsMenu/ActionsMenuPopup.tsx:91
+msgid "There are no actions available."
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:207
+msgid "There are no assignments completed"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:213
+msgid "There are no assignments for today"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:204
+msgid "There are no assignments in progress"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:201
+msgid "There are no assignments to do"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/difference.tsx:29
+msgid "There are no changes"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:210
+msgid "There are no current assignments"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/FiltersList.tsx:52
+msgid "There are no events and planing view filters."
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:216
+msgid "There are no future assignments"
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:586
+msgid "There are no items matching the search."
+msgstr "Нема ставки које одговарају претрази."
+
+#: scripts/core/ui/components/virtual-lists/virtual-list.tsx:206
+msgid "There are no items yet"
+msgstr "Још нема ставки"
+
+#: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:566
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:594
+msgid "There are no items yet."
+msgstr "Још нема ставки."
+
+#: scripts/apps/search-providers/directive.ts:24
+msgid "There are no providers available."
+msgstr ""
+
+#: scripts/core/editor3/components/links/AttachmentList.tsx:83
+msgid ""
+"There are no public attachments yet. Upload some first using Attachments "
+"widget."
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/suggestions.tsx:208
+msgid "There are no resolved suggestions"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:173
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:173
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:333
+msgid "There are no rundowns yet"
+msgstr ""
+
+#: scripts/apps/master-desk/components/UsersComponent.tsx:150
+msgid "There are no users assigned to this desk"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/prefered-cv-items-config.html:15
+msgid "There are no vocabularies configured."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:58
+msgid "There are some unsaved changes, do you want to save and publish it now?"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:70
+msgid "There are some unsaved changes, do you want to save and send it now?"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:45
+msgid "There are some unsaved changes, do you want to save it now?"
+msgstr ""
+
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:71
+msgid "There are some unsaved changes, go to the article to save changes?"
+msgstr "Постоје несачуване измене, желите ли да отворите чланак и сачувате их?"
+
+#: scripts/core/ui/components/prompt-for-unsaved-changes.tsx:35
+msgid "There are some unsaved changes, save it now?"
+msgstr "Постоје несачуване измене, желите ли да их сачувате?"
+
+#: scripts/core/auth/auth.ts:241
+msgid "There are some unsaved changes. Please save them before signing out."
+msgstr "Постоје несачуване измене. Сачувајте их пре одјаве."
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:163
+msgid "There are unsaved changes, but the form is invalid"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:113
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/index.tsx:170
+msgid "There are unsaved changes."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:28
+msgid ""
+"There are unsaved changes. If you navigate away, your changes will be lost."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/notifications.ts:350
+msgid "There is a {{ type }} assignment '{{ slugline }}' {{ state }}"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem.ts:194
+msgid "There is an error. Failed to associate update."
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:40
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/utils/handle-unsaved-rundown-changes.js:18
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundown-view-edit.js:40
+#: scripts/extensions/broadcasting/dist/src/utils/handle-unsaved-rundown-changes.js:18
+#: scripts/extensions/broadcasting/src/rundowns/rundown-view-edit.tsx:90
+#: scripts/extensions/broadcasting/src/utils/handle-unsaved-rundown-changes.ts:23
+msgid "There is an item open in editing mode. Discard changes?"
+msgstr ""
+
+#: ../superdesk-planning/client/services/AssignmentsService.tsx:269
+msgid "There is an update assignment for this story due at ''."
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:296
+msgid "There is no token for subscriber."
+msgstr ""
+
+#: scripts/apps/highlights/controllers/HighlightsConfig.ts:60
+msgid "There was a problem while saving highlights configuration"
+msgstr ""
+
+#: scripts/apps/users/controllers/ChangeAvatarController.ts:51
+#: scripts/apps/users/controllers/ChangeAvatarController.ts:63
+msgid "There was a problem with your upload"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:42
+msgid "There was a problem, Planning item not spiked!"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/ui.ts:63
+msgid "There was a problem, Planning item not unspiked!"
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskeditBasic.ts:61
+msgid "There was a problem, desk not created/updated."
+msgstr ""
+
+#: scripts/apps/desks/controllers/DeskConfigController.ts:106
+msgid "There was a problem, desk not saved. Refresh Desks."
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:50
+msgid "There was a problem, dictionary not created/updated."
+msgstr ""
+
+#: scripts/apps/search/directives/ItemGlobalSearch.ts:59
+#: scripts/apps/search/directives/ItemGlobalSearch.ts:91
+msgid "There was a problem, item can not open."
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskeditPeople.ts:66
+msgid "There was a problem, members not saved. Refresh Desks."
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:291
+msgid "There was a problem, stage not created/updated."
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskeditStages.ts:241
+msgid "There was a problem, stage was not deleted."
+msgstr ""
+
+#: scripts/apps/search/components/ErrorBox.tsx:7
+msgid "There was an error archiving this item"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/multiSelect.ts:255
+msgid "There was an error when exporting."
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:195
+msgid "There was an error when saving the contact."
+msgstr ""
+
+#: scripts/apps/users/directives/UserEditDirective.ts:268
+msgid "There was an error when saving the user account."
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/summary/summary.js:22
+#: scripts/extensions/ai-widget/dist/src/summary/summary.js:22
+#: scripts/extensions/ai-widget/src/summary/summary.tsx:45
+msgid "There was an error when trying to generate a summary."
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-body.js:32
+#: scripts/extensions/ai-widget/dist/src/translations/translations-body.js:32
+#: scripts/extensions/ai-widget/src/translations/translations-body.tsx:70
+msgid "There was an error when trying to generate a translation."
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/headlines/headlines.js:23
+#: scripts/extensions/ai-widget/dist/src/headlines/headlines.js:23
+#: scripts/extensions/ai-widget/src/headlines/headlines.tsx:49
+msgid "There was an error when trying to generate headlines."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:219
+msgid "There was an error, could not delete Events and Planning view filter."
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:92
+msgid "There was an error. Content filter cannot be deleted."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:262
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:477
+msgid "There was an error. Failed to generate update."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:281
+msgid "There was an error. Failed to remove link."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/controllers/ChangeImageController.ts:463
+msgid "There was an error. Failed to save the area of interest."
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:128
+msgid "There was an error. Filter condition cannot be deleted."
+msgstr ""
+
+#: scripts/apps/users/directives/UserRolesDirective.ts:68
+msgid "There was an error. Role cannot be deleted."
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestRoutingContent.ts:55
+msgid "There was an error. Routing scheme cannot be deleted."
+msgstr ""
+
+#: scripts/apps/ingest/directives/IngestRulesContent.ts:54
+msgid "There was an error. Rule set cannot be deleted."
+msgstr ""
+
+#: scripts/apps/templates/directives/TemplatesDirective.ts:371
+msgid "There was an error. Template cannot be deleted."
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:162
+msgid "Third"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:259
+msgid "This Coverage"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:261
+msgid ""
+"This Event is scheduled to occur after the end date of its recurring cycle!"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:28
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:21
+msgid "This Month"
+msgstr ""
+
+#: scripts/core/editor3/components/embeds/EmbedInput.tsx:92
+msgid "This URL could not be embedded."
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:23
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:15
+#: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:26
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:160
+msgid "This Week"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:32
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:27
+msgid "This Year"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:277
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:365
+#: ../superdesk-planning/client/constants/events.ts:174
+msgid "This and all future events"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:276
+msgid "This and all future planning"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:587
+msgid ""
+"This article contains unresolved comments.Click on Cancel to go back to "
+"editing toresolve those comments or OK to ignore and proceed with publishing"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:25
+msgid "This event is a recurring event!"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:84
+msgid "This event is a recurring event. Post all recurring events"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:271
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:362
+#: ../superdesk-planning/client/constants/events.ts:173
+msgid "This event only"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/ArticleEditDirective.ts:58
+msgid "This field is read-only"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentEditor.tsx:181
+#: ../superdesk-planning/client/validators/assignments.tsx:8
+#: ../superdesk-planning/client/validators/events.ts:14
+#: ../superdesk-planning/client/validators/events.ts:19
+#: ../superdesk-planning/client/validators/events.ts:24
+#: ../superdesk-planning/client/validators/events.ts:29
+#: ../superdesk-planning/client/validators/events.ts:35
+#: ../superdesk-planning/client/validators/events.ts:40
+#: ../superdesk-planning/client/validators/index.ts:108
+#: ../superdesk-planning/client/validators/planning.ts:169
+#: ../superdesk-planning/client/validators/planning.ts:207
+#: ../superdesk-planning/client/validators/profile.ts:107
+#: ../superdesk-planning/client/validators/profile.ts:65
+#: ../superdesk-planning/client/validators/profile.ts:77
+#: ../superdesk-planning/client/validators/profile.ts:85
+#: scripts/core/ui/ui.ts:1108
+msgid "This field is required"
+msgstr "Ово поље је обавезно"
+
+#: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:190
+msgid "This field is required by the system"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:72
+#: scripts/apps/contacts/components/Form/MultiTextInput.tsx:34
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:196
+#: scripts/apps/users/views/edit-form.html:118
+#: scripts/apps/users/views/edit-form.html:139
+#: scripts/apps/users/views/edit-form.html:85
+#: scripts/apps/users/views/edit-form.html:97
+msgid "This field is required."
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/editor3/config.tsx:92
+msgid ""
+"This field will initialize with the value of specified field when toggled "
+"from \"off\" to \"on\". Only plain-text gets copied. Formatting options or "
+"links are not preserved."
+msgstr ""
+
+#: scripts/apps/templates/directives/TemplatesDirective.ts:358
+msgid "This is a default template of the following desk(s): {{deskNames}}."
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:351
+msgid "This is a recurring event."
+msgstr ""
+
+#: scripts/apps/authoring/views/theme-select.html:38
+#: scripts/apps/authoring/views/theme-select.html:89
+msgid "This is the headline"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/editor.tsx:175
+msgid "This item is already added"
+msgstr ""
+
+#: scripts/apps/relations/directives/RelatedItemsDirective.ts:154
+msgid "This item is already added as related."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/controllers/AssociationController.ts:211
+msgid "This item is already added."
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:26
+#: ../superdesk-planning/client/planning-extension/src/extension.ts:40
+msgid "This item is linked to in-progress planning coverage."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:118
+msgid "This item was locked by {{username}}."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/ConfirmDirtyService.ts:101
+msgid "This item was unlocked by {{username}}."
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:249
+msgid "This item will be permanently deleted."
+msgstr "Ова ставка ће бити трајно обрисана."
+
+#: scripts/core/editor3/components/BaseUnstyledComponent.tsx:130
+msgid "This link is not embeddable."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModalSubnav.tsx:66
+msgid "This list contains unposted changes!"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:270
+msgid "This planning only"
+msgstr ""
+
+#: scripts/apps/archive/views/preview.html:100
+msgid "This story has been rewritten by:"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:112
+msgid ""
+"This vocabulary is not currently used in any Content Profile and can be "
+"safely removed."
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:42
+msgid "This week"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:46
+msgid ""
+"This widget allows you to create literally any content view you may need in "
+"Superdesk, be it production or ingest. All you need is to select a desk, its "
+"stages or a saved search. Name your view once you are done. Enjoy!"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:83
+msgid "This will also post the related event's entire recurring series"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postponeEventForm.tsx:118
+msgid "This will also postpone the following planning items"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:105
+msgid "This will also remove linked assignments if any"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:762
+msgid ""
+"This will also remove other linked assignments (if any, for story updates). "
+"Are you sure?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:51
+msgid "This will also {{action}} the following events"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/UpdateMethodSelection.tsx:39
+msgid "This will also {{action}} the following planning items"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:119
+msgid ""
+"This will appear below the field in the\n"
+"                                    Editor."
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/convertToRecurringEventForm.tsx:152
+msgid "This will create new events in the remote ({{timeZone}}) timezone"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:269
+msgid "This will create the new event in the remote ({{timeZone}}) timezone"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:222
+msgid "This will mark as rescheduled the following planning items"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/ui.ts:553
+msgid ""
+"This will unlink the text item associated with the assignment. Are you sure ?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:111
+msgid "Thu"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/video-thumbnail-editor.tsx:117
+msgid "Thumbnail"
+msgstr ""
+
+#: scripts/apps/archive/views/related-items-preview.html:12
+#: scripts/apps/relations/views/related-items.html:30
+msgid "Thumbnail for related item"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1457
+#: scripts/core/datetime/datetime.ts:293
+msgid "Thursday"
+msgstr "Четвртак"
+
+#: ../superdesk-planning/client/components/UI/DateTime.tsx:49
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:355
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:194
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:79
+#: scripts/apps/search/views/edit-time-interval.html:15
+msgid "Time"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/time/index.tsx:20
+msgid "Time (authoring-react)"
+msgstr ""
+
+#: scripts/core/editor3/components/media/MediaBlock.tsx:15
+msgid "Time Restricted"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventDateTime.tsx:59
+msgid "Time TBC"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:141
+#: scripts/core/ui/views/sd-timezone.html:1
+msgid "Time Zone"
+msgstr "Временска зона"
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:52
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:64
+#: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:52
+#: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:64
+#: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:131
+#: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:98
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:26
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/components/filtering-inputs.js:36
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:47
+#: scripts/extensions/broadcasting/src/rundowns/components/filtering-inputs.tsx:64
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:59
+#: scripts/extensions/datetimeField/src/editor.tsx:101
+msgid "Time cannot be empty"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:50
+#: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:50
+#: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:92
+msgid "Time from"
+msgstr ""
+
+#: scripts/extensions/datetimeField/dist/src/config.js:33
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:33
+#: scripts/extensions/datetimeField/src/config.tsx:57
+msgid "Time increment steps"
+msgstr ""
+
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/template-editor.js:20
+#: scripts/extensions/datetimeField/dist/src/template-editor.js:20
+#: scripts/extensions/datetimeField/src/template-editor.tsx:26
+msgid ""
+"Time offset is configured to be {{x}} minutes for this field. When an "
+"article is created\n"
+"            based on this template, it's value will initialize to creation "
+"time + {{x}} minutes"
+msgstr ""
+
+#: scripts/apps/profiling/views/profiling.html:34
+msgid "Time per call"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:344
+msgid "Time picker"
+msgstr ""
+
+#: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:315
+msgid "Time spent producing content"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:62
+#: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:62
+#: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:125
+msgid "Time to"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx:113
+#: scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx:180
+msgid "Time zone"
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:559
+msgid "Timeline"
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-tooltip.html:4
+msgid "Times:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:249
+#: scripts/core/lang/missing-translations-strings.ts:34
+msgid "Timezone"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/views/chart-form-options.html:3
+#: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-preview.html:11
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-report-preview.html:2
+#: ../superdesk-analytics/client/planning_usage_report/views/planning-usage-report-preview.html:2
+#: ../superdesk-analytics/client/production_time_report/views/production-time-report-preview.html:2
+#: ../superdesk-analytics/client/publishing_performance_report/views/publishing-performance-report-preview.html:11
+#: ../superdesk-analytics/client/update_time_report/views/update-time-report-preview.html:2
+#: scripts/apps/archive/views/metadata-associateditem-view.html:3
+#: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:197
+#: scripts/apps/authoring/attachments/AttachmentsEditorModal.tsx:61
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:177
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:63
+#: scripts/core/editor3/components/media/MediaBlock.tsx:148
+#: scripts/core/editor3/components/media/MediaBlock.tsx:237
+#: scripts/core/editor3/components/media/MediaBlock.tsx:276
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-items/content-profile.js:52
+#: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:52
+#: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:64
+#: scripts/extensions/predefinedTextField/dist/src/config.js:15
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/config.js:15
+#: scripts/extensions/predefinedTextField/src/config.tsx:23
+msgid "Title"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-carousel/media-carousel.tsx:125
+#: scripts/apps/authoring/views/item-association.html:70
+#: scripts/apps/authoring/views/item-carousel.html:93
+#: scripts/core/editor3/components/media/MediaBlock.tsx:163
+msgid "Title:"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:50
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:262
+#: ../superdesk-planning/client/components/fields/editor/CreationDate.tsx:49
+#: ../superdesk-planning/client/components/fields/editor/EndDateTime.tsx:33
+#: ../superdesk-planning/client/components/fields/preview/index.ts:75
+msgid "To"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:357
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:379
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:65
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/index.tsx:87
+msgid "To Be Confirmed"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/to-desk.tsx:13
+#: scripts/apps/authoring/views/authoring-topbar.html:55
+#: scripts/apps/authoring/views/authoring-topbar.html:56
+#: scripts/apps/authoring/views/authoring-topbar.html:57
+#: scripts/apps/search/constants.ts:13
+#: scripts/apps/search/views/search-parameters.html:115
+msgid "To Desk"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/assignments.ts:200
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:9
+#: scripts/apps/master-desk/components/AssignmentsComponent.tsx:40
+msgid "To Do"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:195
+msgid "To Lowercase"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:196
+msgid "To Uppercase"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:70
+msgid ""
+"To delete this vocabulary, you must first remove it from all Content "
+"Profiles listed above."
+msgstr ""
+
+#: scripts/core/editor3/components/embeds/EmbedInput.tsx:152
+msgid "To get a responsive embed code, paste a URL."
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/difference.tsx:72
+msgid ""
+"To see detailed differences, compare primary and secondary items visually"
+msgstr ""
+
+#: ../superdesk-analytics/client/email_report/views/email-report-modal.html:18
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-modal.html:129
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:31
+msgid "To:"
+msgstr ""
+
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-footer.js:40
+#: scripts/extensions/ai-widget/dist/src/translations/translations-footer.js:40
+#: scripts/extensions/ai-widget/src/translations/translations-footer.tsx:65
+msgid "To: {{ language }}"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:18
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:9
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:276
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:102
+#: ../superdesk-planning/client/components/Main/CalendarNavigation.tsx:25
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DateInputPopup.tsx:209
+#: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:20
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:156
+#: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:18
+#: scripts/apps/highlights/views/highlights_config_modal.html:41
+#: scripts/apps/vocabularies/services/VocabularyService.ts:126
+#: scripts/core/datetime/absdate-directive.ts:20
+#: scripts/core/ui/components/Form/DateInput/DateInputPopup.tsx:191
+#: scripts/extensions/availability-manager/dist/src/correspondent-availability/filters.js:59
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/correspondent-availability/filters.js:59
+#: scripts/extensions/availability-manager/src/correspondent-availability/filters.tsx:71
+msgid "Today"
+msgstr "Данас"
+
+#: ../superdesk-planning/client/constants/assignments.ts:212
+msgid "Todays Assignments"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:78
+msgid "Toggle"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:88
+msgid "Toggle Header"
+msgstr ""
+
+#: scripts/apps/authoring/widgets/widgets.ts:519
+msgid "Toggle Nth widget, where 'N' is order of widget it appears"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:456
+#: scripts/apps/authoring/views/article-edit.html:457
+msgid "Toggle Sign-Off lock"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:89
+msgid "Toggle Suggestions Mode"
+msgstr ""
+
+#: ../superdesk-planning/client/apps/Planning/PlanningSubNav.tsx:142
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:54
+msgid "Toggle advanced Filters"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:43
+msgid "Toggle bold"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-section/get-field-container.tsx:70
+msgid "Toggle field"
+msgstr ""
+
+#: scripts/apps/search/views/search.html:3
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:249
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:249
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:376
+msgid "Toggle filters"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:90
+msgid "Toggle formatting marks"
+msgstr ""
+
+#: scripts/apps/archive/views/preview.html:79
+msgid "Toggle header info"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:49
+msgid "Toggle italic"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:15
+msgid "Toggle main menu"
+msgstr "Прикажи/сакриј главни мени"
+
+#: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:343
+msgid "Toggle search"
+msgstr ""
+
+#: scripts/apps/search/index.ts:139
+msgid "Toggle search view"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:73
+msgid "Toggle strikethrough"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:61
+msgid "Toggle subscript"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:67
+msgid "Toggle superscript"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/integration-wrapper/toggle-theme-button.tsx:13
+#: scripts/apps/authoring/views/authoring.html:33
+msgid "Toggle theme"
+msgstr ""
+
+#: scripts/core/editor3/highlightsConfig.ts:55
+msgid "Toggle underline"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:311
+msgid "Token expiry"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:103
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DateInputPopup.tsx:213
+#: ../superdesk-planning/client/components/fields/editor/RelativeDate.tsx:23
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:158
+#: scripts/apps/vocabularies/services/VocabularyService.ts:131
+#: scripts/core/ui/components/Form/DateInput/DateInputPopup.tsx:195
+msgid "Tomorrow"
+msgstr "Сутра"
+
+#: ../superdesk-planning/client/validators/profile.ts:61
+msgid "Too long"
+msgstr ""
+
+#: scripts/apps/authoring/attachments/AttachmentsWidget.tsx:24
+msgid "Too many files selected. Only 1 file is allowed"
+msgid_plural "Too many files selected. Only {{count}} files are allowed"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../superdesk-planning/client/validators/profile.ts:58
+#: ../superdesk-planning/client/validators/profile.ts:59
+msgid "Too many {{ name }}"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/profile.ts:103
+msgid "Too short"
+msgstr ""
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:432
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:440
+msgid "Total"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:257
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:257
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:394
+msgid "Total Assets: {{ total }}"
+msgstr ""
+
+#: scripts/apps/profiling/views/profiling.html:33
+msgid "Total time"
+msgstr ""
+
+#: scripts/apps/search/views/item-sortbar.html:2
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:732
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:259
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:259
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:402
+msgid "Total:"
+msgstr "Укупно:"
+
+#: scripts/core/lang/missing-translations-strings.ts:21
+msgid "Transformation Rules Management"
+msgstr ""
+
+#: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:244
+#: scripts/apps/authoring-react/toolbar/translate-modal.tsx:100
+#: scripts/apps/authoring-react/toolbar/translate-modal.tsx:124
+#: scripts/apps/translations/index.ts:40
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-footer.js:43
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/translations/translations-widget.js:44
+#: scripts/extensions/ai-widget/dist/src/translations/translations-footer.js:43
+#: scripts/extensions/ai-widget/dist/src/translations/translations-widget.js:44
+#: scripts/extensions/ai-widget/src/translations/translations-footer.tsx:81
+#: scripts/extensions/ai-widget/src/translations/translations-widget.tsx:83
+msgid "Translate"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:352
+msgid "Translate item to"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:196
+#: scripts/apps/authoring/versioning/history/views/history.html:41
+msgid "Translated by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/translations/translations.tsx:63
+#: scripts/apps/authoring/translations/translationsWidget.tsx:53
+#: scripts/apps/authoring/views/authoring-header.html:81
+msgid "Translated from"
+msgstr ""
+
+#: scripts/apps/search/components/fields/translations.tsx:58
+#: scripts/apps/search/components/fields/translations.tsx:72
+msgid "Translation"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/translations/translations.tsx:14
+#: scripts/apps/authoring/translations/index.ts:12
+#: scripts/apps/authoring/views/authoring-topbar.html:348
+#: scripts/apps/search/components/fields/translations.tsx:40
+#: scripts/apps/search/components/fields/translations.tsx:72
+#: scripts/extensions/ai-widget/dist/src/extensions/ai-widget/src/main-panel.js:22
+#: scripts/extensions/ai-widget/dist/src/main-panel.js:22
+#: scripts/extensions/ai-widget/src/main-panel.tsx:45
+msgid "Translations"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:114
+msgid "Transmitted at"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:197
+msgid "Trash"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/base/converters.ts:33
+#: ../superdesk-planning/client/components/fields/preview/base/utils.ts:16
+msgid "True"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:48
+#: scripts/core/auth/reset-password.html:38
+#: scripts/core/auth/reset-password.html:85
+#: scripts/core/auth/secure-login.html:39
+msgid "Trying to reconnect...<br>Please wait."
+msgstr "Покушај поновног повезивања...<br>Сачекајте."
+
+#: ../superdesk-planning/client/utils/filters.ts:136
+msgid "Tu"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:109
+msgid "Tue"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1455
+#: scripts/core/datetime/datetime.ts:291
+msgid "Tuesday"
+msgstr "Уторак"
+
+#: scripts/core/menu/views/menu.html:39
+msgid "Turn off feature preview"
+msgstr "Искључи преглед нових функција"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:198
+#: scripts/apps/users/views/edit-form.html:329
+msgid "Twitter"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:199
+msgid "Twitter Circle"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ExportTemplates/ManageExportTemplates.tsx:36
+#: scripts/apps/archive/views/metadata-view.html:207
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:419
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:423
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:201
+#: scripts/apps/workspace/content/constants.ts:47
+#: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:123
+#: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:155
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:123
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetPreviewPanel.js:155
+#: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:146
+#: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:178
+msgid "Type"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:80
+#: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:80
+#: scripts/extensions/auto-tagging-widget/src/new-item.tsx:191
+msgid "Type is required."
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:89
+msgid "Type to search or create a new label"
+msgstr ""
+
+#: scripts/apps/authoring-react/generic-widgets/comments/CommentsWidget.tsx:184
+#: scripts/core/editor3/components/comments/CommentTextArea.tsx:122
+msgid "Type your comment..."
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/list/ItemType.tsx:18
+#: scripts/extensions/sams/dist/src/components/assets/assetEditor.js:173
+#: scripts/extensions/sams/dist/src/components/assets/assetGridItem.js:122
+#: scripts/extensions/sams/dist/src/components/assets/assetListItem.js:118
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetEditor.js:173
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetGridItem.js:122
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetListItem.js:118
+#: scripts/extensions/sams/src/components/assets/assetEditor.tsx:175
+#: scripts/extensions/sams/src/components/assets/assetGridItem.tsx:147
+#: scripts/extensions/sams/src/components/assets/assetListItem.tsx:131
+msgid "Type:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:139
+msgid "Type: {{ type }}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:152
+msgid "Type: {{type}}"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:121
+msgid "U"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/unspike.tsx:9
+msgid "UNSPIKE"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-topbar.html:149
+msgid "UP"
+msgstr ""
+
+#: scripts/apps/dashboard/workspace-tasks/views/workspace-tasks.html:18
+msgid "UPCOMING"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/update-action.tsx:10
+#: scripts/apps/authoring/views/authoring-header.html:57
+msgid "UPDATE"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:97
+#: scripts/core/editor3/components/links/LinkInput.tsx:67
+msgid "URL"
+msgstr ""
+
+#: scripts/core/editor3/components/embeds/EmbedInput.tsx:95
+msgid "URL not found."
+msgstr ""
+
+#: scripts/apps/vocabularies/views/settings.html:34
+msgid "URLs"
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:211
+msgid "Uknown validation error"
+msgstr "Непозната грешка валидације"
+
+#: scripts/core/lang/missing-translations-strings.ts:21
+msgid "Un Spike"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/uploadAssetModal.js:148
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/uploadAssetModal.js:148
+#: scripts/extensions/sams/src/components/assets/uploadAssetModal.tsx:122
+msgid "Unable to find Asset associated with the file!"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/index.tsx:227
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:208
+#: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:211
+#: scripts/apps/dashboard/workspace-tasks/views/assignee-view.html:8
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:50
+msgid "Unassigned"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:56
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:72
+#: scripts/extensions/availability-manager/dist/src/utils.js:56
+#: scripts/extensions/availability-manager/dist/src/utils.js:72
+#: scripts/extensions/availability-manager/src/utils.ts:59
+#: scripts/extensions/availability-manager/src/utils.ts:75
+msgid "Unavailable"
+msgstr ""
+
+#: scripts/core/views/sdselect.html:14
+msgid "Uncheck all"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:200
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:30
+msgid "Underline"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:77
+msgid "Underline (Ctrl+U)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:201
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:43
+#: scripts/core/editor3/components/toolbar/index.tsx:462
+msgid "Undo"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:203
+#: scripts/apps/content-filters/views/production-test-view.html:19
+#: scripts/apps/legal-archive/views/legal_archive.html:58
+#: scripts/apps/publish/views/publish-queue.html:105
+#: scripts/apps/search/constants.ts:10
+#: scripts/apps/search/views/search-parameters.html:42
+msgid "Unique Name"
+msgstr ""
+
+#: scripts/apps/search/views/item-globalsearch.html:11
+msgid "Unique Name/ID/GUID"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:405
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:197
+msgid "Unique name"
+msgstr ""
+
+#: scripts/core/ui/constants.ts:5
+msgid "Unknow error occured. Try repeating the action or reloading the page."
+msgstr "Дошло је до непознате грешке. Покушајте поново или освежите страницу."
+
+#: scripts/apps/search/services/TagService.ts:198
+msgid "Unknown"
+msgstr ""
+
+#: scripts/apps/archive/directives/ArchivedItemKill.ts:39
+msgid "Unknown Error: Cannot kill the item"
+msgstr ""
+
+#: scripts/apps/archive/directives/ResendItem.ts:45
+msgid "Unknown Error: Cannot resend the item"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:436
+msgid "Unknown Error: Item not published."
+msgstr ""
+
+#: scripts/apps/desks/controllers/DeskConfigController.ts:69
+msgid "Unknown Error: There was a problem, desk was not deleted."
+msgstr ""
+
+#: scripts/core/editor3/components/annotations/AnnotationPopup.tsx:73
+msgid "Unknown Type ({{qcode}})"
+msgstr ""
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:365
+msgid "Unknown error occured, Try descheduling again."
+msgstr ""
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:302
+msgid ""
+"Unknown error occured. Try publishing the item from the article edit view."
+msgstr ""
+
+#: scripts/api/article-send.tsx:248
+msgid "Unknown error occurred"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:161
+msgid "Unlink"
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/dist/planning-extension/src/extension.js:140
+#: ../superdesk-planning/client/planning-extension/src/extension.ts:188
+#: ../superdesk-planning/client/planning-extension/src/planning-details-widget.tsx:155
+msgid "Unlink as Coverage"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AssociatedEventItem.tsx:75
+msgid "Unlink related event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/RelatedPlanningItem.tsx:90
+msgid "Unlink related planning"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:310
+msgid "Unlink update"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:148
+msgid "Unlinked by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:456
+msgid "Unlinked by {{user}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:171
+#: ../superdesk-planning/client/components/LockContainer/LockContainerPopup.tsx:42
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:59
+#: scripts/apps/archive/views/item-lock.html:10
+#: scripts/apps/archive/views/item-lock.html:22
+#: scripts/apps/authoring-react/subcomponents/lock-info-generic.tsx:62
+#: scripts/apps/authoring-react/subcomponents/lock-info.tsx:58
+#: scripts/apps/authoring/views/authoring-topbar.html:22
+msgid "Unlock"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:21
+msgid "Unlock content"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/index.ts:468
+msgid "Unlock current item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:202
+#: scripts/apps/authoring/views/article-edit.html:461
+msgid "Unlocked"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:173
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-mark-for-user-modal.js:22
+#: scripts/extensions/markForUser/dist/src/get-mark-for-user-modal.js:22
+#: scripts/extensions/markForUser/src/get-mark-for-user-modal.tsx:77
+msgid "Unmark"
+msgstr ""
+
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/get-article-actions.js:21
+#: scripts/extensions/markForUser/dist/src/get-article-actions.js:21
+#: scripts/extensions/markForUser/src/get-article-actions.tsx:23
+msgid "Unmark user"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:102
+msgid "Unmarked by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:336
+msgid "Unmarked from desk({{x}}) by {{user}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:302
+msgid "Unmarked from highlight({{x}}) by {{user}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:203
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:27
+msgid "Unordered List"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/StyleButton.tsx:86
+msgid "Unordered list"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:119
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:122
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:382
+msgid "Unpost"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:78
+msgid "Unpost all recurring events or just this one?"
+msgstr ""
+
+#: scripts/apps/authoring-react/toolbar-components/angular-integration/unpublish-action.tsx:14
+#: scripts/apps/authoring/authoring/index.ts:426
+#: scripts/apps/authoring/views/authoring-topbar.html:146
+#: scripts/apps/authoring/views/authoring-topbar.html:147
+#: scripts/apps/authoring/views/authoring-topbar.html:148
+msgid "Unpublish"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/unpublish-confirm-modal.tsx:69
+msgid "Unpublish related items:"
+msgstr ""
+
+#: scripts/apps/search/components/fields/state.tsx:44
+msgid "Unpublished"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/HistoryController.ts:190
+msgid "Unpublished by"
+msgstr ""
+
+#: scripts/apps/authoring-react/generic-widgets/inline-comments.tsx:168
+#: scripts/apps/authoring/track-changes/views/inline-comments-widget.html:3
+msgid "Unresolved"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:499
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:123
+#: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:83
+#: scripts/apps/ingest/directives/IngestSourcesContent.ts:712
+#: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:18
+msgid "Unsaved changes"
+msgstr "Несачуване измене"
+
+#: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:438
+#: ../superdesk-analytics/client/utils.js:165
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:144
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:80
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:164
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:261
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:204
+#: ../superdesk-planning/client/constants/events.ts:155
+#: scripts/apps/authoring/views/authoring-topbar.html:166
+#: scripts/apps/authoring/views/authoring-topbar.html:167
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:89
+#: scripts/core/interactive-article-actions-panel/action-tabs.tsx:15
+#: scripts/core/interactive-article-actions-panel/actions/unspike-action.tsx:76
+msgid "Unspike"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:134
+msgid "Unspike Item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:143
+msgid "Unspike Planning Item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/unspikeEventForm.tsx:99
+msgid "Unspike all recurring events or just this one?"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/planning.ts:136
+msgid "Unspike planning"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:78
+msgid "Unspike {{event}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:49
+msgid "Unspiked"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:237
+#: scripts/apps/authoring/versioning/history/views/history.html:74
+msgid "Unspiked by"
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-subscribe.html:29
+msgid "Unsubscribe"
+msgstr ""
+
+#: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:227
+msgid "Unsubscribe desk"
+msgstr ""
+
+#: scripts/apps/search/directives/SavedSearchManageSubscribers.ts:215
+msgid "Unsubscribe user"
+msgstr ""
+
+#: scripts/validate-instance-configuration.tsx:32
+msgid ""
+"Unsupported extension point is being used: "
+"`contributions.authoringHeaderComponents`"
+msgstr ""
+
+#: ../superdesk-planning/client/components/WorkqueueContainer/WorkqueueItem.tsx:41
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:6
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:4
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-dropdown.html:6
+#: scripts/apps/authoring/multiedit/views/sd-multiedit-inner-dropdown.html:7
+#: scripts/apps/authoring/views/dashboard-articles.html:21
+#: scripts/apps/authoring/views/opened-articles.html:13
+#: scripts/apps/workspace/views/workspace-dropdown.html:25
+#: scripts/apps/workspace/views/workspace-dropdown.html:6
+#: scripts/core/utils.tsx:452
+msgid "Untitled"
+msgstr ""
+
+#: ../superdesk-planning/client/components/IgnoreCancelSaveModal.tsx:138
+#: ../superdesk-planning/client/components/Main/ItemEditor/EditorHeader.tsx:401
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:224
+#: scripts/apps/archive/index.tsx:294
+#: scripts/apps/authoring/attachments/AttachmentsEditorModal.tsx:51
+#: scripts/apps/authoring/views/authoring-topbar.html:118
+#: scripts/apps/authoring/views/authoring-topbar.html:119
+#: scripts/apps/authoring/views/authoring-topbar.html:120
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:231
+msgid "Update"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:256
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:470
+msgid "Update Created."
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:4
+msgid "Update Cycle:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:200
+msgid "Update Due:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:114
+#: ../superdesk-planning/client/constants/events.ts:164
+msgid "Update Repetitions"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:113
+msgid "Update Repetitions of the Series"
+msgstr ""
+
+#: ../superdesk-analytics/client/update_time_report/controllers/UpdateTimeReportController.js:162
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeReportPreview.js:21
+#: ../superdesk-analytics/client/update_time_report/index.js:50
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:93
+msgid "Update Time"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/assignCalendarForm.tsx:96
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:352
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:355
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateTimeForm.tsx:298
+msgid "Update all recurring events or just this one?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:258
+msgid "Update all recurring planning or just this one?"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:121
+msgid "Update every"
+msgstr ""
+
+#: scripts/validate-instance-configuration.tsx:42
+msgid "Update or disable incompatible extensions."
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-subscribe.html:33
+msgid "Update subscription"
+msgstr ""
+
+#: ../superdesk-planning/client/constants/events.ts:160
+msgid "Update time"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:90
+msgid "Update time of {{event}}"
+msgstr ""
+
+#: scripts/apps/search/components/fields/update.tsx:17
+msgid "Update {{sequence}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:44
+#: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:130
+#: ../superdesk-planning/client/components/AuditInformation/index.tsx:121
+#: scripts/apps/archive/views/item-preview.html:12
+#: scripts/apps/archive/views/metadata-view.html:195
+#: scripts/apps/archive/views/preview.html:43
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:251
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:81
+#: scripts/apps/authoring/views/authoring-header.html:65
+#: scripts/apps/contacts/services/ContactsService.ts:41
+#: scripts/apps/content-api/services/ContentAPISearchService.ts:28
+#: scripts/apps/legal-archive/services/LegalArchiveService.ts:24
+#: scripts/apps/legal-archive/tests/legal.spec.ts:66
+#: scripts/apps/search/components/fields/updated.tsx:18
+#: scripts/apps/search/services/SearchService.ts:66
+#: scripts/apps/search/tests/search.spec.ts:248
+#: scripts/apps/workspace/content/views/profile-settings.html:65
+#: scripts/core/itemList/views/relatedItem-list-widget.html:35
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:149
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:149
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:114
+#: scripts/extensions/sams/dist/src/utils/ui.js:114
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:174
+#: scripts/extensions/sams/src/utils/ui.tsx:107
+msgid "Updated"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:129
+msgid "Updated Fields:"
+msgstr ""
+
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:68
+msgid "Updated In"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundowns-list.js:104
+#: scripts/extensions/broadcasting/dist/src/rundowns/rundowns-list.js:104
+#: scripts/extensions/broadcasting/src/rundowns/rundowns-list.tsx:178
+msgid "Updated at {{date}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:129
+#: scripts/apps/authoring/versioning/history/views/history.html:18
+msgid "Updated by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:119
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:135
+msgid "Updated fields:"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetListItem.js:114
+#: scripts/extensions/sams/dist/src/components/common/versionUserDateLines.js:98
+#: scripts/extensions/sams/dist/src/components/sets/setListItem.js:95
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetListItem.js:114
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/versionUserDateLines.js:69
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListItem.js:95
+#: scripts/extensions/sams/src/components/assets/assetListItem.tsx:124
+#: scripts/extensions/sams/src/components/common/versionUserDateLines.tsx:52
+#: scripts/extensions/sams/src/components/sets/setListItem.tsx:80
+msgid "Updated {{ datetime }}"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/common/versionUserDateLines.js:99
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/common/versionUserDateLines.js:70
+#: scripts/extensions/sams/src/components/common/versionUserDateLines.tsx:57
+msgid "Updated {{ datetime }} by"
+msgstr ""
+
+#: scripts/apps/contacts/components/ContactFooter.tsx:18
+msgid "Updated:"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:576
+msgid "Updates"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/services/AuthoringService.ts:34
+msgid ""
+"Updates can only be created for text items. The type of this item is {{type}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:205
+#: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:136
+#: scripts/apps/search/views/multi-image-edit.html:17
+#: scripts/extensions/sams/dist/src/containers/FileUploadModal.js:233
+#: scripts/extensions/sams/dist/src/extensions/sams/src/containers/FileUploadModal.js:233
+#: scripts/extensions/sams/src/containers/FileUploadModal.tsx:295
+msgid "Upload"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/settings.html:9
+msgid "Upload Config"
+msgstr ""
+
+#: scripts/apps/archive/controllers/UploadController.ts:165
+msgid "Upload Error:"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/uploadAssetModal.js:190
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:245
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/uploadAssetModal.js:190
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:245
+#: scripts/extensions/sams/src/components/assets/uploadAssetModal.tsx:200
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:358
+msgid "Upload New Asset(s)"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/UploadConfigModal.tsx:69
+msgid "Upload config"
+msgstr ""
+
+#: scripts/apps/users/controllers/ChangeAvatarController.ts:6
+msgid "Upload from computer"
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:243
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:243
+#: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:342
+msgid "Upload image"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:106
+#: scripts/apps/search/views/multi-image-edit.html:12
+#: scripts/core/ui/components/content-create-dropdown/initial-view.tsx:210
+msgid "Upload media"
+msgstr "Отпреми медиј"
+
+#: scripts/apps/authoring/views/item-carousel.html:166
+msgid "Upload new"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetListPanel.js:62
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetListPanel.js:62
+#: scripts/extensions/sams/src/components/assets/assetListPanel.tsx:36
+msgid "Upload new Assets or change your search filters"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:256
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:256
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:351
+msgid "Uploaded From:"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:258
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:258
+#: scripts/extensions/sams/src/components/assets/assetFilterPanel.tsx:361
+msgid "Uploaded To:"
+msgstr ""
+
+#: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:119
+msgid "Uploading {{current}} of {{total}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/AttachmentsInputStandalone.tsx:118
+msgid "Uploading..."
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:18
+msgid "Uppercase"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:560
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:139
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:467
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:108
+#: ../superdesk-planning/client/components/editor-standalone/field-definitions/urgency-field.ts:45
+#: ../superdesk-planning/client/components/fields/editor/Urgency.tsx:25
+#: ../superdesk-planning/client/components/fields/preview/Urgency.tsx:33
+#: ../superdesk-planning/client/components/fields/preview/index.ts:167
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:115
+#: ../superdesk-planning/client/services/PlanningStoreService.ts:251
+#: ../superdesk-planning/client/utils/contentProfiles.ts:309
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:284
+#: scripts/apps/authoring-react/field-adapters/urgency.ts:37
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:100
+#: scripts/apps/authoring/views/authoring-header.html:319
+#: scripts/apps/content-api/services/ContentAPISearchService.ts:30
+#: scripts/apps/legal-archive/services/LegalArchiveService.ts:26
+#: scripts/apps/legal-archive/tests/legal.spec.ts:68
+#: scripts/apps/search/components/ItemUrgency.tsx:23
+#: scripts/apps/search/components/ItemUrgency.tsx:35
+#: scripts/apps/search/directives/SearchFilters.ts:47
+#: scripts/apps/search/services/SearchService.ts:68
+#: scripts/apps/search/tests/search.spec.ts:249
+#: scripts/apps/workspace/content/constants.ts:48
+msgid "Urgency"
+msgstr ""
+
+#: scripts/apps/ingest/ingest-stats-widget/configuration.html:10
+msgid "Urgency stats"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/urgency.tsx:21
+msgid "Urgency:"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/urls/index.tsx:20
+msgid "Urls (authoring-react)"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setListPanel.js:76
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setListPanel.js:76
+#: scripts/extensions/sams/src/components/sets/setListPanel.tsx:72
+msgid "Usable Sets"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ContactNumberInput.tsx:85
+msgid "Usage"
+msgstr ""
+
+#: scripts/apps/workspace/content/constants.ts:49
+msgid "Usage Terms"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:40
+#: scripts/apps/archive/views/metadata-view.html:181
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:145
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:35
+#: scripts/apps/templates/views/template-editor-modal.html:113
+msgid "Usage terms"
+msgstr ""
+
+#: scripts/apps/authoring/views/confirm-media-associated.html:17
+msgid "Use Media"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:111
+msgid "Use Togglebox"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:18
+msgid "Use Transport Layer Security (FTPS)"
+msgstr ""
+
+#: scripts/apps/users/controllers/ChangeAvatarController.ts:8
+msgid "Use a Web URL"
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:238
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:238
+#: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:329
+msgid "Use current frame"
+msgstr ""
+
+#: scripts/extensions/predefinedTextField/dist/src/editor.js:59
+#: scripts/extensions/predefinedTextField/dist/src/extensions/predefinedTextField/src/editor.js:59
+#: scripts/extensions/predefinedTextField/src/editor.tsx:98
+msgid "Use custom value"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:210
+msgid "Use priority queue for transmission."
+msgstr ""
+
+#: scripts/apps/content-filters/views/manage-filters.html:135
+msgid "Use the article GUID for testing."
+msgstr ""
+
+#: scripts/extensions/annotationsLibrary/dist/src/AnnotationSelectSingleItem.js:14
+#: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.js:14
+#: scripts/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.tsx:36
+msgid "Use this"
+msgstr ""
+
+#: scripts/apps/search/components/fields/used.tsx:16
+#: scripts/apps/search/views/item-preview.html:21
+msgid "Used"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/services/ChartConfig.js:508
+#: ../superdesk-analytics/client/search/services/SearchReport.ts:114
+#: ../superdesk-analytics/client/search/views/user-select.html:5
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:206
+#: ../superdesk-planning/client/components/fields/resources/common.tsx:159
+#: scripts/apps/authoring/metadata/views/metadata-terms.html:52
+#: scripts/apps/users/views/user-privileges.html:18
+msgid "User"
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/index.js:46
+#: scripts/apps/dashboard/user-activity/components/UserActivityWidget.tsx:340
+#: scripts/apps/dashboard/user-activity/user-activity.ts:37
+msgid "User Activity"
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:185
+msgid "User Activity - {{username}}"
+msgstr ""
+
+#: scripts/apps/users/config.ts:38
+#: scripts/core/lang/missing-translations-strings.ts:21
+msgid "User Management"
+msgstr ""
+
+#: scripts/apps/users/import/views/import-user.html:28
+msgid "User Profile to Import"
+msgstr ""
+
+#: scripts/apps/users/config.ts:66 scripts/apps/users/views/settings.html:4
+msgid "User Roles"
+msgstr ""
+
+#: scripts/apps/users/directives/UserPrivilegesDirective.ts:32
+msgid "User not found."
+msgstr ""
+
+#: scripts/apps/users/directives/UserPreferencesDirective.ts:163
+msgid "User preferences could not be saved..."
+msgstr ""
+
+#: scripts/apps/users/directives/UserPreferencesDirective.ts:159
+msgid "User preferences saved"
+msgstr ""
+
+#: scripts/apps/users/directives/UserRolesDirective.ts:35
+msgid "User role created."
+msgstr ""
+
+#: scripts/apps/users/directives/UserPrivilegesDirective.ts:55
+msgid "User role not found."
+msgstr ""
+
+#: scripts/apps/users/directives/UserRolesDirective.ts:37
+msgid "User role updated."
+msgstr ""
+
+#: scripts/apps/users/controllers/UserResolver.ts:12
+msgid "User was not found, sorry."
+msgstr ""
+
+#: scripts/apps/users/directives/UserEditDirective.ts:266
+msgid "User was not found. The account might have been deleted."
+msgstr ""
+
+#: ../superdesk-analytics/client/user_activity_report/views/item-timeline-tooltip.html:2
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:102
+msgid "User:"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/searchConfig.html:2
+#: scripts/apps/publish/views/ftp-config.html:7
+#: scripts/apps/publish/views/ftp-config.html:8
+#: scripts/apps/search-providers/views/search-provider-config.html:109
+#: scripts/apps/users/views/list.html:34
+msgid "Username"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:115
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:413
+#: ../superdesk-analytics/client/user_activity_report/controllers/UserActivityReportController.js:564
+#: scripts/apps/master-desk/MasterDesk.tsx:38
+#: scripts/apps/production-api-keys/config.ts:25
+#: scripts/apps/users/views/list.html:2
+msgid "Users"
+msgstr ""
+
+#: scripts/apps/users/config.ts:56
+msgid "Users Profile"
+msgstr ""
+
+#: scripts/apps/users/views/edit.html:9
+msgid "Users Profile:"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:13
+msgid "Users archive view format"
+msgstr ""
+
+#: scripts/apps/archive/views/export.html:17
+#: scripts/apps/archive/views/export.html:18
+#: scripts/apps/authoring-react/toolbar/export-modal.tsx:104
+msgid "Validate"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:299
+msgid "Validate Characters"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/date/config.tsx:53
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:147
+msgid "Value"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:282
+msgid "Value must be greater than or equal to 2."
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:284
+msgid "Value must be less than or equal to 99."
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:207
+msgid "Value must be unique"
+msgstr "Вредност мора бити јединствена"
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:79
+msgid "Value type"
+msgstr ""
+
+#: scripts/apps/content-filters/views/filter-search.html:26
+#: scripts/apps/content-filters/views/filter-search.html:30
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:77
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:83
+#: scripts/apps/content-filters/views/manage-filter-conditions.html:88
+msgid "Values"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:85
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:366
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:163
+msgid "Version"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:110
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:397
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:186
+msgid "Version creator"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:76
+msgid "Version: {{n}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/index.tsx:40
+#: scripts/apps/authoring/versioning/versioning.ts:8
+#: scripts/apps/authoring/versioning/views/versioning.html:3
+msgid "Versions"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/index.tsx:15
+msgid "Versions and item history"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:207
+#: ../superdesk-planning/client/utils/index.ts:591
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:238
+#: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:62
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/assets.js:110
+#: scripts/extensions/sams/dist/src/utils/assets.js:110
+#: scripts/extensions/sams/src/utils/assets.ts:144
+msgid "Video"
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditor.js:306
+#: scripts/extensions/videoEditor/dist/src/VideoEditor.js:80
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditor.js:306
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditor.js:80
+#: scripts/extensions/videoEditor/src/VideoEditor.tsx:134
+#: scripts/extensions/videoEditor/src/VideoEditor.tsx:422
+msgid "Video is editing, please wait..."
+msgstr ""
+
+#: scripts/extensions/videoEditor/dist/src/VideoEditorThumbnail.js:235
+#: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorThumbnail.js:235
+#: scripts/extensions/videoEditor/src/VideoEditorThumbnail.tsx:322
+msgid "Video thumbnail"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:74
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:74
+#: scripts/extensions/sams/src/components/assets/assetTypeFilterButtons.tsx:57
+msgid "Videos only"
+msgstr ""
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:28
+msgid "View Latest Item Version"
+msgstr ""
+
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:120
+msgid "View Original"
+msgstr ""
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:33
+msgid "View Original Image"
+msgstr ""
+
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:131
+msgid "View Update"
+msgstr ""
+
+#: scripts/apps/monitoring/index.ts:120
+msgid "View an item"
+msgstr ""
+
+#: ../superdesk-analytics/client/index.js:95
+msgid "View analytics reports"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:168
+msgid "View associated event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:155
+msgid "View duplicate event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:140
+msgid "View duplicate planning item"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:14
+#: scripts/apps/users/views/user-preferences.html:43
+msgid "View formats"
+msgstr ""
+
+#: scripts/apps/users/views/list.html:67
+msgid "View full profile"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:516
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:106
+msgid "View item"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:403
+msgid "View linked item"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:13
+msgid "View name"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:49
+msgid "View notifications"
+msgstr "Прикажи обавештења"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:165
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:189
+#: ../superdesk-planning/client/components/fields/state.tsx:32
+msgid "View original event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:152
+msgid "View original planning item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:143
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:204
+msgid "View planning item"
+msgstr ""
+
+#: scripts/core/menu/views/menu.html:58
+msgid "View profile details"
+msgstr "Прикажи детаље профила"
+
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:177
+msgid "View rescheduled event"
+msgstr ""
+
+#: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:58
+msgid "View schedules"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:155
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:180
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:205
+msgid "View source item"
+msgstr ""
+
+#: scripts/apps/contacts/index.ts:23
+msgid "View/Manage media contacts"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/SelectCustomVocabulariesList.tsx:27
+#: ../superdesk-planning/client/components/fields/index.tsx:226
+#: scripts/apps/vocabularies/views/settings.html:16
+msgid "Vocabularies"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:22
+msgid "Vocabularies Management"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/config-main.tsx:82
+msgid "Vocabulary"
+msgstr ""
+
+#: ../superdesk-planning/client/planning-extension/src/extension.ts:283
+msgid "Vocabulary `locators` is not configured!"
+msgstr ""
+
+#: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:101
+msgid "Vocabulary saved successfully"
+msgstr ""
+
+#: scripts/apps/users/views/user-preferences.html:20
+#: scripts/apps/users/views/user-preferences.html:248
+msgid "Vocabulary values"
+msgstr ""
+
+#: scripts/apps/vocabularies/controllers/VocabularyConfigController.ts:243
+msgid "Vocabulary was deleted."
+msgstr ""
+
+#: scripts/validate-instance-configuration.tsx:56
+msgid "Vocabulary with ID \"categories\" is required"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/CalendarNavigation.tsx:56
+msgid "W"
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterConditionsController.ts:44
+msgid "WARNING unknown filter condition value: {{ value }}"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:91
+msgid "WE"
+msgstr ""
+
+#: scripts/apps/archive/views/preview.html:63
+#: scripts/apps/authoring/suggest/SuggestView.html:16
+#: scripts/apps/authoring/suggest/SuggestView.html:64
+#: scripts/apps/authoring/views/authoring-header.html:42
+msgid "WORD"
+msgid_plural "WORDS"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/api/article-send.tsx:103
+#: scripts/apps/system-messages/components/system-messages-settings.tsx:24
+#: scripts/core/auth/auth.ts:242
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:387
+msgid "Warning"
+msgstr "Упозорење"
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:208
+msgid "Warning Sign"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:139
+msgid "We"
+msgstr ""
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:48
+msgid ""
+"We will send occasional updates on Superdesk developments to the email "
+"address you have provided. Your data will be kept secure and it won't be "
+"used for any other purpose. You may opt-out of receiving further email "
+"communications at any time."
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:38
+msgid "Weak"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:110
+msgid "Wed"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1456
+#: scripts/core/datetime/datetime.ts:292
+msgid "Wednesday"
+msgstr "Среда"
+
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:160
+#: ../superdesk-planning/client/apps/Planning/PlanningListSubNav.tsx:80
+#: scripts/extensions/availability-manager/dist/src/constants.js:35
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/constants.js:35
+#: scripts/extensions/availability-manager/src/constants.ts:43
+msgid "Week"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/Days.tsx:32
+msgid "Week Days"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:31
+msgid "Week(s)"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:37
+#: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:23
+msgid "Weekly"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/filters.ts:48
+msgid "Weekly @ {{ time }} to {{ desk }}"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:71
+msgid "Weekly on {{days}} at {{hour}}"
+msgstr ""
+
+#: scripts/core/directives/views/phone-home-modal-directive.html:4
+msgid "Welcome to Superdesk"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:2
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:9
+msgid "When"
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:38
+#: scripts/apps/highlights/views/highlights_config_modal.html:47
+msgid "When creating a highlights package"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:204
+msgid "When enabled it can send multiple items at the same time."
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:55
+msgid "White"
+msgstr ""
+
+#: scripts/apps/dashboard/views/widget.html:11
+#: scripts/apps/dashboard/views/widget.html:12
+msgid "Widget settings"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:8
+msgid ""
+"Widget settings <span translate>for \"{{currentDesk.name}}\" Desk</span>"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:95
+msgid "Widgets"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:58
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:156
+msgid "Width"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:102
+msgid ""
+"Width of the\n"
+"                                    popup window (in pixels)"
+msgstr ""
+
+#: scripts/apps/publish/directives/SubscribersDirective.ts:73
+msgid "Wire/Paper"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/NoCoverage.tsx:15
+msgid "Without Coverage"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-view.html:17
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:288
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:292
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:108
+#: scripts/apps/authoring/metadata/views/metadata-widget.html:112
+msgid "Word Count"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:232
+msgid "Work stages"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:100
+msgid "Work started"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:101
+msgid "Work started on coverage"
+msgstr ""
+
+#: scripts/core/activity/activity.ts:22
+msgid "Workflow"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/preview/index.ts:171
+msgid "Workflow State"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/index.tsx:229
+msgid "Workflow States"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:305
+#: scripts/apps/desks/views/desk-config-modal.html:358
+#: scripts/apps/workspace/content/constants.ts:55
+msgid "Working Stage"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/working-hours-grid-labels.js:16
+#: scripts/extensions/availability-manager/dist/src/settings/working-hours-grid-labels.js:16
+#: scripts/extensions/availability-manager/src/settings/working-hours-grid-labels.tsx:25
+msgid "Working hours"
+msgstr ""
+
+#: scripts/apps/archive/index.tsx:94 scripts/apps/dashboard/index.ts:53
+#: scripts/apps/dashboard/views/workspace.html:24
+#: scripts/apps/dashboard/workspace-tasks/tasks.ts:376
+#: scripts/apps/ingest/index.ts:72 scripts/apps/stream/index.ts:18
+msgid "Workspace"
+msgstr ""
+
+#: scripts/apps/workspace/views/edit-workspace-modal.html:15
+msgid "Workspace name"
+msgstr ""
+
+#: scripts/apps/workspace/views/workspace-dropdown.html:1
+msgid "Workspace:"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/world-clock.ts:209
+#: scripts/core/lang/missing-translations-strings.ts:44
+msgid "World Clock"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/world-clock.ts:42
+msgid "World clock added: {{zone}}"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/world-clock.ts:44
+msgid "World clock removed: {{zone}}"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/world-clock.ts:221
+#: scripts/core/lang/missing-translations-strings.ts:45
+msgid "World clock widget"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/contentProfiles.ts:339
+msgid "XMP File"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:33
+msgid "Year(s)"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:61
+msgid "Yellow"
+msgstr ""
+
+#: scripts/core/ui/components/generic-form/input-types/checkbox.tsx:10
+#: scripts/core/ui/components/generic-form/input-types/yes-no.tsx:6
+msgid "Yes"
+msgstr "Да"
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/shows/create-show-after-modal.js:16
+#: scripts/extensions/broadcasting/dist/src/shows/create-show-after-modal.js:16
+#: scripts/extensions/broadcasting/src/shows/create-show-after-modal.tsx:38
+msgid "Yes, create a template"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/date-filters.html:17
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:8
+msgid "Yesterday"
+msgstr ""
+
+#: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:106
+msgid ""
+"You are about to delete the vocabulary {{name}}. This action can't be undone."
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:109
+msgid ""
+"You are changing you personal preferences. If you would like to set the "
+"default order for the desk, you can do so from the settings page."
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:249
+msgid "You are creating a new planning item."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:73
+msgid "You are currently managing featured story in another session"
+msgstr ""
+
+#: scripts/validate-instance-configuration.tsx:38
+msgid "You are likely running an outdated version of auto tagging extension."
+msgstr ""
+
+#: scripts/apps/workspace/content/services/ContentService.ts:71
+msgid "You are not allowed to create an article there."
+msgstr ""
+
+#: scripts/apps/workspace/content/services/ContentService.ts:69
+msgid "You are not allowed to create article on readonly stage."
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:510
+msgid ""
+"You are trying to add multiple related events when only one is allowed. Only "
+"the first event({{name}}) will be added."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageForm.tsx:233
+msgid "You can associate only one XMP file"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:134
+msgid ""
+"You can choose the default content view of your desk. Use only if you want "
+"to override individual users' monitoring view preferences. Select \"none\" "
+"if you want to let users decide."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/CharacterCountConfigButton.tsx:148
+msgid ""
+"You can either completely block further writing after the characterlimit is "
+"reached or highlight exceeding characters in red."
+msgstr ""
+
+#: scripts/apps/search/controllers/get-bulk-actions.tsx:154
+msgid "You can't multi-edit, because these articles can't be edited"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:35
+msgid "You cannot change workflow status"
+msgstr ""
+
+#: scripts/core/menu/notifications/views/notifications.html:13
+msgid "You don't have any notifications"
+msgstr "Немате ниједно обавештење"
+
+#: scripts/apps/monitoring/views/item-actions-menu.html:44
+msgid "You don't have the privileges to perform any action"
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-subscribe.html:12
+msgid "You have chosen to subscribe to"
+msgstr ""
+
+#: scripts/api/highlights.ts:53 scripts/apps/search/MultiImageEdit.ts:173
+msgid "You have unsaved changes, do you want to continue?"
+msgstr ""
+
+#: scripts/apps/desks/controllers/DeskConfigController.ts:93
+msgid "You have unsaved changes. Do you want to save them now?"
+msgstr ""
+
+#: scripts/core/ui/components/ListPage/show-unsaved-changes-modal.tsx:76
+msgid "You have unsaved changes. What would you like to do?"
+msgstr "Имате несачуване измене. Шта желите да урадите?"
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:242
+msgid ""
+"You made changes to this planning item that is part of a recurring event."
+msgstr ""
+
+#: scripts/apps/production-api-keys/config.ts:40
+msgid ""
+"Your Client ID and Client Secret will be generated when you save. Make sure "
+"to copy the Client Secret immediately. It will only be shown once and it "
+"cannot be retrieved later."
+msgstr ""
+
+#: scripts/apps/users/import/views/import-user.html:11
+msgid "Your Credentials"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:198
+msgid "Your Slack user name without the leading @"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/planning/featuredPlanning.ts:500
+#: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:124
+#: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:84
+msgid "Your changes will be lost if you close now. What would you like to do?"
+msgstr ""
+
+#: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:285
+msgid "Your changes will be lost if you switch now. What would you like to do?"
+msgstr ""
+
+#: scripts/apps/dashboard/world-clock/configuration.html:12
+msgid "Your clock"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:71
+msgid "Your password has expired. Please change your password."
+msgstr "Ваша лозинка је истекла. Промените лозинку."
+
+#: scripts/core/auth/login-modal.html:4
+msgid "Your session has expired."
+msgstr "Ваша сесија је истекла."
+
+#: scripts/apps/vocabularies/components/UploadComplete.tsx:8
+msgid "Your upload was successful"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:209
+msgid "Zoom In"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:210
+msgid "Zoom Out"
+msgstr ""
+
+#: scripts/apps/search/views/saved-searches.html:11
+msgid "[Global]"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/constants.ts:8
+#: scripts/apps/authoring/media/MediaMetadataView.tsx:16
+#: scripts/core/editor3/components/media/MediaBlock.tsx:164
+#: scripts/core/editor3/components/media/MediaBlock.tsx:205
+#: scripts/core/editor3/components/media/MediaBlock.tsx:209
+#: scripts/core/editor3/components/media/MediaBlock.tsx:213
+#: scripts/core/editor3/components/media/MediaBlock.tsx:219
+#: scripts/core/editor3/components/media/MediaBlock.tsx:224
+#: scripts/core/editor3/components/media/MediaBlock.tsx:251
+#: scripts/core/editor3/components/media/MediaBlock.tsx:255
+#: scripts/core/editor3/components/media/MediaBlock.tsx:261
+#: scripts/core/editor3/components/media/MediaBlock.tsx:266
+#: scripts/core/editor3/components/media/MediaBlock.tsx:291
+#: scripts/core/editor3/components/media/MediaBlock.tsx:295
+#: scripts/core/editor3/components/media/MediaBlock.tsx:301
+#: scripts/core/editor3/components/media/MediaBlock.tsx:306
+msgid "[No Value]"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:103
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:97
+msgid "a Recurring Event"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:51
+msgid "a lower case letter (a-z)"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:53
+msgid "a number (0-9)"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:54
+msgid "a special character (!@#$%^&...)"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:36
+msgid "active"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:38
+msgid "added new task {{subject}} of type {{type}}"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:35
+msgid "added new {{type}} item about \"{{subject}}\""
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:35
+msgid "added new {{type}} item with empty header/title"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:78
+msgid "added to workflow"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:167
+#: scripts/apps/users/views/user-preferences.html:147
+#: scripts/core/utils.tsx:342
+msgid "all"
+msgstr ""
+
+#: scripts/apps/desks/views/desk-config-modal.html:289
+#: scripts/apps/highlights/views/highlights_config_modal.html:15
+msgid "already exists"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:103
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:120
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:73
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:79
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:85
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:91
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:97
+msgid "an Event"
+msgstr ""
+
+#: scripts/core/directives/PasswordStrengthDirective.ts:52
+msgid "an upper case letter (A-Z)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:56
+msgid "and"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:45
+msgid "and '{{ user }}'"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:90
+msgid "annotation"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:13
+msgid "archive"
+msgstr ""
+
+#: scripts/apps/search/components/ItemContainer.tsx:20
+msgid "archived"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:140
+msgid "as rewrite of"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:45
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:17
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:22
+msgid "at"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:401
+#: scripts/apps/archive/controllers/UploadController.ts:330
+#: scripts/apps/authoring-react/fields/media/editor.tsx:151
+#: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:198
+#: scripts/core/lang/missing-translations-strings.ts:9
+#: scripts/core/utils.tsx:281 scripts/core/utils.tsx:349
+msgid "audio"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-article.html:7
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:7
+msgid "author"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:27
+msgid "authoring"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:83
+msgid "bold"
+msgstr ""
+
+#: ../superdesk-planning/client/components/UI/Form/FileInput.tsx:205
+#: scripts/core/ui/components/Form/FileInput.tsx:137
+#: scripts/extensions/sams/dist/src/apps/samsAttachmentsWidget.js:197
+#: scripts/extensions/sams/dist/src/apps/samsAttachmentsWidget.js:207
+#: scripts/extensions/sams/dist/src/extensions/sams/src/apps/samsAttachmentsWidget.js:197
+#: scripts/extensions/sams/dist/src/extensions/sams/src/apps/samsAttachmentsWidget.js:207
+#: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:195
+#: scripts/extensions/sams/src/apps/samsAttachmentsWidget.tsx:219
+msgid "browse"
+msgstr "претражи"
+
+#: scripts/apps/search/components/SelectBox.tsx:68
+msgid "bulk actions"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:43
+#: ../superdesk-planning/client/components/AuditInformation/index.tsx:110
+#: ../superdesk-planning/client/components/AuditInformation/index.tsx:121
+#: ../superdesk-planning/client/components/AuditInformation/index.tsx:132
+#: ../superdesk-planning/client/components/Events/EventHistory.tsx:60
+#: ../superdesk-planning/client/utils/history.tsx:64
+#: scripts/apps/archive/views/preview.html:7
+#: scripts/apps/authoring/authoring/created-info.tsx:53
+#: scripts/apps/authoring/suggest/SuggestView.html:23
+#: scripts/apps/authoring/suggest/SuggestView.html:71
+#: scripts/apps/authoring/versioning/versions/views/versions.html:7
+#: scripts/apps/dashboard/workspace-tasks/views/task-preview.html:2
+msgid "by"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:210
+msgid "by {{user}}"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:223
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:223
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:284
+msgid "cancel"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:88
+msgid "cancelled"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:14
+msgid "categories"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:211
+msgid "change password"
+msgstr ""
+
+#: scripts/core/menu/notifications/views/notifications.html:42
+msgid ""
+"changed the following original item. Please make sure to update the "
+"corresponding translated item accordingly"
+msgstr "изменио је следећу оригиналну ставку. Обавезно ажурирајте одговарајућу преведену ставку у складу са тим"
+
+#: scripts/apps/authoring/authoring/components/CharacterCount.tsx:30
+#: scripts/apps/authoring/authoring/components/CharacterCount.tsx:64
+#: scripts/apps/authoring/authoring/directives/CharacterCount.ts:13
+#: scripts/core/editor3/components/toolbar/FloatingCharacterCount.tsx:48
+msgid "characters"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:583
+msgid "city"
+msgstr ""
+
+#: scripts/core/ui/components/virtual-lists/select.tsx:176
+msgid "clear"
+msgstr "очисти"
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:50
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:50
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:116
+msgid "close"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:41
+msgid "closed"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:112
+msgid "color"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/TableControls.tsx:102
+msgid "column"
+msgstr ""
+
+#: scripts/core/menu/notifications/views/notifications.html:31
+msgid "commented on"
+msgstr "коментарисао"
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:91
+msgid "comments"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:13
+msgid "compact"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:9
+#: scripts/core/utils.tsx:283
+msgid "composite"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:390
+msgid "confirm"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:69
+msgid "confirmed"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:181
+msgid "contact saved."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:10
+msgid "content"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:12
+msgid "corrected"
+msgstr ""
+
+#: scripts/apps/search/components/fields/update.tsx:15
+msgid "correction sequence"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/meta-place-directive.html:20
+msgid "country"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:34
+msgid "create"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:189
+msgid "created"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/agenda.ts:240
+msgid "created  planning item."
+msgstr ""
+
+#: ../superdesk-planning/client/actions/agenda.ts:229
+msgid "created / planning item(s)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:42
+#: ../superdesk-planning/client/components/RelatedPlannings/index.tsx:102
+msgid "created by"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:36
+msgid "created new version {{version}} for item {{type}} about \"{{subject}}\""
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:42
+msgid "created user {{user}}"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:379
+msgid "current"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:86
+msgid "custom blocks"
+msgstr ""
+
+#: scripts/apps/workspace/helpers/getTypeForFieldId.ts:17
+msgid "custom vocabulary"
+msgstr ""
+
+#: scripts/apps/workspace/helpers/getTypeForFieldId.ts:8
+msgid "date"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:41
+#: scripts/apps/desks/views/content-expiry.html:3
+msgid "day"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:11
+#: scripts/apps/authoring-react/fields/date/config.tsx:83
+#: scripts/apps/desks/views/content-expiry.html:32
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:153
+msgid "days"
+msgstr ""
+
+#: scripts/apps/users/views/settings-privileges.html:16
+#: scripts/apps/users/views/settings-roles.html:15
+#: scripts/apps/users/views/user-preferences.html:159
+msgid "default"
+msgstr ""
+
+#: scripts/apps/highlights/views/highlights_config_modal.html:21
+msgid "default template"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:26
+msgid "desk Output"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:9
+#: scripts/apps/authoring/versioning/versions/views/versions.html:13
+#: scripts/apps/search/components/ItemContainer.tsx:13
+#: scripts/core/itemList/views/relatedItem-list-widget.html:38
+msgid "desk:"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:272
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:272
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:455
+msgid "details"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:34
+#: scripts/apps/users/views/user-list-item.html:15
+msgid "disabled"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:36
+msgid "disabled user {{user}}"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-replace.html:9
+msgid "done"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:11
+msgid "draft"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/DueDate.tsx:42
+msgid "due"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:58
+msgid "duplicate id"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:463
+msgid "e.g. @cityofsydney"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:338
+msgid "e.g. @superdeskman"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:559
+msgid "e.g. Rhodes, CBD"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:489
+msgid "e.g. cityofsydney from https://www.facebook.com/cityofsydney"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:513
+msgid "e.g. cityofsydney from https://www.instagram.com/cityofsydney"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:447
+msgid "e.g. http://www.website.com"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:254
+msgid "e.g. professor, commissioner"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:303
+msgid "e.g. superdeskman from https://www.facebook.com/superdeskman"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:320
+msgid "e.g. superdeskman from https://www.instagram.com/superdeskman"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:49
+#: scripts/apps/users/views/edit-form.html:131
+msgid "email"
+msgstr ""
+
+#: scripts/apps/archive/views/item-state.html:6
+#: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:225
+msgid "embargo"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:93
+#: scripts/apps/workspace/helpers/getTypeForFieldId.ts:9
+msgid "embed"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:94
+msgid "embed articles"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:97
+#: scripts/extensions/availability-manager/dist/src/utils.js:97
+#: scripts/extensions/availability-manager/src/utils.ts:100
+msgid "end time"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:10
+msgid "error"
+msgstr ""
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:71
+msgid "event"
+msgstr ""
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:71
+msgid "events"
+msgstr ""
+
+#: scripts/apps/publish/views/ftp-config.html:26
+msgid "example"
+msgstr ""
+
+#: scripts/apps/archive/views/item-preview.html:19
+#: scripts/apps/archive/views/preview.html:116
+#: scripts/apps/search/components/MediaInfo.tsx:37
+#: scripts/apps/search/components/fields/expiry.tsx:15
+msgid "expires"
+msgstr ""
+
+#: scripts/apps/publish/views/subscribers.html:276
+msgid "expires:"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:51
+msgid "facebook"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:11
+msgid "failed"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:435
+msgid "fax"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:14
+msgid "feature"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:11
+msgid "fetched"
+msgstr ""
+
+#: scripts/apps/archive/views/fetched-desks.html:2
+#: scripts/apps/search/components/FetchedDesksInfo.tsx:75
+msgid "fetched in"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/form-validation.js:11
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/form-validation.js:20
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/form-validation.js:24
+#: scripts/extensions/broadcasting/dist/src/form-validation.js:11
+#: scripts/extensions/broadcasting/dist/src/form-validation.js:20
+#: scripts/extensions/broadcasting/dist/src/form-validation.js:24
+#: scripts/extensions/broadcasting/src/form-validation.ts:10
+#: scripts/extensions/broadcasting/src/form-validation.ts:18
+#: scripts/extensions/broadcasting/src/form-validation.ts:22
+msgid "field can not be empty"
+msgstr ""
+
+#: scripts/api/article-fetch.tsx:135
+msgid "file name"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:230
+msgid "first"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:275
+#: scripts/apps/users/views/edit-form.html:82
+msgid "first name"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/tests/index_test.ts:208
+msgid "foo"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1428
+msgid "for"
+msgstr ""
+
+#: ../superdesk-analytics/client/publishing_performance_report/widgets/publishing_actions/settings.html:9
+msgid "for \"{{currentDesk.name}}\" Desk"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:2
+msgid "for \"{{name}}\" Desk"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:42
+msgid "for '{{ desk }}'"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:97
+msgid "for desk"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:94
+msgid "for highlight"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1428
+msgid "for {{ repeatCount }} repeats"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:87
+msgid "formatting marks"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:36
+#: scripts/apps/authoring/versioning/history/views/history.html:47
+#: scripts/apps/authoring/versioning/history/views/history.html:69
+msgid "from"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:28
+msgid "from content"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:95
+msgid "from coverage assignment by"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:122
+msgid "from highlight"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:361
+msgid "from highlight: {{x}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:238
+msgid "from {{from}} to {{to}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:228
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:244
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:260
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:276
+msgid "from:"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:73
+msgid "full name"
+msgstr ""
+
+#: scripts/core/itemList/views/relatedItem-list-widget.html:42
+msgid "genre:"
+msgstr ""
+
+#: scripts/core/ui/components/UserPopup/UserPopup.tsx:27
+msgid "go to profile"
+msgstr "иди на профил"
+
+#: scripts/core/utils.tsx:285 scripts/core/utils.tsx:345
+msgid "graphic"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:66
+msgid "h1"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:67
+msgid "h2"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:68
+msgid "h3"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:69
+msgid "h4"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:70
+msgid "h5"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:71
+msgid "h6"
+msgstr ""
+
+#: scripts/api/article-fetch.tsx:137
+msgid "height"
+msgstr ""
+
+#: scripts/core/views/sdSlider.html:3
+msgid "high"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:34
+msgid "highlights"
+msgstr ""
+
+#: scripts/core/utils.tsx:347
+msgid "highlights package"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:255
+msgid "honorific"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:5
+#: scripts/apps/highlights/views/highlights_config_modal.html:45
+msgid "hours"
+msgstr ""
+
+#: scripts/apps/desks/views/content-expiry.html:4
+#: scripts/apps/desks/views/content-expiry.html:40
+msgid "hr"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:162
+msgid "hrs"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extension.js:26
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/extension.js:26
+#: scripts/extensions/auto-tagging-widget/src/extension.tsx:28
+msgid "iMatrics"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:270
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:50
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:270
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:50
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:111
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:444
+msgid "iMatrics service error"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:54
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:54
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:128
+msgid ""
+"iMatrics service has returned tags referencing parents that do not exist in "
+"the response."
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/extension.js:10
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/extension.js:10
+#: scripts/extensions/auto-tagging-widget/src/extension.tsx:11
+msgid "iMatrics tagging"
+msgstr ""
+
+#: scripts/apps/archive/controllers/UploadController.ts:322
+#: scripts/apps/authoring-react/fields/media/editor.tsx:147
+#: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:196
+msgid "image"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/ImageTaggingComponent/ImageTaggingComponent.js:198
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:198
+#: scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.tsx:279
+msgid "image suggestions ({{n}})"
+msgstr ""
+
+#: scripts/core/ui/views/sd-timepicker-popup.html:4
+msgid "in 1 h"
+msgstr "за 1 ч"
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:126
+#: scripts/core/ui/components/Form/TimeInput/TimeInputPopup.tsx:98
+msgid "in 1 hr"
+msgstr "за 1 ч"
+
+#: scripts/core/ui/views/sd-timepicker-popup.html:5
+msgid "in 2 h"
+msgstr "за 2 ч"
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:130
+#: scripts/core/ui/components/Form/TimeInput/TimeInputPopup.tsx:102
+msgid "in 2 hrs"
+msgstr "за 2 ч"
+
+#: ../superdesk-planning/client/components/UI/Form/TimeInput/TimeInputPopup.tsx:122
+#: scripts/core/ui/components/Form/TimeInput/TimeInputPopup.tsx:94
+#: scripts/core/ui/views/sd-timepicker-popup.html:3
+msgid "in 30 min"
+msgstr "за 30 мин"
+
+#: ../superdesk-planning/client/components/RelatedPlannings/index.tsx:76
+msgid "in agenda"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:72
+msgid "in the last 24 hours."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:10
+msgid "in-progress"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:10
+msgid "in_progress"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:35
+#: scripts/apps/users/views/user-list-item.html:16
+msgid "inactive"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:11
+msgid "ingested"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:52
+msgid "instagram"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/attachments/samsAttachmentsList.js:114
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/attachments/samsAttachmentsList.js:114
+#: scripts/extensions/sams/src/components/attachments/samsAttachmentsList.tsx:121
+msgid "internal"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:82
+msgid "italic"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:429
+msgid "item"
+msgstr ""
+
+#: scripts/apps/archive/related-item-widget/relatedItem.ts:166
+msgid "item metadata associated."
+msgstr ""
+
+#: scripts/apps/master-desk/components/OverviewComponent.tsx:235
+msgid "items in production"
+msgstr ""
+
+#: scripts/apps/master-desk/components/AssignmentsComponent.tsx:168
+msgid "items in total"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:12
+msgid "killed"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:111
+msgid "label"
+msgstr ""
+
+#: scripts/apps/packaging/views/sd-package-item-preview.html:24
+msgid "label: <b>{{label.name}}</b>"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:232
+msgid "last"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:296
+#: scripts/apps/users/views/edit-form.html:94
+msgid "last name"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:80
+msgid "last update and last item arrived."
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/ReadingTime.ts:20
+#: scripts/apps/authoring/authoring/directives/ReadingTime.ts:54
+msgid "less than one minute read"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/line-count.tsx:21
+msgid "line"
+msgid_plural "lines"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:77
+msgid "link"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:143
+msgid "linked to"
+msgstr ""
+
+#: scripts/apps/contacts/views/search-results.html:4
+#: scripts/apps/content-api/views/search-results.html:4
+#: scripts/apps/legal-archive/views/legal_archive.html:107
+#: scripts/apps/search/views/search-results.html:6
+msgid "loading"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/ImageTaggingComponent/ImageTaggingComponent.js:197
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:197
+#: scripts/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.tsx:278
+msgid "loading image suggestions..."
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ListPanel.tsx:435
+msgid "loading more items..."
+msgstr ""
+
+#: scripts/apps/desks/directives/DeskeditPeople.ts:13
+#: scripts/apps/desks/directives/DeskeditStages.ts:92
+#: scripts/core/ui/components/virtual-lists/virtual-list.tsx:255
+msgid "loading..."
+msgstr "учитавање..."
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:560
+msgid "locality"
+msgstr ""
+
+#: scripts/apps/search/components/ItemContainer.tsx:16
+msgid "location:"
+msgstr ""
+
+#: scripts/core/views/sdSlider.html:2
+msgid "low"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:100
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:31
+msgid "lowercase"
+msgstr ""
+
+#: scripts/apps/packaging/services/PackagesService.ts:24
+#: scripts/apps/packaging/services/PackagesService.ts:55
+msgid "main"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:390
+msgid "make this mode the default"
+msgstr ""
+
+#: scripts/core/views/sdSearchList.html:17
+msgid "many"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:76
+msgid "media"
+msgstr ""
+
+#: scripts/core/menu/notifications/views/notifications.html:35
+msgid "mentioned you"
+msgstr "поменуо вас је"
+
+#: scripts/core/lang/missing-translations-strings.ts:13
+msgid "mgrid"
+msgstr ""
+
+#: scripts/apps/desks/views/content-expiry.html:48
+#: scripts/apps/desks/views/content-expiry.html:5
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:133
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:174
+msgid "min"
+msgstr ""
+
+#: scripts/extensions/datetimeField/dist/src/config.js:31
+#: scripts/extensions/datetimeField/dist/src/config.js:52
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:31
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/config.js:52
+#: scripts/extensions/datetimeField/src/config.tsx:100
+#: scripts/extensions/datetimeField/src/config.tsx:51
+msgid "minutes"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-widget.html:31
+msgid "miscellaneous"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:47
+msgid "mobile"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:23
+#: scripts/apps/authoring-react/fields/date/config.tsx:85
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:155
+msgid "months"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:85
+msgid "multi-line quote"
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-subscribe.html:23
+msgid "never"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:385
+msgid "new"
+msgstr ""
+
+#: scripts/core/ui/components/content-create-dropdown/content-create-dropdown.tsx:17
+msgid "new item"
+msgstr "нова ставка"
+
+#: scripts/apps/authoring/macros/views/macros-replace.html:8
+#: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:444
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:832
+msgid "next"
+msgstr "следеће"
+
+#: scripts/apps/content-filters/controllers/FilterSearchController.ts:112
+msgid "no results found"
+msgstr ""
+
+#: scripts/apps/profiling/views/profiling.html:10
+#: scripts/apps/publish/views/publish-queue.html:18
+#: scripts/apps/publish/views/publish-queue.html:34
+#: scripts/apps/publish/views/publish-queue.html:50
+#: scripts/apps/publish/views/publish-queue.html:64
+#: scripts/apps/users/views/user-preferences.html:153
+msgid "none"
+msgstr ""
+
+#: scripts/core/interactive-article-actions-panel/subcomponents/controlled-vocabulary-select.tsx:95
+msgid "not"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:650
+msgid "notes"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:13
+msgid "notifications"
+msgstr ""
+
+#: scripts/core/list/views/sdPagination.html:15
+#: scripts/core/list/views/sdPaginationAlt.html:2
+#: scripts/core/views/sdSearchList.html:15
+msgid "of"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:63
+#: ../superdesk-planning/client/utils/events.tsx:1467
+#: scripts/apps/authoring/versioning/history/views/history.html:12
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:17
+#: scripts/apps/authoring/versioning/history/views/publish_queue.html:22
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:11
+msgid "on"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1443
+msgid "on all week (including weekends)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:100
+msgid "on assignment by"
+msgstr ""
+
+#: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:23
+msgid "on the"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1440
+msgid "on week days"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/components/text-statistics.tsx:22
+msgid "one word"
+msgid_plural "{{x}} words"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/core/editor3/components/article-embed/article-embed.tsx:32
+msgid "open in a new window"
+msgstr ""
+
+#: scripts/extensions/markForUser/dist/src/extension.js:48
+#: scripts/extensions/markForUser/dist/src/extensions/markForUser/src/extension.js:48
+#: scripts/extensions/markForUser/src/extension.tsx:55
+msgid "open item"
+msgstr ""
+
+#: scripts/apps/archive/views/upload.html:38
+#: scripts/core/auth/login-modal.html:53
+msgid "or"
+msgstr "или"
+
+#: scripts/apps/users/views/change-avatar.html:31
+msgid "or Select from computer"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:73
+#: scripts/core/editor3/helpers/highlights.ts:67
+msgid "ordered list"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:320
+#: scripts/apps/contacts/constants.ts:71
+msgid "organisation"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:624
+msgid "other"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:400
+#: scripts/core/utils.tsx:346
+msgid "package"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:60
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:60
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:139
+msgid "parent ID"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/searchConfig.html:7
+#: scripts/apps/users/import/views/import-user.html:19
+#: scripts/core/auth/login-modal.html:16
+msgid "password"
+msgstr "лозинка"
+
+#: scripts/core/auth/login-modal.html:81
+#: scripts/core/auth/reset-password.html:54
+msgid "passwords must be same"
+msgstr "лозинке морају бити исте"
+
+#: scripts/apps/users/views/user-list-item.html:17
+msgid "pending"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:48
+msgid "phone"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:177
+msgid "phone number"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:399
+#: scripts/core/lang/missing-translations-strings.ts:9
+#: scripts/core/utils.tsx:287 scripts/core/utils.tsx:344
+msgid "picture"
+msgstr ""
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:75
+msgid "planning item"
+msgstr ""
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:75
+msgid "planning items"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:141
+msgid "please provide a valid email address"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:121
+msgid ""
+"please use only letters (a-z), numbers (0-9), dashes (&mdash;), underscores "
+"(_), apostrophes (') and periods (.)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:121
+msgid "post"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:570
+msgid "postcode"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/history.tsx:84
+msgid "posted"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:74
+msgid "pre"
+msgstr ""
+
+#: scripts/core/editor3/helpers/highlights.ts:68 scripts/core/utils.tsx:289
+msgid "preformatted"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-replace.html:7
+#: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:443
+#: scripts/core/ui/components/ListPage/generic-list-page.tsx:831
+msgid "prev"
+msgstr "претходно"
+
+#: scripts/apps/publish-preview/previewModal.tsx:122
+msgid "preview"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:25
+msgid "production"
+msgstr ""
+
+#: scripts/apps/users/import/views/import-user.html:31
+msgid "profile"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:233
+msgid "public"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:9
+msgid "publish"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:12
+msgid "published"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:59
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:59
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:138
+msgid "qcode"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-widget.html:14
+msgid "quick list"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:75
+#: scripts/core/editor3/helpers/highlights.ts:65
+msgid "quote"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:98
+msgid "redo"
+msgstr ""
+
+#: scripts/apps/workspace/helpers/getTypeForFieldId.ts:10
+#: scripts/apps/workspace/helpers/getTypeForFieldId.ts:7
+msgid "related content"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:89
+msgid "remove all format"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:88
+msgid "remove format"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:111
+msgid "removed desk"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:108
+msgid "removed highlight"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:37
+msgid "removed item {{type}} about {{subject}}"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-replace.html:6
+msgid "replace"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:43
+msgid "replaced item {{type}} about {{subject}}"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:181
+#: scripts/core/editor3/directive.tsx:452
+msgid "required"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:208
+msgid "reset password"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:11
+msgid "retrying"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/versions/views/versions.html:20
+msgid "revert"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:72
+msgid "reverted"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:182
+msgid "rewrite id"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:41
+msgid "role {{role}} is granted new privileges: Please re-login."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:11
+msgid "routed"
+msgstr ""
+
+#: scripts/core/editor3/components/toolbar/TableControls.tsx:90
+msgid "row"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:12
+msgid "scheduled"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:26
+msgid "scheduled Desk Output"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:25
+msgid "search"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:118
+msgid "search provider password"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:110
+msgid "search provider username"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-sources-content.html:144
+msgid "sec"
+msgstr ""
+
+#: scripts/core/views/sdSearchList.html:5
+msgid "selected"
+msgstr ""
+
+#: scripts/apps/search/components/SelectBox.tsx:63
+msgid "selection not allowed"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:9
+msgid "send"
+msgstr ""
+
+#: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:20
+msgid "since"
+msgstr ""
+
+#: scripts/apps/content-filters/controllers/FilterSearchController.ts:31
+msgid "single value is required"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:32
+msgid "slugline"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:10
+msgid "sluglines"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:146
+msgid "sorry, a user with this email already exists"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:119
+msgid "sorry, this username is already taken."
+msgstr ""
+
+#: scripts/apps/search/components/MediaInfo.tsx:26
+msgid "source"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:90
+msgid "source of the search provider"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:12
+msgid "spiked"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:91
+msgid "spiked and unlinked"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:26
+msgid "stage"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:10
+#: scripts/apps/authoring/versioning/versions/views/versions.html:14
+#: scripts/core/itemList/views/relatedItem-list-widget.html:39
+msgid "stage:"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:94
+#: scripts/extensions/availability-manager/dist/src/utils.js:94
+#: scripts/extensions/availability-manager/src/utils.ts:98
+msgid "start time"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:100
+#: scripts/extensions/availability-manager/dist/src/utils.js:100
+#: scripts/extensions/availability-manager/src/utils.ts:102
+msgid ""
+"start time cannot be greater than end time ({{start_time}} - {{end_time}})"
+msgstr ""
+
+#: scripts/apps/authoring/metadata/views/meta-place-directive.html:19
+msgid "state, region, ..."
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:109
+#: scripts/extensions/availability-manager/dist/src/utils.js:109
+#: scripts/extensions/availability-manager/src/utils.ts:114
+msgid "status"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:80
+msgid "strikethrough"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:83
+#: scripts/core/lang/missing-translations-strings.ts:11
+msgid "submitted"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:79
+msgid "subscript"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:32
+msgid "subscription"
+msgstr ""
+
+#: scripts/apps/search/views/saved-search-manage-subscribers.html:16
+#: scripts/apps/search/views/search-panel.html:43
+msgid "subscriptions"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:10
+msgid "success"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:92
+msgid "suggestions"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:78
+msgid "superscript"
+msgstr ""
+
+#: scripts/apps/legal-archive/views/legal_archive.html:16
+msgid "switch to grid view"
+msgstr ""
+
+#: scripts/apps/legal-archive/views/legal_archive.html:17
+msgid "switch to list view"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:95
+msgid "tab"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:96
+msgid "tab as space"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:84
+msgid "table"
+msgstr ""
+
+#: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:58
+#: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:58
+#: scripts/extensions/auto-tagging-widget/src/auto-tagging.tsx:137
+msgid "tag name"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:398
+#: scripts/apps/workspace/helpers/getTypeForFieldId.ts:6
+#: scripts/core/lang/missing-translations-strings.ts:9
+#: scripts/core/utils.tsx:291 scripts/core/utils.tsx:343
+msgid "text"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:84
+#: scripts/apps/authoring/versioning/history/views/history.html:83
+#: scripts/apps/ingest/views/settings/ingest-routing-general.html:72
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/settings/edit-working-hours.js:61
+#: scripts/extensions/availability-manager/dist/src/settings/edit-working-hours.js:61
+#: scripts/extensions/availability-manager/src/settings/edit-working-hours.tsx:121
+msgid "to"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:41
+msgid "to '{{ desk }}'"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:75
+msgid "to coverage assignment by"
+msgstr ""
+
+#: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:150
+msgid "toggle difference"
+msgstr ""
+
+#: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:134
+msgid "toggle primary"
+msgstr ""
+
+#: scripts/apps/authoring-react/compare-articles/compare-articles.tsx:142
+msgid "toggle secondary"
+msgstr ""
+
+#: scripts/apps/authoring/views/authoring-header.html:85
+msgid "translations"
+msgstr ""
+
+#: scripts/apps/contacts/constants.ts:50
+msgid "twitter"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:81
+msgid "underline"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:97
+msgid "undo"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:72
+#: scripts/core/editor3/helpers/highlights.ts:66
+msgid "unordered list"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:121
+msgid "unpost"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/history.tsx:87
+msgid "unposted"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/events.tsx:1413
+msgid "until {{until}}"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:27
+msgid "update"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/eventsPlanning/ui.ts:189
+#: ../superdesk-planning/client/components/Agendas/AgendaListItem.tsx:47
+#: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:140
+#: scripts/apps/search/components/MediaInfo.tsx:32
+msgid "updated"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:40
+msgid "updated Ingest Channel {{name}}"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/history/views/history.html:25
+msgid "updated fields"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:38
+msgid "updated task {{subject}} for item {{type}}"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:34
+msgid "uploaded media {{name}}"
+msgstr ""
+
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:30
+#: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:99
+msgid "uppercase"
+msgstr ""
+
+#: scripts/apps/search-providers/views/search-provider-config.html:98
+msgid "url of the search provider"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:37
+msgid "user {{user}} has been added to desk {{desk}}: Please re-login."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:41
+msgid "user {{user}} is granted new privileges: Please re-login."
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:42
+msgid "user {{user}} is updated to administrator: Please re-login."
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/searchConfig.html:3
+#: scripts/apps/users/import/views/import-user.html:14
+#: scripts/apps/users/views/edit-form.html:106
+#: scripts/core/auth/login-modal.html:15
+msgid "username"
+msgstr "корисничко име"
+
+#: scripts/core/lang/missing-translations-strings.ts:10
+msgid "users"
+msgstr ""
+
+#: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/form-validation.js:27
+#: scripts/extensions/broadcasting/dist/src/form-validation.js:27
+#: scripts/extensions/broadcasting/src/form-validation.ts:26
+msgid "value must be greater than zero"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:241
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:241
+#: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:304
+msgid "value of 0 will disable this restriction"
+msgstr ""
+
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-article.html:5
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-dropdown.html:13
+#: scripts/apps/authoring/compare-versions/views/sd-compare-versions-inner-dropdown.html:6
+#: scripts/apps/authoring/versioning/history/views/history.html:105
+#: scripts/apps/authoring/versioning/history/views/history.html:119
+#: scripts/apps/authoring/versioning/history/views/history.html:137
+#: scripts/apps/authoring/versioning/history/views/history.html:151
+#: scripts/apps/authoring/versioning/history/views/history.html:168
+#: scripts/apps/authoring/versioning/history/views/history.html:179
+#: scripts/apps/authoring/versioning/history/views/history.html:191
+#: scripts/apps/authoring/versioning/history/views/history.html:22
+#: scripts/apps/authoring/versioning/history/views/history.html:33
+#: scripts/apps/authoring/versioning/history/views/history.html:44
+#: scripts/apps/authoring/versioning/history/views/history.html:55
+#: scripts/apps/authoring/versioning/history/views/history.html:66
+#: scripts/apps/authoring/versioning/history/views/history.html:80
+#: scripts/apps/authoring/versioning/history/views/history.html:9
+#: scripts/apps/authoring/versioning/history/views/history.html:91
+#: scripts/apps/authoring/versioning/versions/views/versions.html:18
+msgid "version"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:117
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:121
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:260
+msgid "version {{n}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:161
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:176
+#: scripts/apps/authoring-react/article-widgets/versions-and-item-history/versions-tab.tsx:238
+msgid "version: {{n}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/SourceFilters.js:402
+#: scripts/apps/archive/controllers/UploadController.ts:326
+#: scripts/apps/authoring-react/fields/media/editor.tsx:155
+#: scripts/apps/authoring/authoring/directives/ItemAssociationDirective.ts:197
+#: scripts/core/lang/missing-translations-strings.ts:9
+#: scripts/core/utils.tsx:293 scripts/core/utils.tsx:348
+msgid "video"
+msgstr ""
+
+#: scripts/apps/desks/views/settings.html:77
+msgid "view all"
+msgstr ""
+
+#: scripts/core/notification/notification.ts:231
+msgid ""
+"vocabulary has been updated. Please re-login to see updated vocabulary values"
+msgstr ""
+
+#: scripts/apps/contacts/components/Form/ProfileDetail.tsx:448
+msgid "website"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/views/preview-date-filter.html:17
+#: scripts/apps/authoring-react/fields/date/config.tsx:84
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:154
+msgid "weeks"
+msgstr ""
+
+#: scripts/api/article-fetch.tsx:136
+msgid "width"
+msgstr ""
+
+#: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:110
+#: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:95
+msgid "with"
+msgstr ""
+
+#: scripts/apps/authoring/track-changes/views/suggestions-widget.html:27
+msgid "with:"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:112
+#: scripts/extensions/availability-manager/dist/src/utils.js:112
+#: scripts/extensions/availability-manager/src/utils.ts:118
+msgid "working hours are not set"
+msgstr ""
+
+#: scripts/apps/search/components/ItemContainer.tsx:17
+msgid "workspace"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/date/config.tsx:86
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:156
+msgid "years"
+msgstr ""
+
+#: scripts/apps/dashboard/views/configuration.html:2
+msgid "{{ 'Configuration' }}"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:729
+msgid "{{ :: 'Attachments' | translate }}"
+msgstr ""
+
+#: scripts/core/itemList/views/relatedItem-list-widget.html:51
+msgid "{{ :: action.title }}"
+msgstr ""
+
+#: scripts/apps/authoring/versioning/versions/views/versions.html:19
+msgid "{{ :: version.state | removeLodash }}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/MultiSelectActions.tsx:78
+msgid "{{ count }} {{ type }} selected"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/main.ts:325
+msgid "{{ itemType }} created"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/index.ts:119
+#: ../superdesk-planning/client/validators/planning.ts:170
+#: ../superdesk-planning/client/validators/planning.ts:210
+msgid "{{ key }} is a required field"
+msgstr ""
+
+#: scripts/apps/authoring/macros/views/macros-widget.html:17
+#: scripts/apps/authoring/macros/views/macros-widget.html:26
+#: scripts/apps/authoring/macros/views/macros-widget.html:35
+#: scripts/apps/authoring/macros/views/macros-widget.html:9
+msgid "{{ macro.label }}"
+msgstr ""
+
+#: scripts/apps/search/views/multi-action-bar.html:4
+msgid "{{ multi.count}} Item selected"
+msgid_plural "{{ multi.count}} Items selected"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../superdesk-planning/client/components/fields/calendars.tsx:45
+msgid "{{ name }} (disabled)"
+msgstr ""
+
+#: ../superdesk-planning/client/components/fields/editor/base/multilingualText.tsx:150
+msgid "{{ name }} ({{ language }})"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/assignments.tsx:9
+#: ../superdesk-planning/client/validators/profile.ts:108
+#: ../superdesk-planning/client/validators/profile.ts:66
+#: ../superdesk-planning/client/validators/profile.ts:78
+#: ../superdesk-planning/client/validators/profile.ts:86
+msgid "{{ name }} is a required field"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/profile.ts:62
+msgid "{{ name }} is too long"
+msgstr ""
+
+#: ../superdesk-planning/client/validators/profile.ts:104
+msgid "{{ name }} is too short"
+msgstr ""
+
+#: scripts/apps/monitoring/views/aggregate-settings.html:117
+#: scripts/apps/monitoring/views/aggregate-settings.html:138
+msgid "{{ output.listLabel }}"
+msgstr ""
+
+#: ../superdesk-planning/client/actions/assignments/notifications.ts:371
+msgid "{{ type }} assignment '{{ slugline }}' is deleted"
+msgstr ""
+
+#: scripts/apps/monitoring/aggregate-widget/aggregate-widget.html:4
+msgid "{{ widget.configuration.label || widget.label }}"
+msgstr ""
+
+#: scripts/apps/dashboard/views/configuration.html:2
+msgid "{{ widget.label }}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Archive/ArchivePreview/ArchivePreviewMetadataList.tsx:16
+msgid "{{ wordCount }} words"
+msgstr ""
+
+#: scripts/apps/monitoring/views/monitoring-view.html:25
+msgid "{{:: monitoring.getGroupLabel(card, aggregate.settings.type)}}"
+msgstr ""
+
+#: scripts/apps/authoring/views/item-actions-by-intent.html:5
+msgid "{{::group._id}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:118
+msgid "{{action}} {{event}}"
+msgstr ""
+
+#: ../superdesk-planning/client/components/Main/ItemEditorModal/EditorModalPanel.tsx:166
+msgid "{{action}} {{type}}"
+msgstr ""
+
+#: scripts/apps/search/controllers/get-multi-actions.tsx:370
+msgid "{{count}} articles have been descheduled"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/components/workspaceSubnav.js:224
+#: scripts/extensions/sams/dist/src/extensions/sams/src/components/workspaceSubnav.js:224
+#: scripts/extensions/sams/src/components/workspaceSubnav.tsx:287
+msgid "{{count}} item selected"
+msgid_plural "{{count}} items selected"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:123
+#: ../superdesk-analytics/client/utils.js:196
+msgid "{{days}} days"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:144
+msgid "{{error.email}}"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/ingest-config-errors.html:2
+msgid "{{errorMessage|translate}}"
+msgstr ""
+
+#: scripts/apps/authoring/views/article-edit.html:575
+#: scripts/apps/authoring/views/article-edit.html:627
+#: scripts/apps/authoring/views/article-edit.html:711
+msgid "{{field.display_name}}"
+msgstr ""
+
+#: scripts/apps/ingest/views/settings/service-config.html:47
+msgid "{{field.label | translate}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:112
+msgid "{{field}} (optional)"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:384
+msgid "{{field}} cannot be earlier than now!"
+msgstr ""
+
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:109
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:94
+#: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:97
+#: scripts/extensions/availability-manager/dist/src/utils.js:109
+#: scripts/extensions/availability-manager/dist/src/utils.js:94
+#: scripts/extensions/availability-manager/dist/src/utils.js:97
+#: scripts/extensions/availability-manager/src/utils.ts:100
+#: scripts/extensions/availability-manager/src/utils.ts:114
+#: scripts/extensions/availability-manager/src/utils.ts:98
+msgid "{{field}} cannot be empty"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:372
+msgid "{{field}} date is required!"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:380
+msgid "{{field}} is not a valid date!"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:376
+msgid "{{field}} time is required!"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:118
+#: ../superdesk-analytics/client/utils.js:202
+msgid "{{hours}} hours"
+msgstr ""
+
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:99
+msgid "{{hours}} hours, {{minutes}} minutes"
+msgstr ""
+
+#: ../superdesk-analytics/client/charts/views/chart-colour-picker.html:2
+msgid "{{label | translate}}"
+msgstr ""
+
+#: scripts/core/auth/login-modal.html:62
+msgid "{{labels.saml}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:105
+#: ../superdesk-analytics/client/utils.js:208
+msgid "{{minutes}} minutes"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:133
+msgid "{{months}} months"
+msgstr ""
+
+#: scripts/apps/publish/views/publish-queue.html:84
+msgid "{{multiSelectCount}} Item selected"
+msgid_plural "{{multiSelectCount}} Items selected"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/apps/authoring/authoring/directives/WordCount.html:1
+msgid "{{numWords}} words"
+msgstr ""
+
+#: scripts/api/article-fetch.tsx:117
+msgid "{{n}} images can not be fetched because they are too small."
+msgid_plural "One image can not be fetched because it is too small."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/apps/authoring-react/fields/media/difference.tsx:41
+msgid "{{n}} items added"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/difference.tsx:54
+msgid "{{n}} items modified"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/difference.tsx:62
+msgid "{{n}} items re-ordered"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/difference.tsx:47
+msgid "{{n}} items removed"
+msgstr ""
+
+#: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:105
+msgid "{{n}} of {{total}} matches"
+msgstr ""
+
+#: scripts/apps/users/views/edit-form.html:65
+msgid "{{roles[user.role].name}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/utils.js:213
+msgid "{{seconds}} seconds"
+msgstr ""
+
+#: scripts/apps/users/views/edit.html:19
+msgid "{{section.label}}"
+msgstr ""
+
+#: ../superdesk-planning/client/utils/confirmAddingRelatedItems.tsx:44
+msgid "{{some}} of {{total}} items can not be added as related"
+msgstr ""
+
+#: scripts/core/lang/missing-translations-strings.ts:40
+msgid "{{status}} Ingest Channel {{name}}"
+msgstr ""
+
+#: scripts/apps/archive/views/metadata-associateditem-view.html:1
+msgid "{{title}}"
+msgstr ""
+
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:132
+#: scripts/apps/vocabularies/views/vocabulary-config-modal.html:70
+msgid "{{type.label}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:44
+#: ../superdesk-analytics/client/featuremedia_updates_report/views/featuremedia-updates-table.html:45
+msgid "{{update.date}} - {{update.operation}} by {{update.user}}"
+msgstr ""
+
+#: ../superdesk-analytics/client/search/directives/DateFilters.js:128
+msgid "{{weeks}} weeks"
+msgstr ""
+
+#: scripts/extensions/sams/dist/src/extensions/sams/src/utils/ui.js:124
+#: scripts/extensions/sams/dist/src/utils/ui.js:124
+#: scripts/extensions/sams/src/utils/ui.tsx:119
+msgid "{{width}} * {{height}}"
+msgstr ""
+
+#: scripts/apps/authoring-react/fields/media/media-metadata.tsx:44
+msgid "{{width}} x {{height}} px"
+msgstr ""
+
+#: scripts/apps/dictionaries/views/dictionary-config-modal.html:55
+msgid "{{wordsCount}} word"
+msgid_plural "{{ $count}} words"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/extensions/datetimeField/dist/src/editor.js:76
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:81
+#: scripts/extensions/datetimeField/src/editor.tsx:140
+msgid "{{x}} hour"
+msgid_plural "{{x}} hours"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: scripts/apps/search/components/fields/linesCount.tsx:14
+msgid "{{x}} lines"
+msgstr ""
+
+#: scripts/extensions/datetimeField/dist/src/editor.js:79
+#: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:84
+#: scripts/extensions/datetimeField/src/editor.tsx:149
+msgid "{{x}} min"
+msgstr ""
+
+#: scripts/apps/authoring/authoring/directives/ReadingTime.ts:22
+#: scripts/apps/authoring/authoring/directives/ReadingTime.ts:52
+msgid "{{x}} min read"
+msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -889,7 +889,7 @@ msgstr ""
 
 #: scripts/apps/ingest/views/dashboard/ingest-sources-list.html:1
 msgid "Add Ingest Sources"
-msgstr "Додај изворе доласка"
+msgstr "Додај изворе пријема"
 
 #: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:436
 msgid "Add Item"
@@ -1233,7 +1233,7 @@ msgstr ""
 #: scripts/apps/relations/services/RelationsService.ts:46
 msgid ""
 "Adding ingested items as related is not allowed due to configuration options"
-msgstr "Додавање ставки из доласка као повезаних није дозвољено због подешавања"
+msgstr "Додавање ставки из пријема као повезаних није дозвољено због подешавања"
 
 #: scripts/apps/relations/services/RelationsService.ts:29
 msgid ""
@@ -1939,7 +1939,7 @@ msgstr ""
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:348
 msgid "Are you sure you want to delete Ingest Source?"
-msgstr "Да ли сте сигурни да желите да обришете извор доласка?"
+msgstr "Да ли сте сигурни да желите да обришете извор пријема?"
 
 #: scripts/apps/search-providers/directive.ts:87
 msgid "Are you sure you want to delete Search Provider?"
@@ -4758,7 +4758,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:39
 msgid "Created Ingest Channel {{name}}"
-msgstr "Креиран канал доласка {{name}}"
+msgstr "Креиран канал пријема {{name}}"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:158
 msgid "Created To"
@@ -5376,7 +5376,7 @@ msgstr "Обриши радни простор"
 
 #: scripts/core/lang/missing-translations-strings.ts:40
 msgid "Deleted Ingest Channel {{name}}"
-msgstr "Обрисан канал доласка {{name}}"
+msgstr "Обрисан канал пријема {{name}}"
 
 #: scripts/apps/publish/views/destination.html:22
 msgid "Delivery type"
@@ -5790,7 +5790,7 @@ msgstr "Прекинута веза са сервером обавештења!"
 msgid ""
 "Displaying news ingest statistics. You can switch color themes or graph "
 "sources."
-msgstr "Приказује статистике доласка вести. Можете променити теме боја или изворе графикона."
+msgstr "Приказује статистике пријема вести. Можете променити теме боја или изворе графикона."
 
 #: scripts/core/keyboard/keyboard.ts:401 scripts/core/keyboard/keyboard.ts:410
 msgid "Displays active keyboard shortcuts"
@@ -6363,11 +6363,11 @@ msgstr "Уреди услов филтера"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:109
 msgid "Edit Ingest Source"
-msgstr "Уреди извор доласка"
+msgstr "Уреди извор пријема"
 
 #: scripts/apps/ingest/views/dashboard/ingest-sources-list.html:6
 msgid "Edit Ingest Sources"
-msgstr "Уреди изворе доласка"
+msgstr "Уреди изворе пријема"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:75
 msgid "Edit Line"
@@ -6962,7 +6962,7 @@ msgstr "Грешка: речник већ постоји."
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:359
 msgid "Error: Unable to delete Ingest Source"
-msgstr "Грешка: није могуће обрисати извор доласка"
+msgstr "Грешка: није могуће обрисати извор пријема"
 
 #: scripts/apps/search-providers/directive.ts:98
 msgid "Error: Unable to delete Search Provider."
@@ -8001,7 +8001,7 @@ msgstr "Повратне информације/Предлози"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:92
 msgid "Feeding Service"
-msgstr "Сервис за довод"
+msgstr "Фид сервис"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:64
 msgid "Fern Green"
@@ -8992,7 +8992,7 @@ msgstr "Извините, али дошло је до грешке прилик�
 
 #: scripts/apps/ingest/directives/IngestRoutingContent.ts:188
 msgid "I'm sorry but there was an error when saving the routing scheme."
-msgstr "Извините, али дошло је до грешке приликом чувања шеме усмеравања."
+msgstr "Извините, али дошло је до грешке приликом чувања шеме рутирања."
 
 #: scripts/apps/ingest/directives/IngestRulesContent.ts:37
 msgid "I'm sorry but there was an error when saving the rule set."
@@ -9297,20 +9297,20 @@ msgstr ""
 #: scripts/apps/ingest/views/settings/settings.html:4
 #: scripts/apps/search/views/item-repo.html:3
 msgid "Ingest"
-msgstr "Долазак"
+msgstr "Пријем"
 
 #: scripts/core/lang/missing-translations-strings.ts:18
 msgid "Ingest Channels"
-msgstr "Канали доласка"
+msgstr "Канали пријема"
 
 #: scripts/apps/ingest/index.ts:92
 #: scripts/apps/ingest/views/dashboard/dashboard.html:2
 msgid "Ingest Dashboard"
-msgstr "Контролна табла доласка"
+msgstr "Контролна табла пријема"
 
 #: scripts/apps/ingest/controllers/IngestDashboardController.ts:36
 msgid "Ingest Dashboard preferences could not be saved."
-msgstr "Поставке контролне табле доласка нису могле бити сачуване."
+msgstr "Поставке контролне табле пријема нису могле бити сачуване."
 
 #: scripts/apps/archive/views/metadata-view.html:26
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:263
@@ -9318,11 +9318,11 @@ msgstr "Поставке контролне табле доласка нису �
 #: scripts/apps/publish/views/publish-queue.html:110
 #: scripts/apps/workspace/content/constants.ts:32
 msgid "Ingest Provider"
-msgstr "Провајдер доласка"
+msgstr "Провајдер пријема"
 
 #: scripts/apps/publish/views/publish-queue.html:30
 msgid "Ingest Provider:"
-msgstr "Провајдер доласка:"
+msgstr "Провајдер пријема:"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:596
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:151
@@ -9332,11 +9332,11 @@ msgstr ""
 
 #: scripts/apps/ingest/views/settings/settings.html:15
 msgid "Ingest Routing"
-msgstr "Усмеравање доласка"
+msgstr "Рутирање пријема"
 
 #: scripts/apps/ingest/views/settings/settings.html:12
 msgid "Ingest Rule sets"
-msgstr "Скупови правила доласка"
+msgstr "Скупови правила пријема"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:99
 msgid "Ingest Source"
@@ -9344,16 +9344,16 @@ msgstr ""
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:353
 msgid "Ingest Source deleted."
-msgstr "Извор доласка обрисан."
+msgstr "Извор пријема обрисан."
 
 #: scripts/apps/ingest/views/settings/settings.html:9
 msgid "Ingest Sources"
-msgstr "Извори доласка"
+msgstr "Извори пријема"
 
 #: scripts/apps/ingest/ingest-stats-widget/stats.ts:9
 #: scripts/core/lang/missing-translations-strings.ts:44
 msgid "Ingest Stats"
-msgstr "Статистика доласка"
+msgstr "Статистика пријема"
 
 #: scripts/apps/archive/views/metadata-view.html:128
 msgid "Ingest provider sequence"
@@ -14421,7 +14421,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:22
 msgid "Route incoming content to"
-msgstr "Усмери долазни садржај у"
+msgstr "Рутирај долазни садржај у"
 
 #: scripts/apps/search/components/fields/state.tsx:32
 msgid "Routed"
@@ -14429,31 +14429,31 @@ msgstr ""
 
 #: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:3
 msgid "Routed from"
-msgstr "Усмерено са"
+msgstr "Рутирано са"
 
 #: scripts/apps/dashboard/closed-desk/views/top-menu-info.html:8
 msgid "Routed from other desks"
-msgstr "Усмерено са других дескова"
+msgstr "Рутирано са других дескова"
 
 #: scripts/apps/dashboard/closed-desk/views/top-menu-info.html:9
 msgid "Routed from:"
-msgstr "Усмерено са:"
+msgstr "Рутирано са:"
 
 #: scripts/core/lang/missing-translations-strings.ts:20
 msgid "Routing Rules Management"
-msgstr "Управљање правилима усмеравања"
+msgstr "Управљање правилима рутирања"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:219
 msgid "Routing Scheme"
-msgstr "Шема усмеравања"
+msgstr "Шема рутирања"
 
 #: scripts/apps/ingest/directives/IngestRoutingContent.ts:182
 msgid "Routing scheme saved."
-msgstr "Шема усмеравања сачувана."
+msgstr "Шема рутирања сачувана."
 
 #: scripts/apps/dashboard/closed-desk/views/top-menu-info.html:12
 msgid "Routing to:"
-msgstr "Усмеравање на:"
+msgstr "Рутирање на:"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-content.html:53
 msgid "Rule name"
@@ -14968,7 +14968,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/constants.ts:70
 msgid "Scheduled Desk Output"
-msgstr "Заказани излазни деск"
+msgstr "Заказани излаз деска"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:151
 msgid "Scheduled Export"
@@ -15295,7 +15295,7 @@ msgid ""
 "ingest. If you don't see any, create one\n"
 "                                   <a href=\"#/settings/content-"
 "profiles\">here</a>"
-msgstr "Изаберите подразумевани профил садржаја који се користи за чланке преузете из доласка. Ако ниједан не видите, креирајте га\n                                   <a href=\"#/settings/content-profiles\">овде</a>"
+msgstr "Изаберите подразумевани профил садржаја који се користи за чланке преузете из пријема. Ако ниједан не видите, креирајте га\n                                   <a href=\"#/settings/content-profiles\">овде</a>"
 
 #: scripts/apps/desks/views/desk-config-modal.html:156
 msgid ""
@@ -15689,7 +15689,7 @@ msgid ""
 "sensible name, select a saved search or desk or its workflow stages. Monitor "
 "anything, anywhere, anytime. You can have as many Monitor widgets as you "
 "wish."
-msgstr "Подесите различите мониторе да бисте пратили било које теме из доласка или продукције, излаза дескова или било ког дела радног тока. Све што вам треба је да им дате смислен назив, изаберете сачувану претрагу или деск или његове радне фазе. Пратите било шта, било где, било када. Можете имати онолико виџета Монитора колико желите."
+msgstr "Подесите различите мониторе да бисте пратили било које теме из пријема или продукције, излаза дескова или било ког дела радног тока. Све што вам треба је да им дате смислен назив, изаберете сачувану претрагу или деск или његове радне фазе. Пратите било шта, било где, било када. Можете имати онолико виџета Монитора колико желите."
 
 #: scripts/extensions/sams/dist/src/api/sets.js:57
 #: scripts/extensions/sams/dist/src/extensions/sams/src/api/sets.js:57
@@ -16405,7 +16405,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:31
 msgid "Start routing"
-msgstr "Започни усмеравање"
+msgstr "Започни рутирање"
 
 #: scripts/apps/monitoring/views/monitoring-view.html:87
 #: scripts/apps/search/views/item-searchbar.html:19
@@ -16493,7 +16493,7 @@ msgstr ""
 
 #: scripts/apps/dashboard/closed-desk/views/close-desk-widget.html:37
 msgid "Stop routing"
-msgstr "Заустави усмеравање"
+msgstr "Заустави рутирање"
 
 #: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:254
 #: scripts/extensions/sams/dist/src/components/sets/setPreviewPanel.js:150
@@ -17712,7 +17712,7 @@ msgstr "Дошло је до грешке. Улога не може бити о�
 
 #: scripts/apps/ingest/directives/IngestRoutingContent.ts:55
 msgid "There was an error. Routing scheme cannot be deleted."
-msgstr "Дошло је до грешке. Шема усмеравања не може бити обрисана."
+msgstr "Дошло је до грешке. Шема рутирања не може бити обрисана."
 
 #: scripts/apps/ingest/directives/IngestRulesContent.ts:54
 msgid "There was an error. Rule set cannot be deleted."
@@ -17903,7 +17903,7 @@ msgid ""
 "This widget allows you to create literally any content view you may need in "
 "Superdesk, be it production or ingest. All you need is to select a desk, its "
 "stages or a saved search. Name your view once you are done. Enjoy!"
-msgstr "Овај виџет вам омогућава да креирате буквално било који приказ садржаја који вам је потребан у Superdesk-у, било да се ради о продукцији или доласку. Све што треба је да изаберете деск, његове фазе или сачувану претрагу. Именујте свој приказ када завршите. Уживајте!"
+msgstr "Овај виџет вам омогућава да креирате буквално било који приказ садржаја који вам је потребан у Superdesk-у, било да се ради о продукцији или пријему. Све што треба је да изаберете деск, његове фазе или сачувану претрагу. Именујте свој приказ када завршите. Уживајте!"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/postEventsForm.tsx:83
 msgid "This will also post the related event's entire recurring series"
@@ -21120,7 +21120,7 @@ msgstr "улози {{role}} су додељене нове привилегиј�
 
 #: scripts/core/lang/missing-translations-strings.ts:11
 msgid "routed"
-msgstr "усмерено"
+msgstr "рутирано"
 
 #: scripts/core/editor3/components/toolbar/TableControls.tsx:90
 msgid "row"
@@ -21377,7 +21377,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:40
 msgid "updated Ingest Channel {{name}}"
-msgstr "ажуриран канал доласка {{name}}"
+msgstr "ажуриран канал пријема {{name}}"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:25
 msgid "updated fields"
@@ -21780,7 +21780,7 @@ msgstr ""
 
 #: scripts/core/lang/missing-translations-strings.ts:40
 msgid "{{status}} Ingest Channel {{name}}"
-msgstr "{{status}} канал доласка {{name}}"
+msgstr "{{status}} канал пријема {{name}}"
 
 #: scripts/apps/archive/views/metadata-associateditem-view.html:1
 msgid "{{title}}"

--- a/po/sr.po
+++ b/po/sr.po
@@ -153,7 +153,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/email-config.html:3
 msgid "*at least one visible or hidden recipient needed"
-msgstr ""
+msgstr "*потребан је барем један видљив или скривен прималац"
 
 #: ../superdesk-analytics/client/utils.js:193
 msgid "1 day"
@@ -176,7 +176,7 @@ msgstr ""
 
 #: scripts/apps/publish/controllers/SubscriberTokenController.ts:22
 msgid "1 month"
-msgstr ""
+msgstr "1 месец"
 
 #: ../superdesk-planning/client/components/fields/with-more-items.tsx:52
 msgid "1 more item"
@@ -200,15 +200,15 @@ msgstr[2] ""
 
 #: scripts/apps/publish/controllers/SubscriberTokenController.ts:20
 msgid "1 week"
-msgstr ""
+msgstr "1 недеља"
 
 #: scripts/apps/publish/controllers/SubscriberTokenController.ts:24
 msgid "1 year"
-msgstr ""
+msgstr "1 година"
 
 #: scripts/apps/publish/controllers/SubscriberTokenController.ts:27
 msgid "10 years"
-msgstr ""
+msgstr "10 година"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:186
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:186
@@ -246,7 +246,7 @@ msgstr ""
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:17
 msgid "12 Hours"
-msgstr ""
+msgstr "12 сати"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:204
 msgid "12:00am"
@@ -336,11 +336,11 @@ msgstr ""
 
 #: scripts/apps/publish/controllers/SubscriberTokenController.ts:21
 msgid "2 weeks"
-msgstr ""
+msgstr "2 недеље"
 
 #: scripts/apps/publish/controllers/SubscriberTokenController.ts:25
 msgid "2 years"
-msgstr ""
+msgstr "2 године"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:105
 msgid "200 minimum"
@@ -372,7 +372,7 @@ msgstr ""
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:19
 msgid "24 Hours"
-msgstr ""
+msgstr "24 сата"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:58
 #: ../superdesk-planning/client/utils/filters.ts:109
@@ -435,7 +435,7 @@ msgstr ""
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:20
 msgid "48 Hours"
-msgstr ""
+msgstr "48 сати"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:38
 #: ../superdesk-planning/client/utils/filters.ts:69
@@ -448,7 +448,7 @@ msgstr ""
 
 #: scripts/apps/publish/controllers/SubscriberTokenController.ts:26
 msgid "5 years"
-msgstr ""
+msgstr "5 година"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetFilterPanel.js:188
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetFilterPanel.js:188
@@ -479,11 +479,11 @@ msgstr ""
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:16
 msgid "6 Hours"
-msgstr ""
+msgstr "6 сати"
 
 #: scripts/apps/publish/controllers/SubscriberTokenController.ts:23
 msgid "6 months"
-msgstr ""
+msgstr "6 месеци"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:40
 #: ../superdesk-planning/client/utils/filters.ts:73
@@ -700,7 +700,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/amazon-sqs-fifo-config.html:33
 msgid "Access Key ID"
-msgstr ""
+msgstr "ИД приступног кључа"
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/accreditation-deadline.tsx:24
 #: ../superdesk-planning/client/components/fields/preview/index.ts:188
@@ -723,7 +723,7 @@ msgstr "Потврди пријем"
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:16
 #: scripts/apps/publish/views/publish-queue.html:117
 msgid "Action"
-msgstr ""
+msgstr "Радња"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/index.tsx:318
 #: ../superdesk-planning/client/components/Events/EventItem.tsx:132
@@ -783,7 +783,7 @@ msgstr ""
 #: scripts/apps/workspace/content/views/profile-settings.html:168
 #: scripts/apps/workspace/content/views/profile-settings.html:61
 msgid "Active"
-msgstr ""
+msgstr "Активно"
 
 #: scripts/apps/workspace/content/views/profile-settings.html:22
 msgid "Active only"
@@ -791,7 +791,7 @@ msgstr ""
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:424
 msgid "Active until {{end}}"
-msgstr ""
+msgstr "Активно до {{end}}"
 
 #: scripts/apps/users/views/activity-feed.html:4
 #: scripts/core/lang/missing-translations-strings.ts:44
@@ -919,7 +919,7 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/manageSetsModal.js:103
 #: scripts/extensions/sams/src/components/sets/manageSetsModal.tsx:107
 msgid "Add New"
-msgstr ""
+msgstr "Додај нови"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:4
 msgid "Add New Abbreviations Dictionary"
@@ -939,7 +939,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:227
 msgid "Add New Destination"
-msgstr ""
+msgstr "Додај нову дестинацију"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:5
 msgid "Add New Dictionary"
@@ -980,7 +980,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:69
 msgid "Add New Subscriber"
-msgstr ""
+msgstr "Додај новог претплатника"
 
 #: scripts/apps/templates/views/template-editor-modal.html:4
 msgid "Add New Template"
@@ -1233,18 +1233,18 @@ msgstr ""
 #: scripts/apps/relations/services/RelationsService.ts:46
 msgid ""
 "Adding ingested items as related is not allowed due to configuration options"
-msgstr ""
+msgstr "Додавање ставки из доласка као повезаних није дозвољено због подешавања"
 
 #: scripts/apps/relations/services/RelationsService.ts:29
 msgid ""
 "Adding published items as related is not allowed due to configuration options"
-msgstr ""
+msgstr "Додавање објављених ставки као повезаних није дозвољено због подешавања"
 
 #: scripts/apps/relations/services/RelationsService.ts:36
 msgid ""
 "Adding related items that are not published is not allowed due to "
 "configuration options"
-msgstr ""
+msgstr "Додавање повезаних ставки које нису објављене није дозвољено због подешавања"
 
 #: ../superdesk-planning/client/components/Locations/LocationsEditor.tsx:227
 #: ../superdesk-planning/client/components/Locations/LocationsList.tsx:112
@@ -1495,7 +1495,7 @@ msgstr ""
 #: scripts/apps/users/controllers/UserListController.ts:160
 #: scripts/core/ArticlesListByQueryWithFilters.tsx:178
 msgid "All"
-msgstr ""
+msgstr "Сви"
 
 #: ../superdesk-planning/client/components/PlanningTemplatesModal/PlanningTemplatesModal.tsx:32
 msgid "All Calendars"
@@ -1783,7 +1783,7 @@ msgstr "Дошло је до грешке, покушајте поново."
 
 #: scripts/apps/publish-preview/previewModal.tsx:66
 msgid "An error occurred while trying to preview the item."
-msgstr ""
+msgstr "Дошло је до грешке приликом покушаја прегледа ставке."
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:230
 msgid "An update can not be created"
@@ -1860,7 +1860,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:244
 msgid "Applied Global Block Filters"
-msgstr ""
+msgstr "Примењени глобални филтери блокирања"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:161
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:75
@@ -1894,7 +1894,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/email-config.html:38
 msgid "Apply watermark"
-msgstr ""
+msgstr "Примени водени жиг"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:37
 #: scripts/apps/production-api-keys/config.ts:23
@@ -2293,7 +2293,7 @@ msgstr ""
 #: scripts/apps/publish/views/http-push-config.html:10
 #: scripts/apps/publish/views/http-push-config.html:9
 msgid "Assets URL"
-msgstr ""
+msgstr "URL ресурса"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:216
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:42
@@ -2486,7 +2486,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/ftp-config.html:38
 msgid "Associated/featuremedia path"
-msgstr ""
+msgstr "Путања повезаног/истакнутог медија"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:66
 msgid "At least 2 languages must be selected"
@@ -2582,7 +2582,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:269
 msgid "Authentication Token"
-msgstr ""
+msgstr "Токен за аутентификацију"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:646
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:120
@@ -2854,13 +2854,13 @@ msgstr ""
 #: scripts/apps/publish/directives/SubscribersDirective.ts:66
 #: scripts/apps/publish/views/subscribers.html:149
 msgid "Both"
-msgstr ""
+msgstr "Обоје"
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:200
 msgid ""
 "Both start and end date need to be filled in (or cleared) to save the "
 "subscriber."
-msgstr ""
+msgstr "Морате попунити (или обрисати) и почетни и крајњи датум да бисте сачували претплатника."
 
 #: scripts/apps/authoring/views/change-image.html:242
 msgid "Brightness"
@@ -2943,7 +2943,7 @@ msgstr "ОТКАЖИ"
 
 #: scripts/apps/publish/views/email-config.html:20
 msgid "CID"
-msgstr ""
+msgstr "CID"
 
 #: ../superdesk-planning/client/validators/planning.ts:232
 msgid "COVERAGE SCHEDULE is required"
@@ -3209,7 +3209,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/publish-queue.html:83
 msgid "Cancel Selection"
-msgstr ""
+msgstr "Откажи избор"
 
 #: ../superdesk-planning/client/constants/planning.ts:139
 msgid "Cancel all Coverage(s)"
@@ -3250,7 +3250,7 @@ msgstr ""
 
 #: scripts/apps/relations/directives/RelatedItemsDirective.ts:149
 msgid "Cannot add self as related item."
-msgstr ""
+msgstr "Не можете додати саму ставку као повезану."
 
 #: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:32
 msgid ""
@@ -3307,7 +3307,7 @@ msgstr "Категорије"
 #: scripts/apps/legal-archive/tests/legal.spec.ts:69
 #: scripts/apps/search/directives/SearchFilters.ts:44
 msgid "Category"
-msgstr ""
+msgstr "Категорија"
 
 #: ../superdesk-analytics/client/utils.js:180
 msgid "Change Image"
@@ -3746,7 +3746,7 @@ msgstr ""
 #: scripts/apps/legal-archive/views/legal_archive.html:44
 #: scripts/apps/search/views/search-panel.html:22
 msgid "Close panel"
-msgstr ""
+msgstr "Затвори панел"
 
 #: scripts/apps/search/views/item-preview.html:27
 msgid "Close preview"
@@ -3803,7 +3803,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:158
 msgid "Comma separated values"
-msgstr ""
+msgstr "Вредности раздвојене зарезом"
 
 #: scripts/apps/products/views/products-config-modal.html:55
 msgid "Comma separated values."
@@ -3888,7 +3888,7 @@ msgstr ""
 
 #: scripts/apps/legal-archive/index.ts:38
 msgid "Confidential data"
-msgstr ""
+msgstr "Поверљиви подаци"
 
 #: scripts/apps/highlights/controllers/HighlightsConfig.ts:70
 msgid "Configuration deleted."
@@ -3977,7 +3977,7 @@ msgstr "Повезано на сервер обавештења!"
 #: scripts/apps/publish/views/odbc-config.html:2
 #: scripts/apps/publish/views/odbc-config.html:4
 msgid "Connection string"
-msgstr ""
+msgstr "Стринг везе"
 
 #: ../superdesk-planning/client/planning-extension/src/authoring-react-fields/contact/index.tsx:23
 msgid "Contact"
@@ -4030,7 +4030,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:254
 msgid "Content API"
-msgstr ""
+msgstr "Content API"
 
 #: scripts/apps/content-api/controllers/ContentAPIController.ts:26
 #: scripts/apps/content-api/index.ts:21
@@ -4090,11 +4090,11 @@ msgstr ""
 #: scripts/apps/publish/views/publish-queue.html:107
 #: scripts/apps/workspace/content/views/profile-settings.html:98
 msgid "Content Type"
-msgstr ""
+msgstr "Тип садржаја"
 
 #: scripts/apps/publish/views/publish-queue.html:60
 msgid "Content Type:"
-msgstr ""
+msgstr "Тип садржаја:"
 
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:395
 #: scripts/core/lang/missing-translations-strings.ts:15
@@ -4169,7 +4169,7 @@ msgstr ""
 #: scripts/api/article-send.tsx:93
 #: scripts/apps/desks/views/desk-config-modal.html:421
 msgid "Continue"
-msgstr ""
+msgstr "Настави"
 
 #: scripts/apps/authoring/views/change-image.html:249
 msgid "Contrast"
@@ -4217,7 +4217,7 @@ msgstr ""
 #: scripts/extensions/ai-widget/src/summary/summary.tsx:62
 #: scripts/extensions/ai-widget/src/translations/translations-body.tsx:118
 msgid "Copy"
-msgstr ""
+msgstr "Копирај"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:89
 msgid "Copy assignment Id"
@@ -4620,7 +4620,7 @@ msgstr ""
 #: scripts/extensions/broadcasting/dist/src/page.js:170
 #: scripts/extensions/broadcasting/src/page.tsx:252
 msgid "Create new"
-msgstr ""
+msgstr "Креирај нови"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/page.js:183
 #: scripts/extensions/broadcasting/dist/src/page.js:187
@@ -4874,7 +4874,7 @@ msgstr ""
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:248
 #: scripts/apps/publish/views/subscribers.html:234
 msgid "Critical Errors"
-msgstr ""
+msgstr "Критичне грешке"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:68
 #: scripts/apps/authoring/views/change-image.html:205
@@ -5380,7 +5380,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/destination.html:22
 msgid "Delivery type"
-msgstr ""
+msgstr "Тип испоруке"
 
 #: scripts/apps/authoring-react/article-widgets/demo-widget.tsx:10
 msgid "Demo widget"
@@ -5643,7 +5643,7 @@ msgstr "Дескови"
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:250
 #: scripts/extensions/sams/src/components/sets/setEditorPanel.tsx:325
 msgid "Destination"
-msgstr ""
+msgstr "Дестинација"
 
 #: scripts/apps/internal-destinations/InternalDestinations.tsx:14
 msgid "Destination name"
@@ -5651,7 +5651,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:216
 msgid "Destinations"
-msgstr ""
+msgstr "Дестинације"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/FieldEditor.tsx:151
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:64
@@ -5710,7 +5710,7 @@ msgstr ""
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:72
 msgid "Digital/Internet"
-msgstr ""
+msgstr "Дигитално/Интернет"
 
 #: scripts/apps/archive/views/metadata-associateditem-view.html:45
 #: scripts/apps/archive/views/metadata-view.html:211
@@ -6428,7 +6428,7 @@ msgstr ""
 #: scripts/apps/publish/views/subscribers.html:50
 #: scripts/apps/publish/views/subscribers.html:68
 msgid "Edit Subscriber"
-msgstr ""
+msgstr "Уреди претплатника"
 
 #: scripts/apps/templates/views/templates.html:36
 msgid "Edit Template"
@@ -6691,7 +6691,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:96
 msgid "End Date"
-msgstr ""
+msgstr "Крајњи датум"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:23
 msgid "End Time (exclusive)"
@@ -6724,7 +6724,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/amazon-sqs-fifo-config.html:3
 msgid "Endpoint URL"
-msgstr ""
+msgstr "URL крајње тачке"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:133
 msgid "Ends"
@@ -6734,7 +6734,7 @@ msgstr ""
 msgid ""
 "Ensure correct preview endpoint is configured or contact endpoint "
 "maintainers."
-msgstr ""
+msgstr "Уверите се да је исправна крајња тачка прегледа подешена или контактирајте њене одржаваоце."
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:163
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:535
@@ -6782,7 +6782,7 @@ msgstr ""
 
 #: scripts/api/highlights.ts:44 scripts/api/highlights.ts:48
 msgid "Error creating highlight."
-msgstr ""
+msgstr "Грешка приликом креирања истицања."
 
 #: scripts/apps/search/controllers/get-multi-actions.tsx:339
 #: scripts/apps/search/controllers/get-multi-actions.tsx:381
@@ -6892,7 +6892,7 @@ msgstr ""
 #: scripts/apps/users/controllers/UserEnableCommand.ts:19
 #: scripts/apps/users/directives/UserRolesDirective.ts:66
 msgid "Error:"
-msgstr ""
+msgstr "Грешка:"
 
 #: scripts/apps/search-providers/directive.ts:62
 msgid "Error: A Search Provider with type  already exists."
@@ -6908,7 +6908,7 @@ msgstr ""
 
 #: scripts/apps/publish/controllers/PublishQueueController.ts:183
 msgid "Error: Failed to re-schedule"
-msgstr ""
+msgstr "Грешка: поновно заказивање није успело"
 
 #: scripts/apps/search-providers/directive.ts:66
 msgid "Error: Failed to save Search Provider."
@@ -6916,7 +6916,7 @@ msgstr ""
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:228
 msgid "Error: Failed to save Subscriber."
-msgstr ""
+msgstr "Грешка: чување претплатника није успело."
 
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:151
 msgid "Error: Failed to save content filter."
@@ -6950,11 +6950,11 @@ msgstr "Грешка: слаглајн је обавезан."
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:225
 msgid "Error: Subscriber must have at least one destination."
-msgstr ""
+msgstr "Грешка: претплатник мора имати барем једну дестинацију."
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:222
 msgid "Error: Subscriber with Name  already exists."
-msgstr ""
+msgstr "Грешка: претплатник са овим називом већ постоји."
 
 #: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:24
 msgid "Error: The dictionary already exists."
@@ -6971,7 +6971,7 @@ msgstr ""
 #: scripts/api/article.ts:422
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:100
 msgid "Error: Unique Name is not unique."
-msgstr ""
+msgstr "Грешка: јединствени назив није јединствен."
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:111
 msgid "Error: {{ message }}"
@@ -7294,7 +7294,7 @@ msgstr ""
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:6
 msgid "Exact"
-msgstr ""
+msgstr "Тачно"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:78
 msgid "Exclamation Sign"
@@ -7371,7 +7371,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:304
 msgid "Expire in:"
-msgstr ""
+msgstr "Истиче за:"
 
 #: ../superdesk-planning/client/components/fields/state.tsx:55
 #: ../superdesk-planning/client/utils/index.ts:430
@@ -7459,19 +7459,19 @@ msgstr ""
 
 #: scripts/apps/publish/views/ftp-config.html:27
 msgid "FTP File Extension"
-msgstr ""
+msgstr "FTP екстензија датотеке"
 
 #: scripts/apps/publish/views/ftp-config.html:22
 msgid "FTP Server Path"
-msgstr ""
+msgstr "Путања FTP сервера"
 
 #: scripts/apps/publish/views/ftp-config.html:39
 msgid "FTP Server Path for Associated media items"
-msgstr ""
+msgstr "Путања FTP сервера за повезане медијске ставке"
 
 #: scripts/apps/publish/views/ftp-config.html:4
 msgid "FTP Server URL"
-msgstr ""
+msgstr "URL FTP сервера"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:83
 #: scripts/apps/users/views/edit-form.html:295
@@ -7502,7 +7502,7 @@ msgstr ""
 
 #: scripts/apps/archive/related-item-widget/relatedItem.ts:188
 msgid "Failed to associate update: {{message}}"
-msgstr ""
+msgstr "Повезивање ажурирања није успело: {{message}}"
 
 #: ../superdesk-planning/client/actions/planning/ui.ts:307
 msgid "Failed to cancel all coverage!"
@@ -8046,7 +8046,7 @@ msgstr ""
 
 #: scripts/api/article-fetch.tsx:104
 msgid "Fetch valid({{count}})"
-msgstr ""
+msgstr "Преузми важеће ({{count}})"
 
 #: scripts/apps/search/components/fields/state.tsx:33
 msgid "Fetched"
@@ -8091,7 +8091,7 @@ msgstr ""
 #: scripts/apps/publish/views/file-config.html:9
 #: scripts/apps/publish/views/ftp-config.html:25
 msgid "File Extension"
-msgstr ""
+msgstr "Екстензија датотеке"
 
 #: scripts/apps/authoring/attachments/UploadAttachmentsModal.tsx:201
 msgid "File Name"
@@ -8352,7 +8352,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:218
 msgid "For Content API only subscriber destinations are not required."
-msgstr ""
+msgstr "Само за претплатнике типа Content API дестинације нису обавезне."
 
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:21
 msgid "For Publication"
@@ -8374,7 +8374,7 @@ msgstr "Заборавили лозинку?"
 #: scripts/apps/authoring/views/preview-formatted.html:18
 #: scripts/apps/publish/views/destination.html:9
 msgid "Format"
-msgstr ""
+msgstr "Формат"
 
 #: scripts/apps/archive/views/export.html:10
 #: scripts/apps/authoring-react/toolbar/export-modal.tsx:88
@@ -8495,7 +8495,7 @@ msgstr ""
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:191
 #: scripts/apps/legal-archive/views/legal_archive.html:52
 msgid "GUID"
-msgstr ""
+msgstr "GUID"
 
 #: scripts/apps/desks/views/desk-config-modal.html:10
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:70
@@ -8547,7 +8547,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:318
 msgid "Generate token"
-msgstr ""
+msgstr "Генериши токен"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/template-edit.js:188
 #: scripts/extensions/broadcasting/dist/src/rundown-templates/template-edit.js:191
@@ -8619,7 +8619,7 @@ msgstr ""
 #: scripts/apps/legal-archive/views/legal_archive.html:94
 #: scripts/apps/search/views/item-globalsearch.html:19
 msgid "Go"
-msgstr ""
+msgstr "Иди"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/ManageFiltersModal.tsx:268
 msgid "Go Back"
@@ -8855,7 +8855,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/email-config.html:11
 msgid "Hidden recipients (blind carbon copy)"
-msgstr ""
+msgstr "Скривени примаоци (Bcc)"
 
 #: ../superdesk-planning/client/components/fields/related_events.tsx:40
 msgid "Hide 1 event"
@@ -8897,7 +8897,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:209
 msgid "High priority"
-msgstr ""
+msgstr "Висок приоритет"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:35
 msgid "Highcharts {{licenseType}} License"
@@ -8957,7 +8957,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/ftp-config.html:2
 msgid "Host"
-msgstr ""
+msgstr "Хост"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleHour.tsx:41
 msgid "Hour"
@@ -9031,11 +9031,11 @@ msgstr ""
 
 #: scripts/apps/publish/views/email-config.html:26
 msgid "Identifier for the media in the email template"
-msgstr ""
+msgstr "Идентификатор медија у предлошку имејла"
 
 #: scripts/apps/publish/views/email-config.html:21
 msgid "Identifier for the media within the email html template"
-msgstr ""
+msgstr "Идентификатор медија унутар HTML предлошка имејла"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:53
 msgid "Identifiers have to be specified for all items."
@@ -9122,7 +9122,7 @@ msgstr ""
 
 #: scripts/api/article-fetch.tsx:111
 msgid "Image size validation failed"
-msgstr ""
+msgstr "Провера величине слике није успела"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/ImageTaggingComponent/ImageTaggingComponent.js:199
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:199
@@ -9194,11 +9194,11 @@ msgstr ""
 #: scripts/apps/users/controllers/UserListController.ts:158
 #: scripts/apps/workspace/content/views/profile-settings.html:62
 msgid "Inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #: scripts/apps/publish/views/email-config.html:17
 msgid "Include Feature Media"
-msgstr ""
+msgstr "Укључи истакнути медиј"
 
 #: ../superdesk-planning/client/components/fields/editor/IncludeKilled.tsx:15
 #: ../superdesk-planning/client/components/fields/preview/index.ts:91
@@ -9318,11 +9318,11 @@ msgstr ""
 #: scripts/apps/publish/views/publish-queue.html:110
 #: scripts/apps/workspace/content/constants.ts:32
 msgid "Ingest Provider"
-msgstr ""
+msgstr "Провајдер доласка"
 
 #: scripts/apps/publish/views/publish-queue.html:30
 msgid "Ingest Provider:"
-msgstr ""
+msgstr "Провајдер доласка:"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:596
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:151
@@ -9589,9 +9589,9 @@ msgstr "Профил садржаја ставке није подешен да 
 #: scripts/api/article-duplicate.tsx:42
 msgid "Item duplicated"
 msgid_plural "Items duplicated"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Ставка дуплирана"
+msgstr[1] "Ставке дуплиране"
+msgstr[2] "Ставке дуплиране"
 
 #: scripts/apps/archive/directives/ArchivedItemKill.ts:47
 msgid "Item has been killed."
@@ -9606,7 +9606,7 @@ msgstr ""
 msgid ""
 "Item has changed since it was opened. Please close and reopen the item to "
 "continue. Regrettably, your changes cannot be saved."
-msgstr ""
+msgstr "Ставка је измењена откад је отворена. Затворите и поново је отворите да бисте наставили. Нажалост, ваше измене не могу бити сачуване."
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/transmission-details.tsx:60
 msgid "Item has not been transmitted to any subscriber"
@@ -9617,7 +9617,7 @@ msgstr ""
 #: scripts/apps/legal-archive/views/legal_archive.html:127
 #: scripts/apps/search/views/item-preview.html:18
 msgid "Item history"
-msgstr ""
+msgstr "Историја ставке"
 
 #: scripts/apps/packaging/directives/PackageItemsEdit.ts:21
 msgid "Item is already in this package."
@@ -9664,7 +9664,7 @@ msgstr ""
 
 #: scripts/api/article.ts:380
 msgid "Item published."
-msgstr ""
+msgstr "Ставка објављена."
 
 #: scripts/apps/dashboard/workspace-tasks/tasks.ts:190
 #: scripts/apps/dashboard/workspace-tasks/tasks.ts:257
@@ -9746,7 +9746,7 @@ msgstr "Ставке које је корисник преместио у рад
 
 #: scripts/api/article-fetch.tsx:131
 msgid "Items that can not be fetched"
-msgstr ""
+msgstr "Ставке које не могу бити преузете"
 
 #: ../superdesk-analytics/client/email_report/directives/EmailReportModal.js:91
 #: ../superdesk-analytics/client/scheduled_reports/directives/ScheduledReportsList.js:101
@@ -9933,7 +9933,7 @@ msgstr ""
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:14
 msgid "Last Updated"
-msgstr ""
+msgstr "Последње ажурирано"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:22
 #: ../superdesk-analytics/client/search/views/preview-date-filter.html:14
@@ -9954,7 +9954,7 @@ msgstr ""
 #: scripts/apps/profiling/views/profiling.html:24
 #: scripts/apps/publish/views/publish-queue.html:78
 msgid "Last refreshed at"
-msgstr ""
+msgstr "Последње освежено у"
 
 #: scripts/apps/search/views/saved-search-subscribe.html:21
 msgid "Last report sent on:"
@@ -10022,7 +10022,7 @@ msgstr "Правно"
 
 #: scripts/apps/legal-archive/index.ts:37
 msgid "Legal Archive"
-msgstr ""
+msgstr "Правна архива"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:70
 msgid "License ID:"
@@ -10170,7 +10170,7 @@ msgstr ""
 
 #: scripts/apps/publish-preview/previewModal.tsx:45
 msgid "Loading preview"
-msgstr ""
+msgstr "Учитавање прегледа"
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditor.js:78
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditor.js:78
@@ -10596,11 +10596,11 @@ msgstr ""
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:7
 msgid "Match Any"
-msgstr ""
+msgstr "Поклапа било шта"
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:8
 msgid "Match Prefix"
-msgstr ""
+msgstr "Поклапа префикс"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:97
 msgid "Max"
@@ -10621,7 +10621,7 @@ msgstr ""
 #: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:28
 #: scripts/apps/publish/views/subscribers.html:193
 msgid "Maximum"
-msgstr ""
+msgstr "Максимум"
 
 #: scripts/apps/content-filters/views/manage-filters.html:44
 msgid "Maximum 80 characters."
@@ -10663,7 +10663,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:143
 msgid "Media Type"
-msgstr ""
+msgstr "Тип медија"
 
 #: scripts/apps/vocabularies/constants.ts:18
 msgid "Media gallery"
@@ -10688,11 +10688,11 @@ msgstr "Споји пасусе"
 #: scripts/apps/publish/views/publish-queue.html:116
 #: scripts/apps/system-messages/components/system-messages-settings.tsx:69
 msgid "Message"
-msgstr ""
+msgstr "Порука"
 
 #: scripts/apps/publish/views/amazon-sqs-fifo-config.html:82
 msgid "Message Group ID"
-msgstr ""
+msgstr "ИД групе порука"
 
 #: ../superdesk-planning/client/components/Locations/OpenStreetMapPreviewList.tsx:66
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:19
@@ -10733,12 +10733,12 @@ msgstr "Умањи"
 #: ../superdesk-analytics/client/production_time_report/views/production-time-report-parameters.html:20
 #: scripts/apps/publish/views/subscribers.html:184
 msgid "Minimum"
-msgstr ""
+msgstr "Минимум"
 
 #: scripts/api/article-fetch.tsx:122
 #: scripts/apps/archive/controllers/file-upload-error-modal.tsx:44
 msgid "Minimum allowed image size is {{minWidth}}x{{minHeight}}"
-msgstr ""
+msgstr "Минимална дозвољена величина слике је {{minWidth}}x{{minHeight}}"
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:213
 msgid "Minimum height and width should be greater than or equal to 200"
@@ -11107,7 +11107,7 @@ msgstr ""
 #: scripts/extensions/sams/src/components/workspaceSubnav.tsx:165
 #: scripts/extensions/sams/src/utils/ui.tsx:99
 msgid "Name"
-msgstr ""
+msgstr "Назив"
 
 #: scripts/apps/vocabularies/ManageVocabularyItemTranslations.tsx:28
 msgid "Name ({{language}})"
@@ -11135,7 +11135,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/email-config.html:30
 msgid "Name of the rendition to attach to the email"
-msgstr ""
+msgstr "Назив варијанте за прилагање имејлу"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:71
 msgid "Navy"
@@ -11160,11 +11160,11 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:278
 msgid "Never"
-msgstr ""
+msgstr "Никада"
 
 #: scripts/apps/publish/controllers/SubscriberTokenController.ts:28
 msgid "Never expire"
-msgstr ""
+msgstr "Никад не истиче"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:573
 msgid "New"
@@ -11300,7 +11300,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:57
 msgid "No Subscribers Found"
-msgstr ""
+msgstr "Нема пронађених претплатника"
 
 #: ../superdesk-planning/client/components/fields/editor/ContentTemplate.tsx:70
 #: ../superdesk-planning/client/components/fields/editor/ExportTemplate.tsx:38
@@ -11655,7 +11655,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:148
 msgid "Non-media"
-msgstr ""
+msgstr "Без медија"
 
 #: ../superdesk-planning/client/components/UI/Form/ColouredValueInput/ColouredValuePopup.tsx:129
 #: ../superdesk-planning/client/components/UI/Form/ColouredValueInput/index.tsx:146
@@ -11689,7 +11689,7 @@ msgstr ""
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:432
 msgid "Not Active"
-msgstr ""
+msgstr "Неактивно"
 
 #: scripts/apps/search/constants.ts:35
 msgid "Not Category"
@@ -12273,7 +12273,7 @@ msgstr ""
 #: scripts/apps/publish/views/file-config.html:2
 #: scripts/apps/publish/views/file-config.html:4
 msgid "Output file path"
-msgstr ""
+msgstr "Путања излазне датотеке"
 
 #: scripts/apps/monitoring/directives/AggregateSettings.ts:55
 msgid "Output/Published"
@@ -12369,7 +12369,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/http-push-config.html:2
 msgid "Package individual items"
-msgstr ""
+msgstr "Запакуј појединачне ставке"
 
 #: scripts/apps/authoring-react/data-layer.ts:212
 #: scripts/apps/authoring-react/field-adapters/package_items.ts:9
@@ -12411,7 +12411,7 @@ msgstr "Величина странице:"
 
 #: scripts/apps/legal-archive/views/legal_archive.html:24
 msgid "Pagination"
-msgstr ""
+msgstr "Страничење"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:140
 msgid "Paragraph"
@@ -12419,7 +12419,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:203
 msgid "Parallel publishing"
-msgstr ""
+msgstr "Паралелно објављивање"
 
 #: ../superdesk-analytics/client/content_publishing_report/views/content-publishing-report-panel.html:41
 #: ../superdesk-analytics/client/desk_activity_report/views/desk-activity-report-panel.html:41
@@ -12446,7 +12446,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/ftp-config.html:15
 msgid "Passive mode"
-msgstr ""
+msgstr "Пасивни режим"
 
 #: scripts/apps/ingest/views/settings/searchConfig.html:6
 #: scripts/apps/publish/views/ftp-config.html:11
@@ -12454,7 +12454,7 @@ msgstr ""
 #: scripts/apps/users/views/edit-form.html:17
 #: scripts/apps/users/views/edit-form.html:205
 msgid "Password"
-msgstr ""
+msgstr "Лозинка"
 
 #: scripts/core/directives/PasswordStrengthDirective.ts:75
 msgid "Password is too weak."
@@ -12483,7 +12483,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/ftp-config.html:21
 msgid "Path"
-msgstr ""
+msgstr "Путања"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:142
 msgid "Pause"
@@ -13046,7 +13046,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/destination.html:17
 msgid "Preview endpoint URL"
-msgstr ""
+msgstr "URL крајње тачке прегледа"
 
 #: scripts/apps/authoring/authoring/index.ts:472
 msgid "Preview formatted article, when previewFormats feature configured"
@@ -13109,7 +13109,7 @@ msgstr "Преглед штампе"
 #: scripts/apps/search/services/SearchService.ts:71
 #: scripts/apps/workspace/content/constants.ts:37
 msgid "Priority"
-msgstr ""
+msgstr "Приоритет"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:63
 msgid "Priority modified to"
@@ -13228,7 +13228,7 @@ msgstr ""
 #: scripts/apps/publish/views/subscribers.html:168
 #: scripts/apps/publish/views/subscribers.html:257
 msgid "Products"
-msgstr ""
+msgstr "Производи"
 
 #: scripts/apps/products/views/settings.html:4
 msgid "Products management"
@@ -13343,7 +13343,7 @@ msgstr ""
 
 #: scripts/apps/publish/index.ts:51
 msgid "Publish Queue"
-msgstr ""
+msgstr "Ред објављивања"
 
 #: scripts/apps/archive/views/metadata-view.html:137
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:416
@@ -13396,7 +13396,7 @@ msgstr ""
 
 #: scripts/apps/legal-archive/views/legal_archive.html:84
 msgid "Published From"
-msgstr ""
+msgstr "Објављено од"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:234
 msgid "Published Stories"
@@ -13412,7 +13412,7 @@ msgstr ""
 
 #: scripts/apps/legal-archive/views/legal_archive.html:88
 msgid "Published Until"
-msgstr ""
+msgstr "Објављено до"
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:180
 msgid "Published by"
@@ -13434,7 +13434,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/publish-queue.html:108
 msgid "Publishing Action"
-msgstr ""
+msgstr "Радња објављивања"
 
 #: ../superdesk-analytics/client/publishing_performance_report/widgets/index.js:47
 msgid "Publishing Actions"
@@ -13468,11 +13468,11 @@ msgstr ""
 
 #: scripts/apps/publish/views/ftp-config.html:30
 msgid "Push associated/feature media items"
-msgstr ""
+msgstr "Гурни повезане/истакнуте медијске ставке"
 
 #: scripts/apps/publish/views/ftp-config.html:34
 msgid "Push the original rendition"
-msgstr ""
+msgstr "Гурни оригиналну варијанту"
 
 #: scripts/apps/vocabularies/services/SchemaFactory.ts:7
 msgid "QCode"
@@ -13502,11 +13502,11 @@ msgstr ""
 
 #: scripts/apps/publish/views/amazon-sqs-fifo-config.html:67
 msgid "Queue Name"
-msgstr ""
+msgstr "Назив реда"
 
 #: scripts/apps/publish/views/publish-queue.html:112
 msgid "Queued at"
-msgstr ""
+msgstr "Стављено у ред у"
 
 #: scripts/apps/authoring-react/macros/macros.tsx:57
 msgid "Quick List"
@@ -13652,15 +13652,15 @@ msgstr ""
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:62
 #: scripts/apps/publish/views/email-config.html:2
 msgid "Recipients"
-msgstr ""
+msgstr "Примаоци"
 
 #: scripts/apps/publish/views/email-config.html:10
 msgid "Recipients (Bcc, hidden)"
-msgstr ""
+msgstr "Примаоци (Bcc, скривени)"
 
 #: scripts/apps/publish/views/email-config.html:4
 msgid "Recipients (visible to everybody)"
-msgstr ""
+msgstr "Примаоци (видљиви свима)"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:161
 msgid "Recurring"
@@ -13747,7 +13747,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/amazon-sqs-fifo-config.html:18
 msgid "Region"
-msgstr ""
+msgstr "Регион"
 
 #: ../superdesk-planning/client/components/fields/resources/events.ts:75
 msgid "Registration"
@@ -13779,7 +13779,7 @@ msgstr ""
 
 #: scripts/apps/archive/related-item-widget/relatedItem.ts:114
 msgid "Relate an item"
-msgstr ""
+msgstr "Повежи ставку"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedArticles/EditorFieldEventRelatedItems.tsx:54
 #: ../superdesk-planning/client/components/fields/preview/RelatedArticles.tsx:34
@@ -13796,7 +13796,7 @@ msgstr ""
 #: scripts/apps/archive/related-item-widget/relatedItem.ts:13
 #: scripts/apps/workspace/content/constants.ts:39
 msgid "Related Items"
-msgstr ""
+msgstr "Повезане ставке"
 
 #: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:134
 msgid "Related Planning Items"
@@ -13818,13 +13818,13 @@ msgstr ""
 
 #: scripts/apps/relations/directives/RelatedItemsDirective.ts:237
 msgid "Related item is not available."
-msgstr ""
+msgstr "Повезана ставка није доступна."
 
 #: scripts/apps/relations/directives/RelatedItemsDirective.ts:160
 msgid ""
 "Related item was not added, because the field reached the limit of related "
 "items allowed."
-msgstr ""
+msgstr "Повезана ставка није додата јер је поље достигло ограничење дозвољених повезаних ставки."
 
 #: scripts/apps/vocabularies/constants.ts:22
 msgid "Related items"
@@ -14082,7 +14082,7 @@ msgstr "Преименуј радни простор"
 
 #: scripts/apps/publish/views/email-config.html:29
 msgid "Rendition"
-msgstr ""
+msgstr "Варијанта"
 
 #: ../superdesk-analytics/client/views/renditions-preview.html:11
 msgid "Renditions"
@@ -14250,7 +14250,7 @@ msgstr ""
 #: scripts/apps/publish/views/publish-queue.html:147
 #: scripts/apps/publish/views/publish-queue.html:90
 msgid "Resend"
-msgstr ""
+msgstr "Пошаљи поново"
 
 #: scripts/apps/archive/views/resend-configuration.html:4
 msgid "Resend To"
@@ -14310,7 +14310,7 @@ msgstr ""
 #: scripts/apps/publish/views/http-push-config.html:5
 #: scripts/apps/publish/views/http-push-config.html:6
 msgid "Resource URL"
-msgstr ""
+msgstr "URL ресурса"
 
 #: scripts/core/lang/missing-translations-strings.ts:20
 msgid "Restore"
@@ -14335,7 +14335,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:283
 msgid "Revoke"
-msgstr ""
+msgstr "Опозови"
 
 #: ../superdesk-analytics/client/utils.js:158
 msgid "Rewrite"
@@ -14990,7 +14990,7 @@ msgstr ""
 #: scripts/apps/publish/views/publish-queue.html:113
 #: scripts/apps/templates/views/template-editor-modal.html:156
 msgid "Scheduled at"
-msgstr ""
+msgstr "Заказано за"
 
 #: scripts/apps/authoring/versioning/history/HistoryController.ts:180
 msgid "Scheduled by"
@@ -15002,7 +15002,7 @@ msgstr ""
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:426
 msgid "Scheduled from {{start}} to {{end}}"
-msgstr ""
+msgstr "Заказано од {{start}} до {{end}}"
 
 #: ../superdesk-planning/client/validators/planning.ts:320
 msgid "Scheduled updates have to be after the previous updates."
@@ -15238,11 +15238,11 @@ msgstr "Секунде"
 
 #: scripts/apps/publish/views/amazon-sqs-fifo-config.html:50
 msgid "Secret Access Key"
-msgstr ""
+msgstr "Тајни приступни кључ"
 
 #: scripts/apps/publish/views/http-push-config.html:13
 msgid "Secret Token"
-msgstr ""
+msgstr "Тајни токен"
 
 #: scripts/core/auth/secure-login.html:18
 msgid "Secure Log In"
@@ -15252,7 +15252,7 @@ msgstr "Безбедна пријава"
 #: scripts/apps/publish/views/subscribers.html:10
 #: scripts/core/views/sdSearchList.html:3
 msgid "Select"
-msgstr ""
+msgstr "Изабери"
 
 #: ../superdesk-planning/client/components/Main/FilterSubnavDropdown.tsx:277
 msgid "Select Agenda"
@@ -15413,7 +15413,7 @@ msgstr "Изабери следећу ставку у фокусираној ф�
 
 #: scripts/apps/publish-preview/previewModal.tsx:87
 msgid "Select preview target"
-msgstr ""
+msgstr "Изабери циљ прегледа"
 
 #: scripts/apps/monitoring/index.ts:119
 msgid "Select previous item on focused stage or group"
@@ -15592,7 +15592,7 @@ msgstr ""
 
 #: scripts/api/article-send.tsx:257
 msgid "Sent successfully"
-msgstr ""
+msgstr "Успешно послато"
 
 #: scripts/apps/authoring/versioning/history/views/publish_queue.html:16
 msgid "Sent/Queued as"
@@ -15604,11 +15604,11 @@ msgstr ""
 
 #: scripts/apps/publish/views/publish-queue.html:104
 msgid "Sequence No"
-msgstr ""
+msgstr "Редни број"
 
 #: scripts/apps/publish/views/subscribers.html:181
 msgid "Sequence Number Settings"
-msgstr ""
+msgstr "Подешавања редног броја"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateEventRepetitionsForm.tsx:111
 msgid "Series Start Date"
@@ -15652,7 +15652,7 @@ msgstr ""
 #: scripts/apps/publish/views/ftp-config.html:12
 #: scripts/apps/publish/views/http-push-config.html:14
 msgid "Set and hidden thereafter"
-msgstr ""
+msgstr "Постављено и потом скривено"
 
 #: scripts/apps/users/views/settings-roles.html:50
 msgid "Set as default"
@@ -16046,11 +16046,11 @@ msgstr ""
 #: scripts/apps/search/views/search-parameters.html:6
 #: scripts/apps/workspace/content/constants.ts:41
 msgid "Slugline"
-msgstr ""
+msgstr "Слаглајн"
 
 #: scripts/apps/archive/related-item-widget/relatedItem-configuration.html:4
 msgid "Slugline Match"
-msgstr ""
+msgstr "Поклапање слаглајна"
 
 #: ../superdesk-analytics/client/user_activity_report/views/user-activity-report-tooltip.html:2
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:85
@@ -16086,7 +16086,7 @@ msgstr ""
 #: scripts/api/article-send.tsx:135
 msgid ""
 "Some packages contain the following published items that can not be sent:"
-msgstr ""
+msgstr "Неки пакети садрже следеће објављене ставке које не могу бити послате:"
 
 #: ../superdesk-planning/client/actions/main.ts:477
 msgid "Some related planning item post validation failed"
@@ -16195,7 +16195,7 @@ msgstr ""
 
 #: scripts/apps/legal-archive/views/legal_archive.html:29
 msgid "Sorting"
-msgstr ""
+msgstr "Сортирање"
 
 #: scripts/apps/monitoring/views/monitoring-group-header.html:28
 msgid "Sorting:"
@@ -16381,7 +16381,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:87
 msgid "Start Date"
-msgstr ""
+msgstr "Почетни датум"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:18
 msgid "Start Time (inclusive)"
@@ -16466,14 +16466,14 @@ msgstr ""
 #: scripts/extensions/broadcasting/dist/src/rundown-items/content-profile.js:124
 #: scripts/extensions/broadcasting/src/rundown-items/content-profile.tsx:158
 msgid "Status"
-msgstr ""
+msgstr "Статус"
 
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx:233
 #: scripts/apps/contacts/views/list.html:38
 #: scripts/apps/publish/views/publish-queue.html:46
 #: scripts/apps/publish/views/subscribers.html:15
 msgid "Status:"
-msgstr ""
+msgstr "Статус:"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:112
 msgid "Status: Unassigned"
@@ -16528,7 +16528,7 @@ msgstr ""
 #: scripts/apps/publish/views/odbc-config.html:11
 #: scripts/apps/publish/views/odbc-config.html:9
 msgid "Stored Procedure"
-msgstr ""
+msgstr "Складиштена процедура"
 
 #: scripts/apps/products/views/product-test.html:9
 msgid "Story GUID"
@@ -16537,11 +16537,11 @@ msgstr ""
 #: scripts/apps/legal-archive/views/legal_archive.html:78
 #: scripts/apps/search/views/search-parameters.html:31
 msgid "Story Text"
-msgstr ""
+msgstr "Текст приче"
 
 #: scripts/apps/archive/related-item-widget/relatedItem.ts:183
 msgid "Story is associated as update."
-msgstr ""
+msgstr "Прича је повезана као ажурирање."
 
 #: ../superdesk-planning/client/reducers/featuredPlanning.ts:177
 msgid "Story with slugline \"{{ slugline }}\" is added to the list"
@@ -16668,33 +16668,33 @@ msgstr ""
 #: scripts/apps/search/constants.ts:20
 #: scripts/apps/search/views/search-parameters.html:181
 msgid "Subscriber"
-msgstr ""
+msgstr "Претплатник"
 
 #: scripts/apps/publish/views/subscribers.html:84
 msgid "Subscriber Schedule Settings"
-msgstr ""
+msgstr "Подешавања распореда претплатника"
 
 #: scripts/apps/publish/views/subscribers.html:156
 msgid "Subscriber codes"
-msgstr ""
+msgstr "Кодови претплатника"
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:284
 msgid "Subscriber could not be initialized!"
-msgstr ""
+msgstr "Претплатник није могао бити иницијализован!"
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:213
 msgid "Subscriber saved."
-msgstr ""
+msgstr "Претплатник сачуван."
 
 #: scripts/apps/publish/views/publish-queue.html:14
 msgid "Subscriber:"
-msgstr ""
+msgstr "Претплатник:"
 
 #: scripts/apps/content-filters/views/filter-search-result.html:42
 #: scripts/apps/products/views/products-config-modal.html:16
 #: scripts/apps/publish/index.ts:41 scripts/apps/publish/views/settings.html:4
 msgid "Subscribers"
-msgstr ""
+msgstr "Претплатници"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:182
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:39
@@ -16999,11 +16999,11 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:130
 msgid "Target Type"
-msgstr ""
+msgstr "Циљни тип"
 
 #: scripts/apps/publish/views/subscribers.html:5
 msgid "Target Type:"
-msgstr ""
+msgstr "Циљни тип:"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:67
 msgid "Target Types"
@@ -17023,7 +17023,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:163
 msgid "Targetable by users"
-msgstr ""
+msgstr "Може се циљати од стране корисника"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:188
 #: scripts/apps/dashboard/workspace-tasks/tasks.ts:405
@@ -17300,7 +17300,7 @@ msgstr ""
 #: scripts/apps/authoring/authoring/directives/ItemCarouselDirective.ts:246
 #: scripts/apps/relations/directives/RelatedItemsDirective.ts:141
 msgid "The following status is not allowed in this field: {{status}}"
-msgstr ""
+msgstr "Следећи статус није дозвољен у овом пољу: {{status}}"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:121
 msgid "The helper text must not exceed 120 characters."
@@ -17352,7 +17352,7 @@ msgstr ""
 msgid ""
 "The package \"{{name}}\" contains the following published items that can not "
 "be sent:"
-msgstr ""
+msgstr "Пакет \"{{name}}\" садржи следеће објављене ставке које не могу бити послате:"
 
 #: scripts/apps/authoring-react/authoring-swtich.tsx:19
 msgid "The page needs to be reloaded in order to do that."
@@ -17369,7 +17369,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/email-config.html:35
 msgid "The rendition to attach to the email"
-msgstr ""
+msgstr "Варијанта за прилагање имејлу"
 
 #: scripts/core/editor3/components/comments/CommentPopup.tsx:155
 msgid "The reply will be deleted. Are you sure?"
@@ -17389,19 +17389,19 @@ msgstr ""
 msgid ""
 "The subscriber is currently inactive, but the schedule from {{start}} to "
 "{{end}} is valid. The subscriber will be activated on save."
-msgstr ""
+msgstr "Претплатник је тренутно неактиван, али распоред од {{start}} до {{end}} је важећи. Претплатник ће бити активиран приликом чувања."
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:383
 msgid ""
 "The subscriber is set to start on {{date}}, but the Active switch will "
 "override this and activate the subscriber on save."
-msgstr ""
+msgstr "Претплатник је подешен да почне {{date}}, али ће га прекидач Активно заменити и активирати приликом чувања."
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:391
 msgid ""
 "The subscriber schedule ended on {{date}}, but the Active switch will keep "
 "the subscriber active on save."
-msgstr ""
+msgstr "Распоред претплатника је завршен {{date}}, али ће га прекидач Активно одржати активним приликом чувања."
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:39
 msgid ""
@@ -17459,7 +17459,7 @@ msgstr ""
 
 #: scripts/api/highlights.ts:37
 msgid "There are items locked or not published. Do you want to continue?"
-msgstr ""
+msgstr "Постоје ставке које су закључане или нису објављене. Желите ли да наставите?"
 
 #: ../superdesk-planning/client/components/ItemActionsMenu/ActionsMenuPopup.tsx:91
 msgid "There are no actions available."
@@ -17582,7 +17582,7 @@ msgstr ""
 
 #: scripts/apps/archive/related-item-widget/relatedItem.ts:194
 msgid "There is an error. Failed to associate update."
-msgstr ""
+msgstr "Дошло је до грешке. Повезивање ажурирања није успело."
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/rundown-view-edit.js:40
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/utils/handle-unsaved-rundown-changes.js:18
@@ -17599,7 +17599,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:296
 msgid "There is no token for subscriber."
-msgstr ""
+msgstr "Нема токена за претплатника."
 
 #: scripts/apps/highlights/controllers/HighlightsConfig.ts:60
 msgid "There was a problem while saving highlights configuration"
@@ -17849,7 +17849,7 @@ msgstr ""
 
 #: scripts/apps/relations/directives/RelatedItemsDirective.ts:154
 msgid "This item is already added as related."
-msgstr ""
+msgstr "Ова ставка је већ додата као повезана."
 
 #: scripts/apps/authoring/authoring/controllers/AssociationController.ts:211
 msgid "This item is already added."
@@ -17965,7 +17965,7 @@ msgstr ""
 #: scripts/apps/archive/views/related-items-preview.html:12
 #: scripts/apps/relations/views/related-items.html:30
 msgid "Thumbnail for related item"
-msgstr ""
+msgstr "Минијатура за повезану ставку"
 
 #: ../superdesk-planning/client/utils/events.tsx:1457
 #: scripts/core/datetime/datetime.ts:293
@@ -18277,7 +18277,7 @@ msgstr "Укључи/искључи подвучено"
 
 #: scripts/apps/publish/views/subscribers.html:311
 msgid "Token expiry"
-msgstr ""
+msgstr "Истек токена"
 
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:103
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DateInputPopup.tsx:213
@@ -18381,7 +18381,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/publish-queue.html:114
 msgid "Transmitted at"
-msgstr ""
+msgstr "Пренето у"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:197
 msgid "Trash"
@@ -18567,7 +18567,7 @@ msgstr "Опозови"
 #: scripts/apps/search/constants.ts:10
 #: scripts/apps/search/views/search-parameters.html:42
 msgid "Unique Name"
-msgstr ""
+msgstr "Јединствени назив"
 
 #: scripts/apps/search/views/item-globalsearch.html:11
 msgid "Unique Name/ID/GUID"
@@ -18617,7 +18617,7 @@ msgstr ""
 
 #: scripts/api/article-send.tsx:248
 msgid "Unknown error occurred"
-msgstr ""
+msgstr "Дошло је до непознате грешке"
 
 #: ../superdesk-analytics/client/utils.js:161
 msgid "Unlink"
@@ -19089,7 +19089,7 @@ msgstr ""
 #: scripts/apps/search/tests/search.spec.ts:249
 #: scripts/apps/workspace/content/constants.ts:48
 msgid "Urgency"
-msgstr ""
+msgstr "Хитност"
 
 #: scripts/apps/ingest/ingest-stats-widget/configuration.html:10
 msgid "Urgency stats"
@@ -19135,7 +19135,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/ftp-config.html:18
 msgid "Use Transport Layer Security (FTPS)"
-msgstr ""
+msgstr "Користи безбедност транспортног слоја (FTPS)"
 
 #: scripts/apps/users/controllers/ChangeAvatarController.ts:8
 msgid "Use a Web URL"
@@ -19155,7 +19155,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:210
 msgid "Use priority queue for transmission."
-msgstr ""
+msgstr "Користи ред приоритета за пренос."
 
 #: scripts/apps/content-filters/views/manage-filters.html:135
 msgid "Use the article GUID for testing."
@@ -19248,7 +19248,7 @@ msgstr ""
 #: scripts/apps/search-providers/views/search-provider-config.html:109
 #: scripts/apps/users/views/list.html:34
 msgid "Username"
-msgstr ""
+msgstr "Корисничко име"
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:115
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:413
@@ -19604,7 +19604,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:204
 msgid "When enabled it can send multiple items at the same time."
-msgstr ""
+msgstr "Када је омогућено, може слати више ставки истовремено."
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:55
 msgid "White"
@@ -19637,7 +19637,7 @@ msgstr ""
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:73
 msgid "Wire/Paper"
-msgstr ""
+msgstr "Агенција/Штампа"
 
 #: ../superdesk-planning/client/components/fields/editor/NoCoverage.tsx:15
 msgid "Without Coverage"
@@ -19824,7 +19824,7 @@ msgstr ""
 
 #: scripts/api/highlights.ts:53 scripts/apps/search/MultiImageEdit.ts:173
 msgid "You have unsaved changes, do you want to continue?"
-msgstr ""
+msgstr "Имате несачуване измене, желите ли да наставите?"
 
 #: scripts/apps/desks/controllers/DeskConfigController.ts:93
 msgid "You have unsaved changes. Do you want to save them now?"
@@ -20345,7 +20345,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/ftp-config.html:26
 msgid "example"
-msgstr ""
+msgstr "пример"
 
 #: scripts/apps/archive/views/item-preview.html:19
 #: scripts/apps/archive/views/preview.html:116
@@ -20356,7 +20356,7 @@ msgstr ""
 
 #: scripts/apps/publish/views/subscribers.html:276
 msgid "expires:"
-msgstr ""
+msgstr "истиче:"
 
 #: scripts/apps/contacts/constants.ts:51
 msgid "facebook"
@@ -20397,7 +20397,7 @@ msgstr ""
 
 #: scripts/api/article-fetch.tsx:135
 msgid "file name"
-msgstr ""
+msgstr "назив датотеке"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:230
 msgid "first"
@@ -20519,7 +20519,7 @@ msgstr ""
 
 #: scripts/api/article-fetch.tsx:137
 msgid "height"
-msgstr ""
+msgstr "висина"
 
 #: scripts/core/views/sdSlider.html:3
 msgid "high"
@@ -20661,7 +20661,7 @@ msgstr ""
 
 #: scripts/apps/archive/related-item-widget/relatedItem.ts:166
 msgid "item metadata associated."
-msgstr ""
+msgstr "метаподаци ставке повезани."
 
 #: scripts/apps/master-desk/components/OverviewComponent.tsx:235
 msgid "items in production"
@@ -20721,7 +20721,7 @@ msgstr ""
 #: scripts/apps/legal-archive/views/legal_archive.html:107
 #: scripts/apps/search/views/search-results.html:6
 msgid "loading"
-msgstr ""
+msgstr "учитавање"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/ImageTaggingComponent/ImageTaggingComponent.js:197
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/ImageTaggingComponent/ImageTaggingComponent.js:197
@@ -20844,7 +20844,7 @@ msgstr ""
 #: scripts/apps/publish/views/publish-queue.html:64
 #: scripts/apps/users/views/user-preferences.html:153
 msgid "none"
-msgstr ""
+msgstr "ништа"
 
 #: scripts/core/interactive-article-actions-panel/subcomponents/controlled-vocabulary-select.tsx:95
 msgid "not"
@@ -21015,7 +21015,7 @@ msgstr "претходно"
 
 #: scripts/apps/publish-preview/previewModal.tsx:122
 msgid "preview"
-msgstr ""
+msgstr "преглед"
 
 #: scripts/core/lang/missing-translations-strings.ts:25
 msgid "production"
@@ -21271,11 +21271,11 @@ msgstr ""
 
 #: scripts/apps/legal-archive/views/legal_archive.html:16
 msgid "switch to grid view"
-msgstr ""
+msgstr "пређи на приказ мреже"
 
 #: scripts/apps/legal-archive/views/legal_archive.html:17
 msgid "switch to list view"
-msgstr ""
+msgstr "пређи на приказ листе"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:95
 msgid "tab"
@@ -21499,7 +21499,7 @@ msgstr ""
 
 #: scripts/api/article-fetch.tsx:136
 msgid "width"
-msgstr ""
+msgstr "ширина"
 
 #: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:110
 #: scripts/core/editor3/components/suggestions/SuggestionPopup.tsx:95
@@ -21727,9 +21727,9 @@ msgstr ""
 #: scripts/apps/publish/views/publish-queue.html:84
 msgid "{{multiSelectCount}} Item selected"
 msgid_plural "{{multiSelectCount}} Items selected"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "{{multiSelectCount}} ставка изабрана"
+msgstr[1] "{{multiSelectCount}} ставке изабране"
+msgstr[2] "{{multiSelectCount}} ставки изабрано"
 
 #: scripts/apps/authoring/authoring/directives/WordCount.html:1
 msgid "{{numWords}} words"
@@ -21738,9 +21738,9 @@ msgstr ""
 #: scripts/api/article-fetch.tsx:117
 msgid "{{n}} images can not be fetched because they are too small."
 msgid_plural "One image can not be fetched because it is too small."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Једна слика не може бити преузета јер је премала."
+msgstr[1] "{{n}} слике не могу бити преузете јер су премале."
+msgstr[2] "{{n}} слика не може бити преузето јер су премале."
 
 #: scripts/apps/authoring-react/fields/media/difference.tsx:41
 msgid "{{n}} items added"

--- a/po/sr.po
+++ b/po/sr.po
@@ -29,7 +29,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:240
 msgid "\"{{x}}\" field is required"
-msgstr ""
+msgstr "Поље \"{{x}}\" је обавезно"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/UnlockFeaturedPlanning.tsx:74
 msgid ""
@@ -344,7 +344,7 @@ msgstr "2 године"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:105
 msgid "200 minimum"
-msgstr ""
+msgstr "200 минимум"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduleMonthDay.tsx:54
 #: ../superdesk-planning/client/utils/filters.ts:101
@@ -574,7 +574,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:216
 msgid "A content profile with this name already exists."
-msgstr ""
+msgstr "Профил садржаја са овим називом већ постоји."
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:274
 msgid "A desk is required"
@@ -608,7 +608,7 @@ msgstr "САЖЕТАК је предугачак"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:66
 msgid "ADD WORD"
-msgstr ""
+msgstr "ДОДАЈ РЕЧ"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:35
 msgid "AMP"
@@ -625,7 +625,7 @@ msgstr "И"
 #: scripts/apps/content-filters/views/production-test-view.html:23
 #: scripts/apps/search/services/SearchService.ts:69
 msgid "ANPA Category"
-msgstr ""
+msgstr "ANPA категорија"
 
 #: ../superdesk-planning/client/components/fields/list/Categories.tsx:19
 msgid "ANPA Category:"
@@ -650,15 +650,15 @@ msgstr ""
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:107
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:88
 msgid "Abbreviation"
-msgstr ""
+msgstr "Скраћеница"
 
 #: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:157
 msgid "Abbreviation already exists. Do you want to overwrite it?"
-msgstr ""
+msgstr "Скраћеница већ постоји. Желите ли да је замените?"
 
 #: scripts/apps/dictionaries/views/settings.html:33
 msgid "Abbreviations Dictionary"
-msgstr ""
+msgstr "Речник скраћеница"
 
 #: scripts/core/menu/views/menu.html:115
 msgid "About Superdesk"
@@ -787,7 +787,7 @@ msgstr "Активно"
 
 #: scripts/apps/workspace/content/views/profile-settings.html:22
 msgid "Active only"
-msgstr ""
+msgstr "Само активно"
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:424
 msgid "Active until {{end}}"
@@ -841,7 +841,7 @@ msgstr[2] ""
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:96
 msgid "Add Abbreviation"
-msgstr ""
+msgstr "Додај скраћеницу"
 
 #: ../superdesk-planning/client/constants/planning.ts:140
 msgid "Add As Event"
@@ -877,7 +877,7 @@ msgstr ""
 
 #: scripts/apps/content-filters/views/manage-filters.html:116
 msgid "Add Filter Statement"
-msgstr ""
+msgstr "Додај критеријум филтера"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:28
 msgid "Add Gallery"
@@ -893,7 +893,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:436
 msgid "Add Item"
-msgstr ""
+msgstr "Додај ставку"
 
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:7
 #: scripts/apps/content-filters/views/manage-filters.html:6
@@ -923,15 +923,15 @@ msgstr "Додај нови"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:4
 msgid "Add New Abbreviations Dictionary"
-msgstr ""
+msgstr "Додај нови речник скраћеница"
 
 #: scripts/apps/content-filters/views/manage-filters.html:33
 msgid "Add New Content Filter"
-msgstr ""
+msgstr "Додај нови филтер садржаја"
 
 #: scripts/apps/workspace/content/views/profile-settings.html:79
 msgid "Add New Content Profile"
-msgstr ""
+msgstr "Додај нови профил садржаја"
 
 #: scripts/apps/desks/views/desk-config-modal.html:4
 msgid "Add New Desk"
@@ -943,7 +943,7 @@ msgstr "Додај нову дестинацију"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:5
 msgid "Add New Dictionary"
-msgstr ""
+msgstr "Додај нови речник"
 
 #: ../superdesk-planning/client/components/GeoLookupInput/CreateNewGeoLookup.tsx:129
 msgid "Add New Event Location"
@@ -955,11 +955,11 @@ msgstr ""
 
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:43
 msgid "Add New Filter Condition"
-msgstr ""
+msgstr "Додај нови услов филтера"
 
 #: scripts/apps/products/views/products-config-modal.html:3
 msgid "Add New Product"
-msgstr ""
+msgstr "Додај нови производ"
 
 #: scripts/apps/ingest/views/settings/ingest-rules-content.html:31
 msgid "Add New Rule Set"
@@ -984,7 +984,7 @@ msgstr "Додај новог претплатника"
 
 #: scripts/apps/templates/views/template-editor-modal.html:4
 msgid "Add New Template"
-msgstr ""
+msgstr "Додај нови шаблон"
 
 #: ../superdesk-planning/client/components/Editor/bookmarks/AddPlanningBookmark.tsx:30
 msgid "Add Planning Item"
@@ -1132,7 +1132,7 @@ msgstr "Додај нови"
 
 #: scripts/apps/workspace/content/components/new-field-select.tsx:34
 msgid "Add new field"
-msgstr ""
+msgstr "Додај ново поље"
 
 #: scripts/apps/dashboard/views/workspace.html:69
 msgid "Add new widget"
@@ -1601,7 +1601,7 @@ msgstr "Сви типови корисника"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:267
 msgid "Allow Multiple Items"
-msgstr ""
+msgstr "Дозволи више ставки"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:189
 msgid "Allow Remove Ingested Items"
@@ -1621,7 +1621,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:362
 msgid "Allow field to be toggled"
-msgstr ""
+msgstr "Дозволи укључивање/искључивање поља"
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:38
 msgid "Allow picture"
@@ -1656,7 +1656,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/constants.ts:9
 msgid "Alt text"
-msgstr ""
+msgstr "Алтернативни текст"
 
 #: scripts/apps/authoring-react/fields/media/media-metadata.tsx:15
 #: scripts/apps/authoring/media/MediaMetadataView.tsx:30
@@ -1886,7 +1886,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/components/UploadConfigModal.tsx:80
 msgid "Apply config"
-msgstr ""
+msgstr "Примени конфигурацију"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:244
 msgid "Apply the changes to all recurring planning items or just this one?"
@@ -1904,7 +1904,7 @@ msgstr "Архива"
 
 #: scripts/apps/workspace/content/constants.ts:11
 msgid "Archive description"
-msgstr ""
+msgstr "Опис архиве"
 
 #: scripts/apps/search/views/item-repo.html:6
 msgid "Archived"
@@ -1912,7 +1912,7 @@ msgstr ""
 
 #: scripts/apps/content-filters/views/manage-filters.html:54
 msgid "Archived Block"
-msgstr ""
+msgstr "Архивирани блок"
 
 #: scripts/core/lang/missing-translations-strings.ts:15
 msgid "Archived Management"
@@ -1951,7 +1951,7 @@ msgstr ""
 
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:84
 msgid "Are you sure you want to delete content filter?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете филтер садржаја?"
 
 #: scripts/apps/workspace/services/WorkspaceService.ts:19
 msgid "Are you sure you want to delete current workspace?"
@@ -1959,7 +1959,7 @@ msgstr "Да ли сте сигурни да желите да обришете 
 
 #: scripts/apps/content-filters/controllers/FilterConditionsController.ts:120
 msgid "Are you sure you want to delete filter condition?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете услов филтера?"
 
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundown-templates/manage-rundown-templates.js:47
 #: scripts/extensions/broadcasting/dist/src/extensions/broadcasting/src/rundowns/manage-rundown-items.js:61
@@ -1975,7 +1975,7 @@ msgstr ""
 
 #: scripts/apps/products/controllers/ProductsConfigController.ts:201
 msgid "Are you sure you want to delete product?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете производ?"
 
 #: scripts/apps/ingest/directives/IngestRulesContent.ts:61
 msgid "Are you sure you want to delete rule set?"
@@ -2007,7 +2007,7 @@ msgstr ""
 
 #: scripts/apps/templates/directives/TemplatesDirective.ts:363
 msgid "Are you sure you want to delete the template?"
-msgstr ""
+msgstr "Да ли сте сигурни да желите да обришете шаблон?"
 
 #: scripts/extensions/sams/dist/src/extensions/sams/src/store/assets/actions.js:331
 #: scripts/extensions/sams/dist/src/store/assets/actions.js:331
@@ -2541,7 +2541,7 @@ msgstr ""
 #: scripts/apps/authoring/views/article-edit.html:729
 #: scripts/apps/workspace/content/constants.ts:12
 msgid "Attachments"
-msgstr ""
+msgstr "Прилози"
 
 #: scripts/apps/authoring-react/fields/attachments/index.tsx:41
 msgid "Attachments (authoring-react)"
@@ -2556,7 +2556,7 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/utils/assets.js:113
 #: scripts/extensions/sams/src/utils/assets.ts:146
 msgid "Audio"
-msgstr ""
+msgstr "Аудио"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetTypeFilterButtons.js:75
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetTypeFilterButtons.js:75
@@ -2623,7 +2623,7 @@ msgstr "Дескови за уређивање служе за креирање 
 #: scripts/apps/search/components/fields/authors.tsx:113
 #: scripts/apps/workspace/content/constants.ts:13
 msgid "Authors"
-msgstr ""
+msgstr "Аутори"
 
 #: scripts/apps/users/views/list.html:15
 msgid "Authors only"
@@ -2631,11 +2631,11 @@ msgstr "Само аутори"
 
 #: scripts/apps/templates/views/templates.html:61
 msgid "Automated item creation"
-msgstr ""
+msgstr "Аутоматско креирање ставке"
 
 #: scripts/apps/templates/views/template-editor-modal.html:144
 msgid "Automatically create item"
-msgstr ""
+msgstr "Аутоматски креирај ставку"
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:39
 msgid "Automatically insert items from"
@@ -2691,7 +2691,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:209
 msgid "Available in user/desk preferences"
-msgstr ""
+msgstr "Доступно у поставкама корисника/деска"
 
 #: scripts/apps/authoring-react/toolbar/translate-modal.tsx:108
 msgid "Available languages"
@@ -2798,11 +2798,11 @@ msgstr ""
 
 #: scripts/apps/content-filters/views/manage-filters.html:58
 msgid "Block API"
-msgstr ""
+msgstr "Блокирај API"
 
 #: scripts/apps/products/views/products-config-modal.html:71
 msgid "Blocking"
-msgstr ""
+msgstr "Блокирање"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:56
 msgid "Blue"
@@ -2825,7 +2825,7 @@ msgstr "Тело HTML"
 #: scripts/apps/authoring-react/field-adapters/body_footer.ts:37
 #: scripts/apps/workspace/content/constants.ts:14
 msgid "Body footer"
-msgstr ""
+msgstr "Подножје тела"
 
 #: scripts/apps/authoring-react/field-adapters/body_footer.ts:36
 msgid "Body footer / Helplines / Contact Information"
@@ -3013,7 +3013,7 @@ msgstr "Може се повезати као ажурирање"
 
 #: scripts/apps/workspace/content/views/profile-settings.html:172
 msgid "Can be embedded"
-msgstr ""
+msgstr "Може бити уграђено"
 
 #: scripts/core/editor3/components/article-embed/can-add-article-embed.ts:35
 msgid "Can not embed to item which itself can be embedded."
@@ -3260,7 +3260,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:35
 msgid "Cannot delete vocabulary"
-msgstr ""
+msgstr "Није могуће обрисати вокабулар"
 
 #: ../superdesk-planning/client/validators/events.ts:289
 msgid "Cannot end with \".\""
@@ -3373,7 +3373,7 @@ msgstr "Прекорачен је лимит карактера, деск ниј
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:49
 msgid "Character limit exceeded, dictionary can not be created/updated."
-msgstr ""
+msgstr "Прекорачен је лимит карактера, речник није могуће креирати/ажурирати."
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:14
 msgid "Character limit exceeded, highlight can not be created/updated."
@@ -3462,7 +3462,7 @@ msgid ""
 "                                    in the list. The CVs are grouped under "
 "each label. You can choose only one\n"
 "                                    label."
-msgstr ""
+msgstr "Изаберите постојеће ознаке или креирајте нове\n                                    куцањем. Ознаке се користе само за организовање контролисаних вокабулара\n                                    у листи. КВ су груписани под сваком ознаком. Можете изабрати само једну\n                                    ознаку."
 
 #: scripts/apps/highlights/views/package_highlights_dropdown_directive.html:20
 msgid "Choose highlight list"
@@ -3487,7 +3487,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:274
 msgid "Clean Pasted HTML"
-msgstr ""
+msgstr "Очисти налепљени HTML"
 
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:67
 msgid "Clean pasted HTML"
@@ -3782,7 +3782,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/services/SchemaFactory.ts:8
 msgid "Color"
-msgstr ""
+msgstr "Боја"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:90
 msgid "Column"
@@ -3807,7 +3807,7 @@ msgstr "Вредности раздвојене зарезом"
 
 #: scripts/apps/products/views/products-config-modal.html:55
 msgid "Comma separated values."
-msgstr ""
+msgstr "Вредности раздвојене зарезом."
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:65
 #: scripts/core/editor3/components/comments/Comment.tsx:90
@@ -3840,7 +3840,7 @@ msgstr ""
 #: scripts/apps/search/constants.ts:16
 #: scripts/apps/workspace/content/constants.ts:18
 msgid "Company Codes"
-msgstr ""
+msgstr "Кодови компанија"
 
 #: scripts/core/directives/views/phone-home-modal-directive.html:29
 msgid "Company/Organisation"
@@ -4026,7 +4026,7 @@ msgstr "Садржај"
 msgid ""
 "Content\n"
 "                                Type"
-msgstr ""
+msgstr "Тип\n                                садржаја"
 
 #: scripts/apps/publish/views/subscribers.html:254
 msgid "Content API"
@@ -4050,17 +4050,17 @@ msgstr ""
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:3
 #: scripts/apps/products/views/products-config-modal.html:60
 msgid "Content Filter"
-msgstr ""
+msgstr "Филтер садржаја"
 
 #: scripts/apps/products/views/products-config-modal.html:68
 msgid "Content Filter Type"
-msgstr ""
+msgstr "Тип филтера садржаја"
 
 #: scripts/apps/content-filters/index.ts:38
 #: scripts/apps/content-filters/views/filter-search-result.html:24
 #: scripts/apps/content-filters/views/settings.html:4
 msgid "Content Filters"
-msgstr ""
+msgstr "Филтери садржаја"
 
 #: scripts/apps/monitoring/directives/utils.ts:23
 #: scripts/apps/templates/views/template-editor-modal.html:28
@@ -4119,7 +4119,7 @@ msgstr "Истек садржаја:"
 
 #: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:103
 msgid "Content fields"
-msgstr ""
+msgstr "Поља садржаја"
 
 #: scripts/apps/internal-destinations/InternalDestinations.tsx:31
 msgid "Content filter"
@@ -4127,7 +4127,7 @@ msgstr ""
 
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:58
 msgid "Content filter saved."
-msgstr ""
+msgstr "Филтер садржаја сачуван."
 
 #: scripts/core/activity/activity.ts:32
 msgid "Content flow"
@@ -4240,7 +4240,7 @@ msgstr ""
 #: scripts/apps/archive/views/metadata-view.html:173
 #: scripts/apps/workspace/content/constants.ts:19
 msgid "Copyright holder"
-msgstr ""
+msgstr "Носилац ауторских права"
 
 #: scripts/apps/authoring-react/fields/media/media-metadata.tsx:23
 #: scripts/apps/authoring/media/MediaMetadataView.tsx:20
@@ -4259,7 +4259,7 @@ msgstr "Носилац ауторских права:"
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:68
 #: scripts/apps/workspace/content/constants.ts:20
 msgid "Copyright notice"
-msgstr ""
+msgstr "Обавештење о ауторским правима"
 
 #: scripts/apps/authoring-react/fields/media/media-metadata.tsx:31
 #: scripts/apps/authoring/media/MediaMetadataView.tsx:22
@@ -4940,19 +4940,19 @@ msgstr "Прилагођени блок"
 
 #: scripts/apps/vocabularies/views/settings.html:22
 msgid "Custom blocks"
-msgstr ""
+msgstr "Прилагођени блокови"
 
 #: scripts/apps/vocabularies/views/settings.html:25
 msgid "Custom date fields"
-msgstr ""
+msgstr "Прилагођена поља за датум"
 
 #: scripts/apps/vocabularies/views/settings.html:28
 msgid "Custom embed fields"
-msgstr ""
+msgstr "Прилагођена поља за уграђивање"
 
 #: scripts/apps/vocabularies/views/settings.html:19
 msgid "Custom text fields"
-msgstr ""
+msgstr "Прилагођена поља за текст"
 
 #: ../superdesk-analytics/client/components/HighchartsLicense.tsx:76
 msgid "Customer Installation No.:"
@@ -5254,7 +5254,7 @@ msgid ""
 "Defines the width of the pop-up in the\n"
 "                                    article header. A minimal value of 200 "
 "is required."
-msgstr ""
+msgstr "Дефинише ширину искачућег прозора у\n                                    заглављу чланка. Потребна је минимална вредност 200."
 
 #: scripts/extensions/annotationsLibrary/dist/src/GetFields.js:23
 #: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/GetFields.js:23
@@ -5367,7 +5367,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:87
 msgid "Delete vocabulary?"
-msgstr ""
+msgstr "Обрисати вокабулар?"
 
 #: scripts/apps/dashboard/views/workspace.html:35
 #: scripts/apps/monitoring/views/monitoring-view.html:220
@@ -5601,7 +5601,7 @@ msgstr "Деск са називом {{name}} већ постоји."
 
 #: scripts/apps/templates/views/templates.html:52
 msgid "Desk(s)"
-msgstr ""
+msgstr "Деск(ови)"
 
 #: ../superdesk-planning/client/components/Archive/ArchivePreview/ArchivePreviewMetadataList.tsx:24
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Desk.tsx:12
@@ -5668,7 +5668,7 @@ msgstr ""
 
 #: scripts/apps/dictionaries/index.ts:33
 msgid "Dictionaries"
-msgstr ""
+msgstr "Речници"
 
 #: scripts/core/lang/missing-translations-strings.ts:16
 msgid "Dictionaries List Management"
@@ -5676,31 +5676,31 @@ msgstr "Управљање листом речника"
 
 #: scripts/apps/dictionaries/views/settings.html:23
 msgid "Dictionary"
-msgstr ""
+msgstr "Речник"
 
 #: scripts/apps/dictionaries/controllers/DictionaryConfigController.ts:93
 msgid "Dictionary deleted."
-msgstr ""
+msgstr "Речник обрисан."
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:36
 msgid "Dictionary file"
-msgstr ""
+msgstr "Датотека речника"
 
 #: scripts/apps/dictionaries/views/settings.html:4
 msgid "Dictionary management"
-msgstr ""
+msgstr "Управљање речницима"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:25
 msgid "Dictionary name"
-msgstr ""
+msgstr "Назив речника"
 
 #: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:14
 msgid "Dictionary saved successfully"
-msgstr ""
+msgstr "Речник успешно сачуван"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:28
 msgid "Dictionary with name {{dictionary.name}} already exists."
-msgstr ""
+msgstr "Речник са називом {{dictionary.name}} већ постоји."
 
 #: scripts/apps/authoring-react/compare-articles/view-difference.tsx:74
 msgid ""
@@ -5727,7 +5727,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:169
 msgid "Disable selection of an entire category"
-msgstr ""
+msgstr "Онемогући избор целе категорије"
 
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:487
 msgid "Disable spellchecker"
@@ -5803,7 +5803,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/constants.ts:56
 msgid "Do not show"
-msgstr ""
+msgstr "Не приказуј"
 
 #: scripts/apps/settings/index.ts:20
 msgid "Do some admin chores"
@@ -5848,7 +5848,7 @@ msgstr[2] ""
 
 #: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:148
 msgid "Do you want to remove Abbreviation?"
-msgstr ""
+msgstr "Желите ли да уклоните скраћеницу?"
 
 #: scripts/apps/users/views/edit-form.html:360
 msgid "Do you want to reset the password for user {{user.full_name}} ?"
@@ -5876,11 +5876,11 @@ msgstr ""
 
 #: scripts/apps/content-filters/views/manage-filters.html:147
 msgid "Does match"
-msgstr ""
+msgstr "Поклапа се"
 
 #: scripts/apps/content-filters/views/manage-filters.html:148
 msgid "Doesn't match"
-msgstr ""
+msgstr "Не поклапа се"
 
 #: ../superdesk-planning/client/services/AssignmentsService.tsx:326
 msgid "Don't Fulfil Assignment"
@@ -5945,7 +5945,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/views/vocabulary-config.html:84
 msgid "Download config"
-msgstr ""
+msgstr "Преузми конфигурацију"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/State.tsx:21
 #: ../superdesk-planning/client/components/fields/editor/WorkflowState.tsx:19
@@ -5989,7 +5989,7 @@ msgstr "Превуците датотеке овде или"
 msgid ""
 "Drag one or more files here to upload them,\n"
 "                or select files by clicking the button below"
-msgstr ""
+msgstr "Превуците једну или више датотека овде да их отпремите,\n                или изаберите датотеке кликом на дугме испод"
 
 #: scripts/apps/authoring/attachments/AttachmentsWidgetComponent.tsx:126
 msgid "Drag one or more files here to upload them, or just click here."
@@ -6221,7 +6221,7 @@ msgstr ""
 #: scripts/apps/authoring-react/field-adapters/ednote.ts:20
 #: scripts/apps/workspace/content/constants.ts:24
 msgid "Ed. Note"
-msgstr ""
+msgstr "Ур. напомена"
 
 #: ../superdesk-planning/client/components/Agendas/AgendaListItem.tsx:57
 #: ../superdesk-planning/client/components/Events/ManageEventTemplatesModal.tsx:42
@@ -6304,7 +6304,7 @@ msgstr "Уреди деск \"{{name}}\""
 
 #: scripts/apps/products/views/products-config-modal.html:4
 msgid "Edit \"{{name}}\" Product"
-msgstr ""
+msgstr "Уреди производ \"{{name}}\""
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:4
 msgid "Edit \"{{name}}\" highlight"
@@ -6312,7 +6312,7 @@ msgstr ""
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:7
 msgid "Edit Abbreviations Dictionary"
-msgstr ""
+msgstr "Уреди речник скраћеница"
 
 #: ../superdesk-planning/client/constants/tooltips.ts:23
 msgid "Edit Agenda"
@@ -6333,11 +6333,11 @@ msgstr ""
 #: scripts/apps/content-filters/views/manage-filters.html:20
 #: scripts/apps/content-filters/views/manage-filters.html:32
 msgid "Edit Content Filter"
-msgstr ""
+msgstr "Уреди филтер садржаја"
 
 #: scripts/apps/workspace/content/views/profile-settings.html:47
 msgid "Edit Content Profile"
-msgstr ""
+msgstr "Уреди профил садржаја"
 
 #: scripts/apps/authoring/views/change-image.html:4
 msgid "Edit Crops"
@@ -6345,7 +6345,7 @@ msgstr ""
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:8
 msgid "Edit Dictionary"
-msgstr ""
+msgstr "Уреди речник"
 
 #: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:114
 msgid "Edit Event"
@@ -6359,7 +6359,7 @@ msgstr ""
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:23
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:42
 msgid "Edit Filter Condition"
-msgstr ""
+msgstr "Уреди услов филтера"
 
 #: scripts/apps/ingest/views/dashboard/ingest-dashboard-widget.html:109
 msgid "Edit Ingest Source"
@@ -6432,7 +6432,7 @@ msgstr "Уреди претплатника"
 
 #: scripts/apps/templates/views/templates.html:36
 msgid "Edit Template"
-msgstr ""
+msgstr "Уреди шаблон"
 
 #: scripts/core/lang/missing-translations-strings.ts:17
 msgid "Edit Unique Name"
@@ -6477,7 +6477,7 @@ msgstr "Уреди деск"
 
 #: scripts/apps/dictionaries/views/settings.html:54
 msgid "Edit dictionary"
-msgstr ""
+msgstr "Уреди речник"
 
 #: scripts/core/editor3/components/embeds/EmbedBlock.tsx:83
 msgid "Edit embed"
@@ -6541,7 +6541,7 @@ msgstr "Уреди метаподатке"
 #: scripts/apps/products/views/product-test.html:35
 #: scripts/apps/products/views/products.html:31
 msgid "Edit product"
-msgstr ""
+msgstr "Уреди производ"
 
 #: scripts/apps/users/views/settings-roles.html:17
 msgid "Edit role"
@@ -6581,7 +6581,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/views/profile-settings.html:138
 msgid "Editing"
-msgstr ""
+msgstr "Уређивање"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:124
 msgid "Editor 3"
@@ -6629,7 +6629,7 @@ msgstr ""
 #: scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx:75
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx:126
 msgid "Embargo"
-msgstr ""
+msgstr "Ембарго"
 
 #: scripts/apps/archive/views/metadata-view.html:132
 msgid "Embargo Timestamp"
@@ -6799,7 +6799,7 @@ msgstr ""
 
 #: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:28
 msgid "Error. Dictionary not saved."
-msgstr ""
+msgstr "Грешка. Речник није сачуван."
 
 #: scripts/apps/authoring/authoring/directives/AuthoringDirective.ts:626
 msgid "Error. Item not published."
@@ -6855,7 +6855,7 @@ msgstr "Грешка. Кориснички профил не може бити �
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:120
 msgid "Error. Vocabulary not saved."
-msgstr ""
+msgstr "Грешка. Вокабулар није сачуван."
 
 #: scripts/apps/contacts/components/Form/ContactFormContainer.tsx:199
 #: scripts/apps/content-filters/controllers/FilterConditionsController.ts:107
@@ -6900,11 +6900,11 @@ msgstr ""
 
 #: scripts/apps/products/controllers/ProductsConfigController.ts:208
 msgid "Error: Failed to delete product."
-msgstr ""
+msgstr "Грешка: брисање производа није успело."
 
 #: scripts/apps/content-filters/controllers/ProductionTestController.ts:111
 msgid "Error: Failed to fetch production test results."
-msgstr ""
+msgstr "Грешка: преузимање резултата теста продукције није успело."
 
 #: scripts/apps/publish/controllers/PublishQueueController.ts:183
 msgid "Error: Failed to re-schedule"
@@ -6920,29 +6920,29 @@ msgstr "Грешка: чување претплатника није успел�
 
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:151
 msgid "Error: Failed to save content filter."
-msgstr ""
+msgstr "Грешка: чување филтера садржаја није успело."
 
 #: scripts/apps/content-filters/controllers/FilterConditionsController.ts:112
 msgid "Error: Failed to save filter condition."
-msgstr ""
+msgstr "Грешка: чување услова филтера није успело."
 
 #: scripts/apps/templates/helpers.ts:13
 msgid "Error: Failed to save template."
-msgstr ""
+msgstr "Грешка: чување шаблона није успело."
 
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:76
 msgid "Error: Failed to test content filter."
-msgstr ""
+msgstr "Грешка: тестирање филтера садржаја није успело."
 
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:74
 msgid "Error: Internal error in Filter testing"
-msgstr ""
+msgstr "Грешка: интерна грешка приликом тестирања филтера"
 
 #: scripts/apps/content-filters/controllers/FilterConditionsController.ts:105
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:67
 #: scripts/apps/products/controllers/ProductsConfigController.ts:183
 msgid "Error: Name needs to be unique"
-msgstr ""
+msgstr "Грешка: назив мора бити јединствен"
 
 #: scripts/core/itemList/itemList.ts:110
 msgid "Error: Slugline required."
@@ -6958,7 +6958,7 @@ msgstr "Грешка: претплатник са овим називом већ
 
 #: scripts/apps/dictionaries/controllers/DictionaryEditController.ts:24
 msgid "Error: The dictionary already exists."
-msgstr ""
+msgstr "Грешка: речник већ постоји."
 
 #: scripts/apps/ingest/directives/IngestSourcesContent.ts:359
 msgid "Error: Unable to delete Ingest Source"
@@ -6975,7 +6975,7 @@ msgstr "Грешка: јединствени назив није јединст�
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:111
 msgid "Error: {{ message }}"
-msgstr ""
+msgstr "Грешка: {{ message }}"
 
 #: scripts/apps/users/directives/UserEditDirective.ts:272
 msgid "Error: {{error}}"
@@ -7929,12 +7929,12 @@ msgstr ""
 
 #: scripts/apps/workspace/content/constants.ts:26
 msgid "Feature Image"
-msgstr ""
+msgstr "Истакнута слика"
 
 #: scripts/apps/search/views/search-parameters.html:175
 #: scripts/apps/workspace/content/constants.ts:27
 msgid "Feature Media"
-msgstr ""
+msgstr "Истакнути медиј"
 
 #: scripts/core/lang/missing-translations-strings.ts:17
 msgid "Feature Preview"
@@ -8060,13 +8060,13 @@ msgstr ""
 #: scripts/apps/content-filters/views/filter-search.html:9
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:59
 msgid "Field"
-msgstr ""
+msgstr "Поље"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:66
 msgid ""
 "Field\n"
 "                                    type"
-msgstr ""
+msgstr "Тип\n                                    поља"
 
 #: ../superdesk-planning/client/components/ContentProfiles/FieldTab/index.tsx:200
 msgid "Field \"{{field}}\" will be permanently deleted."
@@ -8161,12 +8161,12 @@ msgstr ""
 
 #: scripts/apps/content-filters/views/manage-filters.html:102
 msgid "Filter Condition"
-msgstr ""
+msgstr "Услов филтера"
 
 #: scripts/apps/content-filters/views/filter-search-result.html:7
 #: scripts/apps/content-filters/views/settings.html:14
 msgid "Filter Conditions"
-msgstr ""
+msgstr "Услови филтера"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/EditFilter.tsx:183
 #: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:36
@@ -8187,19 +8187,19 @@ msgstr ""
 
 #: scripts/apps/content-filters/views/settings.html:19
 msgid "Filter Search"
-msgstr ""
+msgstr "Претрага филтера"
 
 #: scripts/apps/content-filters/views/manage-filters.html:66
 msgid "Filter Statement"
-msgstr ""
+msgstr "Критеријум филтера"
 
 #: scripts/apps/content-filters/views/manage-filters.html:133
 msgid "Filter Test"
-msgstr ""
+msgstr "Тест филтера"
 
 #: scripts/apps/content-filters/views/production-test.html:4
 msgid "Filter Test Results"
-msgstr ""
+msgstr "Резултати теста филтера"
 
 #: ../superdesk-planning/client/components/Assignments/FiltersBar.tsx:111
 msgid "Filter by day:"
@@ -8207,7 +8207,7 @@ msgstr ""
 
 #: scripts/apps/content-filters/controllers/FilterConditionsController.ts:99
 msgid "Filter condition saved."
-msgstr ""
+msgstr "Услов филтера сачуван."
 
 #: scripts/apps/contacts/views/search-panel.html:3
 msgid "Filter contacts"
@@ -8219,11 +8219,11 @@ msgstr "Филтрирај типове датотека"
 
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:50
 msgid "Filter statement {{id}} does not have a filter condition."
-msgstr ""
+msgstr "Критеријум филтера {{id}} нема услов филтера."
 
 #: scripts/apps/templates/views/templates.html:8
 msgid "Filter:"
-msgstr ""
+msgstr "Филтер:"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:76
 msgid "Filtered By"
@@ -8344,11 +8344,11 @@ msgstr "Фонт"
 
 #: scripts/apps/workspace/content/constants.ts:28
 msgid "Footer"
-msgstr ""
+msgstr "Подножје"
 
 #: scripts/apps/workspace/content/constants.ts:29
 msgid "Footers"
-msgstr ""
+msgstr "Подножја"
 
 #: scripts/apps/publish/views/subscribers.html:218
 msgid "For Content API only subscriber destinations are not required."
@@ -8390,13 +8390,13 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:75
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:177
 msgid "Formatting Options"
-msgstr ""
+msgstr "Опције форматирања"
 
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:17
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:316
 #: scripts/apps/workspace/content/views/FormattingOptionsMultiSelect.tsx:34
 msgid "Formatting options"
-msgstr ""
+msgstr "Опције форматирања"
 
 #: ../superdesk-planning/client/components/fields/editor/OverrideAutoAssignToWorkflow.tsx:15
 msgid "Forward Planning"
@@ -8457,7 +8457,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:160
 msgid "Full"
-msgstr ""
+msgstr "Пуно"
 
 #: scripts/apps/users/views/list.html:33
 msgid "Full name"
@@ -8571,7 +8571,7 @@ msgstr ""
 #: scripts/apps/search/services/SearchService.ts:72
 #: scripts/apps/workspace/content/constants.ts:30
 msgid "Genre"
-msgstr ""
+msgstr "Жанр"
 
 #: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:102
 #: ../superdesk-planning/client/components/Archive/ArchiveItem.tsx:78
@@ -8589,7 +8589,7 @@ msgstr ""
 
 #: scripts/apps/content-filters/views/manage-filters.html:51
 msgid "Global Block"
-msgstr ""
+msgstr "Глобална блокада"
 
 #: scripts/apps/desks/views/desk-config-modal.html:249
 #: scripts/apps/desks/views/desk-config-modal.html:350
@@ -8638,7 +8638,7 @@ msgstr "Иди назад"
 
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:41
 msgid "Go to content profiles"
-msgstr ""
+msgstr "Иди на профиле садржаја"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:45
 msgid "Go to items"
@@ -8653,7 +8653,7 @@ msgstr "Иди на"
 #: ../superdesk-planning/client/utils/index.ts:593
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:253
 msgid "Graphic"
-msgstr ""
+msgstr "Графика"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:50
 msgid "Gray"
@@ -8754,7 +8754,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:161
 msgid "Half"
-msgstr ""
+msgstr "Половина"
 
 #: scripts/core/auth/reset-password.html:69
 msgid "Have password? Sign in."
@@ -8762,7 +8762,7 @@ msgstr "Имате лозинку? Пријавите се."
 
 #: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:101
 msgid "Header fields"
-msgstr ""
+msgstr "Поља заглавља"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:101
 msgid "Heading 1"
@@ -8847,7 +8847,7 @@ msgstr "Помозите нам да преведемо Superdesk"
 msgid ""
 "Helper\n"
 "                                    text"
-msgstr ""
+msgstr "Помоћни\n                                    текст"
 
 #: scripts/apps/authoring/views/article-edit.html:395
 msgid "Helplines/Contact Information"
@@ -8873,7 +8873,7 @@ msgstr[2] ""
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:250
 msgid "Hide Date"
-msgstr ""
+msgstr "Сакриј датум"
 
 #: scripts/apps/authoring/views/article-edit.html:586
 msgid "Hide Preview"
@@ -9002,24 +9002,24 @@ msgstr ""
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:29
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:39
 msgid "ID"
-msgstr ""
+msgstr "ИД"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:45
 msgid ""
 "ID\n"
 "                                must contain only letters, digits and "
 "characters -, _."
-msgstr ""
+msgstr "ИД\n                                мора садржати само слова, цифре и знакове -, _."
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:43
 msgid ""
 "ID conflicts\n"
 "                                with system field."
-msgstr ""
+msgstr "ИД је у конфликту\n                                са системским пољем."
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:41
 msgid "ID must be unique."
-msgstr ""
+msgstr "ИД мора бити јединствен."
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:93
 msgid "Icon"
@@ -9046,7 +9046,7 @@ msgid ""
 "If enabled, it will be possible to embed articles using this content profile "
 "into other articles that accept embeds (configurable in content profile "
 "field settings)"
-msgstr ""
+msgstr "Ако је омогућено, биће могуће уградити чланке користећи овај профил садржаја у друге чланке који прихватају уграђени садржај (подесиво у поставкама поља профила садржаја)"
 
 #: scripts/core/interactive-article-actions-panel/actions/send-correction-action.tsx:134
 #: scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx:194
@@ -9098,7 +9098,7 @@ msgstr "Игнориши реч"
 #: scripts/extensions/sams/dist/src/utils/assets.js:107
 #: scripts/extensions/sams/src/utils/assets.ts:142
 msgid "Image"
-msgstr ""
+msgstr "Слика"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:103
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/assets/assetImagePreviewFullScreen.js:103
@@ -9162,7 +9162,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/services/VocabularyService.ts:136
 msgid "In 3 days"
-msgstr ""
+msgstr "За 3 дана"
 
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/field-components/time-header-common.tsx:24
 msgid "In 30 min"
@@ -9506,11 +9506,11 @@ msgstr ""
 
 #: scripts/apps/templates/views/create-template.html:26
 msgid "It will create a new template."
-msgstr ""
+msgstr "Биће креиран нови шаблон."
 
 #: scripts/apps/templates/views/create-template.html:25
 msgid "It will update existing template."
-msgstr ""
+msgstr "Постојећи шаблон ће бити ажуриран."
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:117
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:31
@@ -9712,7 +9712,7 @@ msgstr ""
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:15
 #: scripts/core/views/sdSearchList.html:36
 msgid "Items"
-msgstr ""
+msgstr "Ставке"
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:128
 msgid "Items Count"
@@ -9797,7 +9797,7 @@ msgstr "Пречице на тастатури"
 #: scripts/apps/search/views/search-parameters.html:229
 #: scripts/apps/workspace/content/constants.ts:33
 msgid "Keywords"
-msgstr ""
+msgstr "Кључне речи"
 
 #: ../superdesk-analytics/client/utils.js:162
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:119
@@ -9837,7 +9837,7 @@ msgstr ""
 #: scripts/apps/workspace/content/views/profile-settings.html:115
 #: scripts/apps/workspace/content/views/profile-settings.html:150
 msgid "Label"
-msgstr ""
+msgstr "Ознака"
 
 #: ../superdesk-analytics/client/search/services/SearchReport.ts:126
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/language.ts:36
@@ -9862,7 +9862,7 @@ msgstr "Језик"
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:31
 msgid "Language code"
-msgstr ""
+msgstr "Код језика"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Language.tsx:17
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx:209
@@ -10126,7 +10126,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/services/SchemaFactory.ts:9
 msgid "List Name"
-msgstr ""
+msgstr "Назив листе"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:125
 msgid "List Plus"
@@ -10336,7 +10336,7 @@ msgstr ""
 
 #: scripts/apps/templates/views/template-editor-modal.html:59
 msgid "Make Public"
-msgstr ""
+msgstr "Учини јавним"
 
 #: scripts/apps/search/views/save-search-dialog.html:14
 msgid "Make global"
@@ -10614,7 +10614,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:272
 msgid "Max. number of items"
-msgstr ""
+msgstr "Макс. број ставки"
 
 #: ../superdesk-analytics/client/production_time_report/controllers/ProductionTimeReportController.js:280
 #: ../superdesk-analytics/client/production_time_report/directives/ProductionTimeReportPreview.js:31
@@ -10625,7 +10625,7 @@ msgstr "Максимум"
 
 #: scripts/apps/content-filters/views/manage-filters.html:44
 msgid "Maximum 80 characters."
-msgstr ""
+msgstr "Максимално 80 карактера."
 
 #: scripts/extensions/sams/dist/src/components/sets/setEditorPanel.js:241
 #: scripts/extensions/sams/dist/src/extensions/sams/src/components/sets/setEditorPanel.js:241
@@ -10640,11 +10640,11 @@ msgstr ""
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:44
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:216
 msgid "Maximum length"
-msgstr ""
+msgstr "Максимална дужина"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:226
 msgid "Maximum soft length"
-msgstr ""
+msgstr "Максимална препоручена дужина"
 
 #: scripts/apps/authoring-react/field-adapters/_media_self.ts:29
 #: scripts/apps/publish/views/subscribers.html:147
@@ -10667,7 +10667,7 @@ msgstr "Тип медија"
 
 #: scripts/apps/vocabularies/constants.ts:18
 msgid "Media gallery"
-msgstr ""
+msgstr "Галерија медија"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:57
 msgid "Medium Blue"
@@ -10711,7 +10711,7 @@ msgstr "Метаподаци"
 
 #: scripts/apps/vocabularies/views/settings.html:4
 msgid "Metadata management"
-msgstr ""
+msgstr "Управљање метаподацима"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:86
 msgid "Min"
@@ -10742,12 +10742,12 @@ msgstr "Минимална дозвољена величина слике је {
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:213
 msgid "Minimum height and width should be greater than or equal to 200"
-msgstr ""
+msgstr "Минимална висина и ширина треба да буду веће или једнаке 200"
 
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:32
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:206
 msgid "Minimum length"
-msgstr ""
+msgstr "Минимална дужина"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:129
 msgid "Minus Sign"
@@ -10940,7 +10940,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/constants.ts:52
 msgid "Multi selection"
-msgstr ""
+msgstr "Вишеструки избор"
 
 #: scripts/apps/authoring-react/authoring-integration-wrapper.tsx:167
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:124
@@ -11111,7 +11111,7 @@ msgstr "Назив"
 
 #: scripts/apps/vocabularies/ManageVocabularyItemTranslations.tsx:28
 msgid "Name ({{language}})"
-msgstr ""
+msgstr "Назив ({{language}})"
 
 #: ../superdesk-planning/client/components/ContentProfiles/GroupTab/GroupEditor.tsx:131
 msgid "Name Translations"
@@ -11120,7 +11120,7 @@ msgstr ""
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:218
 msgid ""
 "Name field should only have alphanumeric characters, dashes and underscores"
-msgstr ""
+msgstr "Поље назива треба да садржи само алфанумеричке знакове, цртице и доње црте"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:79
 msgid "Name is not unique."
@@ -11276,7 +11276,7 @@ msgstr ""
 
 #: scripts/apps/templates/constants.ts:11
 msgid "No Desk"
-msgstr ""
+msgstr "Нема деска"
 
 #: ../superdesk-planning/client/components/Main/ListPanel.tsx:343
 msgid "No Event or Planning items found"
@@ -11292,7 +11292,7 @@ msgstr ""
 
 #: scripts/apps/products/views/products.html:39
 msgid "No Products Found"
-msgstr ""
+msgstr "Нема пронађених производа"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:39
 msgid "No Publish actions defined"
@@ -11718,7 +11718,7 @@ msgstr "Није истекло"
 #: scripts/apps/search/components/fields/flags.tsx:17
 #: scripts/apps/templates/views/template-editor-modal.html:104
 msgid "Not For Publication"
-msgstr ""
+msgstr "Није за објаву"
 
 #: scripts/apps/search/constants.ts:34
 msgid "Not Genre"
@@ -11930,7 +11930,7 @@ msgstr ""
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:40
 #: scripts/apps/templates/views/template-editor-modal.html:151
 msgid "On"
-msgstr ""
+msgstr "Укључено"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:175
 msgid "On Days"
@@ -11971,7 +11971,7 @@ msgstr ""
 msgid ""
 "Only allow content with the\n"
 "                                following status:"
-msgstr ""
+msgstr "Дозволи само садржај са\n                                следећим статусом:"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageForm.tsx:247
 msgid "Only one XMP files are accepted"
@@ -12113,7 +12113,7 @@ msgstr ""
 #: scripts/apps/content-filters/views/filter-search.html:18
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:68
 msgid "Operator"
-msgstr ""
+msgstr "Оператор"
 
 #: scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/config.tsx:105
 msgid "Options:"
@@ -12243,7 +12243,7 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/utils/assets.js:125
 #: scripts/extensions/sams/src/utils/assets.ts:154
 msgid "Other"
-msgstr ""
+msgstr "Остало"
 
 #: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:264
 msgid "Other Coverages"
@@ -12255,7 +12255,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/views/settings.html:37
 msgid "Other fields"
-msgstr ""
+msgstr "Остала поља"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:373
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:426
@@ -12298,7 +12298,7 @@ msgstr "Преглед"
 
 #: scripts/apps/templates/views/templates.html:48
 msgid "Owner"
-msgstr ""
+msgstr "Власник"
 
 #: scripts/apps/authoring/views/authoring-topbar.html:79
 msgid "P"
@@ -12357,7 +12357,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:256
 msgid "Package"
-msgstr ""
+msgstr "Пакет"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:138
 msgid "Package Create"
@@ -12386,7 +12386,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/constants.ts:7
 msgid "Package story labels"
-msgstr ""
+msgstr "Ознаке прича у пакету"
 
 #: scripts/apps/authoring-react/packages.tsx:22
 #: scripts/apps/authoring/packages/packages.ts:47
@@ -12511,7 +12511,7 @@ msgstr "Људи"
 
 #: scripts/apps/products/views/products-config-modal.html:70
 msgid "Permitting"
-msgstr ""
+msgstr "Дозвољавање"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/groups.js:13
 #: scripts/extensions/auto-tagging-widget/dist/src/groups.js:13
@@ -12538,7 +12538,7 @@ msgstr "Лично"
 
 #: scripts/apps/dictionaries/views/settings.html:28
 msgid "Personal Dictionary"
-msgstr ""
+msgstr "Лични речник"
 
 #: scripts/apps/monitoring/controllers/AggregateCtrl.ts:40
 msgid "Personal Items"
@@ -12556,7 +12556,7 @@ msgstr ""
 msgid ""
 "Personal dictionary for language \"{{dictionary.language_id}}\" already "
 "exists."
-msgstr ""
+msgstr "Лични речник за језик \"{{dictionary.language_id}}\" већ постоји."
 
 #: scripts/apps/users/controllers/UserEditController.ts:23
 msgid "Personal preferences"
@@ -12588,7 +12588,7 @@ msgstr "Приказ мреже фотографија"
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:110
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:92
 msgid "Phrase"
-msgstr ""
+msgstr "Фраза"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:147
 msgid "Pick"
@@ -12602,7 +12602,7 @@ msgstr "Изабери задатак"
 #: ../superdesk-planning/client/utils/index.ts:589
 #: scripts/apps/workspace/content/controllers/ContentProfilesController.ts:58
 msgid "Picture"
-msgstr ""
+msgstr "Слика"
 
 #: ../superdesk-analytics/client/charts/services/ChartConfig.js:102
 msgid "Pie"
@@ -12628,7 +12628,7 @@ msgstr ""
 #: scripts/extensions/auto-tagging-widget/dist/src/groups.js:21
 #: scripts/extensions/auto-tagging-widget/src/groups.ts:30
 msgid "Place"
-msgstr ""
+msgstr "Место"
 
 #: ../superdesk-planning/client/components/fields/preview/index.ts:137
 #: scripts/core/lang/missing-translations-strings.ts:12
@@ -12803,11 +12803,11 @@ msgstr ""
 msgid ""
 "Please be aware that uploading external config files\n"
 "                will overwrite your existing configuration."
-msgstr ""
+msgstr "Имајте на уму да отпремање спољних конфигурационих датотека\n                ће заменити вашу постојећу конфигурацију."
 
 #: scripts/apps/templates/directives/TemplatesDirective.ts:359
 msgid "Please change the default templates first."
-msgstr ""
+msgstr "Прво промените подразумеване шаблоне."
 
 #: scripts/core/auth/secure-login.html:14
 msgid "Please check that the following id is the same as on your device:"
@@ -12827,7 +12827,7 @@ msgstr "Потврдите да желите да обришете деск."
 
 #: scripts/apps/dictionaries/controllers/DictionaryConfigController.ts:89
 msgid "Please confirm you want to delete dictionary."
-msgstr ""
+msgstr "Потврдите да желите да обришете речник."
 
 #: scripts/apps/search/views/saved-search-subscribe.html:12
 msgid "Please define the frequency and time of your email notifications below."
@@ -12849,11 +12849,11 @@ msgstr "Унесите исправан Twitter налог"
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:129
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:130
 msgid "Please provide an article GUID"
-msgstr ""
+msgstr "Унесите GUID чланка"
 
 #: scripts/apps/products/controllers/ProductsConfigController.ts:234
 msgid "Please provide an article id"
-msgstr ""
+msgstr "Унесите ИД чланка"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:208
 msgid ""
@@ -12866,15 +12866,15 @@ msgstr ""
 #: scripts/apps/workspace/content/views/profile-settings.html:117
 #: scripts/apps/workspace/content/views/profile-settings.html:152
 msgid "Please use less than 40 characters"
-msgstr ""
+msgstr "Користите мање од 40 карактера"
 
 #: scripts/apps/content-filters/views/manage-filters.html:45
 msgid "Please use less than 80 characters"
-msgstr ""
+msgstr "Користите мање од 80 карактера"
 
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:53
 msgid "Please use less than 80 characters."
-msgstr ""
+msgstr "Користите мање од 80 карактера."
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:151
 msgid "Plus Large"
@@ -12995,13 +12995,13 @@ msgstr "Омиљене вредности за вокабуларе"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:374
 msgid "Prefill the field with text from:"
-msgstr ""
+msgstr "Унапред попуни поље текстом из:"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:155
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:37
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:250
 msgid "Preformatted"
-msgstr ""
+msgstr "Преформатирано"
 
 #: scripts/core/editor3/components/toolbar/StyleButton.tsx:91
 msgid "Preformatted text"
@@ -13159,47 +13159,47 @@ msgstr ""
 
 #: scripts/apps/products/views/products-config-modal.html:12
 msgid "Product Details"
-msgstr ""
+msgstr "Детаљи производа"
 
 #: scripts/apps/products/views/products-config-modal.html:26
 msgid "Product ID"
-msgstr ""
+msgstr "ИД производа"
 
 #: scripts/apps/products/views/settings.html:12
 msgid "Product Test"
-msgstr ""
+msgstr "Тест производа"
 
 #: scripts/apps/products/views/products-config-modal.html:44
 msgid "Product Type"
-msgstr ""
+msgstr "Тип производа"
 
 #: scripts/apps/products/controllers/ProductsConfigController.ts:185
 msgid "Product Type is required"
-msgstr ""
+msgstr "Тип производа је обавезан"
 
 #: scripts/apps/products/views/products.html:5
 msgid "Product Type:"
-msgstr ""
+msgstr "Тип производа:"
 
 #: scripts/apps/products/views/products-config-modal.html:53
 msgid "Product codes"
-msgstr ""
+msgstr "Кодови производа"
 
 #: scripts/apps/products/controllers/ProductsConfigController.ts:203
 msgid "Product deleted."
-msgstr ""
+msgstr "Производ обрисан."
 
 #: scripts/apps/products/views/products-config-modal.html:40
 msgid "Product description"
-msgstr ""
+msgstr "Опис производа"
 
 #: scripts/apps/products/controllers/ProductsConfigController.ts:175
 msgid "Product is saved."
-msgstr ""
+msgstr "Производ сачуван."
 
 #: scripts/apps/products/views/products-config-modal.html:36
 msgid "Product name"
-msgstr ""
+msgstr "Назив производа"
 
 #: scripts/apps/search/views/item-repo.html:4
 msgid "Production"
@@ -13232,7 +13232,7 @@ msgstr "Производи"
 
 #: scripts/apps/products/views/settings.html:4
 msgid "Products management"
-msgstr ""
+msgstr "Управљање производима"
 
 #: scripts/apps/profiling/views/profiling.html:6
 msgid "Profile:"
@@ -13476,7 +13476,7 @@ msgstr "Гурни оригиналну варијанту"
 
 #: scripts/apps/vocabularies/services/SchemaFactory.ts:7
 msgid "QCode"
-msgstr ""
+msgstr "QCode"
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditorTools.js:30
 #: scripts/extensions/videoEditor/dist/src/extensions/videoEditor/src/VideoEditorTools.js:30
@@ -13486,7 +13486,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:163
 msgid "Quarter"
-msgstr ""
+msgstr "Четвртина"
 
 #: scripts/apps/search/views/save-search-dialog.html:4
 msgid "Query"
@@ -13814,7 +13814,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/views/settings.html:31
 msgid "Related content"
-msgstr ""
+msgstr "Повезани садржај"
 
 #: scripts/apps/relations/directives/RelatedItemsDirective.ts:237
 msgid "Related item is not available."
@@ -13828,7 +13828,7 @@ msgstr "Повезана ставка није додата јер је поље
 
 #: scripts/apps/vocabularies/constants.ts:22
 msgid "Related items"
-msgstr ""
+msgstr "Повезане ставке"
 
 #: ../superdesk-analytics/client/search/views/date-filters.html:16
 msgid "Relative Days"
@@ -13922,7 +13922,7 @@ msgstr ""
 
 #: scripts/apps/content-filters/views/manage-filters.html:21
 msgid "Remove Content Filter"
-msgstr ""
+msgstr "Уклони филтер садржаја"
 
 #: ../superdesk-planning/client/components/UI/Form/InputArray/index.tsx:84
 msgid "Remove Coverage"
@@ -13938,7 +13938,7 @@ msgstr ""
 
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:30
 msgid "Remove Filter Condition"
-msgstr ""
+msgstr "Уклони услов филтера"
 
 #: ../superdesk-planning/client/components/fields/editor/SelectEditor3FormattingOptions.tsx:35
 msgid "Remove Format"
@@ -13966,7 +13966,7 @@ msgstr ""
 
 #: scripts/apps/templates/views/templates.html:37
 msgid "Remove Template"
-msgstr ""
+msgstr "Уклони шаблон"
 
 #: scripts/core/editor3/components/toolbar/index.tsx:386
 msgid "Remove all formatting"
@@ -13990,7 +13990,7 @@ msgstr "Уклони деск"
 
 #: scripts/apps/dictionaries/views/settings.html:55
 msgid "Remove dictionary"
-msgstr ""
+msgstr "Уклони речник"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:14
 msgid "Remove fetch action"
@@ -14041,7 +14041,7 @@ msgstr "Уклони панел"
 
 #: scripts/apps/products/views/products.html:32
 msgid "Remove product"
-msgstr ""
+msgstr "Уклони производ"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:46
 msgid "Remove publish action"
@@ -14225,7 +14225,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:116
 msgid "Required {{field}} in item {{item}}"
-msgstr ""
+msgstr "Обавезно {{field}} у ставци {{item}}"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:98
 #: ../superdesk-planning/client/constants/events.ts:161
@@ -14318,7 +14318,7 @@ msgstr "Врати"
 
 #: scripts/apps/products/views/product-test.html:15
 msgid "Result Type"
-msgstr ""
+msgstr "Тип резултата"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:166
 msgid "Retweet"
@@ -14536,12 +14536,12 @@ msgstr "СЛАГЛАЈН је предугачак"
 
 #: scripts/apps/workspace/content/constants.ts:42
 msgid "SMS"
-msgstr ""
+msgstr "СМС"
 
 #: scripts/apps/authoring-react/field-adapters/sms_message.ts:21
 #: scripts/apps/workspace/content/constants.ts:43
 msgid "SMS Message"
-msgstr ""
+msgstr "СМС порука"
 
 #: scripts/apps/authoring/views/authoring-header.html:49
 msgid "SOURCE"
@@ -14573,7 +14573,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:188
 msgid "Sample content"
-msgstr ""
+msgstr "Пример садржаја"
 
 #: ../superdesk-planning/client/components/UI/Form/DateInput/DayPicker.tsx:113
 msgid "Sat"
@@ -14699,7 +14699,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/views/profile-settings.html:131
 msgid "Save &amp; Continue"
-msgstr ""
+msgstr "Сачувај &amp; настави"
 
 #: ../superdesk-planning/client/components/ContentProfiles/ContentProfileModal.tsx:388
 #: ../superdesk-planning/client/components/ContentProfiles/CoverageProfileModal.tsx:225
@@ -14921,7 +14921,7 @@ msgstr ""
 
 #: scripts/apps/templates/views/templates.html:56
 msgid "Sched. Desk / Stage"
-msgstr ""
+msgstr "Зак. деск / фаза"
 
 #: ../superdesk-analytics/client/saved_reports/views/save-generate-report.html:27
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:49
@@ -14932,15 +14932,15 @@ msgstr ""
 
 #: scripts/apps/templates/views/template-editor-modal.html:175
 msgid "Schedule Desk"
-msgstr ""
+msgstr "Закажи деск"
 
 #: scripts/apps/templates/views/template-editor-modal.html:197
 msgid "Schedule Macro"
-msgstr ""
+msgstr "Закажи макро"
 
 #: scripts/apps/templates/views/template-editor-modal.html:187
 msgid "Schedule Stage"
-msgstr ""
+msgstr "Закажи фазу"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduledUpdates.tsx:98
 msgid "Schedule an update"
@@ -14968,7 +14968,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/constants.ts:70
 msgid "Scheduled Desk Output"
-msgstr ""
+msgstr "Заказани излазни деск"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/PreviewFilter.tsx:151
 msgid "Scheduled Export"
@@ -14976,11 +14976,11 @@ msgstr ""
 
 #: scripts/apps/workspace/content/constants.ts:38
 msgid "Scheduled Time"
-msgstr ""
+msgstr "Заказано време"
 
 #: scripts/apps/templates/views/templates.html:68
 msgid "Scheduled Time(s)"
-msgstr ""
+msgstr "Заказано(а) време(на)"
 
 #: ../superdesk-planning/client/components/fields/editor/ScheduledUpdates.tsx:64
 #: ../superdesk-planning/client/utils/contentProfiles.ts:331
@@ -15278,7 +15278,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/components/drop-zone.tsx:76
 msgid "Select Files"
-msgstr ""
+msgstr "Изабери датотеке"
 
 #: scripts/apps/archive/views/resend-configuration.html:10
 #: scripts/apps/ingest/views/settings/ingest-routing-action.html:55
@@ -15576,7 +15576,7 @@ msgstr "Слање"
 
 #: scripts/apps/workspace/content/constants.ts:68
 msgid "Sent Desk Output"
-msgstr ""
+msgstr "Послати излаз деска"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:443
 msgid "Sent From"
@@ -15738,7 +15738,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:138
 msgid "Shortcuts"
-msgstr ""
+msgstr "Пречице"
 
 #: ../superdesk-planning/client/validators/planning.ts:305
 #: ../superdesk-planning/client/validators/planning.ts:307
@@ -15779,15 +15779,15 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:332
 msgid "Show Crops"
-msgstr ""
+msgstr "Прикажи исечке"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:186
 msgid "Show Floating Character Count"
-msgstr ""
+msgstr "Прикажи плутајући бројач карактера"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:352
 msgid "Show Image Title"
-msgstr ""
+msgstr "Прикажи наслов слике"
 
 #: ../superdesk-planning/client/components/UI/Preview/ExpandableText.tsx:47
 #: scripts/apps/master-desk/components/HeaderComponent.tsx:226
@@ -15829,7 +15829,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:263
 msgid "Show in preview"
-msgstr ""
+msgstr "Прикажи у прегледу"
 
 #: scripts/apps/authoring-react/fields/media/config.tsx:120
 msgid "Show input for editing description"
@@ -15870,7 +15870,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/WidgetsConfig.tsx:57
 msgid "Show or hide the widgets in the right toolbar in the editor workspace."
-msgstr ""
+msgstr "Прикажи или сакриј виџете у десној траци уређивача."
 
 #: scripts/apps/search/components/fields/nested-link.tsx:28
 msgid "Show previous items"
@@ -15888,7 +15888,7 @@ msgstr ""
 msgid ""
 "Show to users\n"
 "                                as"
-msgstr ""
+msgstr "Прикажи корисницима\n                                као"
 
 #: scripts/apps/archive/views/item-crops.html:1
 #: scripts/apps/authoring-react/fields/media/media-carousel/image-crops.tsx:22
@@ -15945,11 +15945,11 @@ msgstr "Једнократно коришћење"
 #: scripts/apps/authoring-react/fields/editor3/config.tsx:57
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:214
 msgid "Single line"
-msgstr ""
+msgstr "Један ред"
 
 #: scripts/apps/vocabularies/constants.ts:48
 msgid "Single selection"
-msgstr ""
+msgstr "Један избор"
 
 #: scripts/extensions/sams/dist/src/components/assets/assetImagePreviewFullScreen.js:120
 #: scripts/extensions/sams/dist/src/components/assets/assetPreviewPanel.js:152
@@ -16126,7 +16126,7 @@ msgstr ""
 
 #: scripts/apps/templates/views/create-template.html:23
 msgid "Sorry, but template name must be unique."
-msgstr ""
+msgstr "Извините, али назив шаблона мора бити јединствен."
 
 #: scripts/core/auth/login-modal.html:37
 #: scripts/core/auth/reset-password.html:28
@@ -16213,7 +16213,7 @@ msgstr "Сортирање:"
 #: scripts/apps/search-providers/views/search-provider-config.html:89
 #: scripts/apps/workspace/content/constants.ts:44
 msgid "Source"
-msgstr ""
+msgstr "Извор"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:85
 msgid "Source Name"
@@ -16434,7 +16434,7 @@ msgstr "Започни претрагу"
 #: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:154
 #: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:186
 msgid "State"
-msgstr ""
+msgstr "Стање"
 
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:598
 #: scripts/apps/contacts/components/Form/ProfileDetail.tsx:611
@@ -16532,7 +16532,7 @@ msgstr "Складиштена процедура"
 
 #: scripts/apps/products/views/product-test.html:9
 msgid "Story GUID"
-msgstr ""
+msgstr "GUID приче"
 
 #: scripts/apps/legal-archive/views/legal_archive.html:78
 #: scripts/apps/search/views/search-parameters.html:31
@@ -16619,7 +16619,7 @@ msgstr ""
 #: scripts/apps/search/constants.ts:15
 #: scripts/apps/workspace/content/constants.ts:46
 msgid "Subject"
-msgstr ""
+msgstr "Тема"
 
 #: ../superdesk-planning/client/validators/planning.ts:109
 msgid "Subject is a required field"
@@ -16918,7 +16918,7 @@ msgstr ""
 #: scripts/apps/authoring-react/field-adapters/anpa_take_key.ts:20
 #: scripts/apps/workspace/content/constants.ts:10
 msgid "Take Key"
-msgstr ""
+msgstr "Кључ наставка"
 
 #: scripts/apps/users/controllers/ChangeAvatarController.ts:7
 msgid "Take a picture"
@@ -16986,7 +16986,7 @@ msgstr ""
 #: scripts/apps/archive/views/metadata-view.html:151
 #: scripts/apps/products/views/products-config-modal.html:76
 msgid "Target Regions"
-msgstr ""
+msgstr "Циљни региони"
 
 #: scripts/apps/archive/views/metadata-view.html:156
 msgid "Target Subscriber Types"
@@ -16995,7 +16995,7 @@ msgstr ""
 #: scripts/apps/archive/views/metadata-view.html:146
 #: scripts/apps/templates/views/template-editor-modal.html:135
 msgid "Target Subscribers"
-msgstr ""
+msgstr "Циљни претплатници"
 
 #: scripts/apps/publish/views/subscribers.html:130
 msgid "Target Type"
@@ -17063,7 +17063,7 @@ msgstr ""
 
 #: scripts/apps/templates/views/template-editor-modal.html:46
 msgid "Template Type"
-msgstr ""
+msgstr "Тип шаблона"
 
 #: ../superdesk-planning/client/actions/events/api.ts:842
 msgid "Template already exists. Do you want to overwrite it?"
@@ -17087,11 +17087,11 @@ msgstr "Назив шаблона"
 
 #: scripts/apps/templates/directives/TemplatesDirective.ts:248
 msgid "Template saved."
-msgstr ""
+msgstr "Шаблон сачуван."
 
 #: scripts/apps/templates/views/templates.html:45
 msgid "Template type"
-msgstr ""
+msgstr "Тип шаблона"
 
 #: scripts/apps/authoring-react/toolbar/template-modal.tsx:117
 msgid "Template will be updated"
@@ -17100,7 +17100,7 @@ msgstr "Шаблон ће бити ажуриран"
 #: scripts/apps/templates/index.ts:46
 #: scripts/apps/templates/views/templates.html:3
 msgid "Templates"
-msgstr ""
+msgstr "Шаблони"
 
 #: scripts/apps/authoring-react/field-adapters/usageterms.ts:20
 msgid "Terms of use"
@@ -17108,15 +17108,15 @@ msgstr ""
 
 #: scripts/apps/content-filters/views/manage-filters.html:138
 msgid "Test"
-msgstr ""
+msgstr "Тестирај"
 
 #: scripts/apps/content-filters/views/manage-filters.html:19
 msgid "Test Filter Against Content"
-msgstr ""
+msgstr "Тестирај филтер на садржају"
 
 #: scripts/apps/products/views/product-test.html:24
 msgid "Test Products"
-msgstr ""
+msgstr "Тестирај производе"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:189
 #: ../superdesk-planning/client/utils/index.ts:587
@@ -17127,7 +17127,7 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/utils/assets.js:119
 #: scripts/extensions/sams/src/utils/assets.ts:150
 msgid "Text"
-msgstr ""
+msgstr "Текст"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:190
 msgid "Text Format"
@@ -17216,7 +17216,7 @@ msgstr ""
 #: scripts/apps/products/views/products-config-modal.html:31
 msgid ""
 "The Product ID can be copied and used as Superdesk Newshub product query."
-msgstr ""
+msgstr "ИД производа се може копирати и користити као упит за производе у Superdesk Newshub-у."
 
 #: ../superdesk-analytics/client/saved_reports/services/SavedReportsService.js:278
 msgid "The Saved Report you are using was deleted!"
@@ -17304,7 +17304,7 @@ msgstr "Следећи статус није дозвољен у овом пољ
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:121
 msgid "The helper text must not exceed 120 characters."
-msgstr ""
+msgstr "Помоћни текст не сме прелазити 120 карактера."
 
 #: scripts/core/helpers/crud-manager-http.tsx:52
 msgid "The item has been created."
@@ -17417,7 +17417,7 @@ msgstr "Виџет активности корисника пружа инфор
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:226
 msgid "The values should be unique for {{uniqueField}}"
-msgstr ""
+msgstr "Вредности треба да буду јединствене за {{uniqueField}}"
 
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:55
 msgid ""
@@ -17426,9 +17426,9 @@ msgid ""
 msgid_plural ""
 "The vocabulary {{name}} can't be deleted because it is currently used in the "
 "following Content Profiles:"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Вокабулар {{name}} не може бити обрисан јер се тренутно користи у следећем профилу садржаја:"
+msgstr[1] "Вокабулар {{name}} не може бити обрисан јер се тренутно користи у следећим профилима садржаја:"
+msgstr[2] "Вокабулар {{name}} не може бити обрисан јер се тренутно користи у следећим профилима садржаја:"
 
 #: ../superdesk-planning/client/actions/main.ts:468
 msgid "The {{ itemType }} has been posted"
@@ -17628,7 +17628,7 @@ msgstr "Дошло је до проблема, деск није сачуван.
 
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:50
 msgid "There was a problem, dictionary not created/updated."
-msgstr ""
+msgstr "Дошло је до проблема, речник није креиран/ажуриран."
 
 #: scripts/apps/search/directives/ItemGlobalSearch.ts:59
 #: scripts/apps/search/directives/ItemGlobalSearch.ts:91
@@ -17687,7 +17687,7 @@ msgstr ""
 
 #: scripts/apps/content-filters/controllers/ManageContentFiltersController.ts:92
 msgid "There was an error. Content filter cannot be deleted."
-msgstr ""
+msgstr "Дошло је до грешке. Филтер садржаја не може бити обрисан."
 
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:262
 #: scripts/apps/authoring/authoring/services/AuthoringService.ts:477
@@ -17704,7 +17704,7 @@ msgstr ""
 
 #: scripts/apps/content-filters/controllers/FilterConditionsController.ts:128
 msgid "There was an error. Filter condition cannot be deleted."
-msgstr ""
+msgstr "Дошло је до грешке. Услов филтера не може бити обрисан."
 
 #: scripts/apps/users/directives/UserRolesDirective.ts:68
 msgid "There was an error. Role cannot be deleted."
@@ -17720,11 +17720,11 @@ msgstr ""
 
 #: scripts/apps/templates/directives/TemplatesDirective.ts:371
 msgid "There was an error. Template cannot be deleted."
-msgstr ""
+msgstr "Дошло је до грешке. Шаблон не може бити обрисан."
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:162
 msgid "Third"
-msgstr ""
+msgstr "Трећина"
 
 #: ../superdesk-planning/client/components/Planning/PlanningPreviewContent.tsx:259
 msgid "This Coverage"
@@ -17832,7 +17832,7 @@ msgstr ""
 
 #: scripts/apps/templates/directives/TemplatesDirective.ts:358
 msgid "This is a default template of the following desk(s): {{deskNames}}."
-msgstr ""
+msgstr "Ово је подразумевани шаблон следећих десков(а): {{deskNames}}."
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:351
 msgid "This is a recurring event."
@@ -17892,7 +17892,7 @@ msgstr ""
 msgid ""
 "This vocabulary is not currently used in any Content Profile and can be "
 "safely removed."
-msgstr ""
+msgstr "Овај вокабулар се тренутно не користи ни у једном профилу садржаја и може се безбедно уклонити."
 
 #: scripts/apps/highlights/views/highlights_config_modal.html:42
 msgid "This week"
@@ -17935,7 +17935,7 @@ msgstr ""
 msgid ""
 "This will appear below the field in the\n"
 "                                    Editor."
-msgstr ""
+msgstr "Ово ће се појавити испод поља у\n                                    уређивачу."
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/convertToRecurringEventForm.tsx:152
 msgid "This will create new events in the remote ({{timeZone}}) timezone"
@@ -18143,7 +18143,7 @@ msgstr ""
 msgid ""
 "To delete this vocabulary, you must first remove it from all Content "
 "Profiles listed above."
-msgstr ""
+msgstr "Да бисте обрисали овај вокабулар, прво га уклоните из свих профила садржаја наведених изнад."
 
 #: scripts/core/editor3/components/embeds/EmbedInput.tsx:152
 msgid "To get a responsive embed code, paste a URL."
@@ -18248,7 +18248,7 @@ msgstr "Прикажи/сакриј главни мени"
 
 #: scripts/apps/vocabularies/components/VocabularyItemsViewEdit.tsx:343
 msgid "Toggle search"
-msgstr ""
+msgstr "Прикажи/сакриј претрагу"
 
 #: scripts/apps/search/index.ts:139
 msgid "Toggle search view"
@@ -18438,7 +18438,7 @@ msgstr ""
 #: scripts/extensions/sams/src/components/assets/assetImagePreviewFullScreen.tsx:146
 #: scripts/extensions/sams/src/components/assets/assetPreviewPanel.tsx:178
 msgid "Type"
-msgstr ""
+msgstr "Тип"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/new-item.js:80
 #: scripts/extensions/auto-tagging-widget/dist/src/new-item.js:80
@@ -18448,7 +18448,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:89
 msgid "Type to search or create a new label"
-msgstr ""
+msgstr "Куцајте за претрагу или креирајте нову ознаку"
 
 #: scripts/apps/authoring-react/generic-widgets/comments/CommentsWidget.tsx:184
 #: scripts/core/editor3/components/comments/CommentTextArea.tsx:122
@@ -18508,7 +18508,7 @@ msgstr "URL није пронађен."
 
 #: scripts/apps/vocabularies/views/settings.html:34
 msgid "URLs"
-msgstr ""
+msgstr "URL-ови"
 
 #: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:211
 msgid "Uknown validation error"
@@ -18995,7 +18995,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/views/settings.html:9
 msgid "Upload Config"
-msgstr ""
+msgstr "Отпреми конфигурацију"
 
 #: scripts/apps/archive/controllers/UploadController.ts:165
 msgid "Upload Error:"
@@ -19012,7 +19012,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/components/UploadConfigModal.tsx:69
 msgid "Upload config"
-msgstr ""
+msgstr "Отпреми конфигурацију"
 
 #: scripts/apps/users/controllers/ChangeAvatarController.ts:6
 msgid "Upload from computer"
@@ -19115,7 +19115,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/constants.ts:49
 msgid "Usage Terms"
-msgstr ""
+msgstr "Услови коришћења"
 
 #: scripts/apps/archive/views/metadata-associateditem-view.html:40
 #: scripts/apps/archive/views/metadata-view.html:181
@@ -19123,7 +19123,7 @@ msgstr ""
 #: scripts/apps/authoring/metadata/views/metadata-widget.html:35
 #: scripts/apps/templates/views/template-editor-modal.html:113
 msgid "Usage terms"
-msgstr ""
+msgstr "Услови коришћења"
 
 #: scripts/apps/authoring/views/confirm-media-associated.html:17
 msgid "Use Media"
@@ -19159,7 +19159,7 @@ msgstr "Користи ред приоритета за пренос."
 
 #: scripts/apps/content-filters/views/manage-filters.html:135
 msgid "Use the article GUID for testing."
-msgstr ""
+msgstr "Користите GUID чланка за тестирање."
 
 #: scripts/extensions/annotationsLibrary/dist/src/AnnotationSelectSingleItem.js:14
 #: scripts/extensions/annotationsLibrary/dist/src/extensions/annotationsLibrary/src/AnnotationSelectSingleItem.js:14
@@ -19279,20 +19279,20 @@ msgstr "Провери"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:299
 msgid "Validate Characters"
-msgstr ""
+msgstr "Провери карактере"
 
 #: scripts/apps/authoring-react/fields/date/config.tsx:53
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:147
 msgid "Value"
-msgstr ""
+msgstr "Вредност"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:282
 msgid "Value must be greater than or equal to 2."
-msgstr ""
+msgstr "Вредност мора бити већа или једнака 2."
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:284
 msgid "Value must be less than or equal to 99."
-msgstr ""
+msgstr "Вредност мора бити мања или једнака 99."
 
 #: scripts/core/ui/components/ListPage/generic-list-page-item-view-edit.tsx:207
 msgid "Value must be unique"
@@ -19308,7 +19308,7 @@ msgstr ""
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:83
 #: scripts/apps/content-filters/views/manage-filter-conditions.html:88
 msgid "Values"
-msgstr ""
+msgstr "Вредности"
 
 #: scripts/apps/archive/views/metadata-view.html:85
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:366
@@ -19344,7 +19344,7 @@ msgstr ""
 #: scripts/extensions/sams/dist/src/utils/assets.js:110
 #: scripts/extensions/sams/src/utils/assets.ts:144
 msgid "Video"
-msgstr ""
+msgstr "Видео"
 
 #: scripts/extensions/videoEditor/dist/src/VideoEditor.js:306
 #: scripts/extensions/videoEditor/dist/src/VideoEditor.js:80
@@ -19470,7 +19470,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/index.tsx:226
 #: scripts/apps/vocabularies/views/settings.html:16
 msgid "Vocabularies"
-msgstr ""
+msgstr "Вокабулари"
 
 #: scripts/core/lang/missing-translations-strings.ts:22
 msgid "Vocabularies Management"
@@ -19486,7 +19486,7 @@ msgstr ""
 
 #: scripts/apps/vocabularies/controllers/VocabularyEditController.tsx:101
 msgid "Vocabulary saved successfully"
-msgstr ""
+msgstr "Вокабулар успешно сачуван"
 
 #: scripts/apps/users/views/user-preferences.html:20
 #: scripts/apps/users/views/user-preferences.html:248
@@ -19495,7 +19495,7 @@ msgstr "Вредности вокабулара"
 
 #: scripts/apps/vocabularies/controllers/VocabularyConfigController.ts:243
 msgid "Vocabulary was deleted."
-msgstr ""
+msgstr "Вокабулар је обрисан."
 
 #: scripts/validate-instance-configuration.tsx:56
 msgid "Vocabulary with ID \"categories\" is required"
@@ -19507,7 +19507,7 @@ msgstr ""
 
 #: scripts/apps/content-filters/controllers/FilterConditionsController.ts:44
 msgid "WARNING unknown filter condition value: {{ value }}"
-msgstr ""
+msgstr "УПОЗОРЕЊЕ непозната вредност услова филтера: {{ value }}"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:91
 msgid "WE"
@@ -19622,18 +19622,18 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/ContentProfileFieldsConfig.tsx:95
 msgid "Widgets"
-msgstr ""
+msgstr "Виџети"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/scheduled-reports-list.html:58
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:156
 msgid "Width"
-msgstr ""
+msgstr "Ширина"
 
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:102
 msgid ""
 "Width of the\n"
 "                                    popup window (in pixels)"
-msgstr ""
+msgstr "Ширина\n                                    искачућег прозора (у пикселима)"
 
 #: scripts/apps/publish/directives/SubscribersDirective.ts:73
 msgid "Wire/Paper"
@@ -19751,7 +19751,7 @@ msgstr ""
 #: scripts/apps/vocabularies/components/VocabularyDeletionModal.tsx:106
 msgid ""
 "You are about to delete the vocabulary {{name}}. This action can't be undone."
-msgstr ""
+msgstr "Управо ћете обрисати вокабулар {{name}}. Ова радња не може бити поништена."
 
 #: scripts/apps/monitoring/views/aggregate-settings.html:109
 msgid ""
@@ -19773,11 +19773,11 @@ msgstr ""
 
 #: scripts/apps/workspace/content/services/ContentService.ts:71
 msgid "You are not allowed to create an article there."
-msgstr ""
+msgstr "Није вам дозвољено да креирате чланак тамо."
 
 #: scripts/apps/workspace/content/services/ContentService.ts:69
 msgid "You are not allowed to create article on readonly stage."
-msgstr ""
+msgstr "Није вам дозвољено да креирате чланак у фази само за читање."
 
 #: ../superdesk-planning/client/utils/events.tsx:510
 msgid ""
@@ -19878,7 +19878,7 @@ msgstr "Ваша сесија је истекла."
 
 #: scripts/apps/vocabularies/components/UploadComplete.tsx:8
 msgid "Your upload was successful"
-msgstr ""
+msgstr "Ваше отпремање је успешно"
 
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:209
 msgid "Zoom In"
@@ -19983,7 +19983,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:90
 msgid "annotation"
-msgstr ""
+msgstr "анотација"
 
 #: scripts/core/lang/missing-translations-strings.ts:13
 msgid "archive"
@@ -20023,7 +20023,7 @@ msgstr "уређивање"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:83
 msgid "bold"
-msgstr ""
+msgstr "подебљано"
 
 #: ../superdesk-planning/client/components/UI/Form/FileInput.tsx:205
 #: scripts/core/ui/components/Form/FileInput.tsx:137
@@ -20122,7 +20122,7 @@ msgstr "коментарисао"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:91
 msgid "comments"
-msgstr ""
+msgstr "коментари"
 
 #: scripts/core/lang/missing-translations-strings.ts:13
 msgid "compact"
@@ -20196,7 +20196,7 @@ msgstr "тренутно"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:86
 msgid "custom blocks"
-msgstr ""
+msgstr "прилагођени блокови"
 
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:17
 msgid "custom vocabulary"
@@ -20323,7 +20323,7 @@ msgstr "уграђени садржај"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:94
 msgid "embed articles"
-msgstr ""
+msgstr "уградња чланака"
 
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/utils.js:97
 #: scripts/extensions/availability-manager/dist/src/utils.js:97
@@ -20442,7 +20442,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:87
 msgid "formatting marks"
-msgstr ""
+msgstr "ознаке форматирања"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:36
 #: scripts/apps/authoring/versioning/history/views/history.html:47
@@ -20653,7 +20653,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:82
 msgid "italic"
-msgstr ""
+msgstr "курзив"
 
 #: scripts/apps/authoring-react/article-widgets/versions-and-item-history/history-tab.tsx:429
 msgid "item"
@@ -20710,7 +20710,7 @@ msgstr[2] ""
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:77
 msgid "link"
-msgstr ""
+msgstr "линк"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:143
 msgid "linked to"
@@ -20754,7 +20754,7 @@ msgstr ""
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:100
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:31
 msgid "lowercase"
-msgstr ""
+msgstr "мала слова"
 
 #: scripts/apps/packaging/services/PackagesService.ts:24
 #: scripts/apps/packaging/services/PackagesService.ts:55
@@ -20771,7 +20771,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:76
 msgid "media"
-msgstr ""
+msgstr "медиј"
 
 #: scripts/core/menu/notifications/views/notifications.html:35
 msgid "mentioned you"
@@ -20809,11 +20809,11 @@ msgstr ""
 #: scripts/apps/authoring-react/fields/date/config.tsx:85
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:155
 msgid "months"
-msgstr ""
+msgstr "месеци"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:85
 msgid "multi-line quote"
-msgstr ""
+msgstr "цитат у више редова"
 
 #: scripts/apps/search/views/saved-search-subscribe.html:23
 msgid "never"
@@ -20835,7 +20835,7 @@ msgstr "следеће"
 
 #: scripts/apps/content-filters/controllers/FilterSearchController.ts:112
 msgid "no results found"
-msgstr ""
+msgstr "нема пронађених резултата"
 
 #: scripts/apps/profiling/views/profiling.html:10
 #: scripts/apps/publish/views/publish-queue.html:18
@@ -21054,7 +21054,7 @@ msgstr "цитат"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:98
 msgid "redo"
-msgstr ""
+msgstr "понови"
 
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:10
 #: scripts/apps/workspace/helpers/getTypeForFieldId.ts:7
@@ -21063,11 +21063,11 @@ msgstr "повезани садржај"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:89
 msgid "remove all format"
-msgstr ""
+msgstr "уклони сво форматирање"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:88
 msgid "remove format"
-msgstr ""
+msgstr "уклони форматирање"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:111
 msgid "removed desk"
@@ -21168,7 +21168,7 @@ msgstr ""
 
 #: scripts/apps/content-filters/controllers/FilterSearchController.ts:31
 msgid "single value is required"
-msgstr ""
+msgstr "обавезна је једна вредност"
 
 #: scripts/core/lang/missing-translations-strings.ts:32
 msgid "slugline"
@@ -21237,7 +21237,7 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:80
 msgid "strikethrough"
-msgstr ""
+msgstr "прецртано"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:83
 #: scripts/core/lang/missing-translations-strings.ts:11
@@ -21246,7 +21246,7 @@ msgstr "поднето"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:79
 msgid "subscript"
-msgstr ""
+msgstr "индекс"
 
 #: scripts/core/lang/missing-translations-strings.ts:32
 msgid "subscription"
@@ -21263,11 +21263,11 @@ msgstr "успех"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:92
 msgid "suggestions"
-msgstr ""
+msgstr "сугестије"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:78
 msgid "superscript"
-msgstr ""
+msgstr "експонент"
 
 #: scripts/apps/legal-archive/views/legal_archive.html:16
 msgid "switch to grid view"
@@ -21279,15 +21279,15 @@ msgstr "пређи на приказ листе"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:95
 msgid "tab"
-msgstr ""
+msgstr "таб"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:96
 msgid "tab as space"
-msgstr ""
+msgstr "таб као размак"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:84
 msgid "table"
-msgstr ""
+msgstr "табела"
 
 #: scripts/extensions/auto-tagging-widget/dist/src/auto-tagging.js:58
 #: scripts/extensions/auto-tagging-widget/dist/src/extensions/auto-tagging-widget/src/auto-tagging.js:58
@@ -21341,11 +21341,11 @@ msgstr ""
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:81
 msgid "underline"
-msgstr ""
+msgstr "подвучено"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:97
 msgid "undo"
-msgstr ""
+msgstr "опозови"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:72
 #: scripts/core/editor3/helpers/highlights.ts:66
@@ -21394,7 +21394,7 @@ msgstr "отпремио медиј {{name}}"
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:30
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:99
 msgid "uppercase"
-msgstr ""
+msgstr "велика слова"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:98
 msgid "url of the search provider"
@@ -21495,7 +21495,7 @@ msgstr ""
 #: scripts/apps/authoring-react/fields/date/config.tsx:84
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:154
 msgid "weeks"
-msgstr ""
+msgstr "недеље"
 
 #: scripts/api/article-fetch.tsx:136
 msgid "width"
@@ -21523,7 +21523,7 @@ msgstr ""
 #: scripts/apps/authoring-react/fields/date/config.tsx:86
 #: scripts/apps/vocabularies/views/vocabulary-config-modal.html:156
 msgid "years"
-msgstr ""
+msgstr "године"
 
 #: scripts/apps/dashboard/views/configuration.html:2
 msgid "{{ 'Configuration' }}"
@@ -21813,9 +21813,9 @@ msgstr ""
 #: scripts/apps/dictionaries/views/dictionary-config-modal.html:55
 msgid "{{wordsCount}} word"
 msgid_plural "{{ $count}} words"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "{{wordsCount}} реч"
+msgstr[1] "{{wordsCount}} речи"
+msgstr[2] "{{wordsCount}} речи"
 
 #: scripts/extensions/datetimeField/dist/src/editor.js:76
 #: scripts/extensions/datetimeField/dist/src/extensions/datetimeField/src/editor.js:81

--- a/po/sr.po
+++ b/po/sr.po
@@ -108,7 +108,7 @@ msgstr "(Приватно)"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:269
 msgid "(advanced mode)"
-msgstr ""
+msgstr "(напредни режим)"
 
 #: scripts/apps/monitoring/views/monitoring-group-header.html:44
 msgid "(as defined for all groups)"
@@ -863,7 +863,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:267
 msgid "Add Coverages"
-msgstr ""
+msgstr "Додај извештавања"
 
 #: ../superdesk-analytics/client/utils.js:176
 msgid "Add Featuremedia"
@@ -1013,7 +1013,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Coverages/CoverageArrayInput.tsx:165
 #: ../superdesk-planning/client/components/fields/editor/Coverages.tsx:139
 msgid "Add a coverage"
-msgstr ""
+msgstr "Додај извештавање"
 
 #: ../superdesk-planning/client/components/GeoLookupInput/AddGeoLookupResultsPopUp.tsx:239
 msgid "Add a new location"
@@ -1207,7 +1207,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/MultiSelectActions.tsx:129
 #: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:52
 msgid "Add to workflow"
-msgstr ""
+msgstr "Додај у радни ток"
 
 #: scripts/apps/authoring-react/fields/urls/editor.tsx:85
 msgid "Add url"
@@ -1228,7 +1228,7 @@ msgstr "Додато у истакнуте приче"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:236
 msgid "Added to workflow"
-msgstr ""
+msgstr "Додато у радни ток"
 
 #: scripts/apps/relations/services/RelationsService.ts:46
 msgid ""
@@ -1306,7 +1306,7 @@ msgstr "Напредни филтери"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageAddButton/CoveragesMenuPopup.tsx:66
 msgid "Advanced mode"
-msgstr ""
+msgstr "Напредни режим"
 
 #: scripts/apps/search/views/search-panel.html:58
 msgid "Advanced search"
@@ -1362,7 +1362,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:38
 msgid "After"
-msgstr ""
+msgstr "После"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/createPlanningForm.tsx:46
 msgid "Agenda"
@@ -1559,7 +1559,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Events/EventDateTime.tsx:134
 msgid "All day"
-msgstr ""
+msgstr "Цео дан"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:122
 msgid "All featured planning items are currently selected"
@@ -2298,7 +2298,7 @@ msgstr "URL ресурса"
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:216
 #: ../superdesk-planning/client/components/UI/IconSelectButton/icons.ts:42
 msgid "Assign"
-msgstr ""
+msgstr "Додели"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:131
 msgid "Assign \"{{calendar}}\" Calendar to Series"
@@ -2368,12 +2368,12 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoveragePreview/CoveragePreviewTopBar.tsx:53
 msgid "Assignee"
-msgstr ""
+msgstr "Извршилац"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:254
 #: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:271
 msgid "Assignee:"
-msgstr ""
+msgstr "Извршилац:"
 
 #: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:44
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:78
@@ -2401,27 +2401,27 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:144
 msgid "Assignment has been cancelled, unable to reassign"
-msgstr ""
+msgstr "Задатак је отказан, није могуће поново доделити"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:145
 msgid "Assignment has been cancelled, unable to remove"
-msgstr ""
+msgstr "Задатак је отказан, није могуће уклонити"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:141
 msgid "Assignment has been completed, unable to reassign"
-msgstr ""
+msgstr "Задатак је завршен, није могуће поново доделити"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:142
 msgid "Assignment has been completed, unable to remove"
-msgstr ""
+msgstr "Задатак је завршен, није могуће уклонити"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:147
 msgid "Assignment is locked, unable to reassign"
-msgstr ""
+msgstr "Задатак је закључан, није могуће поново доделити"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:148
 msgid "Assignment is locked, unable to remove"
-msgstr ""
+msgstr "Задатак је закључан, није могуће уклонити"
 
 #: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:123
 msgid "Assignment locked"
@@ -2433,7 +2433,7 @@ msgstr "Приоритет задатка је ажуриран."
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:97
 msgid "Assignment removed"
-msgstr ""
+msgstr "Задатак уклоњен"
 
 #: ../superdesk-planning/client/actions/assignments/api.ts:362
 msgid "Assignment reverted."
@@ -2478,7 +2478,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoveragePreview/index.tsx:151
 msgid "Associated XMP File"
-msgstr ""
+msgstr "Повезана XMP датотека"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:94
 msgid "Associated an event"
@@ -3205,7 +3205,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:127
 msgid "Cancel Scheduled Update"
-msgstr ""
+msgstr "Откажи заказано ажурирање"
 
 #: scripts/apps/publish/views/publish-queue.html:83
 msgid "Cancel Selection"
@@ -3226,7 +3226,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/index.tsx:264
 #: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:51
 msgid "Cancel coverage"
-msgstr ""
+msgstr "Откажи извештавање"
 
 #: ../superdesk-planning/client/components/fields/resources/profiles.ts:53
 msgid "Cancel planning items with Event"
@@ -4143,7 +4143,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:72
 msgid "Content linked to coverage"
-msgstr ""
+msgstr "Садржај повезан са извештавањем"
 
 #: ../superdesk-planning/client/apps/Assignments/AssignmentPreview.tsx:122
 msgid "Content locked"
@@ -4160,7 +4160,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:95
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:77
 msgid "Content unlinked"
-msgstr ""
+msgstr "Веза садржаја уклоњена"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/fields/Content.tsx:24
 msgid "Content: {{ numberOfContent }}"
@@ -4197,7 +4197,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:80
 msgid "Converted to recurring event"
-msgstr ""
+msgstr "Конвертовано у понављајући догађај"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:92
 msgid "Copied to clipboard"
@@ -4407,7 +4407,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:266
 #: ../superdesk-planning/client/components/Coverages/CoveragePreview/CoveragePreviewTopBar.tsx:60
 msgid "Coverage Provider:"
-msgstr ""
+msgstr "Провајдер извештавања:"
 
 #: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/ScheduledUpdateForm.tsx:156
 #: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:231
@@ -4415,21 +4415,21 @@ msgstr ""
 #: ../superdesk-planning/client/components/fields/preview/index.ts:205
 #: ../superdesk-planning/client/utils/contentProfiles.ts:327
 msgid "Coverage Status"
-msgstr ""
+msgstr "Статус извештавања"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageAddButton/CoveragesMenuPopup.tsx:51
 #: ../superdesk-planning/client/components/fields/editor/CoverageType.tsx:34
 #: ../superdesk-planning/client/components/fields/preview/index.ts:70
 msgid "Coverage Type"
-msgstr ""
+msgstr "Тип извештавања"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:85
 msgid "Coverage added to workflow"
-msgstr ""
+msgstr "Извештавање додато у радни ток"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:32
 msgid "Coverage assigned"
-msgstr ""
+msgstr "Извештавање додељено"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:69
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:72
@@ -4438,31 +4438,31 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:89
 msgid "Coverage availability confirmed"
-msgstr ""
+msgstr "Доступност извештавања потврђена"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:93
 msgid "Coverage availability reverted"
-msgstr ""
+msgstr "Доступност извештавања враћена"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:68
 msgid "Coverage cancelled"
-msgstr ""
+msgstr "Извештавање отказано"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:105
 msgid "Coverage completed"
-msgstr ""
+msgstr "Извештавање завршено"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:64
 msgid "Coverage edited"
-msgstr ""
+msgstr "Извештавање измењено"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:293
 msgid "Coverage enabled"
-msgstr ""
+msgstr "Извештавање омогућено"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:287
 msgid "Coverage has been added to workflow"
-msgstr ""
+msgstr "Извештавање је додато у радни ток"
 
 #: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:28
 msgid "Coverage must be assigned to a desk"
@@ -4474,11 +4474,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:25
 msgid "Coverage of type {{ type }} created"
-msgstr ""
+msgstr "Креирано извештавање типа {{ type }}"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:81
 msgid "Coverage priority modified"
-msgstr ""
+msgstr "Приоритет извештавања измењен"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:51
 msgid "Coverage re-assigned to"
@@ -4486,11 +4486,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:30
 msgid "Coverage reassigned"
-msgstr ""
+msgstr "Извештавање поново додељено"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:52
 msgid "Coverage removed"
-msgstr ""
+msgstr "Извештавање уклоњено"
 
 #: ../superdesk-planning/client/components/fields/editor/AddCoverageToWorkflow.tsx:20
 msgid "Coverage was cancelled"
@@ -4791,11 +4791,11 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:92
 msgid "Created from 'update repetitions'"
-msgstr ""
+msgstr "Креирано из 'ажурирања понављања'"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:104
 msgid "Created from a planning item"
-msgstr ""
+msgstr "Креирано из ставке планирања"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:37
 msgid "Created from content"
@@ -4899,15 +4899,15 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:78
 msgid "Current Date"
-msgstr ""
+msgstr "Тренутни датум"
 
 #: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:82
 msgid "Current Date (Based on Event timezone)"
-msgstr ""
+msgstr "Тренутни датум (према временској зони догађаја)"
 
 #: ../superdesk-planning/client/components/Events/RepeatEventSummary/index.tsx:14
 msgid "Current Repeat Summary"
-msgstr ""
+msgstr "Тренутни сажетак понављања"
 
 #: ../superdesk-planning/client/components/Planning/FeaturedPlanning/FeaturedPlanningModal.tsx:181
 msgid "Currently Selected"
@@ -5109,7 +5109,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:113
 #: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:88
 msgid "Date:"
-msgstr ""
+msgstr "Датум:"
 
 #: scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx:352
 #: scripts/apps/authoring-react/field-adapters/dateline.ts:12
@@ -5156,7 +5156,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:30
 msgid "Day(s)"
-msgstr ""
+msgstr "Дан(а)"
 
 #: scripts/apps/ingest/views/settings/ingest-routing-schedule.html:4
 msgid "Days"
@@ -5612,11 +5612,11 @@ msgstr "Деск(ови)"
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateAssignmentForm.tsx:157
 #: ../superdesk-planning/client/components/fields/editor/EventRelatedPlannings/EmbeddedCoverageForm.tsx:166
 msgid "Desk:"
-msgstr ""
+msgstr "Деск:"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:111
 msgid "Desk: {{ desk }}"
-msgstr ""
+msgstr "Деск: {{ desk }}"
 
 #: ../superdesk-analytics/client/search/directives/PreviewSourceFilter.js:109
 #: ../superdesk-analytics/client/search/directives/SourceFilters.js:383
@@ -6064,7 +6064,7 @@ msgstr "Време рока"
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:119
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateAssignmentForm.tsx:128
 msgid "Due:"
-msgstr ""
+msgstr "Рок:"
 
 #: ../superdesk-analytics/client/desk_activity_report/controllers/DeskActivityReportController.js:435
 #: ../superdesk-analytics/client/utils.js:169
@@ -6079,11 +6079,11 @@ msgstr ""
 #: scripts/apps/search/controllers/get-bulk-actions.tsx:242
 #: scripts/core/interactive-article-actions-panel/actions/duplicate-to-action.tsx:92
 msgid "Duplicate"
-msgstr ""
+msgstr "Дуплирај"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/index.tsx:230
 msgid "Duplicate As"
-msgstr ""
+msgstr "Дуплирај као"
 
 #: scripts/core/lang/missing-translations-strings.ts:16
 msgid "Duplicate Content within a Desk"
@@ -6349,7 +6349,7 @@ msgstr "Уреди речник"
 
 #: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:114
 msgid "Edit Event"
-msgstr ""
+msgstr "Уреди догађај"
 
 #: ../superdesk-planning/client/components/EventsPlanningFilters/FilterItem.tsx:96
 #: ../superdesk-planning/client/constants/tooltips.ts:35
@@ -6728,7 +6728,7 @@ msgstr "URL крајње тачке"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:133
 msgid "Ends"
-msgstr ""
+msgstr "Завршава се"
 
 #: scripts/apps/publish-preview/previewModal.tsx:67
 msgid ""
@@ -7154,7 +7154,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Events/EventEditor/index.tsx:182
 msgid "Event Name"
-msgstr ""
+msgstr "Назив догађаја"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:47
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:65
@@ -7172,7 +7172,7 @@ msgstr "Догађај поново заказан"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:51
 msgid "Event Rescheduled from"
-msgstr ""
+msgstr "Догађај поново заказан са"
 
 #: ../superdesk-planning/client/components/fields/editor/EventSchedule.tsx:206
 msgid "Event Starts"
@@ -7180,7 +7180,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:60
 msgid "Event cancelled"
-msgstr ""
+msgstr "Догађај отказан"
 
 #: ../superdesk-planning/client/validators/events.ts:154
 msgid "Event duration is greater than {{maxDuration}} days."
@@ -7204,7 +7204,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:84
 msgid "Event repetitions modified"
-msgstr ""
+msgstr "Понављања догађаја измењена"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:522
 msgid "Event repetitions updated"
@@ -7212,7 +7212,7 @@ msgstr "Понављања догађаја ажурирана"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:31
 msgid "Event spiked"
-msgstr ""
+msgstr "Догађај премештен у корпу"
 
 #: ../superdesk-planning/client/actions/events/ui.ts:507
 msgid "Event time has been updated"
@@ -7220,11 +7220,11 @@ msgstr "Време догађаја је ажурирано"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:76
 msgid "Event time modified"
-msgstr ""
+msgstr "Време догађаја измењено"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:35
 msgid "Event unspiked"
-msgstr ""
+msgstr "Догађај враћен из корпе"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/rescheduleEventForm.tsx:234
 msgid "Event will be changed to a multi-day event!"
@@ -7261,7 +7261,7 @@ msgstr "Само догађаји"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:101
 msgid "Every"
-msgstr ""
+msgstr "Сваких"
 
 #: ../superdesk-planning/client/utils/filters.ts:163
 #: ../superdesk-planning/client/utils/filters.ts:180
@@ -7442,7 +7442,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:237
 #: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:116
 msgid "External Links"
-msgstr ""
+msgstr "Спољашњи линкови"
 
 #: ../superdesk-planning/client/components/Events/EventEditor/index.tsx:172
 #: ../superdesk-planning/client/components/editor-standalone/field-definitions/index.ts:61
@@ -10842,7 +10842,7 @@ msgstr "Месец"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:32
 msgid "Month(s)"
-msgstr ""
+msgstr "Месец(и)"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:40
 #: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:26
@@ -11427,7 +11427,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:251
 #: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:129
 msgid "No external links added."
-msgstr ""
+msgstr "Нису додати спољашњи линкови."
 
 #: scripts/apps/ingest/views/settings/ingest-routing-general.html:20
 msgid "No fetch or publish actions defined"
@@ -11534,7 +11534,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:149
 msgid "No related planning items."
-msgstr ""
+msgstr "Нема повезаних ставки планирања."
 
 #: ../superdesk-planning/client/components/Locations/LocationsList.tsx:79
 msgid "No result"
@@ -11783,13 +11783,13 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:134
 msgid "Not scheduled"
-msgstr ""
+msgstr "Није заказано"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:152
 #: ../superdesk-planning/client/components/fields/preview/index.ts:200
 #: ../superdesk-planning/client/utils/planning.tsx:1816
 msgid "Not scheduled yet"
-msgstr ""
+msgstr "Још није заказано"
 
 #: scripts/extensions/availability-manager/dist/src/components/status-select.js:20
 #: scripts/extensions/availability-manager/dist/src/extensions/availability-manager/src/components/status-select.js:20
@@ -11934,7 +11934,7 @@ msgstr "Укључено"
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:175
 msgid "On Days"
-msgstr ""
+msgstr "У данима"
 
 #: ../superdesk-planning/client/components/ExportAsArticleModal.tsx:341
 msgid ""
@@ -11975,7 +11975,7 @@ msgstr "Дозволи само садржај са\n                           
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageForm.tsx:247
 msgid "Only one XMP files are accepted"
-msgstr ""
+msgstr "Прихвата се само једна XMP датотека"
 
 #: scripts/apps/archive/controllers/UploadController.ts:229
 msgid "Only one file can be uploaded"
@@ -12772,7 +12772,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:72
 msgid "Planning item created"
-msgstr ""
+msgstr "Ставка планирања креирана"
 
 #: ../superdesk-planning/client/components/fields/editor/AssociatedEvent.tsx:97
 msgid "Planning item has to be created before adding related events"
@@ -13289,7 +13289,7 @@ msgstr "Провајдер {{name}} је неуобичајено тих. Пос
 #: ../superdesk-planning/client/components/Coverages/CoverageItem.tsx:279
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/editPriorityForm.tsx:110
 msgid "Provider:"
-msgstr ""
+msgstr "Провајдер:"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentItem/index.tsx:218
 msgid "Provider: {{ name }}"
@@ -13631,7 +13631,7 @@ msgstr ""
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:155
 #: ../superdesk-planning/client/constants/assignments.ts:192
 msgid "Reassign"
-msgstr ""
+msgstr "Поново додели"
 
 #: scripts/apps/search/components/fields/state.tsx:43
 msgid "Recalled"
@@ -13800,7 +13800,7 @@ msgstr "Повезане ставке"
 
 #: ../superdesk-planning/client/components/Events/EventPreviewContent.tsx:134
 msgid "Related Planning Items"
-msgstr ""
+msgstr "Повезане ставке планирања"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/forms/updateRecurringEventsForm.tsx:220
 msgid "Related Planning(s)"
@@ -13930,7 +13930,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Events/EventMetadata/index.tsx:127
 msgid "Remove Event"
-msgstr ""
+msgstr "Уклони догађај"
 
 #: ../superdesk-analytics/client/utils.js:179
 msgid "Remove Featuremedia"
@@ -13954,7 +13954,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/ScheduledUpdate/index.tsx:154
 msgid "Remove Scheduled Update"
-msgstr ""
+msgstr "Уклони заказано ажурирање"
 
 #: scripts/apps/search-providers/views/search-provider-config.html:17
 msgid "Remove Search Provider"
@@ -13982,7 +13982,7 @@ msgstr "Уклони конфигурацију"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/index.tsx:277
 msgid "Remove coverage"
-msgstr ""
+msgstr "Уклони извештавање"
 
 #: scripts/apps/desks/views/settings.html:53
 msgid "Remove desk"
@@ -14110,12 +14110,12 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/DaysOfWeekInput.tsx:98
 msgid "Repeat On"
-msgstr ""
+msgstr "Понови у"
 
 #: ../superdesk-planning/client/components/Events/EventScheduleSummary/index.tsx:99
 #: ../superdesk-planning/client/components/Events/RepeatEventSummary/index.tsx:15
 msgid "Repeat Summary"
-msgstr ""
+msgstr "Сажетак понављања"
 
 #: ../superdesk-planning/client/validators/profile.ts:44
 #: ../superdesk-planning/client/validators/profile.ts:45
@@ -14131,7 +14131,7 @@ msgstr "Понавља се"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:88
 msgid "Repetitions updated"
-msgstr ""
+msgstr "Понављања ажурирана"
 
 #: scripts/apps/authoring-react/article-widgets/find-and-replace.tsx:125
 #: scripts/apps/authoring-react/macros/interactive-macros-display.tsx:161
@@ -14524,7 +14524,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoveragePreview/index.tsx:178
 msgid "SCHEDULED UPDATES"
-msgstr ""
+msgstr "ЗАКАЗАНА АЖУРИРАЊА"
 
 #: scripts/apps/authoring/views/authoring-header.html:45
 msgid "SIGNAL"
@@ -16477,11 +16477,11 @@ msgstr "Статус:"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:112
 msgid "Status: Unassigned"
-msgstr ""
+msgstr "Статус: Недодељено"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:143
 msgid "Status: {{ state }}"
-msgstr ""
+msgstr "Статус: {{ state }}"
 
 #: scripts/apps/ingest/views/settings/ingest-sources-content.html:11
 msgid "Status: {{filter}}"
@@ -16853,7 +16853,7 @@ msgstr ""
 #: ../superdesk-planning/client/utils/planning.tsx:1380
 #: ../superdesk-planning/client/utils/planning.tsx:1795
 msgid "TBC"
-msgstr ""
+msgstr "TBC"
 
 #: ../superdesk-analytics/client/scheduled_reports/views/report-schedule-input.html:99
 msgid "TH"
@@ -17915,7 +17915,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageFormHeader.tsx:105
 msgid "This will also remove linked assignments if any"
-msgstr ""
+msgstr "Ово ће такође уклонити повезане задатке ако постоје"
 
 #: ../superdesk-planning/client/actions/assignments/ui.ts:762
 msgid ""
@@ -17990,7 +17990,7 @@ msgstr "Временски ограничено"
 
 #: ../superdesk-planning/client/components/Events/EventDateTime.tsx:59
 msgid "Time TBC"
-msgstr ""
+msgstr "Време TBC"
 
 #: scripts/apps/archive/views/metadata-view.html:141
 #: scripts/core/ui/views/sd-timezone.html:1
@@ -18470,7 +18470,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:139
 msgid "Type: {{ type }}"
-msgstr ""
+msgstr "Тип: {{ type }}"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentPreviewContainer/AssignmentPreviewHeader.tsx:152
 msgid "Type: {{type}}"
@@ -18849,7 +18849,7 @@ msgstr "Циклус ажурирања:"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageIcons.tsx:200
 msgid "Update Due:"
-msgstr ""
+msgstr "Рок ажурирања:"
 
 #: ../superdesk-planning/client/components/ItemActionConfirmation/modal.tsx:114
 #: ../superdesk-planning/client/constants/events.ts:164
@@ -18931,7 +18931,7 @@ msgstr "Ажурирано"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:129
 msgid "Updated Fields:"
-msgstr ""
+msgstr "Ажурирана поља:"
 
 #: ../superdesk-analytics/client/update_time_report/directives/UpdateTimeTable.js:68
 msgid "Updated In"
@@ -19397,7 +19397,7 @@ msgstr "Прикажи повезан догађај"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:155
 msgid "View duplicate event"
-msgstr ""
+msgstr "Прикажи дупликат догађаја"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:140
 msgid "View duplicate planning item"
@@ -19433,7 +19433,7 @@ msgstr "Прикажи обавештења"
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:189
 #: ../superdesk-planning/client/components/fields/state.tsx:32
 msgid "View original event"
-msgstr ""
+msgstr "Прикажи оригинални догађај"
 
 #: ../superdesk-planning/client/components/Planning/PlanningHistory.tsx:152
 msgid "View original planning item"
@@ -19442,7 +19442,7 @@ msgstr "Прикажи оригиналну ставку планирања"
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:143
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:204
 msgid "View planning item"
-msgstr ""
+msgstr "Прикажи ставку планирања"
 
 #: scripts/core/menu/views/menu.html:58
 msgid "View profile details"
@@ -19450,7 +19450,7 @@ msgstr "Прикажи детаље профила"
 
 #: ../superdesk-planning/client/components/Events/EventHistory.tsx:177
 msgid "View rescheduled event"
-msgstr ""
+msgstr "Прикажи поново заказан догађај"
 
 #: ../superdesk-analytics/client/saved_reports/views/saved-report-item.html:58
 msgid "View schedules"
@@ -19573,7 +19573,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:31
 msgid "Week(s)"
-msgstr ""
+msgstr "Недеља(е)"
 
 #: ../superdesk-analytics/client/scheduled_reports/directives/ReportScheduleInput.js:37
 #: ../superdesk-planning/client/components/fields/editor/ScheduleFrequency.tsx:23
@@ -19661,7 +19661,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:101
 msgid "Work started on coverage"
-msgstr ""
+msgstr "Започет рад на извештавању"
 
 #: scripts/core/activity/activity.ts:22
 msgid "Workflow"
@@ -19726,7 +19726,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Events/RecurringRulesInput/index.tsx:33
 msgid "Year(s)"
-msgstr ""
+msgstr "Година(е)"
 
 #: ../superdesk-analytics/client/charts/directives/ChartColourPicker.js:61
 msgid "Yellow"
@@ -19787,7 +19787,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageEditor/CoverageForm.tsx:233
 msgid "You can associate only one XMP file"
-msgstr ""
+msgstr "Можете повезати само једну XMP датотеку"
 
 #: scripts/apps/desks/views/desk-config-modal.html:134
 msgid ""
@@ -19979,7 +19979,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:45
 msgid "and '{{ user }}'"
-msgstr ""
+msgstr "и '{{ user }}'"
 
 #: scripts/apps/workspace/content/components/get-content-profiles-form-config.tsx:90
 msgid "annotation"
@@ -20426,7 +20426,7 @@ msgstr "за деск \"{{name}}\""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:42
 msgid "for '{{ desk }}'"
-msgstr ""
+msgstr "за '{{ desk }}'"
 
 #: scripts/apps/authoring/versioning/history/views/history.html:97
 msgid "for desk"
@@ -20452,7 +20452,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:28
 msgid "from content"
-msgstr ""
+msgstr "из садржаја"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:95
 msgid "from coverage assignment by"
@@ -20763,7 +20763,7 @@ msgstr ""
 
 #: ../superdesk-planning/client/components/Coverages/CoverageAddAdvancedModal.tsx:390
 msgid "make this mode the default"
-msgstr ""
+msgstr "постави овај режим као подразумевани"
 
 #: scripts/core/views/sdSearchList.html:17
 msgid "many"
@@ -21313,7 +21313,7 @@ msgstr "до"
 
 #: ../superdesk-planning/client/components/Coverages/CoverageHistory.tsx:41
 msgid "to '{{ desk }}'"
-msgstr ""
+msgstr "на '{{ desk }}'"
 
 #: ../superdesk-planning/client/components/Assignments/AssignmentHistory.tsx:75
 msgid "to coverage assignment by"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -449,6 +449,7 @@ function getDefaults(grunt) {
             'pt_BR',
             'pl',
             'ja',
+            'sr',
         ],
 
         userOnlineMinutes: 15,


### PR DESCRIPTION
### Purpose
Adds full Serbian Cyrillic (`sr`) UI translation so Serbian-speaking
newsroom staff can use Superdesk in their native language. The
translation work was reviewed up-front by a native Serbian language
expert, and terminology decisions are locked in a glossary so
follow-up batches stay consistent.

Also fixes a dev-mode bug discovered while validating the work: any
non-English UI was silently broken under `grunt server` because
`dist/languages/<lang>.json` was never generated.

### What has changed
- **`po/sr.po`** — new Serbian Cyrillic catalog: 4261 / 4302 entries
  translated (99.0%) across core UI, authoring, planning, publishing,
  settings/admin, analytics, and extensions. Ekavian dialect, neutral
  Serbian. 41 entries deliberately left untranslated (compact 1–3
  letter button labels like `C`, `K`, `C & C`, `P & C`, `S & D`, `T D`,
  HTML element tags `h1`–`h6`/`pre`, technical ids like `mgrid`, three
  HTML-heavy `<sd-spinner>` save buttons, and pure-placeholder msgids
  like `{{macro.label}}`).
- **`docs/i18n/sr-glossary.md`** — new glossary documenting the locked
  terminology (e.g. `slugline → слаглајн`, `desk → деск`,
  `coverage → извештавање`, `spike → корпа`, `ingest → пријем`,
  `routing scheme → шема рутирања`).
- **`webpack.config.js`** — adds `'sr'` to `profileLanguages` so
  "Српски" is selectable in the user-manager language dropdown.
- **`Gruntfile.js`** — registers a new `po-to-json` grunt task and adds
  it to the `server` task chain. The runtime (`scripts/init.ts`,
  `scripts/reload-language.ts`) expects catalogs in gettext.js flat
  format produced by `@superdesk/build-tools po-to-json`. Production
  builds run that command via `build-tools` `build-root-repo`, but
  `grunt server` ran neither it nor `nggettext_compile`, so devs got
  silent 404s for `/languages/<lang>.json` and the UI fell back to
  English regardless of the user's selected language.

### Steps to test
1. Pull the branch and run `grunt server` (or `grunt server --server=...`
   from `e2e/client/`).
2. In the user manager, edit a user → set Language to "Српски" → save.
3. Refresh the page. UI should render in Serbian Cyrillic across the
   areas you visit (lists, modals, settings panels, planning, etc.).
4. Verify other languages still work — e.g. switch to Spanish or
   Japanese and confirm those translations still load (this PR doesn't
   touch their `.po` files but the new dev-server step affects how all
   catalogs are compiled in dev).
5. Run `npx @superdesk/build-tools po-to-json po dist/languages` (the
   production path) — should still produce valid catalogs.
6. (Optional) glance over `docs/i18n/sr-glossary.md` if you want to see
   which terminology choices were locked.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
