### PR TITLE
Reduce e2e flakiness on CI

### DIFF
--- a/e2e/client/playwright.config.ts
+++ b/e2e/client/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
     /* Retry on CI only */
-    retries: !!process.env.CI ? 3 : 0,
+    retries: process.env.CI ? 3 : 0,
     /* Opt out of parallel tests on CI. */
     workers: process.env.CI ? 1 : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/e2e/client/playwright.config.ts
+++ b/e2e/client/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
     /* Retry on CI only */
-    retries: 0,
+    retries: process.env.CI ? 3 : 0,
     /* Opt out of parallel tests on CI. */
     workers: process.env.CI ? 1 : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -39,7 +39,7 @@ export default defineConfig({
             maxDiffPixelRatio: 0.05,
         },
 
-        timeout: 10000,
+        timeout: 15000,
     },
 
     /* Configure projects for major browsers */

--- a/e2e/client/playwright.config.ts
+++ b/e2e/client/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
     /* Retry on CI only */
-    retries: process.env.CI ? 3 : 0,
+    retries: !!process.env.CI ? 3 : 0,
     /* Opt out of parallel tests on CI. */
     workers: process.env.CI ? 1 : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/e2e/client/playwright/templates.spec.ts
+++ b/e2e/client/playwright/templates.spec.ts
@@ -117,9 +117,12 @@ test('legal-flag toggle on a template persists across edit', async ({page}) => {
     await page.locator(s('template-edit-view')).getByRole('button', {name: 'Save'}).click();
     await expect(page.locator(s('template-edit-view'))).not.toBeVisible();
 
-    // Reload to force a fresh template list — the post-save in-place state
-    // sometimes leaves the actions dropdown unresponsive.
+    // Reload to force a fresh template list. The save above triggers a
+    // template:update websocket event that re-runs fetchTemplates() in
+    // TemplatesDirective; if that fetch resolves mid-click, ng-repeat
+    // re-renders the cards and the Edit button gets detached.
     await page.goto('/#/settings/templates');
+    await page.waitForLoadState('networkidle');
     await page.locator(s('template-content', 'content-template=story 2', 'template-actions')).click();
     await page.locator(s('template-actions--options')).getByRole('button', {name: 'Edit'}).click();
     await page.locator('#template-editor-metadata').click();


### PR DESCRIPTION
### Purpose

Two changes:

- `playwright.config.ts`: retry up to 3 times on CI (was 0) and bump the expect timeout from 10s to 15s. The most common shape of these flakes is a single locator-stability or attribute-update race that recovers on a retry. This is kind of a temporary improvement while I figure out a better implementation for those flaky ones. 

- `templates.spec.ts` (legal-flag toggle): wait for `networkidle` after the post-save reload. TemplatesDirective listens for the template:update websocket event and re-runs `fetchTemplates()`, which reassigns `$scope.content_templates` and triggers an ng-repeat re-render. If that re-render lands mid-click, the Edit button detaches and the click times out.
