### PR TITLE
[SDESK-7925] Add `dev-link` and self-prepare `grunt server` so local dev works in one step

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,14 +81,40 @@ module.exports = function(grunt) {
         });
     });
 
+    // Extension preparation tasks. These mirror what build-tools' build-root-repo does
+    // around the production build, so `grunt server` produces a working dev environment
+    // from a fresh checkout without needing an external wrapper command. Each task
+    // requires @superdesk/build-tools lazily inside the action so a missing dep doesn't
+    // break Gruntfile load for callers that don't need these tasks.
+    grunt.registerTask('install-extensions', 'Install each loaded extension', function() {
+        var installExtensions = require('@superdesk/build-tools/src/extensions/install-extensions');
+
+        installExtensions(process.cwd());
+    });
+
+    grunt.registerTask('namespace-css', 'Generate the namespaced extension stylesheet', function() {
+        var {namespaceCSS} = require('@superdesk/build-tools/src/extensions/css');
+
+        namespaceCSS(process.cwd());
+    });
+
+    grunt.registerTask('merge-extension-translations', 'Merge translations from loaded extensions', function() {
+        var {mergeTranslationsFromExtensions} = require('@superdesk/build-tools/src/extensions/translations');
+
+        mergeTranslationsFromExtensions(process.cwd());
+    });
+
     // Development server
     grunt.registerTask('server', [
+        'install-extensions',
+        'namespace-css',
         'clean',
         'ngtemplates:index',
         'copy:index',
         'copy:config',
         'copy:locales',
         'po-to-json',
+        'merge-extension-translations',
         'ngtemplates:gen-apps',
         'ngtemplates:dev',
         'webpack-dev-server:start',

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superdesk/build-tools",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/build-tools/src/dev-link.js
+++ b/build-tools/src/dev-link.js
@@ -83,7 +83,8 @@ function ensureSymlink(target, linkPath) {
         }
     }
 
-    fs.symlinkSync(target, linkPath, 'dir');
+    fs.mkdirSync(path.dirname(linkPath), {recursive: true});
+    fs.symlinkSync(target, linkPath, process.platform === 'win32' ? 'junction' : 'dir');
 }
 
 function devLink(consumerDir, sources) {

--- a/build-tools/src/dev-link.js
+++ b/build-tools/src/dev-link.js
@@ -1,0 +1,138 @@
+/**
+ * `dev-link` CLI command. Symlinks one or more local source repos into the
+ * current working directory's node_modules so a Superdesk template can be
+ * developed against unpublished local checkouts (e.g. superdesk-client-core,
+ * superdesk-planning) without using `npm link`.
+ *
+ * For each source path:
+ *   1. Read its package.json to get the package name. The symlink in
+ *      node_modules uses this name, not the directory name (so
+ *      superdesk-client-core correctly lands as node_modules/superdesk-core).
+ *   2. Run `npm install` in the source root, and also in any client/<subdir>
+ *      that has its own package.json (covers superdesk-planning's nested
+ *      client/planning-extension without hard-coding it).
+ *   3. Replace whatever is currently at node_modules/<package-name> with a
+ *      symlink to the source's absolute path.
+ *
+ * Pre-condition: node_modules must already exist in the cwd. The command
+ * errors out otherwise to catch the common mistake of linking before the
+ * template's own `npm install` has run.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {execFileSync} = require('child_process');
+
+function readPkg(dir) {
+    return JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf-8'));
+}
+
+/**
+ * Returns every directory inside `sourceRoot` that contains a package.json
+ * we need to install. That is the root itself, plus any `client/*` subdir
+ * that ships its own package.json (covers the superdesk-planning layout
+ * where the host-build-relevant deps live under client/planning-extension).
+ */
+function findInstallTargets(sourceRoot) {
+    const targets = [];
+
+    if (fs.existsSync(path.join(sourceRoot, 'package.json'))) {
+        targets.push(sourceRoot);
+    }
+
+    const clientDir = path.join(sourceRoot, 'client');
+
+    if (fs.existsSync(clientDir) && fs.statSync(clientDir).isDirectory()) {
+        for (const entry of fs.readdirSync(clientDir, {withFileTypes: true})) {
+            if (!entry.isDirectory()) {
+                continue;
+            }
+
+            const nestedPkg = path.join(clientDir, entry.name, 'package.json');
+
+            if (fs.existsSync(nestedPkg)) {
+                targets.push(path.join(clientDir, entry.name));
+            }
+        }
+    }
+
+    return targets;
+}
+
+function npmInstall(dir) {
+    console.info(`  installing dependencies in ${dir}`);
+    execFileSync('npm', ['install'], {stdio: 'inherit', cwd: dir});
+}
+
+function ensureSymlink(target, linkPath) {
+    let existing;
+
+    try {
+        existing = fs.lstatSync(linkPath);
+    } catch (e) {
+        if (e.code !== 'ENOENT') {
+            throw e;
+        }
+    }
+
+    if (existing != null) {
+        if (existing.isSymbolicLink() || !existing.isDirectory()) {
+            fs.unlinkSync(linkPath);
+        } else {
+            fs.rmSync(linkPath, {recursive: true, force: true});
+        }
+    }
+
+    fs.symlinkSync(target, linkPath, 'dir');
+}
+
+function devLink(consumerDir, sources) {
+    const consumerNodeModules = path.join(consumerDir, 'node_modules');
+
+    if (!fs.existsSync(consumerNodeModules)) {
+        throw new Error(
+            `Consumer node_modules not found at ${consumerNodeModules}. `
+            + 'Run `npm install` in the template first, then re-run dev-link.'
+        );
+    }
+
+    for (const source of sources) {
+        const sourceAbs = path.resolve(consumerDir, source);
+
+        if (!fs.existsSync(sourceAbs)) {
+            throw new Error(`Source path does not exist: ${sourceAbs}`);
+        }
+
+        const pkg = readPkg(sourceAbs);
+        const packageName = pkg.name;
+
+        if (packageName == null) {
+            throw new Error(`Source ${sourceAbs} has no name field in package.json`);
+        }
+
+        console.info(`\n${packageName}  <-  ${sourceAbs}`);
+
+        for (const target of findInstallTargets(sourceAbs)) {
+            npmInstall(target);
+        }
+
+        const linkPath = path.join(consumerNodeModules, packageName);
+
+        ensureSymlink(sourceAbs, linkPath);
+        console.info(`  linked node_modules/${packageName}`);
+    }
+}
+
+function register(program, currentDir) {
+    program.command('dev-link <source...>')
+        .description(
+            'symlink one or more local source repos into the current node_modules '
+            + 'for local development. Runs `npm install` in each source (and in any '
+            + 'nested client/<extension> packages) before linking.'
+        )
+        .action((sources) => {
+            devLink(currentDir, sources);
+        });
+}
+
+module.exports = {register, devLink};

--- a/build-tools/src/index.js
+++ b/build-tools/src/index.js
@@ -9,6 +9,7 @@ const installExtensions = require('./extensions/install-extensions');
 const {mergeTranslationsFromExtensions} = require('./extensions/translations');
 const {extractTranslations} = require('./extensions/extract-translations');
 const {namespaceCSS, watchCSS} = require('./extensions/css');
+const devLink = require('./dev-link');
 
 const {Command} = require('commander');
 const program = new Command();
@@ -107,6 +108,8 @@ extensions
     });
 
 program.addCommand(extensions);
+
+devLink.register(program, currentDir);
 
 program.version(require('../package.json').version);
 program.parse(process.argv);


### PR DESCRIPTION
### Purpose
Local development against checkouts of `superdesk-client-core` or `superdesk-planning` was too fragile. It required manual installs, deleting package copies from `node_modules`, and creating symlinks by hand, and small mistakes caused misleading failures. A fresh checkout also could not reliably start the dev server because `grunt server` skipped the extension setup steps that `npm run build` performed.

This PR makes local linking and dev startup work without that manual setup.

### What has changed

A new `dev-link` command was added to build-tools to automate local linking. It accepts one or more local source paths, reads each source `package.json` to determine the correct package name, runs `npm install` in the source root and any nested `client/<extension>` package that has its own `package.json`, and replaces the consumer's `node_modules` entry with a symlink to the resolved absolute path. It is idempotent and fails fast if the consumer has not run `npm install` yet.

The implementation lives in `build-tools/src/dev-link.js`, with command registration kept in `index.js`.

The Gruntfile now adds lazy-required wrappers for `install-extensions`, `namespace-css`, and `merge-extension-translations`, following the same pattern as `po-to-json` so Gruntfile loading does not fail when build-tools is not needed. The `server` task now runs:
- `install-extensions` and `namespace-css` before `clean`
- `merge-extension-translations` right after `po-to-json`

This means a fresh checkout can start the dev server without first running a full production build. The `build` task is unchanged in this PR.

### Steps to test
1. In a Superdesk project (template project), run `npm install`.
2. Run the new `dev-link` command against a local checkout of `superdesk-client-core` or `superdesk-planning`.
3. Verify the command installs dependencies, replaces the matching package in `node_modules` with a symlink, and can be run repeatedly without breaking the setup.
4. Run `npm run start`.
5. Confirm the dev server starts from a fresh checkout without needing `npm run build` first.
6. Verify extension setup still works during startup: extension install, CSS namespacing, and translation merging should all happen as part of `grunt server`.

[SDESK-7925] [SDESK-4688]

[SDESK-7925]: https://sofab.atlassian.net/browse/SDESK-7925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ