### PR TITLE
[STT-1657] - Spell checking unavailable in stories created from highlight templates

### DIFF
--- a/scripts/apps/authoring/views/authoring-topbar.html
+++ b/scripts/apps/authoring/views/authoring-topbar.html
@@ -252,7 +252,7 @@
         </button>
 
         <div id="authoring-extra-dropdown"
-             ng-if="item._type !== 'legal_archive' && item._type !== 'archived' && !highlight && item.state !== 'spiked' && buttonsToHide['article-edit--topbar--actions'] !== true"
+             ng-if="item._type !== 'legal_archive' && item._type !== 'archived' && item.state !== 'spiked' && buttonsToHide['article-edit--topbar--actions'] !== true"
              class="dropdown pull-left strict" dropdown>
             <button
               id="more-actions"


### PR DESCRIPTION
### Purpose
This PR is a cherry-pick of #5170 into release/3.5

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I reviewed my code
- [X] I tested all affected functionality and made sure it works

Resolves: [STT-1657](https://sofab.atlassian.net/browse/STT-1657)


[STT-1657]: https://sofab.atlassian.net/browse/STT-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ