### PR TITLE
[SDCP-1158] - Cannot "remove" an uploaded media, X does not work

### DIFF
--- a/scripts/apps/search/views/multi-image-edit.html
+++ b/scripts/apps/search/views/multi-image-edit.html
@@ -53,7 +53,13 @@
                                     style="display: flex; align-items: center; justify-content: center;">
                                 </div>
 
-                                <a ng-if="onRemoveItem" class="icn-btn sd-grid-item__remove" sd-tooltip="{{'Remove item' | translate}}" flow="left">
+                                <a
+                                    ng-if="onRemoveItem"
+                                    class="icn-btn sd-grid-item__remove"
+                                    sd-tooltip="{{'Remove item' | translate}}"
+                                    flow="left"
+                                    ng-click="onRemoveItem(image)"
+                                >
                                     <i class="icon-close-small"></i>
                                 </a>
 


### PR DESCRIPTION
### Purpose
This PR fix the broken remove action in the media upload flow cause clicking the X on an uploaded media item did nothing before.

### What has changed
- Wire the remove icon directly to `onRemoveItem(image)` via ng-click.

### Steps to test
1. Open the upload flow and upload multiple media items.
2. Click the X on one of the uploaded items.
3. Verify the selected item is removed immediately and remaining items stay in the list

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I reviewed my code
- [X] I tested all affected functionality and made sure it works

Resolves: [SDCP-1158](https://sofab.atlassian.net/browse/SDCP-1158)


[SDCP-1158]: https://sofab.atlassian.net/browse/SDCP-1158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ