### PR TITLE
Show seconds in publish schedule when configured (develop)

### DIFF
--- a/scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx
+++ b/scripts/core/interactive-article-actions-panel/subcomponents/publishing-date-options.tsx
@@ -115,6 +115,7 @@ export class PublishingDateOptions extends React.PureComponent<IProps> {
 
         const canSetEmbargo = this.props.allowSettingEmbargo && sdApi.user.hasPrivilege('embargo');
         const canSetPublishSchedule = this.props.allowSettingPublishSchedule;
+        const allowSeconds = appConfig.authoring?.panels?.publish?.allowSeconds ?? false;
 
         if (items.length !== 1) {
             return null;
@@ -127,6 +128,7 @@ export class PublishingDateOptions extends React.PureComponent<IProps> {
                         <DateTimePicker
                             value={embargo}
                             valueType="date"
+                            allowSeconds={allowSeconds}
                             locale={{
                                 type: 'full',
                                 payload: getLocaleForDatePicker(),
@@ -154,6 +156,7 @@ export class PublishingDateOptions extends React.PureComponent<IProps> {
                         <DateTimePicker
                             value={publishSchedule}
                             valueType="date"
+                            allowSeconds={allowSeconds}
                             locale={{
                                 type: 'full',
                                 payload: getLocaleForDatePicker(),

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -3799,6 +3799,7 @@ declare module 'superdesk-api' {
 
             panels?: {
                 publish?: {
+                    allowSeconds?: boolean;
                     publishSchedule?: boolean
                     publishingTarget?: boolean;
                 }


### PR DESCRIPTION
Bringing https://github.com/superdesk/superdesk-client-core/pull/5133 to develop. 

This is one of the many PRs which happened in [SDANSA-576](https://sofab.atlassian.net/browse/SDANSA-576). https://github.com/superdesk/superdesk-client-core/pull/5137 is skipped for now as `develop` uses newer version of the UIF than `4.1.5` which was required for `release/2.10`. 

Resolves: [SDANSA-576](https://sofab.atlassian.net/browse/SDANSA-576)


[SDANSA-576]: https://sofab.atlassian.net/browse/SDANSA-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDANSA-576]: https://sofab.atlassian.net/browse/SDANSA-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ