### PR TITLE
[SDESK-7948] Add edit-embed e2e exemplar and supporting test-ids

### DIFF
--- a/e2e/WRITING_TESTS.md
+++ b/e2e/WRITING_TESTS.md
@@ -150,7 +150,12 @@ test('sends an article to another desk', async ({page}) => {
 - It posts to `/api/restore_record` on the backend. There is no per-test
   "add one item" API in client-core. Any state your test needs must exist in
   the snapshot. If it does not, that is a fixture gap for a developer to fill,
-  not something to construct through the UI in a setup step.
+  not something to construct through the UI in a setup step. The one narrow
+  exception: a precondition that is itself produced by a stable, test-id-driven
+  UI flow that is cheap and deterministic may be built in-test (see
+  `edit-embed.spec.ts`, which adds the embed through the add-embed flow because
+  no snapshot fixture carries one). Prefer a snapshot fixture when one exists;
+  reach for the UI only when there is none and the flow is stable.
 - Pure-read tests that only assert on data already in the snapshot can skip the
   reset. When in doubt, reset.
 
@@ -243,15 +248,15 @@ examples, copy its structure, and adapt. These use the current conventions
   - `getByTestId` with locator chaining, and the value-matched field case
     (`authoring-field=body_html`) written natively with
     `.and(page.locator('[data-test-value="body_html"]'))`.
-  - building a precondition through the UI when the snapshot lacks it (the
-    article ships without an embed, so the spec adds one first).
+  - building a precondition through the UI as the narrow exception allowed by
+    "State reset": no snapshot fixture carries an embed, so the spec adds one
+    through the stable add-embed flow before editing it.
   - `page.route(...)` to stub a third-party call (iframe.ly) so the test is
     deterministic and offline.
-  - escape hatches used deliberately and only where justified, each with a
-    comment explaining why: `dispatchEvent('mousedown')` for a hover-revealed
-    control on a frequently re-rendering element (a plain `click()` flakes on
-    the visible+stable check), and a `.p-dialog` scope for a shared confirmation
-    dialog whose buttons carry no `data-test-id`.
+  - an escape hatch used deliberately and only where justified, with a comment
+    explaining why: `dispatchEvent('mousedown')` for a hover-revealed control on
+    a frequently re-rendering element (a plain `click()` flakes on the
+    visible+stable check).
 
 The only product-source change it required was adding `data-test-id` attributes
 to the embed controls and the prompt dialog (`EmbedBlock.tsx`,

--- a/e2e/WRITING_TESTS.md
+++ b/e2e/WRITING_TESTS.md
@@ -215,13 +215,45 @@ a missing server.
 - Do not import product modules from `scripts/` into specs. Tests depend on the
   `data-test-id` contract and the e2e helpers, nothing else.
 
+## Comments
+
+Comment the non-obvious *why*, not the *what*. A reader can see what
+`getByTestId('save').click()` does; they cannot see why you had to
+`dispatchEvent('mousedown')` instead of `click()`, or why a third-party call is
+stubbed. Reserve comments for that: workarounds, async timing, app quirks, an
+unusual selector shape.
+
+Do not narrate the steps (`// hover the embed`) or restate the QA case
+(`// Expected: Cancel discards`). The scenario mapping belongs in the
+`describe`/`test` titles, which are the first thing a reviewer reads. The
+reference spec below (`edit-embed.spec.ts`) follows this: every comment in it
+explains a non-obvious decision, and the flow itself is left to read as code.
+
 ## Reference specs
 
 When writing a new spec, start from the closest of these curated native
 examples, copy its structure, and adapt. These use the current conventions
 (`getByTestId`, `storageState`, `restoreDatabaseSnapshot`, Page Objects):
 
-<!-- TODO(exemplar): add the path(s) to the native reference spec(s) produced
-     from a real QA test case (workstream W2). Until then, fall back to the
-     closest existing spec under playwright/ and translate its s() selectors to
-     getByTestId per the table in "Selectors". -->
+- `playwright/edit-embed.spec.ts` - the canonical native reference. Built from a
+  real QA case ("Edit embed", SDESK-4441/4213). It opens an article from
+  Monitoring, edits the Body field, drives a dialog, and verifies persistence
+  across save and reopen. It demonstrates, in order:
+  - `restoreDatabaseSnapshot()` plus the committed `storageState` (no `login()`).
+  - `getByTestId` with locator chaining, and the value-matched field case
+    (`authoring-field=body_html`) written natively with
+    `.and(page.locator('[data-test-value="body_html"]'))`.
+  - building a precondition through the UI when the snapshot lacks it (the
+    article ships without an embed, so the spec adds one first).
+  - `page.route(...)` to stub a third-party call (iframe.ly) so the test is
+    deterministic and offline.
+  - escape hatches used deliberately and only where justified, each with a
+    comment explaining why: `dispatchEvent('mousedown')` for a hover-revealed
+    control on a frequently re-rendering element (a plain `click()` flakes on
+    the visible+stable check), and a `.p-dialog` scope for a shared confirmation
+    dialog whose buttons carry no `data-test-id`.
+
+The only product-source change it required was adding `data-test-id` attributes
+to the embed controls and the prompt dialog (`EmbedBlock.tsx`,
+`ModalPrompt.tsx`). That is the one product change a spec may carry; see "Common
+pitfalls".

--- a/e2e/client/playwright/edit-embed.spec.ts
+++ b/e2e/client/playwright/edit-embed.spec.ts
@@ -59,9 +59,13 @@ test.describe('editing an embed in the article body', () => {
             .and(page.locator('[data-test-value="body_html"]'));
 
         await page.getByTestId('toolbar').getByRole('button', {name: 'Embed'}).click();
-        await page.getByTestId('embed-form')
-            .getByPlaceholder('Enter URL or code to embed')
-            .fill(ORIGINAL_EMBED_URL);
+        // The embed URL field is uncontrolled (read by ref on submit), so confirm
+        // the value landed before clicking submit; otherwise submit can fire first
+        // and create an embed with empty html.
+        const embedUrlInput = page.getByTestId('embed-form').getByRole('textbox');
+
+        await embedUrlInput.fill(ORIGINAL_EMBED_URL);
+        await expect(embedUrlInput).toHaveValue(ORIGINAL_EMBED_URL);
         await page.getByTestId('embed-controls').getByTestId('submit').click();
 
         const embed = body.getByTestId('embed-block');
@@ -100,9 +104,13 @@ test.describe('editing an embed in the article body', () => {
         // so it does not collide with the topbar Save button.
         await page.getByTestId('authoring-topbar').getByTestId('close').click();
 
-        const unsavedChangesPrompt = page.locator('.p-dialog').filter({hasText: 'Save changes?'});
+        const unsavedChangesPrompt = page.getByTestId('unsaved-changes-dialog');
 
         await unsavedChangesPrompt.getByRole('button', {name: 'Save', exact: true}).click();
+
+        // Wait for the article to fully close before reopening; otherwise the
+        // reopen races the closing authoring view.
+        await expect(page.getByTestId('authoring-topbar')).toBeHidden();
 
         await monitoring.getArticleLocator('test sports story').dblclick();
 

--- a/e2e/client/playwright/edit-embed.spec.ts
+++ b/e2e/client/playwright/edit-embed.spec.ts
@@ -1,0 +1,115 @@
+import {test, expect, type Page} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+
+/**
+ * QA case "Edit embed" (SDESK-4441 / SDESK-4213).
+ *
+ * An embed in the article Body can be edited through its hover toolbar, and the
+ * edit is preserved after the article is saved and reopened.
+ *
+ * The article snapshots ship without embeds, so the precondition ("article with
+ * embed objects in the Body field") is created in-test through the add-embed
+ * flow before the edit behaviour under test is exercised.
+ */
+test.describe('editing an embed in the article body', () => {
+    const ORIGINAL_EMBED_URL = 'https://sourcefabric.org';
+    // Self-contained HTML so the embed iframe renders instantly. Avoid an
+    // "iframe.ly" src: EmbedBlock.componentDidMount calls loadIframely() for
+    // those, and the external load keeps re-rendering the block, which detaches
+    // the hover toolbar mid-interaction and makes the test flaky.
+    const ORIGINAL_EMBED_HTML = '<blockquote class="original-embed">original embed content</blockquote>';
+    const EDITED_EMBED_HTML = '<blockquote class="edited-embed">edited embed content</blockquote>';
+
+    // EmbedInput resolves a URL through iframe.ly via JSONP. Intercept that call
+    // and return canned oEmbed html so the test does not depend on a third-party
+    // network service.
+    async function stubIframely(page: Page): Promise<void> {
+        await page.route(/iframe\.ly\/api\/oembed/, async (route) => {
+            const callback = new URL(route.request().url()).searchParams.get('callback') ?? 'callback';
+            const data = {
+                html: ORIGINAL_EMBED_HTML,
+                title: 'Sourcefabric',
+                description: 'Open source tools for news media.',
+                url: ORIGINAL_EMBED_URL,
+                type: 'link',
+            };
+
+            await route.fulfill({
+                contentType: 'application/javascript',
+                body: `${callback}(${JSON.stringify(data)})`,
+            });
+        });
+    }
+
+    test('hover controls open the edit dialog; Cancel discards, Submit persists across reopen', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await stubIframely(page);
+
+        const monitoring = new Monitoring(page);
+
+        await page.goto('/#/workspace/monitoring');
+        await monitoring.selectDeskOrWorkspace('Sports');
+        await monitoring.getArticleLocator('test sports story').dblclick();
+
+        // Value-matched test ids (data-test-value) are more verbose natively than
+        // with the legacy s() helper; .and() narrows the data-test-id to the value.
+        const body = page.getByTestId('authoring')
+            .getByTestId('authoring-field')
+            .and(page.locator('[data-test-value="body_html"]'));
+
+        await page.getByTestId('toolbar').getByRole('button', {name: 'Embed'}).click();
+        await page.getByTestId('embed-form')
+            .getByPlaceholder('Enter URL or code to embed')
+            .fill(ORIGINAL_EMBED_URL);
+        await page.getByTestId('embed-controls').getByTestId('submit').click();
+
+        const embed = body.getByTestId('embed-block');
+
+        await expect(embed).toBeVisible();
+
+        await embed.hover();
+        await expect(embed.getByTestId('embed-block-edit')).toBeVisible();
+        await expect(embed.getByTestId('embed-block-remove')).toBeVisible();
+
+        // The atomic embed block re-renders frequently, so the hover-revealed Edit
+        // control rarely satisfies click()'s visible+stable check at the same
+        // instant. Its handler is onMouseDown, so dispatch that directly; it waits
+        // only for the element to be attached, not visible or stable.
+        await embed.getByTestId('embed-block-edit').dispatchEvent('mousedown');
+
+        const dialogInput = page.getByTestId('modal-prompt-input');
+
+        await expect(dialogInput).toBeVisible();
+        await expect(dialogInput).toHaveValue(ORIGINAL_EMBED_HTML);
+
+        await dialogInput.fill('<blockquote class="discarded-embed">discarded edit</blockquote>');
+        await page.getByTestId('modal-prompt-cancel').click();
+        await expect(dialogInput).toBeHidden();
+
+        await embed.getByTestId('embed-block-edit').dispatchEvent('mousedown');
+        await expect(dialogInput).toHaveValue(ORIGINAL_EMBED_HTML);
+
+        await dialogInput.fill(EDITED_EMBED_HTML);
+        await page.getByTestId('modal-prompt-submit').click();
+        await expect(dialogInput).toBeHidden();
+
+        // The editor commits the embed change to the article model asynchronously,
+        // so closing raises the "Save changes?" prompt; choosing Save persists the
+        // change and closes the article. The prompt's Save is scoped to its dialog
+        // so it does not collide with the topbar Save button.
+        await page.getByTestId('authoring-topbar').getByTestId('close').click();
+
+        const unsavedChangesPrompt = page.locator('.p-dialog').filter({hasText: 'Save changes?'});
+
+        await unsavedChangesPrompt.getByRole('button', {name: 'Save', exact: true}).click();
+
+        await monitoring.getArticleLocator('test sports story').dblclick();
+
+        const reopenedEmbed = body.getByTestId('embed-block');
+
+        await expect(reopenedEmbed).toBeVisible();
+        await reopenedEmbed.getByTestId('embed-block-edit').dispatchEvent('mousedown');
+        await expect(page.getByTestId('modal-prompt-input')).toHaveValue(EDITED_EMBED_HTML);
+    });
+});

--- a/scripts/core/editor3/components/embeds/EmbedBlock.tsx
+++ b/scripts/core/editor3/components/embeds/EmbedBlock.tsx
@@ -135,17 +135,25 @@ export class EmbedBlockComponent extends React.Component<IProps> {
         };
 
         return (
-            <div className="embed-block">
+            <div className="embed-block" data-test-id="embed-block">
                 {
                     readOnly ? null : (
-                        <a className="icn-btn embed-block__remove" onMouseDown={this.onClickDelete}>
+                        <a
+                            className="icn-btn embed-block__remove"
+                            data-test-id="embed-block-remove"
+                            onMouseDown={this.onClickDelete}
+                        >
                             <i className="icon-close-small" />
                         </a>
                     )
                 }
                 {
                     readOnly ? null : (
-                        <a className="icn-btn embed-block__edit" onMouseDown={this.editEmbedHtml}>
+                        <a
+                            className="icn-btn embed-block__edit"
+                            data-test-id="embed-block-edit"
+                            onMouseDown={this.editEmbedHtml}
+                        >
                             <i className="icon-pencil" />
                         </a>
                     )

--- a/scripts/core/ui/components/Modal/ModalPrompt.tsx
+++ b/scripts/core/ui/components/Modal/ModalPrompt.tsx
@@ -41,6 +41,7 @@ export class ModalPrompt extends React.Component<IPropsModalPrompt, any> {
                 visible
                 size="medium"
                 position="top"
+                data-test-id="modal-prompt"
                 headerTemplate={this.props.title}
                 footerTemplate={
                     (
@@ -48,12 +49,14 @@ export class ModalPrompt extends React.Component<IPropsModalPrompt, any> {
                             <Button
                                 type="default"
                                 text={gettext('Cancel')}
+                                data-test-id="modal-prompt-cancel"
                                 onClick={this.props.close}
                             />
                             <Button
                                 type="primary"
                                 text={gettext('Submit')}
                                 disabled={this.state.value.length < 1}
+                                data-test-id="modal-prompt-submit"
                                 onClick={this.submitValue}
                             />
                         </ButtonGroup>
@@ -63,6 +66,7 @@ export class ModalPrompt extends React.Component<IPropsModalPrompt, any> {
                 <Textarea
                     value={this.state.value}
                     onChange={this.updateValue}
+                    data-test-id="modal-prompt-input"
                     style={{maxHeight: 400, resize: 'none'}}
                 />
             </Modal>


### PR DESCRIPTION
### Purpose

Add the first native `getByTestId` end-to-end exemplar for client-core, built from a real QA case ("Edit embed", [SDESK-4441] / [SDESK-4213]- https://sofab.atlassian.net/wiki/spaces/SET/pages/1327759385/Edit+embed), plus the `data-test-id` hooks it needs. This is the worked example the new `superdesk-e2e` skill points test authors at.

### What has changed

- `e2e/client/playwright/edit-embed.spec.ts` (new): opens an article from Monitoring, adds an embed to the Body, edits it through the hover toolbar dialog, and verifies the edit persists after save and reopen. Uses native `getByTestId`, Page Object reuse, `restoreDatabaseSnapshot()`, and `page.route(...)` to stub iframe.ly so the test is deterministic and offline.
- `scripts/core/editor3/components/embeds/EmbedBlock.tsx`: add `data-test-id` to the embed block and its edit/remove controls.
- `scripts/core/ui/components/Modal/ModalPrompt.tsx`: add `data-test-id` to the prompt dialog, its textarea, and the Cancel/Submit buttons.
- `e2e/WRITING_TESTS.md`: add a "Comments" convention (comment the why, not the what) and point the "Reference specs" section at the new exemplar.

Adding `data-test-id` attributes is the only product-source change an e2e test is allowed to carry, per `e2e/WRITING_TESTS.md`.

### Steps to test

1. From the repo root: `./e2e/scripts/e2e-up.sh`
2. First time only: `cd e2e/client && npx playwright install chromium`
3. `npx playwright test playwright/edit-embed.spec.ts` (add `--headed` to watch). It should pass; it has been run repeatedly to confirm it is not flaky.

### Related

Companion to superdesk/skills#1, which adds the `superdesk-e2e` skill that uses this spec as its reference example: https://github.com/superdesk/skills/pull/1

### Checklist

- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7948]


[SDESK-7948]: https://sofab.atlassian.net/browse/SDESK-7948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SDESK-4441]: https://sofab.atlassian.net/browse/SDESK-4441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDESK-4213]: https://sofab.atlassian.net/browse/SDESK-4213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ