### PR TITLE
[SDESK-7948] Prepare e2e for AI-assisted test authoring

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,11 @@ jobs:
 
   playwright-e2e:
     runs-on: ubuntu-latest
+    env:
+      # CI runs the e2e server on :5000 (docker-compose PORT default; no AirPlay
+      # conflict on Linux). The test helpers and client build read SUPERDESK_URL,
+      # which defaults to 5002 locally to dodge macOS AirPlay; pin it to the CI port.
+      SUPERDESK_URL: http://localhost:5000/api
     strategy:
       fail-fast: false
       matrix:

--- a/e2e/WRITING_TESTS.md
+++ b/e2e/WRITING_TESTS.md
@@ -1,0 +1,227 @@
+# Writing end-to-end tests for superdesk-client-core
+
+How to write a Playwright end-to-end test in this repo. Read this before
+authoring a spec. A companion doc exists in `superdesk-planning`; the two share
+most conventions but differ in auth and state-reset, so do not copy planning's
+patterns verbatim here.
+
+## TL;DR
+
+Every new spec:
+
+- Lives flat under `e2e/client/playwright/` as `<scenario>.spec.ts` with a
+  descriptive hyphenated name (`article-send-to.spec.ts`).
+- Selects elements with `page.getByTestId('...')` and locator chaining. Never
+  the legacy `s()` helper (see "Selectors" for why, and what to do when you
+  copy an existing spec that uses it).
+- Starts logged in via the committed `storageState`. No `login()` call unless
+  the spec needs a non-default user or exercises the login flow itself.
+- Resets state with `await restoreDatabaseSnapshot()` at the start of any test
+  that mutates server data.
+- Reuses Page Objects from `playwright/page-object-models/`.
+- Asserts with web-first assertions (`await expect(locator).toBeVisible()`).
+  Never `page.waitForTimeout(...)`.
+
+## Where specs and helpers live
+
+```
+e2e/client/playwright/
+├── <scenario>.spec.ts          <- specs are flat here, hyphenated names
+├── page-object-models/
+│   └── <feature>.ts            <- Page Object classes (Authoring, Monitoring, ...)
+└── utils/
+    ├── index.ts                <- restoreDatabaseSnapshot, login, helpers
+    └── storage-state.ts        <- getStorageState
+```
+
+- Specs are flat files directly under `playwright/`. Do not create
+  `<feature>/` subdirectories for specs. Name the file after the user-visible
+  behaviour: `assign-coverage.spec.ts`, not `test1.spec.ts` or `bug-123.spec.ts`.
+- Page Objects live in `playwright/page-object-models/<feature>.ts`, one class
+  per feature area, methods named after user-facing operations.
+- Import helpers and Page Objects with local relative paths:
+  ```ts
+  import {restoreDatabaseSnapshot} from './utils';
+  import {Monitoring} from './page-object-models/monitoring';
+  ```
+  There is no published helpers package. Do not import from
+  `@superdesk/end-to-end-testing-helpers` or any `@superdesk/...` path for e2e
+  helpers; it does not exist.
+
+## Selectors
+
+The Playwright config sets `testIdAttribute: 'data-test-id'`, so `getByTestId`
+matches Superdesk's `data-test-id` attributes directly.
+
+### Primary selector: `getByTestId` with chaining
+
+```ts
+await page.getByTestId('save-button').click();
+
+// "the child inside this specific parent": chain, do not build a CSS string
+await page.getByTestId('action-bar').getByTestId('save').click();
+```
+
+### Do not use `s()` in new specs
+
+Most existing specs use a local helper `s('a', 'b')` that builds a CSS selector
+string (`[data-test-id="a"] [data-test-id="b"]`) passed to `page.locator(...)`.
+It still works, but new specs use `getByTestId` instead, because:
+
+- It is the standard, documented Playwright API. QA and AI agents can look it up.
+- `planning` already uses it, so both repos share one idiom.
+- It returns a real Locator that composes with `.filter()`, `.and()`, `.nth()`.
+
+When you copy an existing spec for structure (see "Reference specs"), translate
+its `s()` selectors to `getByTestId`. Do not carry `s()` into a new spec.
+
+Translation reference:
+
+| Legacy `s()` | Native equivalent |
+|---|---|
+| `s('save-button')` | `page.getByTestId('save-button')` |
+| `s('action-bar', 'save')` | `page.getByTestId('action-bar').getByTestId('save')` |
+| `s('article-item=story 2')` | `page.getByTestId('article-item').filter({hasText: 'story 2'})` when the value is visible text, otherwise `page.getByTestId('article-item').and(page.locator('[data-test-value="story 2"]'))` |
+
+The value-matched case (`s('id=value')`, which matches `data-test-value`) is
+more verbose natively. Prefer `.filter({hasText})` when the value is the visible
+text of the element (it is substring-based and whitespace-tolerant, so it is
+also more robust than the old exact-attribute match). Fall back to
+`.and(page.locator('[data-test-value="..."]'))` only when the value is a
+non-text attribute.
+
+### What not to use for primary selectors
+
+- CSS class chains (`.sd-list-item .item-title`): brittle, drift-prone.
+- Text matching for actionable elements (buttons, links): breaks under
+  localization.
+- XPath.
+
+### Fine for assertions
+
+- `getByRole('button', {name: '...'})` for accessibility-shape checks.
+- `getByText(...)` / `toHaveText(...)` for asserting user-facing copy.
+- Text matching where the text itself is the behaviour under test (a toast
+  message, a validation error).
+
+## Authentication
+
+The browser starts logged in as the default admin user via a committed
+`storageState` file (`playwright/.auth/user.json`), wired into the Playwright
+config's project. That session is valid because it is also present in the `main`
+database snapshot that `restoreDatabaseSnapshot()` restores. Most specs need no
+login step.
+
+To override application config while keeping the auth session, use
+`getStorageState`:
+
+```ts
+import {getStorageState} from './utils/storage-state';
+
+test.use({storageState: getStorageState({featureName: true})});
+```
+
+Exceptions that do need an explicit login:
+
+- A different user role, or exercising the login flow itself. The repo has a
+  `login(page)` helper in `./utils`, but note it is currently `s()`-based legacy
+  code. If you write a new spec that needs a fresh login, prefer driving the
+  login form with `getByTestId` directly rather than extending the legacy helper.
+
+## State reset
+
+If a test creates, edits, or deletes server data, restore the base snapshot
+first:
+
+```ts
+import {restoreDatabaseSnapshot} from './utils';
+
+test('sends an article to another desk', async ({page}) => {
+    await restoreDatabaseSnapshot();          // restores the 'main' snapshot
+    await page.goto('/#/workspace/monitoring');
+    // ...
+});
+```
+
+- `restoreDatabaseSnapshot()` defaults to the `'main'` snapshot. Pass
+  `{snapshotName: 'legacy'}` only if you specifically need the legacy dataset
+  (which has a known session-expiry quirk; see `dismissSessionExpiry` in
+  `utils`).
+- It posts to `/api/restore_record` on the backend. There is no per-test
+  "add one item" API in client-core. Any state your test needs must exist in
+  the snapshot. If it does not, that is a fixture gap for a developer to fill,
+  not something to construct through the UI in a setup step.
+- Pure-read tests that only assert on data already in the snapshot can skip the
+  reset. When in doubt, reset.
+
+## Page Objects
+
+Reuse the classes in `playwright/page-object-models/`. They take a `Page` in the
+constructor and expose methods named after user operations:
+
+```ts
+import {Monitoring} from './page-object-models/monitoring';
+
+const monitoring = new Monitoring(page);
+await monitoring.selectDeskOrWorkspace('Sports');
+```
+
+When an interaction is not covered by an existing method, add a method to the
+relevant Page Object rather than inlining it in the spec. Keep Page Objects
+stateless beyond holding the `Page`; they are interaction wrappers, not models.
+New Page Object methods use `getByTestId`, not `s()`.
+
+## Running tests
+
+The bootstrap script runs from the repo root. Playwright runs from `e2e/client/`.
+Do not run `npm test` at the repo root; that is unit tests and lint, not e2e.
+
+```sh
+# From the repo root: bring up the stack (idempotent; rebuilds the client if
+# product source changed since the last build).
+./e2e/scripts/e2e-up.sh
+
+# From e2e/client/: run one spec
+cd e2e/client
+npx playwright test playwright/<scenario>.spec.ts
+
+# Watch it execute in a real browser
+npx playwright test playwright/<scenario>.spec.ts --headed
+
+# After a failure, open the trace
+npx playwright show-trace test-results/<run-id>/trace.zip
+
+# From the repo root: tear down
+./e2e/scripts/e2e-down.sh
+```
+
+The backend defaults to `http://localhost:5002/api` (override via the
+`SUPERDESK_URL` env var, from which the bootstrap script derives the port). Port
+5000 is avoided because macOS AirPlay Receiver answers on it and silently masks
+a missing server.
+
+## Common pitfalls
+
+- `page.waitForTimeout(N)` to paper over a race is almost always wrong. Wait for
+  the actual condition: `await expect(page.getByTestId('result')).toBeVisible()`.
+  Web-first assertions auto-retry until they pass or time out.
+- Order-dependent selectors (`.nth(2)`) only when order is the behaviour under
+  test. Otherwise find the item by a stable value.
+- "Passes solo, fails in a suite" is a shared-state problem. Add
+  `restoreDatabaseSnapshot()`.
+- The only acceptable product-source change from a test is adding a
+  `data-test-id` attribute. Anything more, including renaming an existing
+  `data-test-id`, belongs in a separate PR with product review.
+- Do not import product modules from `scripts/` into specs. Tests depend on the
+  `data-test-id` contract and the e2e helpers, nothing else.
+
+## Reference specs
+
+When writing a new spec, start from the closest of these curated native
+examples, copy its structure, and adapt. These use the current conventions
+(`getByTestId`, `storageState`, `restoreDatabaseSnapshot`, Page Objects):
+
+<!-- TODO(exemplar): add the path(s) to the native reference spec(s) produced
+     from a real QA test case (workstream W2). Until then, fall back to the
+     closest existing spec under playwright/ and translate its s() selectors to
+     getByTestId per the table in "Selectors". -->

--- a/e2e/client/package.json
+++ b/e2e/client/package.json
@@ -21,7 +21,6 @@
     "playwright": "playwright test --workers 1",
     "playwright-interactive": "playwright test --ui",
     "start-client-server": "http-server dist -p 9000 -s &",
-    "stop-client-server": "fuser -k 9000/tcp",
     "start-test-server": "cd ../server && docker-compose build && docker-compose up -d",
     "stop-test-server": "cd ../server && docker-compose stop"
   }

--- a/e2e/client/playwright.config.ts
+++ b/e2e/client/playwright.config.ts
@@ -26,6 +26,14 @@ export default defineConfig({
         /* Base URL to use in actions like `await page.goto('/')`. */
         baseURL: 'http://localhost:9000',
 
+        /*
+         * Superdesk emits `data-test-id` attributes. Playwright's getByTestId
+         * default is `data-testid` (no middle hyphen), so this must be set for
+         * getByTestId to resolve. Legacy specs that build CSS via the s() helper
+         * are unaffected (they call page.locator, which ignores this option).
+         */
+        testIdAttribute: 'data-test-id',
+
         viewport: {width: 1280, height: 800},
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */

--- a/e2e/client/playwright/utils/index.ts
+++ b/e2e/client/playwright/utils/index.ts
@@ -1,7 +1,7 @@
 import * as request from 'request';
 import {expect, Locator, Page} from '@playwright/test';
 
-const SUPERDESK_API_URL = (process.env.SUPERDESK_URL || 'http://localhost:5000/api').replace(/\/$/, '');
+const SUPERDESK_API_URL = (process.env.SUPERDESK_URL || 'http://localhost:5002/api').replace(/\/$/, '');
 
 export function restoreDatabaseSnapshot(options?: {snapshotName?: string}): Promise<void> {
     return new Promise((resolve) => {

--- a/e2e/scripts/e2e-up.sh
+++ b/e2e/scripts/e2e-up.sh
@@ -10,7 +10,7 @@
 #   ./e2e/scripts/e2e-up.sh --reinstall      # force `npm ci` in every dependency root
 #   ./e2e/scripts/e2e-up.sh --rebuild        # force docker compose build
 #
-# Exits 0 only when both the server (http://localhost:5000/api/) and the
+# Exits 0 only when both the server (http://localhost:5002/api/) and the
 # client (http://localhost:9000/) respond. Otherwise exits non-zero with a
 # clear error message.
 
@@ -34,18 +34,30 @@ E2E_SERVER="$REPO_ROOT/e2e/server"
 
 # SUPERDESK_URL is the single knob: point it at the e2e backend's /api root.
 # PORT (docker container bind) and SERVER_NAME (Quart config) are derived from
-# it so port-overriding (e.g. macOS AirPlay grabs 5000) needs only one export:
-#   export SUPERDESK_URL=http://localhost:5002/api
-SUPERDESK_URL="${SUPERDESK_URL:-http://localhost:5000/api}"
+# it so any port override needs only one export:
+#   export SUPERDESK_URL=http://localhost:5003/api
+# Default is 5002, chosen to avoid 5000 (macOS AirPlay answers on it).
+SUPERDESK_URL="${SUPERDESK_URL:-http://localhost:5002/api}"
 SERVER_URL="${SUPERDESK_URL%/}/"
 CLIENT_URL="http://localhost:9000/"
 SUPERDESK_HOST_PORT="$(printf '%s\n' "$SUPERDESK_URL" | sed -E 's#^https?://##; s#/.*$##')"
 PORT="${PORT:-${SUPERDESK_HOST_PORT##*:}}"
+case "$PORT" in
+    ''|*[!0-9]*)
+        printf '\n[e2e-up] ERROR: could not derive a numeric backend port from SUPERDESK_URL="%s". Include an explicit port, e.g. http://localhost:5002/api.\n' "$SUPERDESK_URL" >&2
+        exit 1
+        ;;
+esac
 SERVER_NAME="${SERVER_NAME:-$SUPERDESK_HOST_PORT}"
 export SUPERDESK_URL PORT SERVER_NAME
 
 log() { printf '\n[e2e-up] %s\n' "$*"; }
 fail() { printf '\n[e2e-up] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# Strict HTTP status (echoes the code, or 000 on connection failure). Unlike
+# reachable(), this lets callers require a specific code, e.g. a real 200 on a
+# bundle rather than "the port answered".
+http_status() { curl -sS --max-time 5 -o /dev/null -w '%{http_code}' "$1" 2>/dev/null || echo "000"; }
 
 reachable() {
     # Any HTTP response counts as "up" — the superdesk e2e server returns 403
@@ -132,10 +144,38 @@ ensure_deps "$REPO_ROOT"
 ensure_deps "$REPO_ROOT/build-tools"
 ensure_deps "$E2E_CLIENT"
 
-# 3. Client build (only if dist is missing or stale relative to scripts/)
-if [ "$REINSTALL" = true ] || [ ! -d "$E2E_CLIENT/dist" ] || [ -z "$(ls -A "$E2E_CLIENT/dist" 2>/dev/null)" ]; then
-    log "building client (this is the slow step on a cold cache)"
-    (cd "$E2E_CLIENT" && npm run build)
+# 3. Client build.
+# Rebuild when forced, deps reinstalled, the app bundles are missing, OR the
+# dist was built against a different SUPERDESK_URL. The last two matter because:
+#   - a failed/partial build leaves a non-empty dist/ WITHOUT the bundles, so
+#     "is dist empty?" is not a sufficient staleness test;
+#   - the backend URL is baked into the bundle at build time (webpack
+#     DefinePlugin), so a dist built for one port silently breaks on another.
+REQUIRED_BUNDLES="app.bundle.js init.bundle.js app.bundle.css"
+BUILD_META="$E2E_CLIENT/dist/.e2e-built-with"
+
+client_build_complete() {
+    for b in $REQUIRED_BUNDLES; do
+        [ -f "$E2E_CLIENT/dist/$b" ] || return 1
+    done
+    return 0
+}
+build_url_matches() {
+    [ -f "$BUILD_META" ] && [ "$(cat "$BUILD_META" 2>/dev/null)" = "$SUPERDESK_URL" ]
+}
+
+if [ "$REBUILD" = true ] || [ "$REINSTALL" = true ] || ! client_build_complete || ! build_url_matches; then
+    if ! client_build_complete; then
+        log "client bundles missing or incomplete; (re)building client"
+    elif ! build_url_matches; then
+        log "dist was built for a different backend URL; rebuilding for $SUPERDESK_URL"
+    else
+        log "building client (this is the slow step on a cold cache)"
+    fi
+    (cd "$E2E_CLIENT" && SUPERDESK_URL="$SUPERDESK_URL" npm run build)
+    client_build_complete || fail "client build finished but the app bundles are missing from dist/ ($REQUIRED_BUNDLES). The build failed; re-read the build output above and re-run with --rebuild."
+    printf '%s\n' "$SUPERDESK_URL" > "$BUILD_META"
+    log "client build complete (backend baked as $SUPERDESK_URL)"
 fi
 
 # 4. Client dev server (http-server serving dist on :9000)
@@ -145,6 +185,14 @@ else
     log "starting client server on $CLIENT_URL"
     (cd "$E2E_CLIENT" && npm run start-client-server)
     wait_until_reachable "$CLIENT_URL" "client" 60
+fi
+
+# Final health gate: the app entry bundle must actually be served with a 200.
+# A 200 on / (index.html) is returned even when the bundles 404 -> blank page.
+# This is the difference between "the port answers" and "the app works".
+bundle_status="$(http_status "${CLIENT_URL}app.bundle.js")"
+if [ "$bundle_status" != "200" ]; then
+    fail "client is up but app.bundle.js returns HTTP $bundle_status, the app would render blank. The build is incomplete; re-run: ./e2e/scripts/e2e-up.sh --rebuild"
 fi
 
 log "ready"


### PR DESCRIPTION
### Purpose

Prepare superdesk-client-core's e2e setup so it can be driven by a QA-facing AI test-authoring skill: a single reliable command to bring the local stack up, native `getByTestId` conventions (aligned with superdesk-planning), and a configurable backend port. The goal is that a non-technical QA author only has to write the test, never debug the environment.

### What has changed

Three separable commits:

1. **Conventions and `getByTestId`.** Sets `testIdAttribute: 'data-test-id'` in the Playwright config so `getByTestId` resolves Superdesk's `data-test-id` attributes (Playwright's default is `data-testid`). Adds `e2e/WRITING_TESTS.md` documenting native conventions for new specs, including translating the legacy `s()` helper. Existing `s()`-based specs are unaffected.
2. **Bootstrap hardening and configurable port.** Defaults the backend to `http://localhost:5002/api` (5000 conflicts with macOS AirPlay), overridable via `SUPERDESK_URL` (updates `e2e-up.sh` and the test helper). Hardens `e2e-up.sh`: verifies the build emitted the app bundles, rebuilds when bundles are missing or were built for a different backend URL, fails fast on a non-numeric derived port, and gates readiness on the app bundle actually being served. Removes the dead, macOS-broken `stop-client-server` npm script.
3. **CI port pin.** Pins `SUPERDESK_URL` to `:5000` in the e2e CI job to match the CI docker server (which binds its default `:5000`); local stays 5002.

### Steps to test

1. From the repo root: `./e2e/scripts/e2e-up.sh`. It should reach `ready` (server http://localhost:5002/api/, client http://localhost:9000/). First run is a cold build.
2. Open http://localhost:9000/, confirm the app loads and login works (admin / admin).
3. First time only: `cd e2e/client && npx playwright install chromium`. Then `npx playwright test playwright/article-versions.spec.ts`. It should pass.
4. Tear down: `./e2e/scripts/e2e-down.sh`.

Resolves: [SDESK-7948]

[SDESK-7948]: https://sofab.atlassian.net/browse/SDESK-7948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ