### PR TITLE
[SDESK-7806] Fix print preview crash and polish labels in authoring-react

### DIFF
--- a/e2e/client/playwright/print-preview.authoring-react.spec.ts
+++ b/e2e/client/playwright/print-preview.authoring-react.spec.ts
@@ -1,0 +1,34 @@
+import {test, expect} from '@playwright/test';
+import {Authoring} from './page-object-models/authoring';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot, s} from './utils';
+import {getStorageState} from './utils/storage-state';
+
+test.use({
+    storageState: getStorageState({}, {authoringReact: true}),
+});
+
+test('print preview renders the document without crashing (authoring-react)', async ({page}) => {
+    await restoreDatabaseSnapshot();
+    const monitoring = new Monitoring(page);
+    const authoring = new Authoring(page);
+
+    await page.goto('/#/workspace/monitoring');
+    await monitoring.selectDeskOrWorkspace('Sports');
+
+    await monitoring.executeActionOnMonitoringItem(
+        page.locator(s('monitoring-group=Sports / Working Stage', 'article-item=test sports story')),
+        'Edit',
+    );
+
+    await authoring.waitForAuthoringReactToInitialize();
+
+    await page.getByRole('button', {name: 'Print preview'}).click();
+
+    // The preview iterates every profile field and renders its previewComponent.
+    // A render crash (e.g. an unguarded field preview) would leave this empty.
+    const preview = page.locator(s('print-preview'));
+
+    await expect(preview).toBeVisible();
+    await expect(preview.getByText('test sports story').first()).toBeVisible();
+});

--- a/scripts/apps/authoring-react/authoring-react.tsx
+++ b/scripts/apps/authoring-react/authoring-react.tsx
@@ -1291,7 +1291,7 @@ export class AuthoringReact<T extends IBaseRestApiResponse>
             },
             printPreview: () => {
                 previewAuthoringEntity(
-                    state.profile,
+                    state.itemWithChanges,
                     state.profile,
                     state.fieldsDataWithChanges,
                 );

--- a/scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/preview.tsx
+++ b/scripts/apps/authoring-react/fields/dropdown/dropdown-manual-entry/preview.tsx
@@ -19,7 +19,9 @@ export class PreviewManualEntry extends React.PureComponent<IProps> {
                     return [value];
                 }
             })()
-                .map((val) => options.find((_option) => _option.id === val));
+                .map((val) => options.find((_option) => _option.id === val))
+                // an article may still reference an option that was removed from the profile config
+                .filter((option) => option != null);
 
         const noPadding = optionsToPreview.every(({color}) => color == null);
 

--- a/scripts/apps/authoring-react/fields/dropdown/dropdown-remote-source/preview.tsx
+++ b/scripts/apps/authoring-react/fields/dropdown/dropdown-remote-source/preview.tsx
@@ -8,8 +8,12 @@ type IProps = IPreviewComponentProps<IDropdownValue, IDropdownConfigRemoteSource
 export class PreviewRemoteSource extends React.PureComponent<IProps> {
     render() {
         const {config, value} = this.props;
-        const optionsToPreview =
-            (Array.isArray(value) ? value : [value]);
+
+        if (value == null) {
+            return null;
+        }
+
+        const optionsToPreview = Array.isArray(value) ? value : [value];
 
         const Template = getValueTemplate(config);
 

--- a/scripts/apps/authoring-react/fields/tests/preview-guards.spec.tsx
+++ b/scripts/apps/authoring-react/fields/tests/preview-guards.spec.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {
+    IDropdownConfigManualSource,
+    IDropdownConfigRemoteSource,
+    IUrlsFieldConfig,
+} from 'superdesk-api';
+import {Preview as UrlsPreview} from 'apps/authoring-react/fields/urls/preview';
+import {PreviewManualEntry} from 'apps/authoring-react/fields/dropdown/dropdown-manual-entry/preview';
+import {PreviewRemoteSource} from 'apps/authoring-react/fields/dropdown/dropdown-remote-source/preview';
+
+/**
+ * These previews are rendered by the print-preview and compare-versions views for every field in a
+ * content profile, including fields the article never filled in. The values below mirror the shapes
+ * that actually reach the components at runtime (the field types do not capture null/undefined or
+ * stale references), which is why no value is mocked. A render that throws fails the mount outright.
+ */
+describe('authoring-react field previews tolerate missing and stale values', () => {
+    describe('<UrlsPreview />', () => {
+        const config: IUrlsFieldConfig = {};
+
+        it('renders nothing when there is no value', () => {
+            const wrapper = mount(<UrlsPreview item={{}} value={null as any} config={config} />);
+
+            expect(wrapper.isEmptyRender()).toBe(true);
+        });
+
+        it('renders nothing for an empty list', () => {
+            const wrapper = mount(<UrlsPreview item={{}} value={[]} config={config} />);
+
+            expect(wrapper.isEmptyRender()).toBe(true);
+        });
+
+        it('renders a url that has no description', () => {
+            const wrapper = mount(
+                <UrlsPreview item={{}} value={[{url: 'http://example.com'}]} config={config} />,
+            );
+
+            expect(wrapper.text()).toContain('http://example.com');
+        });
+
+        it('renders both url and description when present', () => {
+            const wrapper = mount(
+                <UrlsPreview
+                    item={{}}
+                    value={[{url: 'http://example.com', description: 'Example'}]}
+                    config={config}
+                />,
+            );
+
+            expect(wrapper.text()).toContain('http://example.com');
+            expect(wrapper.text()).toContain('Example');
+        });
+    });
+
+    describe('<PreviewManualEntry />', () => {
+        const config: IDropdownConfigManualSource = {
+            source: 'manual-entry',
+            type: 'text',
+            options: [{id: 'a', label: 'Option A'}],
+            roundCorners: false,
+            multiple: true,
+        };
+
+        it('renders nothing when there is no value', () => {
+            const wrapper = mount(<PreviewManualEntry item={{}} value={null} config={config} />);
+
+            expect(wrapper.text()).toBe('');
+        });
+
+        it('ignores a value referencing an option no longer in the config', () => {
+            const wrapper = mount(
+                <PreviewManualEntry item={{}} value={['removed-option-id']} config={config} />,
+            );
+
+            expect(wrapper.text()).toBe('');
+        });
+
+        it('renders the label of a known option', () => {
+            const wrapper = mount(<PreviewManualEntry item={{}} value={['a']} config={config} />);
+
+            expect(wrapper.text()).toContain('Option A');
+        });
+
+        it('renders only the known options when a value mixes known and stale ids', () => {
+            const wrapper = mount(
+                <PreviewManualEntry item={{}} value={['a', 'removed-option-id']} config={config} />,
+            );
+
+            expect(wrapper.text()).toContain('Option A');
+        });
+    });
+
+    describe('<PreviewRemoteSource />', () => {
+        const config: IDropdownConfigRemoteSource = {
+            source: 'remote-source',
+            searchOptions: () => undefined,
+            getLabel: (item: {name: string}) => item.name,
+            getId: (item: {id: string}) => item.id,
+            multiple: true,
+        };
+
+        it('renders nothing when there is no value', () => {
+            const wrapper = mount(<PreviewRemoteSource item={{}} value={null} config={config} />);
+
+            expect(wrapper.isEmptyRender()).toBe(true);
+        });
+
+        it('renders a single value', () => {
+            const wrapper = mount(
+                <PreviewRemoteSource item={{}} value={{id: '1', name: 'Remote A'}} config={config} />,
+            );
+
+            expect(wrapper.text()).toContain('Remote A');
+        });
+
+        it('renders every value in a list', () => {
+            const wrapper = mount(
+                <PreviewRemoteSource
+                    item={{}}
+                    value={[{id: '1', name: 'Remote A'}, {id: '2', name: 'Remote B'}]}
+                    config={config}
+                />,
+            );
+
+            expect(wrapper.text()).toContain('Remote A');
+            expect(wrapper.text()).toContain('Remote B');
+        });
+    });
+});

--- a/scripts/apps/authoring-react/fields/urls/preview.tsx
+++ b/scripts/apps/authoring-react/fields/urls/preview.tsx
@@ -18,7 +18,7 @@ export class Preview extends React.PureComponent<IProps> {
                             <div>{url}</div>
 
                             {
-                                description.length > 0 && (
+                                (description ?? '').length > 0 && (
                                     <div>{description}</div>
                                 )
                             }

--- a/scripts/apps/authoring-react/preview-article-modal.tsx
+++ b/scripts/apps/authoring-react/preview-article-modal.tsx
@@ -4,6 +4,7 @@ import {showPrintableModal} from 'core/services/modalService';
 import {PreviewAuthoringItem} from './preview-authoring-item';
 import {Button} from 'superdesk-ui-framework/react';
 import {gettext} from 'core/utils';
+import {formatDate} from 'core/get-superdesk-api-implementation';
 
 export function previewAuthoringEntity(
     item: any,
@@ -43,12 +44,28 @@ export function previewAuthoringEntity(
                 </React.Fragment>
             )}
             contentSections={[
-                <PreviewAuthoringItem
-                    key="0"
-                    item={item}
-                    profile={profile}
-                    fieldsData={fieldsData}
-                />,
+                <React.Fragment key="0">
+                    {item.versioncreated != null && (
+                        <div className="css-table" data-test-id="print-preview-last-modified">
+                            <div className="tr">
+                                <div className="td" style={{paddingBlockEnd: 4}}>
+                                    <span className="form-label">{gettext('Last modified')}</span>
+                                </div>
+                                <div className="td" style={{paddingInlineStart: 30, paddingBlockEnd: 4}}>
+                                    {formatDate(new Date(item.versioncreated))}
+                                </div>
+                            </div>
+                        </div>
+                    )}
+
+                    <br />
+
+                    <PreviewAuthoringItem
+                        item={item}
+                        profile={profile}
+                        fieldsData={fieldsData}
+                    />
+                </React.Fragment>,
             ]}
         />
     ));

--- a/scripts/apps/authoring-react/preview-authoring-item.tsx
+++ b/scripts/apps/authoring-react/preview-authoring-item.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Map} from 'immutable';
 import {IContentProfileV2} from 'superdesk-api';
+import {appConfig} from 'appConfig';
 import {Spacer} from 'core/ui/components/Spacer';
 import {ErrorBoundary} from 'core/helpers/ErrorBoundary';
 import {getField} from 'apps/fields';
@@ -25,12 +26,13 @@ export class PreviewAuthoringItem extends React.PureComponent<IProps> {
 
                         return (
                             <div key={field.id} style={{width: '100%', padding: fieldPadding ?? 0}}>
-                                <span
-                                    className="field-label--base"
-                                    style={{marginBottom: 20}}
-                                >
-                                    {field.name}
-                                </span>
+                                {
+                                    appConfig?.authoring?.preview?.hideContentLabels === true ? null : (
+                                        <h3 style={{marginBlockStart: 20, marginBlockEnd: 10}}>
+                                            {field.name}
+                                        </h3>
+                                    )
+                                }
 
                                 <div>
                                     {/* A single misbehaving field preview must not blank the whole document. */}

--- a/scripts/apps/authoring-react/preview-authoring-item.tsx
+++ b/scripts/apps/authoring-react/preview-authoring-item.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Map} from 'immutable';
 import {IContentProfileV2} from 'superdesk-api';
 import {Spacer} from 'core/ui/components/Spacer';
+import {ErrorBoundary} from 'core/helpers/ErrorBoundary';
 import {getField} from 'apps/fields';
 
 interface IProps {
@@ -17,7 +18,7 @@ export class PreviewAuthoringItem extends React.PureComponent<IProps> {
         const allFields = profile.header.merge(profile.content);
 
         return (
-            <Spacer v gap="16" noWrap>
+            <Spacer v gap="16" noWrap data-test-id="print-preview">
                 {
                     allFields.map((field) => {
                         const FieldEditorConfig = getField(field.fieldType);
@@ -32,11 +33,14 @@ export class PreviewAuthoringItem extends React.PureComponent<IProps> {
                                 </span>
 
                                 <div>
-                                    <FieldEditorConfig.previewComponent
-                                        item={this.props.item}
-                                        value={fieldsData.get(field.id)}
-                                        config={field.fieldConfig}
-                                    />
+                                    {/* A single misbehaving field preview must not blank the whole document. */}
+                                    <ErrorBoundary>
+                                        <FieldEditorConfig.previewComponent
+                                            item={this.props.item}
+                                            value={fieldsData.get(field.id)}
+                                            config={field.fieldConfig}
+                                        />
+                                    </ErrorBoundary>
                                 </div>
                             </div>
                         );

--- a/scripts/core/helpers/ErrorBoundary.tsx
+++ b/scripts/core/helpers/ErrorBoundary.tsx
@@ -24,10 +24,9 @@ export class ErrorBoundary extends React.PureComponent<{}, IState> {
     }
 
     render() {
-        if (this.state.hasError) {
+        if (this.state.hasError)
             return null;
-        } else {
-            return this.props.children;
-        }
+
+        return this.props.children;
     }
 }


### PR DESCRIPTION
### Purpose
The authoring-react print preview could crash (blanking the whole document) when a single field preview threw, and the preview was being given the content profile where the article item was expected. This fixes the crash, contains field-level failures, and polishes the preview to match legacy authoring.

### What has changed
- **Crash root cause**: `printPreview` in `authoring-react.tsx` now passes `state.itemWithChanges` (the article) instead of `state.profile` to `previewAuthoringEntity`.
- **Containment**: each field preview in `preview-authoring-item.tsx` is wrapped in an `ErrorBoundary`, so one misbehaving field no longer blanks the entire preview.
- **Guards**: null/edge guards added to the `urls` and `dropdown` (manual-entry and remote-source) preview components.
- **Label polish**: field labels render as proper-case `<h3>` headings instead of the grey uppercase `field-label--base` pill, matching legacy `fullPreview.tsx`. Honors `appConfig.authoring.preview.hideContentLabels`.
- **Last modified row**: added a "Last modified" row at the top of the print preview (legacy parity), using `formatDate(item.versioncreated)`.
- Minor `ErrorBoundary.render()` simplification.

### Steps to test
1. Enable authoring-react (`localStorage.setItem('auth-react', true)`).
2. Open an article and trigger the print preview from the authoring actions.
3. Verify the preview renders without crashing, including items that contain url/dropdown fields.
4. Verify field labels appear as proper-case headings and that a "Last modified" row shows at the top.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7806]


[SDESK-7806]: https://sofab.atlassian.net/browse/SDESK-7806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ