### PR TITLE
[SDESK-7942]: Item sent to Personal space still available in the Sent Desk Output stage

### DIFF
--- a/scripts/apps/monitoring/services/CardsService.ts
+++ b/scripts/apps/monitoring/services/CardsService.ts
@@ -139,8 +139,10 @@ export function CardsService(search, session, desks, $location) {
             case SENT_OUTPUT:
                 deskId = card._id.substring(0, card._id.indexOf(':'));
                 query.filter({bool: {
-                    filter: {term: {'task.desk_history': deskId}},
-                    must: {exists: {field: 'task.desk'}},
+                    must: [
+                        {term: {'task.desk_history': deskId}},
+                        {exists: {field: 'task.desk'}},
+                    ],
                     must_not: {term: {'task.desk': deskId}},
                 }});
                 break;

--- a/scripts/apps/monitoring/services/CardsService.ts
+++ b/scripts/apps/monitoring/services/CardsService.ts
@@ -140,6 +140,7 @@ export function CardsService(search, session, desks, $location) {
                 deskId = card._id.substring(0, card._id.indexOf(':'));
                 query.filter({bool: {
                     filter: {term: {'task.desk_history': deskId}},
+                    must: {exists: {field: 'task.desk'}},
                     must_not: {term: {'task.desk': deskId}},
                 }});
                 break;

--- a/scripts/apps/monitoring/tests/monitoring.spec.ts
+++ b/scripts/apps/monitoring/tests/monitoring.spec.ts
@@ -181,6 +181,17 @@ describe('monitoring', () => {
             });
         }));
 
+        it('can get criteria for sent desk output', inject((cards, session) => {
+            var card: any = {_id: '1:sent', type: 'sentDeskOutput'};
+            var criteria = cards.criteria(card);
+
+            expect(criteria.source.query.filtered.filter.and).toContain({bool: {
+                filter: {term: {'task.desk_history': '1'}},
+                must: {exists: {field: 'task.desk'}},
+                must_not: {term: {'task.desk': '1'}},
+            }});
+        }));
+
         it('can get criteria for highlight', inject((cards, session) => {
             var card = {type: 'highlights'};
             var queryParam = {highlight: '123'};

--- a/scripts/apps/monitoring/tests/monitoring.spec.ts
+++ b/scripts/apps/monitoring/tests/monitoring.spec.ts
@@ -186,8 +186,10 @@ describe('monitoring', () => {
             var criteria = cards.criteria(card);
 
             expect(criteria.source.query.filtered.filter.and).toContain({bool: {
-                filter: {term: {'task.desk_history': '1'}},
-                must: {exists: {field: 'task.desk'}},
+                must: [
+                    {term: {'task.desk_history': '1'}},
+                    {exists: {field: 'task.desk'}},
+                ],
                 must_not: {term: {'task.desk': '1'}},
             }});
         }));


### PR DESCRIPTION
### Purpose
This PR fixes an issue where items copied to Personal Space were still appearing in the originating desk’s Sent Desk Output stage. This caused the same item to be visible in both places and made edits in Personal Space appear in Sent Desk Output.

### What has changed
- Updated sentDeskOutput monitoring filtering to exclude Personal Space items.
- Added test

### Steps to test
1. Enable Sent Desk Output on a desk.
2. Create an article on Desk 1 and send it to Desk 2.
3. Confirm it appears in Desk 1 Sent Desk Output.
4. From Desk 1, send that item to Personal Space.
5. Refresh Desk 1 Sent Desk Output and confirm the Personal Space copy is no longer visible.
6. Confirm the item still appears in Personal Space and can be edited there without leaking back into Sent Desk Output.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7942](https://sofab.atlassian.net/browse/SDESK-7942)

[SDESK-7942]: https://sofab.atlassian.net/browse/SDESK-7942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ