### PR TITLE
[SDESK-7948] Automate Remove Embed test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ yarn-error.log
 .idea
 
 .DS_Store
+.agents/
+skills-lock.json

--- a/e2e/client/playwright/edit-embed.spec.ts
+++ b/e2e/client/playwright/edit-embed.spec.ts
@@ -1,6 +1,7 @@
 import {test, expect, type Page} from '@playwright/test';
 import {Monitoring} from './page-object-models/monitoring';
 import {restoreDatabaseSnapshot} from './utils';
+import {addEditor3Embed} from './utils/editor3';
 
 /**
  * QA case "Edit embed" (SDESK-4441 / SDESK-4213).
@@ -58,15 +59,7 @@ test.describe('editing an embed in the article body', () => {
             .getByTestId('authoring-field')
             .and(page.locator('[data-test-value="body_html"]'));
 
-        await page.getByTestId('toolbar').getByRole('button', {name: 'Embed'}).click();
-        // The embed URL field is uncontrolled (read by ref on submit), so confirm
-        // the value landed before clicking submit; otherwise submit can fire first
-        // and create an embed with empty html.
-        const embedUrlInput = page.getByTestId('embed-form').getByRole('textbox');
-
-        await embedUrlInput.fill(ORIGINAL_EMBED_URL);
-        await expect(embedUrlInput).toHaveValue(ORIGINAL_EMBED_URL);
-        await page.getByTestId('embed-controls').getByTestId('submit').click();
+        await addEditor3Embed(body, ORIGINAL_EMBED_URL);
 
         const embed = body.getByTestId('embed-block');
 

--- a/e2e/client/playwright/remove-embed.spec.ts
+++ b/e2e/client/playwright/remove-embed.spec.ts
@@ -1,0 +1,130 @@
+import {test, expect, type Locator, type Page} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+import {addEditor3Embed} from './utils/editor3';
+
+/**
+ * QA case "Remove embed" (SDESK-4441).
+ *
+ * The article snapshots ship without embeds, so the precondition is built in-test
+ * with addEditor3Embed. Two embeds are added (not more) because the add-embed flow
+ * is only reliable for a couple of sequential adds; two is enough to show that
+ * removing one leaves the other untouched.
+ */
+test.describe('removing an embed from the article body', () => {
+    // Self-contained HTML so each embed iframe renders instantly. Avoid an
+    // "iframe.ly" src: EmbedBlock.componentDidMount calls loadIframely() for
+    // those, and the external load keeps re-rendering the block, which detaches
+    // the hover toolbar mid-interaction and makes the test flaky. The per-embed
+    // class is a stable marker that survives the body_html save/reopen round-trip.
+    const EMBEDS = [
+        {url: 'https://a.example.com', marker: 'embed-a', html: '<blockquote class="embed-a">A content</blockquote>'},
+        {url: 'https://b.example.com', marker: 'embed-b', html: '<blockquote class="embed-b">B content</blockquote>'},
+    ];
+
+    // EmbedInput resolves a URL through iframe.ly via JSONP. Intercept that call
+    // and return canned oEmbed html keyed by the requested URL, so each embed
+    // gets distinct, identifiable content without a third-party network call.
+    async function stubIframely(page: Page): Promise<void> {
+        // EmbedInput loads cdn.iframe.ly/embed.js when the add-embed popup opens.
+        // Stub it with a no-op so the test stays offline and does not wait on a
+        // third-party script.
+        await page.route(/cdn\.iframe\.ly\/embed\.js/, async (route) => {
+            await route.fulfill({
+                contentType: 'application/javascript',
+                body: 'window.iframely=window.iframely||{};window.iframely.widgets={load:function(){}};',
+            });
+        });
+
+        await page.route(/iframe\.ly\/api\/oembed/, async (route) => {
+            const requestUrl = new URL(route.request().url());
+            const callback = requestUrl.searchParams.get('callback') ?? 'callback';
+            const resolvedUrl = requestUrl.searchParams.get('url');
+            const data = {
+                html: EMBEDS.find((embed) => embed.url === resolvedUrl)?.html ?? '',
+                title: 'stub',
+                description: '',
+                url: resolvedUrl,
+                type: 'link',
+            };
+
+            await route.fulfill({
+                contentType: 'application/javascript',
+                body: `${callback}(${JSON.stringify(data)})`,
+            });
+        });
+    }
+
+    async function markerOf(embedBlock: Locator): Promise<string> {
+        const srcdoc = await embedBlock.locator('iframe').getAttribute('srcdoc') ?? '';
+
+        return EMBEDS.find((embed) => srcdoc.includes(embed.marker))!.marker;
+    }
+
+    test('removing one embed deletes only it and preserves the other across reopen', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await stubIframely(page);
+
+        const monitoring = new Monitoring(page);
+
+        await page.goto('/#/workspace/monitoring');
+        await monitoring.selectDeskOrWorkspace('Sports');
+        await monitoring.getArticleLocator('test sports story').dblclick();
+
+        // Value-matched test ids (data-test-value) are more verbose natively than
+        // with the legacy s() helper; .and() narrows the data-test-id to the value.
+        const body = page.getByTestId('authoring')
+            .getByTestId('authoring-field')
+            .and(page.locator('[data-test-value="body_html"]'));
+
+        for (const embed of EMBEDS) {
+            await addEditor3Embed(body, embed.url);
+        }
+
+        const embedBlocks = body.getByTestId('embed-block');
+
+        await expect(embedBlocks).toHaveCount(2);
+
+        // Read the actual rendered order rather than assuming insertion direction,
+        // then remove the first block. The second is the one whose content and
+        // presence must survive the removal.
+        const removedMarker = await markerOf(embedBlocks.nth(0));
+        const survivingMarker = await markerOf(embedBlocks.nth(1));
+        const removedEmbed = embedBlocks.nth(0);
+
+        await removedEmbed.hover();
+        await expect(removedEmbed.getByTestId('embed-block-remove')).toBeVisible();
+        await expect(removedEmbed.getByTestId('embed-block-edit')).toBeVisible();
+
+        // The remove control's handler is onMouseDown and the atomic embed block
+        // re-renders often, so a plain click() flakes on the visible+stable check.
+        // Dispatching mousedown only needs the element attached.
+        await removedEmbed.getByTestId('embed-block-remove').dispatchEvent('mousedown');
+
+        await expect(embedBlocks).toHaveCount(1);
+        await expect(body.locator(`iframe[srcdoc*="${removedMarker}"]`)).toHaveCount(0);
+        await expect(embedBlocks.nth(0).locator('iframe')).toHaveAttribute('srcdoc', new RegExp(survivingMarker));
+
+        // The editor commits the removal to the article model asynchronously, so
+        // closing raises the "Save changes?" prompt; choosing Save persists it.
+        // The prompt's Save is scoped to its dialog so it does not collide with the
+        // topbar Save button.
+        await page.getByTestId('authoring-topbar').getByTestId('close').click();
+
+        const unsavedChangesPrompt = page.getByTestId('unsaved-changes-dialog');
+
+        await unsavedChangesPrompt.getByRole('button', {name: 'Save', exact: true}).click();
+
+        // Wait for the article to fully close before reopening; otherwise the
+        // reopen races the closing authoring view.
+        await expect(page.getByTestId('authoring-topbar')).toBeHidden();
+
+        await monitoring.getArticleLocator('test sports story').dblclick();
+
+        const reopenedEmbeds = body.getByTestId('embed-block');
+
+        await expect(reopenedEmbeds).toHaveCount(1);
+        await expect(body.locator(`iframe[srcdoc*="${removedMarker}"]`)).toHaveCount(0);
+        await expect(reopenedEmbeds.nth(0).locator('iframe')).toHaveAttribute('srcdoc', new RegExp(survivingMarker));
+    });
+});

--- a/e2e/client/playwright/utils/editor3.tsx
+++ b/e2e/client/playwright/utils/editor3.tsx
@@ -1,4 +1,4 @@
-import {Locator} from '@playwright/test';
+import {Locator, expect} from '@playwright/test';
 import {s} from '.';
 
 export function getEditor3Paragraphs(field: Locator): Promise<Array<string>> {
@@ -25,6 +25,47 @@ export async function getEditor3FormattingOptions(field: Locator): Promise<Array
     }
 
     return result;
+}
+
+/**
+ * Adds an embed to an editor3 field through the add-embed flow (toolbar Embed >
+ * enter URL > submit) and waits for it to fully settle.
+ *
+ * `field` is the editor3 field locator (e.g. the body_html authoring-field). The
+ * URL is resolved through iframe.ly, so a test that calls this must stub that
+ * network (see remove-embed.spec.ts / edit-embed.spec.ts).
+ *
+ * The flow is fiddly enough to need a single hardened implementation:
+ * - EmbedInput's URL field is uncontrolled (read by ref on submit) and the popup
+ *   can re-render right after it opens, dropping the typed value. Filling and
+ *   verifying as a retried unit re-fills if the value did not stick. Submitting an
+ *   empty ref injects a malformed embed that crashes the editor, so the value must
+ *   be present before submit.
+ * - A new embed renders before its iframe onLoad sets the height (EmbedBlock sets
+ *   iframe.height = scrollHeight), and that height change reflows the editor.
+ *   Waiting for every embed iframe to carry a height attribute defers the caller
+ *   (e.g. a second add) until the reflow is done, so it is not churned mid-interaction.
+ */
+export async function addEditor3Embed(field: Locator, url: string): Promise<void> {
+    const page = field.page();
+    const embedBlocks = field.getByTestId('embed-block');
+    const countBefore = await embedBlocks.count();
+
+    await field.getByTestId('toolbar').getByRole('button', {name: 'Embed'}).click();
+
+    const embedForm = page.getByTestId('embed-form');
+    const urlInput = embedForm.getByRole('textbox');
+
+    await expect(async () => {
+        await urlInput.fill(url);
+        await expect(urlInput).toHaveValue(url);
+    }).toPass();
+
+    await page.getByTestId('embed-controls').getByTestId('submit').click();
+    await expect(embedForm).toBeHidden();
+
+    await expect(embedBlocks).toHaveCount(countBefore + 1);
+    await expect(field.locator('iframe[height]')).toHaveCount(countBefore + 1);
 }
 
 export async function setEditor3FieldValue(locator: Locator, value: string) {

--- a/e2e/client/playwright/utils/editor3.tsx
+++ b/e2e/client/playwright/utils/editor3.tsx
@@ -29,7 +29,8 @@ export async function getEditor3FormattingOptions(field: Locator): Promise<Array
 
 /**
  * Adds an embed to an editor3 field through the add-embed flow (toolbar Embed >
- * enter URL > submit) and waits for it to fully settle.
+ * enter URL > submit) and waits for its layout to settle (the iframe onLoad height
+ * applied), so a following interaction is not churned by the reflow.
  *
  * `field` is the editor3 field locator (e.g. the body_html authoring-field). The
  * URL is resolved through iframe.ly, so a test that calls this must stub that
@@ -43,8 +44,8 @@ export async function getEditor3FormattingOptions(field: Locator): Promise<Array
  *   be present before submit.
  * - A new embed renders before its iframe onLoad sets the height (EmbedBlock sets
  *   iframe.height = scrollHeight), and that height change reflows the editor.
- *   Waiting for every embed iframe to carry a height attribute defers the caller
- *   (e.g. a second add) until the reflow is done, so it is not churned mid-interaction.
+ *   Waiting for every embed's iframe to carry a height attribute defers the caller
+ *   (e.g. a second add) until that reflow has happened.
  */
 export async function addEditor3Embed(field: Locator, url: string): Promise<void> {
     const page = field.page();
@@ -65,7 +66,7 @@ export async function addEditor3Embed(field: Locator, url: string): Promise<void
     await expect(embedForm).toBeHidden();
 
     await expect(embedBlocks).toHaveCount(countBefore + 1);
-    await expect(field.locator('iframe[height]')).toHaveCount(countBefore + 1);
+    await expect(embedBlocks.locator('iframe[height]')).toHaveCount(countBefore + 1);
 }
 
 export async function setEditor3FieldValue(locator: Locator, value: string) {


### PR DESCRIPTION
### Purpose
Part of the [SDESK-7948] effort to convert manual QA cases into Playwright e2e tests. This PR automates the "Remove embed" QA case [SDESK-4441]: removing an embed from the article Body field and confirming the change is saved correctly, while the other embeds are preserved.

It also extracts the add-embed flow shared by the embed specs into a single reusable helper, so each spec does not re-implement (and re-debug) the same fiddly interaction.

### What has changed
This is test-only. There are no product or runtime changes (the embed `data-test-id` attributes the tests rely on were added previously in #5222).

- New spec `e2e/client/playwright/remove-embed.spec.ts`. It opens `test sports story` from Monitoring, builds the precondition in-test by adding two embeds to the Body, hovers an embed to assert the Remove and Edit controls appear, removes one, and verifies after save and reopen that the removed embed is gone and the other keeps its content. iframe.ly is stubbed so the test is offline and deterministic.
- New helper `addEditor3Embed(field, url)` in `e2e/client/playwright/utils/editor3.tsx`. It drives the add-embed flow (toolbar Embed, enter URL, submit) and waits for the embed to fully settle. The flow is flaky on the product side: EmbedInput's URL field is uncontrolled and the popup can drop the typed value, and a new embed reflows the editor when its iframe sets its height. The helper hardens both (retry the fill until it sticks, wait for the iframe height to settle), so callers do not re-derive it.
- `edit-embed.spec.ts` now uses `addEditor3Embed` instead of its own inline add-embed block, which also makes it inherit the same robustness.
- `.gitignore`: ignore local agent/skill tooling artifacts (`.agents/`, `skills-lock.json`).

### Steps to test
1. From the repo root, bring up the e2e stack: `./e2e/scripts/e2e-up.sh`
2. From `e2e/client`, run the embed specs:
   `npx playwright test playwright/remove-embed.spec.ts playwright/edit-embed.spec.ts`
3. Optionally check stability: append `--repeat-each 10` (both pass 20/20 locally).
4. What to look out for: in remove-embed, one of the two embeds is removed and the other survives with its content across save and reopen; edit-embed still passes through the shared helper.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7948]


[SDESK-7948]: https://sofab.atlassian.net/browse/SDESK-7948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDESK-4441]: https://sofab.atlassian.net/browse/SDESK-4441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDESK-7948]: https://sofab.atlassian.net/browse/SDESK-7948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ