### PR TITLE
[SDESK-7925] Build extensions from source so local-linked dev setups stop breaking

### DIFF
--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.0.19",
+  "version": "1.1.0",
   "publishConfig": {
     "access": "public"
   },

--- a/build-tools/src/extensions/install-extensions.js
+++ b/build-tools/src/extensions/install-extensions.js
@@ -83,6 +83,24 @@ module.exports = function installExtensions(clientDir) {
     directories.forEach(({extensionRootPath, extensionSrcPath}) => {
         // if src dir doesn't exist, assume that the extension is already built (e.g. when installed from npm)
         if (fs.existsSync(extensionSrcPath)) {
+            const pkgPath = path.join(extensionRootPath, 'package.json');
+            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+
+            // Extensions whose `main` points at TypeScript source are consumed
+            // directly by webpack's ts-loader. Skip compile and the legacy
+            // `correct*` fixups. Still install runtime `dependencies` so webpack
+            // can resolve them via the extension's nested node_modules walk.
+            // (When workspaces land, this per-extension install goes away.)
+            if (typeof pkg.main === 'string' && /\.(ts|tsx)$/.test(pkg.main)) {
+                if (pkg.dependencies && Object.keys(pkg.dependencies).length > 0) {
+                    execSync(
+                        `cd ${extensionRootPath} && npm install --no-audit --omit=dev`,
+                        {stdio: 'inherit'}
+                    );
+                }
+                return;
+            }
+
             correctApiDefinitionsPath(extensionRootPath, clientDir);
 
             execSync(

--- a/build-tools/src/extensions/install-extensions.js
+++ b/build-tools/src/extensions/install-extensions.js
@@ -94,8 +94,8 @@ module.exports = function installExtensions(clientDir) {
             if (typeof pkg.main === 'string' && /\.(ts|tsx)$/.test(pkg.main)) {
                 if (pkg.dependencies && Object.keys(pkg.dependencies).length > 0) {
                     execSync(
-                        `cd ${extensionRootPath} && npm install --no-audit --omit=dev`,
-                        {stdio: 'inherit'}
+                        'npm install --no-audit --omit=dev',
+                        {stdio: 'inherit', cwd: extensionRootPath}
                     );
                 }
                 return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,6 +127,7 @@
         "angular-mocks": "1.6.9",
         "enzyme": "3.11.0",
         "enzyme-adapter-react-16": "^1.15.5",
+        "fork-ts-checker-webpack-plugin": "^9.0.0",
         "grunt-karma": "^4.0.2",
         "karma": "^6.4.3",
         "karma-chrome-launcher": "^3.2.0",
@@ -141,7 +142,7 @@
     },
     "build-tools": {
       "name": "@superdesk/build-tools",
-      "version": "1.0.19",
+      "version": "1.2.0",
       "dev": true,
       "dependencies": {
         "commander": "^7.2.0",
@@ -164,6 +165,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -4043,6 +4059,33 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -4502,6 +4545,16 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/default-browser": {
       "version": "5.4.0",
@@ -5233,6 +5286,16 @@
       },
       "bin": {
         "errno": "cli.js"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
@@ -6362,6 +6425,137 @@
         "node": "*"
       }
     },
+    "node_modules/fork-ts-checker-webpack-plugin": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-9.1.0.tgz",
+      "integrity": "sha512-mpafl89VFPJmhnJ1ssH+8wmM2b50n+Rew5x42NeI2U78aRWgtkEtGmctp7iT16UjquJTjorEmIfESj3DxdW84Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.16.7",
+        "chalk": "^4.1.2",
+        "chokidar": "^4.0.1",
+        "cosmiconfig": "^8.2.0",
+        "deepmerge": "^4.2.2",
+        "fs-extra": "^10.0.0",
+        "memfs": "^3.4.1",
+        "minimatch": "^3.0.4",
+        "node-abort-controller": "^3.0.1",
+        "schema-utils": "^3.1.1",
+        "semver": "^7.3.5",
+        "tapable": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "typescript": ">3.6.0",
+        "webpack": "^5.11.0"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/memfs": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
+      "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "fs-monkey": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
@@ -6415,6 +6609,13 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/fs-monkey": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
+      "integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -8500,6 +8701,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-async-function": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
@@ -9722,6 +9930,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/load-grunt-config": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/load-grunt-config/-/load-grunt-config-4.0.1.tgz",
@@ -10478,6 +10693,13 @@
         "lower-case": "^1.1.1"
       }
     },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -11052,6 +11274,25 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -11222,6 +11463,16 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pbkdf2": {
       "version": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint": "^8.57.1",
     "eslint-plugin-react": "^7.37.0",
     "file-loader": "^6.2.0",
+    "fork-ts-checker-webpack-plugin": "^9.0.0",
     "gettext.js": "0.9.0",
     "git-rev-sync": "1.10.0",
     "gridster": "github:superdesk/gridster.js#885d0c9",

--- a/scripts/extensions/ai-widget/package-lock.json
+++ b/scripts/extensions/ai-widget/package-lock.json
@@ -9,7 +9,7 @@
         "typescript": "~4.9.5"
       },
       "peerDependencies": {
-        "@sourcefabric/common": "^0.0.69"
+        "@sourcefabric/common": "*"
       }
     },
     "node_modules/@babel/runtime": {

--- a/scripts/extensions/ai-widget/package-lock.json
+++ b/scripts/extensions/ai-widget/package-lock.json
@@ -4,12 +4,12 @@
   "requires": true,
   "packages": {
     "": {
-      "dependencies": {
-        "@sourcefabric/common": "0.0.66"
-      },
       "devDependencies": {
         "superdesk-code-style": "1.3.0",
         "typescript": "~4.9.5"
+      },
+      "peerDependencies": {
+        "@sourcefabric/common": "^0.0.69"
       }
     },
     "node_modules/@babel/runtime": {
@@ -17,6 +17,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -25,15 +26,17 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@sourcefabric/common": {
-      "version": "0.0.66",
-      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.66.tgz",
-      "integrity": "sha512-fgxp7rZKNrfiL9c21+imXqdcFWRDudw/VSwlcbGch+dtkXDdH4owSPfTdR/Sb/UClcbrGgZQHK0asQF2XpVpDA==",
+      "version": "0.0.69",
+      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.69.tgz",
+      "integrity": "sha512-Uopya/TWgewqPz0T1SxNIpT92ujeKYQ8ba3OPTDcBYOAL4Bs58ONljaRA+FrOFtEzRpJzeBuUz9t8Vovb/ko+Q==",
+      "peer": true,
       "dependencies": {
         "date-fns": "^4.1.0",
         "lodash": "4.17.19",
@@ -51,6 +54,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -61,6 +65,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
       "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -75,6 +80,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
       "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -90,6 +96,7 @@
       "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
       "integrity": "sha512-v1CDCvdfoR3zLGNp6qsBa4J1BWMEVH25+UKxF/RvQRh+mrB+emqtVHMgZ+WreUiKJoEaiwYoScaueIKhMVBHUg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.2.0",
         "invariant": "^2.2.4",
@@ -106,6 +113,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
       "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -1668,6 +1676,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -2359,6 +2368,7 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/primereact/-/primereact-6.6.0.tgz",
       "integrity": "sha512-onoowjhlOz9Kcjna1DYEKWTGjKah4MjqZchm9E3BkcWjeXoCLv3F5QnIo8eVF9q+xymEK/6Oh7zHlfCJYyWwDw==",
+      "peer": true,
       "peerDependencies": {
         "react": "^17.0.1",
         "react-dom": "^17.0.1"
@@ -2989,6 +2999,7 @@
       "version": "6.3.7",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
       "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }

--- a/scripts/extensions/ai-widget/package.json
+++ b/scripts/extensions/ai-widget/package.json
@@ -1,16 +1,14 @@
 {
   "private": true,
-  "main": "dist/src/extension.js",
+  "main": "src/extension.ts",
   "scripts": {
-    "compile": "tsc -p src",
-    "compile-e2e": "echo 'No end-to-end tests defined'",
-    "watch": "tsc -watch -p src"
+    "compile-e2e": "echo 'No end-to-end tests defined'"
   },
   "devDependencies": {
     "superdesk-code-style": "1.3.0",
     "typescript": "~4.9.5"
   },
-  "dependencies": {
-    "@sourcefabric/common": "0.0.66"
+  "peerDependencies": {
+    "@sourcefabric/common": "^0.0.69"
   }
 }

--- a/scripts/extensions/ai-widget/package.json
+++ b/scripts/extensions/ai-widget/package.json
@@ -9,6 +9,6 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@sourcefabric/common": "^0.0.69"
+    "@sourcefabric/common": "*"
   }
 }

--- a/scripts/extensions/annotationsLibrary/package-lock.json
+++ b/scripts/extensions/annotationsLibrary/package-lock.json
@@ -10,7 +10,7 @@
         "typescript": "~4.9.5"
       },
       "peerDependencies": {
-        "react": "16.8.6"
+        "react": "*"
       }
     },
     "node_modules/@types/prop-types": {

--- a/scripts/extensions/annotationsLibrary/package.json
+++ b/scripts/extensions/annotationsLibrary/package.json
@@ -1,10 +1,8 @@
 {
   "private": true,
-  "main": "dist/src/extension.js",
+  "main": "src/extension.tsx",
   "scripts": {
-    "compile": "tsc -p src",
-    "compile-e2e": "echo 'No end-to-end tests defined'",
-    "watch": "tsc -watch -p src"
+    "compile-e2e": "echo 'No end-to-end tests defined'"
   },
   "devDependencies": {
     "@types/react": "16.8.23",

--- a/scripts/extensions/annotationsLibrary/package.json
+++ b/scripts/extensions/annotationsLibrary/package.json
@@ -10,6 +10,6 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "react": "16.8.6"
+    "react": "*"
   }
 }

--- a/scripts/extensions/availability-manager/package-lock.json
+++ b/scripts/extensions/availability-manager/package-lock.json
@@ -12,8 +12,8 @@
         "typescript": "~4.9.5"
       },
       "peerDependencies": {
-        "@sourcefabric/common": "^0.0.69",
-        "date-fns": "^4.1.0"
+        "@sourcefabric/common": "*",
+        "date-fns": "*"
       }
     },
     "node_modules/@babel/runtime": {

--- a/scripts/extensions/availability-manager/package-lock.json
+++ b/scripts/extensions/availability-manager/package-lock.json
@@ -4,16 +4,16 @@
   "requires": true,
   "packages": {
     "": {
-      "dependencies": {
-        "@sourcefabric/common": "0.0.66",
-        "date-fns": "^4.1.0"
-      },
       "devDependencies": {
         "@types/mocha": "9.1.1",
         "mocha": "11.7.5",
         "superdesk-code-style": "1.3.0",
         "ts-node": "10.9.1",
         "typescript": "~4.9.5"
+      },
+      "peerDependencies": {
+        "@sourcefabric/common": "^0.0.69",
+        "date-fns": "^4.1.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -21,6 +21,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -180,15 +181,17 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@sourcefabric/common": {
-      "version": "0.0.66",
-      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.66.tgz",
-      "integrity": "sha512-fgxp7rZKNrfiL9c21+imXqdcFWRDudw/VSwlcbGch+dtkXDdH4owSPfTdR/Sb/UClcbrGgZQHK0asQF2XpVpDA==",
+      "version": "0.0.69",
+      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.69.tgz",
+      "integrity": "sha512-Uopya/TWgewqPz0T1SxNIpT92ujeKYQ8ba3OPTDcBYOAL4Bs58ONljaRA+FrOFtEzRpJzeBuUz9t8Vovb/ko+Q==",
+      "peer": true,
       "dependencies": {
         "date-fns": "^4.1.0",
         "lodash": "4.17.19",
@@ -205,13 +208,15 @@
     "node_modules/@sourcefabric/common/node_modules/lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "peer": true
     },
     "node_modules/@sourcefabric/common/node_modules/react": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
       "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -226,6 +231,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
       "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -241,6 +247,7 @@
       "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
       "integrity": "sha512-v1CDCvdfoR3zLGNp6qsBa4J1BWMEVH25+UKxF/RvQRh+mrB+emqtVHMgZ+WreUiKJoEaiwYoScaueIKhMVBHUg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.2.0",
         "invariant": "^2.2.4",
@@ -257,6 +264,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
       "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -746,6 +754,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -1440,6 +1449,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -2305,6 +2315,7 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/primereact/-/primereact-6.6.0.tgz",
       "integrity": "sha512-onoowjhlOz9Kcjna1DYEKWTGjKah4MjqZchm9E3BkcWjeXoCLv3F5QnIo8eVF9q+xymEK/6Oh7zHlfCJYyWwDw==",
+      "peer": true,
       "peerDependencies": {
         "react": "^17.0.1",
         "react-dom": "^17.0.1"
@@ -2815,6 +2826,7 @@
       "version": "6.3.7",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
       "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }

--- a/scripts/extensions/availability-manager/package.json
+++ b/scripts/extensions/availability-manager/package.json
@@ -1,10 +1,8 @@
 {
   "private": true,
-  "main": "dist/src/extension.js",
+  "main": "src/extension.ts",
   "scripts": {
-    "compile": "tsc -p src",
     "compile-e2e": "echo 'No end-to-end tests defined'",
-    "watch": "tsc -watch -p src",
     "test": "mocha",
     "debug-tests": "mocha --inspect-brk"
   },
@@ -15,8 +13,8 @@
     "ts-node": "10.9.1",
     "typescript": "~4.9.5"
   },
-  "dependencies": {
-    "@sourcefabric/common": "0.0.66",
+  "peerDependencies": {
+    "@sourcefabric/common": "^0.0.69",
     "date-fns": "^4.1.0"
   }
 }

--- a/scripts/extensions/availability-manager/package.json
+++ b/scripts/extensions/availability-manager/package.json
@@ -14,7 +14,7 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@sourcefabric/common": "^0.0.69",
-    "date-fns": "^4.1.0"
+    "@sourcefabric/common": "*",
+    "date-fns": "*"
   }
 }

--- a/scripts/extensions/availability-manager/src/tsconfig.json
+++ b/scripts/extensions/availability-manager/src/tsconfig.json
@@ -7,5 +7,6 @@
             "dom",
             "ES2019",
         ],
-    }
+    },
+    "exclude": ["**/*.spec.ts", "**/*.test.ts"]
 }

--- a/scripts/extensions/broadcasting/package-lock.json
+++ b/scripts/extensions/broadcasting/package-lock.json
@@ -12,7 +12,7 @@
         "typescript": "~4.9.5"
       },
       "peerDependencies": {
-        "@sourcefabric/common": "^0.0.69"
+        "@sourcefabric/common": "*"
       }
     },
     "node_modules/@babel/runtime": {

--- a/scripts/extensions/broadcasting/package-lock.json
+++ b/scripts/extensions/broadcasting/package-lock.json
@@ -4,15 +4,15 @@
   "requires": true,
   "packages": {
     "": {
-      "dependencies": {
-        "@sourcefabric/common": "0.0.66"
-      },
       "devDependencies": {
         "@types/mocha": "9.1.1",
         "mocha": "8.4.0",
         "superdesk-code-style": "1.3.0",
         "ts-node": "10.9.1",
         "typescript": "~4.9.5"
+      },
+      "peerDependencies": {
+        "@sourcefabric/common": "^0.0.69"
       }
     },
     "node_modules/@babel/runtime": {
@@ -20,6 +20,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -65,15 +66,17 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@sourcefabric/common": {
-      "version": "0.0.66",
-      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.66.tgz",
-      "integrity": "sha512-fgxp7rZKNrfiL9c21+imXqdcFWRDudw/VSwlcbGch+dtkXDdH4owSPfTdR/Sb/UClcbrGgZQHK0asQF2XpVpDA==",
+      "version": "0.0.69",
+      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.69.tgz",
+      "integrity": "sha512-Uopya/TWgewqPz0T1SxNIpT92ujeKYQ8ba3OPTDcBYOAL4Bs58ONljaRA+FrOFtEzRpJzeBuUz9t8Vovb/ko+Q==",
+      "peer": true,
       "dependencies": {
         "date-fns": "^4.1.0",
         "lodash": "4.17.19",
@@ -90,13 +93,15 @@
     "node_modules/@sourcefabric/common/node_modules/lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "peer": true
     },
     "node_modules/@sourcefabric/common/node_modules/react": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
       "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -111,6 +116,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
       "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -126,6 +132,7 @@
       "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
       "integrity": "sha512-v1CDCvdfoR3zLGNp6qsBa4J1BWMEVH25+UKxF/RvQRh+mrB+emqtVHMgZ+WreUiKJoEaiwYoScaueIKhMVBHUg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.2.0",
         "invariant": "^2.2.4",
@@ -142,6 +149,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
       "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -710,6 +718,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -1528,6 +1537,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -2465,6 +2475,7 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/primereact/-/primereact-6.6.0.tgz",
       "integrity": "sha512-onoowjhlOz9Kcjna1DYEKWTGjKah4MjqZchm9E3BkcWjeXoCLv3F5QnIo8eVF9q+xymEK/6Oh7zHlfCJYyWwDw==",
+      "peer": true,
       "peerDependencies": {
         "react": "^17.0.1",
         "react-dom": "^17.0.1"
@@ -2941,6 +2952,7 @@
       "version": "6.3.7",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
       "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }

--- a/scripts/extensions/broadcasting/package.json
+++ b/scripts/extensions/broadcasting/package.json
@@ -14,6 +14,6 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@sourcefabric/common": "^0.0.69"
+    "@sourcefabric/common": "*"
   }
 }

--- a/scripts/extensions/broadcasting/package.json
+++ b/scripts/extensions/broadcasting/package.json
@@ -1,10 +1,8 @@
 {
   "private": true,
-  "main": "dist/src/extension.js",
+  "main": "src/extension.ts",
   "scripts": {
-    "compile": "tsc -p ./",
     "compile-e2e": "echo 'No end-to-end tests defined'",
-    "watch": "tsc -watch -p ./",
     "test": "mocha",
     "debug-tests": "mocha --inspect-brk"
   },
@@ -15,7 +13,7 @@
     "ts-node": "10.9.1",
     "typescript": "~4.9.5"
   },
-  "dependencies": {
-    "@sourcefabric/common": "0.0.66"
+  "peerDependencies": {
+    "@sourcefabric/common": "^0.0.69"
   }
 }

--- a/scripts/extensions/datetimeField/package-lock.json
+++ b/scripts/extensions/datetimeField/package-lock.json
@@ -13,7 +13,7 @@
         "typescript": "~4.9.5"
       },
       "peerDependencies": {
-        "superdesk-ui-framework": "4.0.47"
+        "superdesk-ui-framework": "*"
       }
     },
     "node_modules/@babel/runtime": {

--- a/scripts/extensions/datetimeField/package.json
+++ b/scripts/extensions/datetimeField/package.json
@@ -1,18 +1,16 @@
 {
   "private": true,
-  "main": "dist/src/extension.js",
+  "main": "src/extension.tsx",
   "scripts": {
-    "compile": "tsc -p src",
-    "compile-e2e": "echo 'No end-to-end tests defined'",
-    "watch": "tsc -watch -p src"
+    "compile-e2e": "echo 'No end-to-end tests defined'"
+  },
+  "dependencies": {
+    "date-fns": "2.7.0"
   },
   "devDependencies": {
     "@types/react": "16.8.23",
     "superdesk-code-style": "1.3.0",
     "typescript": "~4.9.5"
-  },
-  "dependencies": {
-    "date-fns": "2.7.0"
   },
   "peerDependencies": {
     "superdesk-ui-framework": "4.0.47"

--- a/scripts/extensions/datetimeField/package.json
+++ b/scripts/extensions/datetimeField/package.json
@@ -13,6 +13,6 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "superdesk-ui-framework": "4.0.47"
+    "superdesk-ui-framework": "*"
   }
 }

--- a/scripts/extensions/helloWorld/package.json
+++ b/scripts/extensions/helloWorld/package.json
@@ -1,10 +1,8 @@
 {
   "private": true,
-  "main": "dist/src/extension.js",
+  "main": "src/extension.ts",
   "scripts": {
-    "compile": "tsc -p src",
     "compile-e2e": "echo 'No end-to-end tests defined'",
-    "watch": "tsc -watch -p src",
     "test": "mocha",
     "debug-tests": "mocha --inspect-brk"
   },

--- a/scripts/extensions/helloWorld/src/tsconfig.json
+++ b/scripts/extensions/helloWorld/src/tsconfig.json
@@ -2,5 +2,6 @@
     "extends": "superdesk-code-style/tsconfig-strict",
     "compilerOptions": {
         "outDir": "../dist/src"
-    }
+    },
+    "exclude": ["**/*.spec.ts", "**/*.test.ts"]
 }

--- a/scripts/extensions/helloWorld/yarn.lock
+++ b/scripts/extensions/helloWorld/yarn.lock
@@ -11,7 +11,7 @@
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
-  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  resolved "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz"
   integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
   dependencies:
     string-width "^5.1.2"
@@ -41,7 +41,7 @@
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@tsconfig/node10@^1.0.7":
@@ -68,6 +68,13 @@
   version "9.1.1"
   resolved "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz"
   integrity sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==
+
+"@types/node@*":
+  version "24.10.1"
+  resolved "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz"
+  integrity sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==
+  dependencies:
+    undici-types "~7.16.0"
 
 acorn-jsx@^3.0.0:
   version "3.0.1"
@@ -101,7 +108,7 @@ ajv-keywords@^2.1.0:
   resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz"
   integrity sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=
 
-ajv@^5.2.3, ajv@^5.3.0:
+ajv@^5.0.0, ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz"
   integrity sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
@@ -133,7 +140,7 @@ ansi-regex@^5.0.1:
 
 ansi-regex@^6.0.1:
   version "6.2.2"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz"
   integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
 
 ansi-styles@^2.2.1:
@@ -148,7 +155,14 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+ansi-styles@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
+ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -157,7 +171,7 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
 
 ansi-styles@^6.1.0:
   version "6.2.3"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz"
   integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 arg@^4.1.0:
@@ -210,14 +224,14 @@ brace-expansion@^1.1.7:
 
 brace-expansion@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz"
   integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
   dependencies:
     balanced-match "^1.0.0"
 
 browser-stdout@^1.3.1:
   version "1.3.1"
-  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
+  resolved "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
 buffer-from@^1.0.0:
@@ -264,7 +278,7 @@ chalk@^2.0.0, chalk@^2.1.0:
 
 chalk@^4.1.0:
   version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
@@ -277,7 +291,7 @@ chardet@^0.4.0:
 
 chokidar@^4.0.1:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.3.tgz#7be37a4c03c9aee1ecfe862a4a23b2c70c205d30"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz"
   integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
   dependencies:
     readdirp "^4.0.1"
@@ -301,7 +315,7 @@ cli-width@^2.0.0:
 
 cliui@^8.0.1:
   version "8.0.1"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz"
   integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
   dependencies:
     string-width "^4.2.0"
@@ -327,15 +341,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
-
 color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -373,7 +387,7 @@ cross-spawn@^5.1.0:
 
 cross-spawn@^7.0.6:
   version "7.0.6"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
@@ -389,7 +403,7 @@ debug@^3.1.0:
 
 debug@^4.3.5:
   version "4.4.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
@@ -418,7 +432,7 @@ diff@^4.0.1:
 
 diff@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-7.0.0.tgz#3fb34d387cd76d803f6eebea67b921dab0182a9a"
+  resolved "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz"
   integrity sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==
 
 doctrine@^2.1.0:
@@ -430,7 +444,7 @@ doctrine@^2.1.0:
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  resolved "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
 emoji-regex@^8.0.0:
@@ -440,7 +454,7 @@ emoji-regex@^8.0.0:
 
 emoji-regex@^9.2.2:
   version "9.2.2"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 es-abstract@^1.17.0, es-abstract@^1.17.0-next.1:
@@ -470,9 +484,9 @@ es-to-primitive@^1.2.1:
     is-symbol "^1.0.2"
 
 escalade@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz"
-  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz"
+  integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -481,7 +495,7 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 eslint-plugin-angular@^3.1.1:
@@ -522,7 +536,7 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^4.11.0:
+"eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0", eslint@^4.11.0:
   version "4.19.1"
   resolved "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz"
   integrity sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==
@@ -644,7 +658,7 @@ file-entry-cache@^2.0.0:
 
 find-up@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
   dependencies:
     locate-path "^6.0.0"
@@ -667,7 +681,7 @@ flat@^5.0.2:
 
 foreground-child@^3.1.0:
   version "3.3.1"
-  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  resolved "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz"
   integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
   dependencies:
     cross-spawn "^7.0.6"
@@ -695,7 +709,7 @@ get-caller-file@^2.0.5:
 
 glob@^10.4.5:
   version "10.5.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  resolved "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz"
   integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
   dependencies:
     foreground-child "^3.1.0"
@@ -758,7 +772,7 @@ has@^1.0.3:
 
 he@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 iconv-lite@^0.4.17:
@@ -786,7 +800,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.3:
+inherits@^2.0.3, inherits@~2.0.3, inherits@2:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -833,7 +847,7 @@ is-fullwidth-code-point@^3.0.0:
 
 is-path-inside@^3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  resolved "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-obj@^2.1.0:
@@ -872,7 +886,7 @@ is-symbol@^1.0.2:
 
 is-unicode-supported@^0.1.0:
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  resolved "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
 isarray@~1.0.0:
@@ -887,7 +901,7 @@ isexe@^2.0.0:
 
 jackspeak@^3.1.2:
   version "3.4.3"
-  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  resolved "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz"
   integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
   dependencies:
     "@isaacs/cliui" "^8.0.2"
@@ -909,7 +923,7 @@ js-yaml@^3.9.1:
 
 js-yaml@^4.1.0:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz"
   integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
@@ -954,7 +968,7 @@ lodash@^4.17.4, lodash@^4.3.0:
 
 log-symbols@^4.1.0:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  resolved "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz"
   integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
   dependencies:
     chalk "^4.1.0"
@@ -969,7 +983,7 @@ loose-envify@^1.4.0:
 
 lru-cache@^10.2.0:
   version "10.4.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
 lru-cache@^4.0.1:
@@ -999,7 +1013,7 @@ minimatch@^3.0.2, minimatch@^3.0.4:
 
 minimatch@^9.0.4, minimatch@^9.0.5:
   version "9.0.5"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz"
   integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
   dependencies:
     brace-expansion "^2.0.1"
@@ -1011,7 +1025,7 @@ minimist@0.0.8:
 
 "minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
   version "7.1.2"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
+  resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
 mkdirp@^0.5.1:
@@ -1023,7 +1037,7 @@ mkdirp@^0.5.1:
 
 mocha@11.7.5:
   version "11.7.5"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-11.7.5.tgz#58f5bbfa5e0211ce7e5ee6128107cefc2515a627"
+  resolved "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz"
   integrity sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==
   dependencies:
     browser-stdout "^1.3.1"
@@ -1048,9 +1062,14 @@ mocha@11.7.5:
     yargs-parser "^21.1.1"
     yargs-unparser "^2.0.0"
 
-ms@^2.1.1, ms@^2.1.3:
+ms@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.1.3:
   version "2.1.3"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 mute-stream@0.0.7:
@@ -1165,7 +1184,7 @@ p-locate@^5.0.0:
 
 package-json-from-dist@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  resolved "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
 path-exists@^4.0.0:
@@ -1185,7 +1204,7 @@ path-is-inside@^1.0.2:
 
 path-key@^3.1.0:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.6:
@@ -1195,7 +1214,7 @@ path-parse@^1.0.6:
 
 path-scurry@^1.11.1:
   version "1.11.1"
-  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  resolved "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz"
   integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
   dependencies:
     lru-cache "^10.2.0"
@@ -1203,7 +1222,7 @@ path-scurry@^1.11.1:
 
 picocolors@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 pluralize@^7.0.0:
@@ -1267,7 +1286,7 @@ readable-stream@^2.2.2:
 
 readdirp@^4.0.1:
   version "4.1.2"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz"
   integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
 
 regexpp@^1.0.1:
@@ -1351,7 +1370,7 @@ semver@^5.3.0:
 
 serialize-javascript@^6.0.2:
   version "6.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
+  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz"
   integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
   dependencies:
     randombytes "^2.1.0"
@@ -1365,7 +1384,7 @@ shebang-command@^1.2.0:
 
 shebang-command@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"
   integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
     shebang-regex "^3.0.0"
@@ -1377,7 +1396,7 @@ shebang-regex@^1.0.0:
 
 shebang-regex@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 signal-exit@^3.0.2:
@@ -1387,7 +1406,7 @@ signal-exit@^3.0.2:
 
 signal-exit@^4.0.1:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 slice-ansi@1.0.0:
@@ -1402,9 +1421,16 @@ sprintf-js@~1.0.2:
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
     emoji-regex "^8.0.0"
@@ -1419,9 +1445,27 @@ string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+string-width@^4.1.0:
   version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
     emoji-regex "^8.0.0"
@@ -1430,7 +1474,7 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz"
   integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
   dependencies:
     eastasianwidth "^0.2.0"
@@ -1453,16 +1497,9 @@ string.prototype.trimright@^2.1.1:
     define-properties "^1.1.3"
     function-bind "^1.1.1"
 
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
-  dependencies:
-    safe-buffer "~5.1.0"
-
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
@@ -1490,14 +1527,14 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
 
 strip-ansi@^7.0.1:
   version "7.1.2"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.2.tgz#132875abde678c7ea8d691533f2e7e22bb744dba"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz"
   integrity sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==
   dependencies:
     ansi-regex "^6.0.1"
 
 strip-json-comments@^3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 strip-json-comments@~2.0.1:
@@ -1536,7 +1573,7 @@ supports-color@^7.1.0:
 
 supports-color@^8.1.1:
   version "8.1.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
@@ -1601,10 +1638,15 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@~4.9.5:
+typescript@>=2.7, typescript@~4.9.5:
   version "4.9.5"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -1625,7 +1667,7 @@ which@^1.2.9:
 
 which@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
@@ -1637,12 +1679,12 @@ word-wrap@~1.2.3:
 
 workerpool@^9.2.0:
   version "9.3.4"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.4.tgz#f6c92395b2141afd78e2a889e80cb338fe9fca41"
+  resolved "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz"
   integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
@@ -1660,7 +1702,7 @@ wrap-ansi@^7.0.0:
 
 wrap-ansi@^8.1.0:
   version "8.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz"
   integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
   dependencies:
     ansi-styles "^6.1.0"
@@ -1691,12 +1733,12 @@ yallist@^2.1.2:
 
 yargs-parser@^21.1.1:
   version "21.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs-unparser@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
+  resolved "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz"
   integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
   dependencies:
     camelcase "^6.0.0"
@@ -1706,7 +1748,7 @@ yargs-unparser@^2.0.0:
 
 yargs@^17.7.2:
   version "17.7.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"

--- a/scripts/extensions/markForUser/package-lock.json
+++ b/scripts/extensions/markForUser/package-lock.json
@@ -4,9 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "dependencies": {
-        "@sourcefabric/common": "0.0.66"
-      },
       "devDependencies": {
         "@superdesk/end-to-end-testing-helpers": "1.0.8",
         "@types/jasmine": "2.8.9",
@@ -15,6 +12,7 @@
         "typescript": "~4.9.5"
       },
       "peerDependencies": {
+        "@sourcefabric/common": "^0.0.69",
         "react": "16.8.6"
       }
     },
@@ -22,6 +20,7 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -30,15 +29,17 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@sourcefabric/common": {
-      "version": "0.0.66",
-      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.66.tgz",
-      "integrity": "sha512-fgxp7rZKNrfiL9c21+imXqdcFWRDudw/VSwlcbGch+dtkXDdH4owSPfTdR/Sb/UClcbrGgZQHK0asQF2XpVpDA==",
+      "version": "0.0.69",
+      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.69.tgz",
+      "integrity": "sha512-Uopya/TWgewqPz0T1SxNIpT92ujeKYQ8ba3OPTDcBYOAL4Bs58ONljaRA+FrOFtEzRpJzeBuUz9t8Vovb/ko+Q==",
+      "peer": true,
       "dependencies": {
         "date-fns": "^4.1.0",
         "lodash": "4.17.19",
@@ -56,6 +57,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -64,13 +66,15 @@
     "node_modules/@sourcefabric/common/node_modules/lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "peer": true
     },
     "node_modules/@sourcefabric/common/node_modules/primereact": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/primereact/-/primereact-6.6.0.tgz",
       "integrity": "sha512-onoowjhlOz9Kcjna1DYEKWTGjKah4MjqZchm9E3BkcWjeXoCLv3F5QnIo8eVF9q+xymEK/6Oh7zHlfCJYyWwDw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^17.0.1",
         "react-dom": "^17.0.1"
@@ -81,6 +85,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
       "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -1431,6 +1436,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -2274,6 +2280,7 @@
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
       "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -2293,6 +2300,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
       "integrity": "sha512-v1CDCvdfoR3zLGNp6qsBa4J1BWMEVH25+UKxF/RvQRh+mrB+emqtVHMgZ+WreUiKJoEaiwYoScaueIKhMVBHUg==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.2.0",
         "invariant": "^2.2.4",
@@ -2497,6 +2505,7 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
       "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -2779,6 +2788,7 @@
       "version": "6.3.7",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
       "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }

--- a/scripts/extensions/markForUser/package-lock.json
+++ b/scripts/extensions/markForUser/package-lock.json
@@ -12,8 +12,8 @@
         "typescript": "~4.9.5"
       },
       "peerDependencies": {
-        "@sourcefabric/common": "^0.0.69",
-        "react": "16.8.6"
+        "@sourcefabric/common": "*",
+        "react": "*"
       }
     },
     "node_modules/@babel/runtime": {

--- a/scripts/extensions/markForUser/package.json
+++ b/scripts/extensions/markForUser/package.json
@@ -1,10 +1,8 @@
 {
   "private": true,
-  "main": "dist/src/extension.js",
+  "main": "src/extension.tsx",
   "scripts": {
-    "compile": "tsc -p src",
-    "compile-e2e": "tsc -p spec",
-    "watch": "tsc -watch -p src"
+    "compile-e2e": "tsc -p spec"
   },
   "devDependencies": {
     "@superdesk/end-to-end-testing-helpers": "1.0.8",
@@ -14,9 +12,7 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
+    "@sourcefabric/common": "^0.0.69",
     "react": "16.8.6"
-  },
-  "dependencies": {
-    "@sourcefabric/common": "0.0.66"
   }
 }

--- a/scripts/extensions/markForUser/package.json
+++ b/scripts/extensions/markForUser/package.json
@@ -12,7 +12,7 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@sourcefabric/common": "^0.0.69",
-    "react": "16.8.6"
+    "@sourcefabric/common": "*",
+    "react": "*"
   }
 }

--- a/scripts/extensions/predefinedTextField/package-lock.json
+++ b/scripts/extensions/predefinedTextField/package-lock.json
@@ -10,7 +10,7 @@
         "typescript": "~4.9.5"
       },
       "peerDependencies": {
-        "superdesk-ui-framework": "4.0.47"
+        "superdesk-ui-framework": "*"
       }
     },
     "node_modules/@babel/runtime": {

--- a/scripts/extensions/predefinedTextField/package.json
+++ b/scripts/extensions/predefinedTextField/package.json
@@ -1,10 +1,8 @@
 {
   "private": true,
-  "main": "dist/src/extension.js",
+  "main": "src/extension.tsx",
   "scripts": {
-    "compile": "tsc -p src",
-    "compile-e2e": "echo 'No end-to-end tests defined'",
-    "watch": "tsc -watch -p src"
+    "compile-e2e": "echo 'No end-to-end tests defined'"
   },
   "devDependencies": {
     "@types/react": "16.8.23",

--- a/scripts/extensions/predefinedTextField/package.json
+++ b/scripts/extensions/predefinedTextField/package.json
@@ -10,6 +10,6 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "superdesk-ui-framework": "4.0.47"
+    "superdesk-ui-framework": "*"
   }
 }

--- a/scripts/extensions/sams/package-lock.json
+++ b/scripts/extensions/sams/package-lock.json
@@ -17,12 +17,12 @@
         "typescript": "~4.9.5"
       },
       "peerDependencies": {
-        "@sourcefabric/common": "^0.0.69",
-        "classnames": "^2.2.5",
-        "json-merge-patch": "0.2.3",
-        "lodash": "^4.17.5",
-        "react": "^16.9.0",
-        "superdesk-ui-framework": "4.0.47"
+        "@sourcefabric/common": "*",
+        "classnames": "*",
+        "json-merge-patch": "*",
+        "lodash": "*",
+        "react": "*",
+        "superdesk-ui-framework": "*"
       }
     },
     "node_modules/@babel/runtime": {

--- a/scripts/extensions/sams/package-lock.json
+++ b/scripts/extensions/sams/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "dependencies": {
-        "@sourcefabric/common": "0.0.66",
         "reselect": "~4.0.0"
       },
       "devDependencies": {
@@ -18,6 +17,7 @@
         "typescript": "~4.9.5"
       },
       "peerDependencies": {
+        "@sourcefabric/common": "^0.0.69",
         "classnames": "^2.2.5",
         "json-merge-patch": "0.2.3",
         "lodash": "^4.17.5",
@@ -29,6 +29,7 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -37,15 +38,17 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@sourcefabric/common": {
-      "version": "0.0.66",
-      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.66.tgz",
-      "integrity": "sha512-fgxp7rZKNrfiL9c21+imXqdcFWRDudw/VSwlcbGch+dtkXDdH4owSPfTdR/Sb/UClcbrGgZQHK0asQF2XpVpDA==",
+      "version": "0.0.69",
+      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.69.tgz",
+      "integrity": "sha512-Uopya/TWgewqPz0T1SxNIpT92ujeKYQ8ba3OPTDcBYOAL4Bs58ONljaRA+FrOFtEzRpJzeBuUz9t8Vovb/ko+Q==",
+      "peer": true,
       "dependencies": {
         "date-fns": "^4.1.0",
         "lodash": "4.17.19",
@@ -62,13 +65,15 @@
     "node_modules/@sourcefabric/common/node_modules/lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "peer": true
     },
     "node_modules/@sourcefabric/common/node_modules/react-dom": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
       "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -84,6 +89,7 @@
       "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
       "integrity": "sha512-v1CDCvdfoR3zLGNp6qsBa4J1BWMEVH25+UKxF/RvQRh+mrB+emqtVHMgZ+WreUiKJoEaiwYoScaueIKhMVBHUg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.2.0",
         "invariant": "^2.2.4",
@@ -655,6 +661,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -1431,6 +1438,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -2014,6 +2022,7 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/primereact/-/primereact-6.6.0.tgz",
       "integrity": "sha512-onoowjhlOz9Kcjna1DYEKWTGjKah4MjqZchm9E3BkcWjeXoCLv3F5QnIo8eVF9q+xymEK/6Oh7zHlfCJYyWwDw==",
+      "peer": true,
       "peerDependencies": {
         "react": "^17.0.1",
         "react-dom": "^17.0.1"
@@ -2061,6 +2070,7 @@
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
       "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -2365,6 +2375,7 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
       "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -2789,6 +2800,7 @@
       "version": "6.3.7",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
       "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }

--- a/scripts/extensions/sams/package.json
+++ b/scripts/extensions/sams/package.json
@@ -17,11 +17,11 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@sourcefabric/common": "^0.0.69",
-    "react": "^16.9.0",
-    "superdesk-ui-framework": "4.0.47",
-    "classnames": "^2.2.5",
-    "lodash": "^4.17.5",
-    "json-merge-patch": "0.2.3"
+    "@sourcefabric/common": "*",
+    "react": "*",
+    "superdesk-ui-framework": "*",
+    "classnames": "*",
+    "lodash": "*",
+    "json-merge-patch": "*"
   }
 }

--- a/scripts/extensions/sams/package.json
+++ b/scripts/extensions/sams/package.json
@@ -1,13 +1,10 @@
 {
   "private": true,
-  "main": "dist/src/extension.js",
+  "main": "src/extension.ts",
   "scripts": {
-    "compile": "tsc -p src",
-    "compile-e2e": "echo 'No end-to-end tests defined'",
-    "watch": "tsc -watch -p src"
+    "compile-e2e": "echo 'No end-to-end tests defined'"
   },
   "dependencies": {
-    "@sourcefabric/common": "0.0.66",
     "reselect": "~4.0.0"
   },
   "devDependencies": {
@@ -20,6 +17,7 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
+    "@sourcefabric/common": "^0.0.69",
     "react": "^16.9.0",
     "superdesk-ui-framework": "4.0.47",
     "classnames": "^2.2.5",

--- a/scripts/extensions/usageMetrics/package.json
+++ b/scripts/extensions/usageMetrics/package.json
@@ -1,10 +1,8 @@
 {
   "private": true,
-  "main": "dist/src/extension.js",
+  "main": "src/extension.ts",
   "scripts": {
-    "compile": "tsc -p src",
-    "compile-e2e": "echo 'No end-to-end tests defined'",
-    "watch": "tsc -watch -p src"
+    "compile-e2e": "echo 'No end-to-end tests defined'"
   },
   "devDependencies": {
     "superdesk-code-style": "1.3.0",

--- a/scripts/extensions/videoEditor/package-lock.json
+++ b/scripts/extensions/videoEditor/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "dependencies": {
-        "@sourcefabric/common": "0.0.66",
         "react-image-crop": "8.4.2"
       },
       "devDependencies": {
@@ -15,6 +14,7 @@
         "typescript": "~4.9.5"
       },
       "peerDependencies": {
+        "@sourcefabric/common": "^0.0.69",
         "react": "16.8.6"
       }
     },
@@ -22,6 +22,7 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -30,15 +31,17 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@sourcefabric/common": {
-      "version": "0.0.66",
-      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.66.tgz",
-      "integrity": "sha512-fgxp7rZKNrfiL9c21+imXqdcFWRDudw/VSwlcbGch+dtkXDdH4owSPfTdR/Sb/UClcbrGgZQHK0asQF2XpVpDA==",
+      "version": "0.0.69",
+      "resolved": "https://registry.npmjs.org/@sourcefabric/common/-/common-0.0.69.tgz",
+      "integrity": "sha512-Uopya/TWgewqPz0T1SxNIpT92ujeKYQ8ba3OPTDcBYOAL4Bs58ONljaRA+FrOFtEzRpJzeBuUz9t8Vovb/ko+Q==",
+      "peer": true,
       "dependencies": {
         "date-fns": "^4.1.0",
         "lodash": "4.17.19",
@@ -56,6 +59,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -66,6 +70,7 @@
       "resolved": "https://registry.npmjs.org/primereact/-/primereact-6.6.0.tgz",
       "integrity": "sha512-onoowjhlOz9Kcjna1DYEKWTGjKah4MjqZchm9E3BkcWjeXoCLv3F5QnIo8eVF9q+xymEK/6Oh7zHlfCJYyWwDw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^17.0.1",
         "react-dom": "^17.0.1"
@@ -76,6 +81,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
       "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -1180,6 +1186,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -1756,6 +1763,7 @@
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
       "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -1788,6 +1796,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
       "integrity": "sha512-v1CDCvdfoR3zLGNp6qsBa4J1BWMEVH25+UKxF/RvQRh+mrB+emqtVHMgZ+WreUiKJoEaiwYoScaueIKhMVBHUg==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.2.0",
         "invariant": "^2.2.4",
@@ -1956,6 +1965,7 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
       "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -2191,6 +2201,7 @@
       "version": "6.3.7",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
       "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }

--- a/scripts/extensions/videoEditor/package-lock.json
+++ b/scripts/extensions/videoEditor/package-lock.json
@@ -14,8 +14,8 @@
         "typescript": "~4.9.5"
       },
       "peerDependencies": {
-        "@sourcefabric/common": "^0.0.69",
-        "react": "16.8.6"
+        "@sourcefabric/common": "*",
+        "react": "*"
       }
     },
     "node_modules/@babel/runtime": {

--- a/scripts/extensions/videoEditor/package.json
+++ b/scripts/extensions/videoEditor/package.json
@@ -1,10 +1,11 @@
 {
   "private": true,
-  "main": "dist/src/extension.js",
+  "main": "src/extension.tsx",
   "scripts": {
-    "compile": "tsc -p src",
-    "compile-e2e": "echo 'No end-to-end tests defined'",
-    "watch": "tsc -watch -p src"
+    "compile-e2e": "echo 'No end-to-end tests defined'"
+  },
+  "dependencies": {
+    "react-image-crop": "8.4.2"
   },
   "devDependencies": {
     "@types/react": "^16.8.6",
@@ -12,11 +13,8 @@
     "superdesk-code-style": "1.3.0",
     "typescript": "~4.9.5"
   },
-  "dependencies": {
-    "@sourcefabric/common": "0.0.66",
-    "react-image-crop": "8.4.2"
-  },
   "peerDependencies": {
+    "@sourcefabric/common": "^0.0.69",
     "react": "16.8.6"
   }
 }

--- a/scripts/extensions/videoEditor/package.json
+++ b/scripts/extensions/videoEditor/package.json
@@ -14,7 +14,7 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@sourcefabric/common": "^0.0.69",
-    "react": "16.8.6"
+    "@sourcefabric/common": "*",
+    "react": "*"
   }
 }

--- a/tasks/verify-client-api-changes.js
+++ b/tasks/verify-client-api-changes.js
@@ -5,7 +5,7 @@
  * against their own tsconfig, since they no longer carry a compile step.
  */
 
-const execSync = require('child_process').execSync;
+const {execSync, execFileSync} = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
@@ -16,7 +16,7 @@ function getDirectories(p) {
 }
 
 const allExtensions = 'scripts/extensions';
-const tsc = path.join('node_modules', '.bin', 'tsc');
+const tscEntry = require.resolve('typescript/bin/tsc');
 
 getDirectories(allExtensions).forEach((extensionDir) => {
     const extensionPath = `${allExtensions}/${extensionDir}`;
@@ -24,7 +24,7 @@ getDirectories(allExtensions).forEach((extensionDir) => {
     const main = pkg.main;
     const isMigrated = typeof main === 'string' && /\.(ts|tsx)$/.test(main);
 
-    execSync(`cd ${extensionPath} && npm install`, {stdio: 'inherit'});
+    execSync('npm install', {stdio: 'inherit', cwd: extensionPath});
 
     if (isMigrated) {
         const tsconfig = ['src/tsconfig.json', 'tsconfig.json']
@@ -35,8 +35,12 @@ getDirectories(allExtensions).forEach((extensionDir) => {
             throw new Error(`Migrated extension ${extensionDir} has no tsconfig.json`);
         }
 
-        execSync(`${tsc} --noEmit -p ${tsconfig}`, {stdio: 'inherit'});
+        execFileSync(
+            process.execPath,
+            [tscEntry, '--noEmit', '-p', tsconfig],
+            {stdio: 'inherit'}
+        );
     } else {
-        execSync(`cd ${extensionPath} && npm run compile`, {stdio: 'inherit'});
+        execSync('npm run compile', {stdio: 'inherit', cwd: extensionPath});
     }
 });

--- a/tasks/verify-client-api-changes.js
+++ b/tasks/verify-client-api-changes.js
@@ -1,22 +1,42 @@
 /**
- * Compile extensions in order to check whether API changes
- * are not breaking existing extensions.
+ * Type-check extensions to make sure client API changes don't break them.
+ * Legacy extensions still use their `compile` script. Migrated extensions
+ * (`main` points to a .ts/.tsx source) are type-checked via `tsc --noEmit`
+ * against their own tsconfig, since they no longer carry a compile step.
  */
 
 const execSync = require('child_process').execSync;
 const fs = require('fs');
+const path = require('path');
 
-function getDirectories(path) {
-    return fs.readdirSync(path).filter((file) => {
-        return fs.statSync(path + '/' + file).isDirectory();
+function getDirectories(p) {
+    return fs.readdirSync(p).filter((file) => {
+        return fs.statSync(p + '/' + file).isDirectory();
     });
 }
 
 const allExtensions = 'scripts/extensions';
+const tsc = path.join('node_modules', '.bin', 'tsc');
 
 getDirectories(allExtensions).forEach((extensionDir) => {
-    execSync(
-        `cd ${allExtensions}/${extensionDir} && npm install && npm run compile`,
-        {stdio: 'inherit'}
-    );
+    const extensionPath = `${allExtensions}/${extensionDir}`;
+    const pkg = JSON.parse(fs.readFileSync(`${extensionPath}/package.json`, 'utf-8'));
+    const main = pkg.main;
+    const isMigrated = typeof main === 'string' && /\.(ts|tsx)$/.test(main);
+
+    execSync(`cd ${extensionPath} && npm install`, {stdio: 'inherit'});
+
+    if (isMigrated) {
+        const tsconfig = ['src/tsconfig.json', 'tsconfig.json']
+            .map((c) => path.join(extensionPath, c))
+            .find((c) => fs.existsSync(c));
+
+        if (tsconfig == null) {
+            throw new Error(`Migrated extension ${extensionDir} has no tsconfig.json`);
+        }
+
+        execSync(`${tsc} --noEmit -p ${tsconfig}`, {stdio: 'inherit'});
+    } else {
+        execSync(`cd ${extensionPath} && npm run compile`, {stdio: 'inherit'});
+    }
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,42 @@ var lodash = require('lodash');
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const fs = require('fs');
+
+// Discover loaded extensions that still build from TypeScript sources so each
+// one can get its own ForkTsCheckerWebpackPlugin instance. We start from the
+// same loaded-extension set used by installExtensions, ignore unloaded
+// extensions to avoid noise from optional per-extension deps, and treat an
+// extension as migrated when its package.json `main` points to .ts or .tsx.
+const getExtensionDirectoriesSync = require('./build-tools/src/extensions/get-extension-directories-sync');
+
+// Only consumers (templates) ship superdesk.config.js; running webpack directly
+// in superdesk-client-core (e.g. for tests) has no extensions to discover.
+const loadedExtensions = fs.existsSync(path.join(process.cwd(), 'superdesk.config.js'))
+    ? getExtensionDirectoriesSync(process.cwd())
+    : [];
+
+const migratedExtensionTsConfigs = loadedExtensions
+    .filter(({extensionRootPath}) => {
+        const pkgPath = path.join(extensionRootPath, 'package.json');
+
+        if (!fs.existsSync(pkgPath)) {
+            return false;
+        }
+
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+
+        return typeof pkg.main === 'string' && /\.(ts|tsx)$/.test(pkg.main);
+    })
+    .map(({extensionRootPath}) => {
+        // Resolve the extension's tsconfig.json, checking src/ first then the package root.
+        return [
+            path.join(extensionRootPath, 'src/tsconfig.json'),
+            path.join(extensionRootPath, 'tsconfig.json'),
+        ].find((candidate) => fs.existsSync(candidate));
+    })
+    .filter(Boolean);
 
 function getModuleDir(moduleName) {
     return path.join(
@@ -167,12 +202,37 @@ module.exports = function makeConfig(grunt) {
                 filename: '[name].bundle.css',
                 chunkFilename: '[id].bundle.css',
             }),
+
             // Webpack 5 removed automatic Node.js polyfills for browser builds
             // This plugin restores them for legacy code that depends on Node APIs (e.g., Buffer, process, stream)
             // Exclude 'console' since browsers provide their own implementation
             new NodePolyfillPlugin({
                 excludeAliases: ['console'],
             }),
+
+            // Type-check the core scripts tree. Extensions are checked by their
+            // own ForkTsCheckerWebpackPlugin instances below, and because
+            // ts-loader runs with transpileOnly: true, this is what makes core
+            // type errors fail the webpack build.
+            new ForkTsCheckerWebpackPlugin({
+                typescript: {
+                    configFile: path.join(__dirname, 'scripts/tsconfig.json'),
+                },
+            }),
+
+            // Give each loaded migrated extension its own checker, using the
+            // tsconfig discovered above. We silence its success logger to avoid
+            // one "No typescript errors found" line per extension; actual issues
+            // still flow through webpack's normal reporting.
+            ...migratedExtensionTsConfigs.map((absPath) => new ForkTsCheckerWebpackPlugin({
+                typescript: {
+                    configFile: absPath,
+                },
+                logger: {
+                    log: () => {}, // eslint-disable-line no-empty-function
+                    error: (message) => process.stderr.write(String(message) + '\n'),
+                },
+            })),
         ],
 
         resolve: {


### PR DESCRIPTION
### Purpose
Local development with `npm link` between repositories (for example, linking a local checkout of `superdesk-planning` into a Superdesk template) breaks the webpack build because of how extensions are compiled. Each extension ships a pre-compiled `dist/` produced by its own `tsc -p src` step, and the consumer's install pipeline rewrites the extension's `package.json` `main` field to point at it. When the extension is consumed through a symlink, `tsc` resolves `rootDir` through the symlinked path and produces recursive output like `dist/superdesk/client/node_modules/superdesk-planning/client/planning-extension/dist/...`, and the install-time `package.json` rewrite corrupts the source repository on the other side of the symlink.

This PR removes that whole class of problem by stopping the per-extension compile step entirely. Extensions are consumed by the host's webpack as TypeScript sources, through the same toolchain that already builds core. There is no extension-side `dist/` to go wrong and no install-time rewriting on migrated extensions.

> [!NOTE]
> - `@superdesk/build-tools@1.1.0` must be published first, and then pin it in superdesk templates repos
> - There will be a second PR for `superdesk-planning` to update the extension to use the new approach

### What has changed

**Extension discovery and compilation in `webpack.config.js`**
Webpack reuses `getExtensionDirectoriesSync` to find loaded extensions, but only when `superdesk.config.js` is present so direct runs inside `superdesk-client-core` still work. Discovery failures now surface instead of being swallowed.

Each loaded extension whose `main` points at `.ts` or `.tsx` gets its own `ForkTsCheckerWebpackPlugin` instance. That restores type checking for extension code while `ts-loader` runs in `transpileOnly: true`, and the per-extension success logger is silenced to avoid noisy clean builds.

**`install-extensions` shim in `@superdesk/build-tools` (1.1.0)**
For migrated extensions (`main` points to TypeScript), the installer skips the legacy rewrite steps and only runs `npm install --omit=dev` when the extension declares runtime `dependencies`. Unmigrated third-party extensions keep the old compile-and-correct path.

**In-tree extension package metadata**
Eleven in-tree extensions now point `main` at `src/extension.ts` or `src/extension.tsx`, and no longer carry per-extension `compile`, `watch`, or `prepublish` scripts:

`ai-widget`, `annotationsLibrary`, `availability-manager`, `broadcasting`, `datetimeField`, `helloWorld`, `markForUser`, `predefinedTextField`, `sams`, `usageMetrics`, `videoEditor`.

**Dependency model for extensions**
Extension-specific runtime dependencies stay in each extension's own `package.json` and are installed by the shim. Host-provided packages such as `react` and `@sourcefabric/common` are declared as `peerDependencies` so the consumer provides them without duplication.

**Test-file exclusion in two extension tsconfigs**
`helloWorld/src/tsconfig.json` and `availability-manager/src/tsconfig.json` now exclude `**/*.spec.ts` and `**/*.test.ts`, so fork-ts-checker does not try to resolve mocha types those extensions do not install.

**`fork-ts-checker-webpack-plugin` moved to `dependencies`**
This plugin runs in the consumer's webpack build, so it must be a regular dependency rather than a devDependency.

### Steps to test
1. In a Superdesk template that consumes this branch of `superdesk-client-core`, run `npm install` and `npm run start`. The build should complete with no extension-related errors. None of the recursive `dist/superdesk/client/...` paths should appear in the output.
2. Symlink a local checkout of `superdesk-planning` (matching branch) into the template's `node_modules/superdesk-planning` and rebuild. The build should still succeed.
3. Introduce a deliberate TypeScript error in any migrated extension (e.g. `scripts/extensions/helloWorld/src/extension.ts`). The webpack build should fail and report the error against the extension's source, not a `dist/` file.
4. Confirm that an unmigrated extension (an extension where `package.json` `main` still points at a `.js` file under `dist/`) still builds via the legacy compile-and-correct path. The bundled `auto-tagging-widget` is an explicit example that remains on the legacy path.
5. Run `npm run lint` and `npm run unit` in `superdesk-client-core` itself. Direct webpack invocations against this repo (no `superdesk.config.js` present) should not attempt extension discovery and should not crash.

[SDESK-7925]


[SDESK-7925]: https://sofab.atlassian.net/browse/SDESK-7925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ