### PR TITLE
[SDESK-7801] Add Check spelling action to authoring-react

### DIFF
--- a/e2e/client/playwright/editor3.spellchecker.authoring-react.spec.ts
+++ b/e2e/client/playwright/editor3.spellchecker.authoring-react.spec.ts
@@ -1,0 +1,86 @@
+import {test, expect} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot, s} from './utils';
+import {getStorageState} from './utils/storage-state';
+
+test.use({
+    storageState: getStorageState({}, {authoringReact: true}),
+});
+
+test('adding a word to the dictionary removes its spellchecker warnings (authoring-react)', async ({page}) => {
+    await restoreDatabaseSnapshot({snapshotName: 'spellchecker'});
+    const monitoring = new Monitoring(page);
+
+    await page.goto('/#/workspace/monitoring');
+    await monitoring.selectDeskOrWorkspace('Sports');
+
+    await page.locator(
+        s('monitoring-group=Sports / Working Stage', 'article-item=spellchecker test'),
+    ).dblclick();
+
+    // Wait for editor3 + dictionary to load. Mirrors the legacy spec; no UI
+    // indicator exists for "spellchecker ready".
+    await page.waitForTimeout(3000);
+
+    const warnings = page.locator(s('authoring', 'authoring-field=body_html', 'spellchecker-warning'));
+
+    await expect(warnings).toHaveCount(2);
+
+    await warnings.first().click({button: 'right'});
+
+    await page.locator(s('spellchecker-menu')).getByRole('button', {name: 'Add to dictionary'}).click();
+
+    await expect(warnings).toHaveCount(0);
+});
+
+test('toggling spellchecker on/off shows/clears warnings (authoring-react)', async ({page}) => {
+    await restoreDatabaseSnapshot({snapshotName: 'spellchecker'});
+    const monitoring = new Monitoring(page);
+
+    await page.goto('/#/workspace/monitoring');
+    await monitoring.selectDeskOrWorkspace('Sports');
+
+    await page.locator(
+        s('monitoring-group=Sports / Working Stage', 'article-item=spellchecker test'),
+    ).dblclick();
+
+    await page.waitForTimeout(3000);
+
+    const warnings = page.locator(s('authoring', 'authoring-field=body_html', 'spellchecker-warning'));
+
+    await expect(warnings).toHaveCount(2);
+
+    await page.getByRole('button', {name: 'Actions menu'}).click();
+    await page.getByText('Disable spellchecker', {exact: true}).click();
+
+    await expect(warnings).toHaveCount(0);
+
+    await page.getByRole('button', {name: 'Actions menu'}).click();
+    await page.getByText('Enable spellchecker', {exact: true}).click();
+
+    await expect(warnings).toHaveCount(2);
+});
+
+test('"Check spelling" shows error toast when no dictionary is available (authoring-react)', async ({page}) => {
+    await restoreDatabaseSnapshot();
+    const monitoring = new Monitoring(page);
+
+    await page.goto('/#/workspace/monitoring');
+    await monitoring.selectDeskOrWorkspace('Sports');
+
+    await page.locator(
+        s('monitoring-group=Sports / Working Stage', 'article-item=test sports story'),
+    ).dblclick();
+
+    // Wait for editor3 to mount; spellchecker init will leave isActiveDictionary=false
+    // because the default snapshot has no dictionary configured for the article language.
+    await page.waitForTimeout(3000);
+
+    await page.getByRole('button', {name: 'Actions menu'}).click();
+    await page.getByText('Check spelling', {exact: true}).click();
+
+    await expect(
+        page.locator(s('notifications', 'notification--error'))
+            .getByText('No dictionary available for spell checking.'),
+    ).toBeVisible();
+});

--- a/scripts/apps/authoring-react/authoring-integration-wrapper.tsx
+++ b/scripts/apps/authoring-react/authoring-integration-wrapper.tsx
@@ -21,6 +21,9 @@ import {appConfig, extensions} from 'appConfig';
 import {getAuthoringActionsFromExtensions} from 'core/superdesk-api-helpers';
 import {gettext} from 'core/utils';
 import {sdApi} from 'api';
+import ng from 'core/services/ng';
+import {notify} from 'core/notify/notify';
+import {getSpellchecker} from 'core/editor3/components/spellchecker/default-spellcheckers';
 import {
     IActionsInteractiveActionsPanelHOC,
     IStateInteractiveActionsPanelHOC,
@@ -486,13 +489,9 @@ export class AuthoringIntegrationWrapper extends React.PureComponent<IPropsWrapp
                                         label: spellchecker.enabled
                                             ? gettext('Disable spellchecker')
                                             : gettext('Enable spellchecker'),
+                                        groupId: 'spellchecker',
                                         onTrigger: () => {
                                             spellchecker.setSpellcheckerStatus(!spellchecker.enabled);
-                                        },
-                                        keyBindings: {
-                                            'ctrl+shift+y': () => {
-                                                spellchecker.setSpellcheckerStatus(!spellchecker.enabled);
-                                            },
                                         },
                                     } satisfies IAuthoringAction;
                                 }
@@ -500,10 +499,49 @@ export class AuthoringIntegrationWrapper extends React.PureComponent<IPropsWrapp
                                 return null;
                             };
 
+                            const getCheckSpellingAction = (): IAuthoringAction | null => {
+                                if (appConfig.features.useTansaProofing === true) {
+                                    return null;
+                                }
+
+                                const runCheck = () => {
+                                    const language = getLatestItem().language;
+                                    const spellcheck = ng.get('spellcheck');
+                                    const dictAvailable =
+                                        spellcheck.isActiveDictionary
+                                        || getSpellchecker(language) != null;
+
+                                    if (!dictAvailable) {
+                                        notify.error(gettext('No dictionary available for spell checking.'));
+                                        return;
+                                    }
+
+                                    // Mirrors legacy SpellcheckMenuController.runSpellchecker: enables
+                                    // auto-mode and re-runs the check. Calling with `true` when already
+                                    // enabled re-dispatches the editor3 spellcheck via the existing event.
+                                    spellchecker.setSpellcheckerStatus(true);
+                                };
+
+                                return {
+                                    label: gettext('Check spelling'),
+                                    groupId: 'spellchecker',
+                                    onTrigger: runCheck,
+                                    keyBindings: {
+                                        'ctrl+shift+y': runCheck,
+                                    },
+                                } satisfies IAuthoringAction;
+                            };
+
                             const spellcheckerAction = getSpellcheckerAction();
 
                             if (spellcheckerAction != null) {
                                 actions.push(spellcheckerAction);
+                            }
+
+                            const checkSpellingAction = getCheckSpellingAction();
+
+                            if (checkSpellingAction != null) {
+                                actions.push(checkSpellingAction);
                             }
 
                             return actions;

--- a/scripts/apps/authoring-react/authoring-integration-wrapper.tsx
+++ b/scripts/apps/authoring-react/authoring-integration-wrapper.tsx
@@ -505,7 +505,9 @@ export class AuthoringIntegrationWrapper extends React.PureComponent<IPropsWrapp
                                 }
 
                                 const runCheck = () => {
-                                    const language = getLatestItem().language;
+                                    // Must match the editor3 `getLanguage` fallback, or this can
+                                    // report "no dictionary" while the editor spellchecks with 'en'.
+                                    const language = getLatestItem().language ?? 'en';
                                     const spellcheck = ng.get('spellcheck');
                                     const dictAvailable =
                                         spellcheck.isActiveDictionary


### PR DESCRIPTION
### Purpose

Improve the spellchecker UX in authoring-react so it has parity with the legacy Angular actions menu. Previously, the menu only exposed an "Enable/Disable spellchecker" toggle; there was no explicit "Check spelling" entry, and triggering a check with no dictionary configured for the article language silently did nothing.

### What has changed

- Added a "Check spelling" action to the authoring-react actions menu.
  - Before running, it verifies a dictionary is available for the article language (active dictionary or a registered default spellchecker).
  - If no dictionary is available, it surfaces an error toast ("No dictionary available for spell checking.") instead of silently doing nothing.
- Moved the `Ctrl+Shift+Y` shortcut from the toggle to the new "Check spelling" action, matching the legacy behavior.
- Grouped both actions under a shared `spellchecker` group id for future section-header parity.
- Added a Playwright spec (`editor3.spellchecker.authoring-react.spec.ts`) covering:
  - Adding a word to the dictionary clears its warnings.
  - Toggling the spellchecker off clears warnings; toggling back on restores them.
  - "Check spelling" with no available dictionary shows the error toast.

### Steps to test

1. Enable authoring-react: in the browser console run `localStorage.setItem('auth-react', true)` and reload.
2. Open an article whose language has a configured dictionary.
   - Actions menu, "Check spelling", confirm warnings appear on misspelled words.
   - Toggle "Disable spellchecker", confirm warnings clear. Toggle "Enable spellchecker", confirm they reappear.
   - Press `Ctrl+Shift+Y`, confirm it triggers "Check spelling".
3. Open an article whose language has no dictionary configured (e.g. set the article language to one without a dictionary).
   - Actions menu, "Check spelling", confirm an error toast: "No dictionary available for spell checking."
4. Confirm the spellchecker still works correctly in the legacy Angular authoring (regression check).

### Screenshots
<img width="850" alt="image" src="https://github.com/user-attachments/assets/0c7c36f0-a7c1-42fd-87ec-1f298c6a05d5" />


### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: SDESK-7801