### PR TITLE
[SDESK-7940] Fix metadata dropdown reset timing

### DIFF
--- a/scripts/apps/authoring/metadata/metadata.ts
+++ b/scripts/apps/authoring/metadata/metadata.ts
@@ -294,7 +294,7 @@ function MetadropdownFocusDirective(keyboardManager) {
     return {
         require: 'dropdown',
         link: function(scope, elem, attrs, dropdown) {
-            scope.$watch(dropdown.isOpen, (isOpen) => {
+            scope.$watch(dropdown.isOpen, (isOpen, oldIsOpen) => {
                 if (isOpen) {
                     _.defer(() => {
                         var keyboardOptions = {inputDisabled: false, propagate: false};
@@ -332,6 +332,10 @@ function MetadropdownFocusDirective(keyboardManager) {
                 } else if (isOpen === false) {
                     keyboardManager.pop('down');
                     keyboardManager.pop('up');
+
+                    if (oldIsOpen === true && typeof scope.resetDropdownState === 'function') {
+                        scope.resetDropdownState();
+                    }
                 }
             });
         },

--- a/scripts/apps/authoring/metadata/metadata.ts
+++ b/scripts/apps/authoring/metadata/metadata.ts
@@ -294,7 +294,7 @@ function MetadropdownFocusDirective(keyboardManager) {
     return {
         require: 'dropdown',
         link: function(scope, elem, attrs, dropdown) {
-            scope.$watch(dropdown.isOpen, (isOpen, oldIsOpen) => {
+            scope.$watch(dropdown.isOpen, (isOpen) => {
                 if (isOpen) {
                     _.defer(() => {
                         var keyboardOptions = {inputDisabled: false, propagate: false};
@@ -332,10 +332,6 @@ function MetadropdownFocusDirective(keyboardManager) {
                 } else if (isOpen === false) {
                     keyboardManager.pop('down');
                     keyboardManager.pop('up');
-
-                    if (oldIsOpen === true && typeof scope.resetDropdownState === 'function') {
-                        scope.resetDropdownState();
-                    }
                 }
             });
         },
@@ -984,6 +980,12 @@ function MetaTermsDirective(metadata, $filter, $timeout, preferencesService, des
                 scope.activeTree = scope.tree.null;
                 setPreferredItems();
                 scope.searchTerms();
+            };
+
+            scope.onDropdownToggle = function(isOpen) {
+                if (isOpen === false) {
+                    scope.resetDropdownState();
+                }
             };
 
             function setPreferredItems() {

--- a/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.ts
+++ b/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.ts
@@ -114,6 +114,7 @@ describe('metadata terms directive', () => {
     itemSubjects = [{name: 'b', qcode: '456', parent: '123'}, {name: 'test', qcode: '111'}];
 
     beforeEach(window.module('superdesk.templates-cache'));
+    beforeEach(window.module('superdesk.core.ui'));
     beforeEach(window.module('superdesk.core.api'));
     beforeEach(window.module('superdesk.core.filters'));
     beforeEach(window.module('superdesk.apps.publish'));
@@ -412,6 +413,34 @@ describe('metadata terms directive', () => {
         expect(iScope.activeTree.length).toBe(3);
         expect(iScope.terms.length).toBe(8);
         expect(iScope.preferredView).toBe(null);
+    }));
+
+    it('resets dropdown state only when the dropdown closes after being open', inject(($rootScope, $compile) => {
+        var scope = $rootScope.$new(),
+            elm;
+
+        scope.open = false;
+        scope.resetDropdownState = jasmine.createSpy('resetDropdownState');
+
+        elm = $compile(
+            '<div dropdown sd-dropdown-focus is-open="open">' +
+                '<button class="dropdown__toggle" dropdown__toggle></button>' +
+                '<ul class="dropdown__menu"><li><button type="button">Item</button></li></ul>' +
+            '</div>',
+        )(scope);
+
+        scope.$digest();
+        expect(scope.resetDropdownState).not.toHaveBeenCalled();
+
+        scope.open = true;
+        scope.$digest();
+        expect(scope.resetDropdownState).not.toHaveBeenCalled();
+
+        scope.open = false;
+        scope.$digest();
+        expect(scope.resetDropdownState).toHaveBeenCalledTimes(1);
+
+        elm.remove();
     }));
 });
 

--- a/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.ts
+++ b/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.ts
@@ -413,7 +413,6 @@ describe('metadata terms directive', () => {
         expect(iScope.terms.length).toBe(8);
         expect(iScope.preferredView).toBe(null);
     }));
-
 });
 
 describe('dateline dropdown', () => {

--- a/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.ts
+++ b/scripts/apps/authoring/metadata/tests/MetadataWidgetCtrl.spec.ts
@@ -114,7 +114,6 @@ describe('metadata terms directive', () => {
     itemSubjects = [{name: 'b', qcode: '456', parent: '123'}, {name: 'test', qcode: '111'}];
 
     beforeEach(window.module('superdesk.templates-cache'));
-    beforeEach(window.module('superdesk.core.ui'));
     beforeEach(window.module('superdesk.core.api'));
     beforeEach(window.module('superdesk.core.filters'));
     beforeEach(window.module('superdesk.apps.publish'));
@@ -415,33 +414,6 @@ describe('metadata terms directive', () => {
         expect(iScope.preferredView).toBe(null);
     }));
 
-    it('resets dropdown state only when the dropdown closes after being open', inject(($rootScope, $compile) => {
-        var scope = $rootScope.$new(),
-            elm;
-
-        scope.open = false;
-        scope.resetDropdownState = jasmine.createSpy('resetDropdownState');
-
-        elm = $compile(
-            '<div dropdown sd-dropdown-focus is-open="open">' +
-                '<button class="dropdown__toggle" dropdown__toggle></button>' +
-                '<ul class="dropdown__menu"><li><button type="button">Item</button></li></ul>' +
-            '</div>',
-        )(scope);
-
-        scope.$digest();
-        expect(scope.resetDropdownState).not.toHaveBeenCalled();
-
-        scope.open = true;
-        scope.$digest();
-        expect(scope.resetDropdownState).not.toHaveBeenCalled();
-
-        scope.open = false;
-        scope.$digest();
-        expect(scope.resetDropdownState).toHaveBeenCalledTimes(1);
-
-        elm.remove();
-    }));
 });
 
 describe('dateline dropdown', () => {

--- a/scripts/apps/authoring/metadata/views/metadata-terms.html
+++ b/scripts/apps/authoring/metadata/views/metadata-terms.html
@@ -1,5 +1,5 @@
 <div class="term-editor data visible" ng-if="!header" ng-attr-title="{{helperText}}">
-    <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="tree[item[uniqueField]] ? openTree(item) : selectTerm(item)" close="resetDropdownState()" data-disabled="disabled">
+    <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="tree[item[uniqueField]] ? openTree(item) : selectTerm(item)" data-disabled="disabled">
         <ul ng-if="activeTerm || activeList">
             <li typeahead-item="t" ng-repeat="t in terms track by t[uniqueField]" data-test-id="dropdown__item">
                 <button
@@ -36,7 +36,7 @@
     </button>
     <ul class="dropdown__menu nested-menu pull-right" style="{{ cv.popup_width ? 'min-width: 0; width: ' + cv.popup_width + 'px' : ''}}" id="metadata-terms-dropdown-users">
         <li ng-show="!activeTerm && header">
-            <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="tree[item[uniqueField]] ? openTree(item, $event) : selectTerm(item, $event)" close="resetDropdownState()" always-visible="header" data-disabled="disabled || allSelected">
+            <div sd-typeahead items="terms" term="selectedTerm" search="searchTerms(term)" select="tree[item[uniqueField]] ? openTree(item, $event) : selectTerm(item, $event)" always-visible="header" data-disabled="disabled || allSelected">
                 <ul class="item-list" vs-repeat ng-if="!activeTree.length || activeList">
                     <li typeahead-item="t" ng-repeat="t in terms track by t[uniqueField]" data-test-id="dropdown__item">
                         <button

--- a/scripts/apps/authoring/metadata/views/metadata-terms.html
+++ b/scripts/apps/authoring/metadata/views/metadata-terms.html
@@ -30,6 +30,7 @@
 </div>
 
 <div class="dropdown dropdown-terms" dropdown sd-dropdown-focus sd-dropdown-position
+    on-toggle="onDropdownToggle(open)"
     ng-attr-title="{{ allSelected ? 'All items selected' : helperText  | translate }}">
     <button class="dropdown__toggle" dropdown__toggle tabindex="{{tabindex}}" ng-disabled="disabled" ng-if="header && !disabled" aria-label="{{ 'Add new' | translate }}">
         <i class="icon--white icon-plus-large"></i>


### PR DESCRIPTION
### Purpose
This builds on #5199 and reworks the metadata CV dropdown reset behavior after it was noticed the subgroup navigation could bounce back to the root/preferred view in newer Chrome versions. One theory is that Chrome’s focus/blur timing exposed the issue, so the dropdown flow has been adjusted to avoid resetting subgroup state too early.

### What has changed  
- Removed the sd-typeahead close hook from the metadata terms dropdown.
- Moved state reset to the actual outer dropdown close transition.
- Preserved subgroup navigation state while the dropdown remains open.

### Steps to test  
1. Import the CV from the ticket and add it to the content profile.
2. Configure some preferred CV items for a desk.
3. Open authoring and search for motori.
4. Click Motori.
5. Verify the subgroup list opens correctly and stays in the subgroup view.
6. Verify on other browsers.

### Screenshots
https://github.com/user-attachments/assets/8aa39be3-0cfa-4a9a-91a7-672493727f49

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7940](https://sofab.atlassian.net/browse/SDESK-7940)


[SDESK-7940]: https://sofab.atlassian.net/browse/SDESK-7940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ