### PR TITLE
[SDESK-7940] - Selecting CV items parent not working properly first time in desks with preffered items set

### DIFF
--- a/scripts/apps/authoring/metadata/metadata.ts
+++ b/scripts/apps/authoring/metadata/metadata.ts
@@ -750,7 +750,7 @@ function MetaTermsDirective(metadata, $filter, $timeout, preferencesService, des
             };
 
             scope.openTree = function(term, $event) {
-                if ($event.altKey) {
+                if ($event?.altKey) {
                     let activeTree = scope.tree[term ? term[scope.uniqueField] : null];
 
                     return angular.forEach(activeTree, (_term) => {
@@ -762,7 +762,7 @@ function MetaTermsDirective(metadata, $filter, $timeout, preferencesService, des
                 scope.activeTerm = term;
                 scope.termPath.push(term);
                 scope.activeTree = scope.tree[term ? term[scope.uniqueField] : null];
-                $event.stopPropagation();
+                $event?.stopPropagation();
                 _.defer(() => {
                     const el = elem.find('button:not([disabled]):not(.dropdown__toggle)');
 

--- a/scripts/apps/authoring/metadata/metadata.ts
+++ b/scripts/apps/authoring/metadata/metadata.ts
@@ -758,6 +758,7 @@ function MetaTermsDirective(metadata, $filter, $timeout, preferencesService, des
                     });
                 }
 
+                scope.preferredView = null;
                 scope.activeTerm = term;
                 scope.termPath.push(term);
                 scope.activeTree = scope.tree[term ? term[scope.uniqueField] : null];
@@ -969,6 +970,16 @@ function MetaTermsDirective(metadata, $filter, $timeout, preferencesService, des
                 if (scope.activeTerm) {
                     scope.openParent({}, $event);
                 }
+            };
+
+            scope.resetDropdownState = function() {
+                scope.activeTerm = null;
+                scope.termPath = [];
+                scope.selectedTerm = '';
+                scope.activeList = false;
+                scope.activeTree = scope.tree.null;
+                setPreferredItems();
+                scope.searchTerms();
             };
 
             function setPreferredItems() {

--- a/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.ts
+++ b/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.ts
@@ -353,7 +353,7 @@ describe('metadata terms directive', () => {
 
         $rootScope.$digest();
         iScope = elm.isolateScope();
-        iScope.searchTerms('abc');
+        iScope.searchTerms('foo');
         expect(iScope.terms.length).toBe(1);
         expect(iScope.activeTree.length).toBe(2);
         expect(elm[0].querySelectorAll('.nested-indicator').length).toBe(1);

--- a/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.ts
+++ b/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.ts
@@ -356,7 +356,7 @@ describe('metadata terms directive', () => {
         iScope.searchTerms('foo');
         expect(iScope.terms.length).toBe(1);
         expect(iScope.activeTree.length).toBe(2);
-        expect(elm[0].querySelectorAll('.nested-indicator').length).toBe(1);
+        expect(iScope.tree[iScope.terms[0].qcode]).toEqual(jasmine.any(Array));
     }));
 
     it('select metadata term from tree type metadata dropdown', inject(() => {

--- a/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.ts
+++ b/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.ts
@@ -356,7 +356,7 @@ describe('metadata terms directive', () => {
         iScope.searchTerms('foo');
         expect(iScope.terms.length).toBe(1);
         expect(iScope.activeTree.length).toBe(2);
-        expect(iScope.tree[iScope.terms[0].qcode]).toEqual(jasmine.any(Array));
+        expect(iScope.tree[iScope.terms[0].parent]).toEqual(jasmine.any(Array));
     }));
 
     it('select metadata term from tree type metadata dropdown', inject(() => {

--- a/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.ts
+++ b/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.ts
@@ -353,9 +353,10 @@ describe('metadata terms directive', () => {
 
         $rootScope.$digest();
         iScope = elm.isolateScope();
-        iScope.searchTerms('foo');
+        iScope.searchTerms('abc');
         expect(iScope.terms.length).toBe(1);
         expect(iScope.activeTree.length).toBe(2);
+        expect(elm[0].querySelectorAll('.nested-indicator').length).toBe(1);
     }));
 
     it('select metadata term from tree type metadata dropdown', inject(() => {
@@ -405,10 +406,12 @@ describe('metadata terms directive', () => {
 
         $rootScope.$digest();
         iScope = elm.isolateScope();
+        iScope.preferredView = 'desk';
         iScope.openTree({name: 'test', qcode: '111'}, event);
         expect(iScope.item[iScope.field].length).toBe(2);
         expect(iScope.activeTree.length).toBe(3);
         expect(iScope.terms.length).toBe(8);
+        expect(iScope.preferredView).toBe(null);
     }));
 });
 

--- a/scripts/apps/authoring/metadata/views/metadata-terms.html
+++ b/scripts/apps/authoring/metadata/views/metadata-terms.html
@@ -1,7 +1,30 @@
 <div class="term-editor data visible" ng-if="!header" ng-attr-title="{{helperText}}">
-    <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="selectTerm(item)" data-disabled="disabled">
+    <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="selectTerm(item)" close="resetDropdownState()" data-disabled="disabled">
         <ul ng-if="activeTerm || activeList">
-            <li typeahead-item="t" ng-repeat="t in terms track by t[uniqueField]">{{getLocaleName(t, item)}}</li>
+            <li typeahead-item="t" ng-repeat="t in terms track by t[uniqueField]" data-test-id="dropdown__item">
+                <button
+                    ng-if="tree[t[uniqueField]]"
+                    class="nested-toggle flex-row sibling-spacer-10"
+                    style="display: flex;"
+                    ng-click="selectTerm(t, $event)"
+                    title="{{getLocaleName(t, item)}}"
+                >
+                    <span ng-if="t.user != null">
+                        <sd-user-avatar data-user="t.user"></sd-user-avatar>
+                    </span>
+                    <span>{{getLocaleName(t, item)}}</span>
+                    <i class="icon-chevron-right-thin sd-margin-start--auto nested-indicator"></i>
+                </button>
+                <button
+                    ng-if="!tree[t[uniqueField]]"
+                    ng-click="selectTerm(t, $event)"
+                    title="{{getLocaleName(t, item)}}"
+                    ng-class="{'greyout': isSelected(t)}"
+                    ng-disabled="isSelected(t)"
+                >
+                    {{getLocaleName(t, item)}}
+                </button>
+            </li>
         </ul>
     </div>
 </div>
@@ -13,16 +36,28 @@
     </button>
     <ul class="dropdown__menu nested-menu pull-right" style="{{ cv.popup_width ? 'min-width: 0; width: ' + cv.popup_width + 'px' : ''}}" id="metadata-terms-dropdown-users">
         <li ng-show="!activeTerm && header">
-            <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="selectTerm(item, $event)" always-visible="header" data-disabled="disabled || allSelected">
+            <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="selectTerm(item, $event)" close="resetDropdownState()" always-visible="header" data-disabled="disabled || allSelected">
                 <ul class="item-list" vs-repeat ng-if="!activeTree.length || activeList">
-                    <li typeahead-item="t" ng-repeat="t in terms track by t[uniqueField]">
+                    <li typeahead-item="t" ng-repeat="t in terms track by t[uniqueField]" data-test-id="dropdown__item">
                         <button
+                            ng-if="tree[t[uniqueField]]"
                             class="nested-toggle flex-row sibling-spacer-10"
                             style="display: flex;"
                             ng-click="selectTerm(t, $event)"
+                            title="{{getLocaleName(t, item)}}"
                         >
                             <sd-user-avatar ng-if="t.user != null" data-user="t.user" scroll-container="'#metadata-terms-dropdown-users'"></sd-user-avatar>
                             <span>{{getLocaleName(t, item)}}</span>
+                            <i class="icon-chevron-right-thin sd-margin-start--auto nested-indicator"></i>
+                        </button>
+                        <button
+                            ng-if="!tree[t[uniqueField]]"
+                            ng-click="selectTerm(t, $event)"
+                            title="{{getLocaleName(t, item)}}"
+                            ng-class="{'greyout': isSelected(t)}"
+                            ng-disabled="isSelected(t)"
+                        >
+                            {{getLocaleName(t, item)}}
                         </button>
                     </li>
                 </ul>

--- a/scripts/apps/authoring/metadata/views/metadata-terms.html
+++ b/scripts/apps/authoring/metadata/views/metadata-terms.html
@@ -1,12 +1,12 @@
 <div class="term-editor data visible" ng-if="!header" ng-attr-title="{{helperText}}">
-    <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="selectTerm(item)" close="resetDropdownState()" data-disabled="disabled">
+    <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="tree[item[uniqueField]] ? openTree(item) : selectTerm(item)" close="resetDropdownState()" data-disabled="disabled">
         <ul ng-if="activeTerm || activeList">
             <li typeahead-item="t" ng-repeat="t in terms track by t[uniqueField]" data-test-id="dropdown__item">
                 <button
                     ng-if="tree[t[uniqueField]]"
                     class="nested-toggle flex-row sibling-spacer-10"
                     style="display: flex;"
-                    ng-click="selectTerm(t, $event)"
+                    ng-click="openTree(t)"
                     title="{{getLocaleName(t, item)}}"
                 >
                     <span ng-if="t.user != null">
@@ -36,14 +36,14 @@
     </button>
     <ul class="dropdown__menu nested-menu pull-right" style="{{ cv.popup_width ? 'min-width: 0; width: ' + cv.popup_width + 'px' : ''}}" id="metadata-terms-dropdown-users">
         <li ng-show="!activeTerm && header">
-            <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="selectTerm(item, $event)" close="resetDropdownState()" always-visible="header" data-disabled="disabled || allSelected">
+            <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="tree[item[uniqueField]] ? openTree(item, $event) : selectTerm(item, $event)" close="resetDropdownState()" always-visible="header" data-disabled="disabled || allSelected">
                 <ul class="item-list" vs-repeat ng-if="!activeTree.length || activeList">
                     <li typeahead-item="t" ng-repeat="t in terms track by t[uniqueField]" data-test-id="dropdown__item">
                         <button
                             ng-if="tree[t[uniqueField]]"
                             class="nested-toggle flex-row sibling-spacer-10"
                             style="display: flex;"
-                            ng-click="selectTerm(t, $event)"
+                            ng-click="openTree(t, $event)"
                             title="{{getLocaleName(t, item)}}"
                         >
                             <sd-user-avatar ng-if="t.user != null" data-user="t.user" scroll-container="'#metadata-terms-dropdown-users'"></sd-user-avatar>

--- a/scripts/core/directives/TypeaheadDirective.ts
+++ b/scripts/core/directives/TypeaheadDirective.ts
@@ -114,7 +114,6 @@ export default angular.module('superdesk.core.directives.typeahead', [])
             link: function(scope, element, attrs, controller) {
                 var $input = element.find('.input-term > input');
                 var $list = element.find('.item-list');
-                let wasVisible = false;
 
                 $input.on('focus', () => {
                     scope.$applyAsync(() => {
@@ -206,12 +205,10 @@ export default angular.module('superdesk.core.directives.typeahead', [])
                     }
                 });
 
-                scope.$watch('isVisible()', (visible) => {
-                    if (wasVisible && !visible && !scope.focused && typeof scope.close === 'function') {
+                scope.$watch('isVisible()', (visible, oldVisible) => {
+                    if (oldVisible === true && visible === false && !scope.focused && typeof scope.close === 'function') {
                         scope.close();
                     }
-
-                    wasVisible = visible;
 
                     if (visible || scope.alwaysVisible) {
                         scope.hide = false;

--- a/scripts/core/directives/TypeaheadDirective.ts
+++ b/scripts/core/directives/TypeaheadDirective.ts
@@ -207,7 +207,7 @@ export default angular.module('superdesk.core.directives.typeahead', [])
                 });
 
                 scope.$watch('isVisible()', (visible) => {
-                    if (wasVisible && !visible && typeof scope.close === 'function') {
+                    if (wasVisible && !visible && !scope.focused && typeof scope.close === 'function') {
                         scope.close();
                     }
 

--- a/scripts/core/directives/TypeaheadDirective.ts
+++ b/scripts/core/directives/TypeaheadDirective.ts
@@ -206,7 +206,12 @@ export default angular.module('superdesk.core.directives.typeahead', [])
                 });
 
                 scope.$watch('isVisible()', (visible, oldVisible) => {
-                    if (oldVisible === true && visible === false && !scope.focused && typeof scope.close === 'function') {
+                    if (
+                        oldVisible === true &&
+                        visible === false &&
+                        !scope.focused &&
+                        typeof scope.close === 'function'
+                    ) {
                         scope.close();
                     }
 

--- a/scripts/core/directives/TypeaheadDirective.ts
+++ b/scripts/core/directives/TypeaheadDirective.ts
@@ -15,7 +15,9 @@ export default angular.module('superdesk.core.directives.typeahead', [])
      * @param {Boolen} alwaysVisible List of posible choices always stay visible.
      * @param {Function} search Callback for filtering choice action.
      * @param {Function} select Callback for select item aciton.
-     * @param {Boolean} keepinput if true, the input text after selecting an item-selection will not be deleted/nulled
+     * @param {Function} close Callback for when the dropdown closes.
+     * @param {Boolean} keepinput if true, the input text after selecting
+     *   an item-selection will not be deleted/nulled
      *
      * @description Typeahead directive.
      *
@@ -42,6 +44,7 @@ export default angular.module('superdesk.core.directives.typeahead', [])
                 alwaysVisible: '=',
                 disabled: '=',
                 blur: '&',
+                close: '&?',
                 placeholder: '@',
                 tabindex: '=',
                 style: '=',
@@ -111,6 +114,7 @@ export default angular.module('superdesk.core.directives.typeahead', [])
             link: function(scope, element, attrs, controller) {
                 var $input = element.find('.input-term > input');
                 var $list = element.find('.item-list');
+                let wasVisible = false;
 
                 $input.on('focus', () => {
                     scope.$applyAsync(() => {
@@ -203,6 +207,12 @@ export default angular.module('superdesk.core.directives.typeahead', [])
                 });
 
                 scope.$watch('isVisible()', (visible) => {
+                    if (wasVisible && !visible && typeof scope.close === 'function') {
+                        scope.close();
+                    }
+
+                    wasVisible = visible;
+
                     if (visible || scope.alwaysVisible) {
                         scope.hide = false;
                     } else {


### PR DESCRIPTION
### Purpose
This PR fixes the CV metadata dropdown so subgroup results behave consistently when searching even for desks with preferred CV items configured.

### What has changed
- Updated the metadata terms dropdown to render searched group items the same way as browsed group items.
- Added the group `>` indicator for matching subgroup results in search mode.
- Reset dropdown state on close so reopening returns to the expected desk preferred view or root list.

### Steps to test
1. Import the `Products.json` in the ticket into a content profile and assign it to a desk.
2. Configure some preferred CV items for that desk.
3. Open authoring and use the CV dropdown/search.
4. Search for a subgroup like `Motori`.
5. Verify `Motori` appears as a group in search results with the `>` indicator.
6. Click `Motori` and verify it opens the subgroup list with the proper header/navigation.
7. Close and reopen the dropdown and verify it returns to the expected preferred/root state without losing the search input behavior.

### Screenshots
#### Before
<img width="506" height="298" alt="image" src="https://github.com/user-attachments/assets/5ba30383-0073-4c59-b2ae-bca7fec1e007" />

#### After
<img width="615" height="305" alt="2026-06-01_14-33-56" src="https://github.com/user-attachments/assets/cf5eef20-5ed8-4421-957d-6fb3d311dd19" />


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7940](https://sofab.atlassian.net/browse/SDESK-7940)


[SDESK-7940]: https://sofab.atlassian.net/browse/SDESK-7940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ