### PR TITLE
[SDESK-7852] Modernize SCSS off Sass color, math, and unit deprecations

### DIFF
--- a/scripts/apps/authoring/styles/authoring.scss
+++ b/scripts/apps/authoring/styles/authoring.scss
@@ -1,6 +1,8 @@
 // article-edit.scss
 // Styling for the superdesk article edit module
 // ----------------------------------------------------------------------------------------
+@use "sass:color";
+@use "sass:math";
 @import '~mixins.scss';
 @import '~variables.scss';
 @import "~sf-additional.scss";
@@ -205,7 +207,7 @@ $bottom-bar-item-border-color-active: transparent;
         text-overflow: ellipsis;
         white-space: nowrap;
         transition: all 0.2s ease-in-out;
-        gap: $sd-base-increment / 2;
+        gap: math.div($sd-base-increment, 2);
         .opened-articles-bar__item-close {
             height: 2.2rem;
             width: 2.2rem;
@@ -239,7 +241,7 @@ $bottom-bar-item-border-color-active: transparent;
             font-size: 1.2rem;
             transition: color 0.2s ease-in-out;
             opacity: 0.75;
-            gap: $sd-base-increment / 2;
+            gap: math.div($sd-base-increment, 2);
             i {
                 margin-inline-end: 0.4rem;
             }
@@ -1829,7 +1831,7 @@ feature-image {
     .draggable-list {
         .placeholder {
             border: 2px dotted $sd-blue;
-            background-color: scale-color($sd-blue, $alpha: -90%);
+            background-color: color.scale($sd-blue, $alpha: -90%);
             min-height: 58px !important;
             margin: 0 0 1rem;
         }
@@ -1847,7 +1849,7 @@ feature-image {
     }
     &.dragover {
         border: 1px dashed $sd-blue;
-        background-color: scale-color($sd-blue, $alpha: -90%);
+        background-color: color.scale($sd-blue, $alpha: -90%);
     }
     .groups {
         padding: 0 !important;

--- a/scripts/apps/dashboard/workspace-tasks/styles/tasks.scss
+++ b/scripts/apps/dashboard/workspace-tasks/styles/tasks.scss
@@ -1,6 +1,7 @@
 // tasks.scss
 // Styling for the superdesk dashboard page (gridster, widgets)
 // ----------------------------------------------------------------------------------------
+@use "sass:color";
 @import '~mixins.scss';
 @import '~variables.scss';
 
@@ -398,7 +399,7 @@ TASK PAGE
             border-color: #505050 !important;
             border-block-start: 0 !important;
             color: #fff !important;
-            @include box-shadow(inset 0 2px 0px darken(#505050, 10%) !important);
+            @include box-shadow(inset 0 2px 0px color.adjust(#505050, $lightness: -10%) !important);
             &:hover {
                 background: #505050 !important;
             }

--- a/scripts/apps/desks/styles/desks.scss
+++ b/scripts/apps/desks/styles/desks.scss
@@ -1,6 +1,7 @@
 // desk.scss
 // Styling for the superdesk desk module
 // ----------------------------------------------------------------------------------------
+@use "sass:color";
 @import '~mixins.scss';
 @import '~variables.scss';
 @import '~labels.scss';
@@ -14,9 +15,9 @@ $desk-width: 270px;
 
 /* board colors */
 @mixin status-config-color($color) {
-    $r: red($color);
-    $g: green($color);
-    $b: blue($color);
+    $r: color.channel($color, "red", $space: rgb);
+    $g: color.channel($color, "green", $space: rgb);
+    $b: color.channel($color, "blue", $space: rgb);
     background: rgba($r, $g, $b, 25%);
     color: rgb($r, $g, $b);
     &.active {
@@ -248,7 +249,7 @@ $desk-width: 270px;
         }
         &.active {
             .action button:hover {
-                background: darken($sd-hover, 10%);
+                background: color.adjust($sd-hover, $lightness: -10%);
             }
         }
         &.shifted:hover {
@@ -681,7 +682,7 @@ $desk-width: 270px;
     }
     &.active {
         .action button:hover {
-            background: darken($sd-hover, 10%);
+            background: color.adjust($sd-hover, $lightness: -10%);
         }
         &.custom-monitoring {
             background-color: #eff7fa !important;

--- a/scripts/apps/ingest/styles/settings.scss
+++ b/scripts/apps/ingest/styles/settings.scss
@@ -1,6 +1,7 @@
 // settings.scss
 // Styling for the superdesk ingest settings
 // ----------------------------------------------------------------------------------------
+@use "sass:color";
 @import '~mixins.scss';
 @import '~variables.scss';
 
@@ -163,7 +164,7 @@
     }
     .ui-sortable-placeholder {
         border: 1px dashed $sd-blue !important;
-        background-color: scale-color($sd-blue, $alpha: -90%) !important;
+        background-color: color.scale($sd-blue, $alpha: -90%) !important;
         visibility: visible !important;
         box-shadow: none !important;
         &:after {

--- a/scripts/apps/search/styles/search.scss
+++ b/scripts/apps/search/styles/search.scss
@@ -1,6 +1,7 @@
 // search.scss
 // Styling for search page, and search functionalities
 // ----------------------------------------------------------------------------------------
+@use "sass:math";
 @import '~mixins.scss';
 @import '~variables.scss';
 @import '~animation.scss';
@@ -366,7 +367,7 @@
 
 .sortbar {
     .label-total {
-        margin: 0 $sd-base-increment / 2;
+        margin: 0 math.div($sd-base-increment, 2);
         background-color: var(--sd-colour-bg--09);
     }
 }

--- a/scripts/core/editor3/styles.scss
+++ b/scripts/core/editor3/styles.scss
@@ -1,5 +1,7 @@
 //TODO: Refactor these styles into separate smaller files.
 
+@use "sass:color";
+@use "sass:math";
 @import '~mixins.scss';
 @import '~variables/_typography.scss';
 @import '~variables/_colors.scss';
@@ -457,7 +459,7 @@ $editor-styleButton-size: 			3rem;
         &.unstyled__block--over {
 			border-bottom-width: 1.5em;
 			transition: border-width 0.1s ease-in-out;
-            border-bottom-color: scale-color($blue, $alpha: -70%);
+            border-bottom-color: color.scale($blue, $alpha: -70%);
 		}
 		&:only-child {
 			border-bottom-width: 0.6em;
@@ -483,7 +485,7 @@ $editor-styleButton-size: 			3rem;
 
     .unstyled--over {
         padding-block-start: 0;
-		border-block-start: 1.5em solid scale-color($blue, $alpha: -70%);
+		border-block-start: 1.5em solid color.scale($blue, $alpha: -70%);
 		transition: border-width 0.1s ease-in-out;
 	}
 
@@ -622,7 +624,7 @@ $editor-styleButton-size: 			3rem;
 	min-width: $editor-styleButton-size;
 	padding: 0.6rem;
 	display: inline-block;
-	border-radius: $editor-styleButton-size / 2;
+	border-radius: math.div($editor-styleButton-size, 2);
 	text-align: center;
 	line-height: 1.6rem;
 	[class*="icon-"] {

--- a/scripts/core/menu/styles/menu.scss
+++ b/scripts/core/menu/styles/menu.scss
@@ -1,6 +1,7 @@
 // menu.scss
 // Styling for the superdesk top menu and sidebar main menu
 // ----------------------------------------------------------------------------------------
+@use "sass:math";
 @import '~variables.scss';
 @import '~mixins.scss';
 
@@ -522,8 +523,8 @@
         inset-inline-end: 0 !important;
     }
     hr {
-        width: $sidebar-width / 2;
-        margin: 18px $sidebar-width / 4;
+        width: math.div($sidebar-width, 2);
+        margin: 18px math.div($sidebar-width, 4);
         border-block-start: 1px dotted var(--sd-colour-line--medium);
         border-block-end: 0;
     }

--- a/scripts/core/notify/styles/notify.scss
+++ b/scripts/core/notify/styles/notify.scss
@@ -1,6 +1,7 @@
 // notify.scss
 // Styling for notifications displayed on top of the page
 // ----------------------------------------------------------------------------------------
+@use "sass:math";
 @import '~mixins.scss';
 @import '~variables.scss';
 
@@ -12,7 +13,7 @@ $notif-holder-w : 340px;
     width: $notif-holder-w;
     inset-block-start: -5px;
     inset-inline-start: 50%;
-    margin-inline-start: -$notif-holder-w/2;
+    margin-inline-start: math.div(-$notif-holder-w, 2);
     overflow: hidden;
     padding: 0 10px 10px;
     .alert {

--- a/styles/sass/button-groups.scss
+++ b/styles/sass/button-groups.scss
@@ -1,5 +1,6 @@
 // BUTTON GROUPS
 // -------------
+@use "sass:math";
 
 
 // Make the div behave like a button
@@ -15,8 +16,8 @@
 
 // Optional: Group multiple button groups together for a toolbar
 .btn-toolbar {
-  margin-block-start: $baseLineHeight / 2;
-  margin-block-end: $baseLineHeight / 2;
+  margin-block-start: math.div($baseLineHeight, 2);
+  margin-block-end: math.div($baseLineHeight, 2);
   .btn-group {
     display: inline-block;
   }

--- a/styles/sass/buttons/_toggle-buttons.scss
+++ b/styles/sass/buttons/_toggle-buttons.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $toggleButtonTextColor: $sd-text-light;
 $toggleButtonBorderColor: var(--sd-colour-line--medium);
 $toggleButtonBorderColorHover: var(--sd-colour-line--strong);
@@ -104,7 +106,7 @@ $checkBtnColorActive: #78909C;
     @include border-radius(3px);
     &:hover {
         cursor: pointer;
-        background: lighten($checkBtnColor, 5%);
+        background: color.adjust($checkBtnColor, $lightness: 5%);
     }
     &.focus, &:focus {
         outline: 1px solid $sd-blue;
@@ -128,7 +130,7 @@ $checkBtnColorActive: #78909C;
       cursor: default;
     }
     &:active {
-        background: darken($checkBtnColorActive, 5%);
+        background: color.adjust($checkBtnColorActive, $lightness: -5%);
         @include box-shadow (inset 0 3px 0 0 rgba(0,0,0,0.2));
         &:after {
           @include opacity(10);

--- a/styles/sass/forms.scss
+++ b/styles/sass/forms.scss
@@ -1,4 +1,5 @@
 
+@use "sass:color";
 @import '~mixins.scss';
 // Forms.scss
 // Base styles for various input types, form layouts, and states
@@ -496,7 +497,7 @@ textarea[readonly] {
         z-index: 5;
     }
     .active {
-        background-color: lighten($green, 30);
+        background-color: color.adjust($green, $lightness: 30%);
         border-color: $green;
     }
 }

--- a/styles/sass/hamburger.scss
+++ b/styles/sass/hamburger.scss
@@ -1,5 +1,7 @@
 // Settings
 // ==================================================
+@use "sass:math";
+
 $hamburger-layer-width         : 18px !default;
 $hamburger-layer-height        : 3px !default;
 $hamburger-layer-spacing       : 3px !default;
@@ -45,7 +47,7 @@ $hamburger-active-hover-opacity: $hamburger-hover-opacity !default;
   .hamburger__inner {
     display: block;
     inset-block-start: 50%;
-    margin-block-start: $hamburger-layer-height / -2;
+    margin-block-start: math.div($hamburger-layer-height, -2);
   
     &,
     &::before,

--- a/styles/sass/labels.scss
+++ b/styles/sass/labels.scss
@@ -1,5 +1,6 @@
 // LABELS
 // ------
+@use "sass:color";
 
 // Label lite
 .label--lite {
@@ -239,7 +240,7 @@ $priority-label-color-6 : #c0c9a1;
     }
     &.state-killed {
         @include state-color($state-color-red);
-        background-color: lighten($state-color-red, 58%);
+        background-color: color.adjust($state-color-red, $lightness: 58%);
     }
     &.state-on_hold, 
     &.state-scheduled {

--- a/styles/sass/layouts.scss
+++ b/styles/sass/layouts.scss
@@ -678,7 +678,7 @@ $slide-pane-width: 400px;
     inset-block-end: 32px;
     inset-inline-end: -$notification-pane-width - 16px;
     width: $notification-pane-width;
-    background: hsla(214, 13%, 12, 0.82);
+    background: hsla(214, 13%, 12%, 0.82);
     backdrop-filter: blur(6px);
     box-shadow: 0 2px 12px hsla(0, 0%, 0%, 0.32), 0 1px 4px hsla(0, 0%, 0%, 0.32), 0 0 0 1px var(--sd-colour-line--light);
     z-index: 100;

--- a/styles/sass/media-archive.scss
+++ b/styles/sass/media-archive.scss
@@ -1,6 +1,8 @@
 // media-archive.scss
 // Styling for the superdesk media archive and ingest
 // ----------------------------------------------------------------------------------------
+@use "sass:color";
+@use "sass:math";
 @import '~mixins.scss';
 @import '~variables.scss';
 
@@ -156,7 +158,7 @@
     min-width: 10rem;
     padding: 0.8rem 1.6rem;
     border-radius: 0 0 4px 4px;
-    border: 1px solid lighten($sd-blue-text, 10%);
+    border: 1px solid color.adjust($sd-blue-text, $lightness: 10%);
     border-width: 0 1px 1px;
     text-align: center;
     font-size: 1.3rem;
@@ -729,7 +731,7 @@ $rightfield-width:60px;
                 overflow: hidden;
                 text-overflow: ellipsis;
                 & + .takekey, & + .provider {
-                    margin-inline-start: $sd-base-increment / 2;
+                    margin-inline-start: math.div($sd-base-increment, 2);
                 }
             }
             .language-label {

--- a/styles/sass/mixins.scss
+++ b/styles/sass/mixins.scss
@@ -1,6 +1,8 @@
 // Mixins.scss
 // Snippets of reusable CSS to develop faster and keep code readable
 // -----------------------------------------------------------------
+@use "sass:color";
+@use "sass:math";
 
 
 // UTILITY MIXINS
@@ -122,8 +124,8 @@
         color: $textColor;
         border-color: $borderColor;
         &:focus {
-            border-color: darken($borderColor, 10%);
-            @include box-shadow(0 0 6px lighten($borderColor, 20%));
+            border-color: color.adjust($borderColor, $lightness: -10%);
+            @include box-shadow(0 0 6px color.adjust($borderColor, $lightness: 20%));
         }
     }
     // Give a small background color for input-prepend/-append
@@ -233,7 +235,7 @@
 
 // Opacity
 @mixin opacity($opacity: 100) {
-    opacity: $opacity / 100;
+    opacity: math.div($opacity, 100);
      filter: "alpha(opacity=#{$opacity})";
 }
 
@@ -259,7 +261,7 @@
 // Dividers (basically an hr) within dropdowns and nav lists
 @mixin nav-divider() {
     height: 1px;
-    margin: (($baseLineHeight / 2) - 1) 1px; // 8px 1px
+    margin: ((math.div($baseLineHeight, 2)) - 1) 1px; // 8px 1px
     overflow: hidden;
     background-color: var(--sd-colour-line--medium);
     //border-block-end: 1px solid $white;

--- a/styles/sass/modals.scss
+++ b/styles/sass/modals.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @import '~variables.scss';
 
 // // MODALS
@@ -381,5 +382,5 @@ $sd-leftNavBtn-transition: background-color 0.2s ease-out, color 0.1s ease-out;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: $sd-base-increment / 2;
+    gap: math.div($sd-base-increment, 2);
 }

--- a/styles/sass/sf-additional.scss
+++ b/styles/sass/sf-additional.scss
@@ -1,5 +1,7 @@
 // Styling for the superdesk specific elements
 // ----------------------------------------------------------------------------------------
+@use "sass:color";
+@use "sass:math";
 
 
 // Webkit scroll
@@ -452,7 +454,7 @@
                 color: $grayLighter;
                 background: #505050;
                 border-color: #505050;
-                @include box-shadow(inset 0 1px 0px darken(#505050, 10%) !important);
+                @include box-shadow(inset 0 1px 0px color.adjust(#505050, $lightness: -10%) !important);
             }
 
             a {
@@ -460,7 +462,7 @@
                 background: #505050 !important;
                 border-color: #373737 #505050 #505050 !important;
                 color: #fff !important;
-                @include box-shadow(inset 0 2px 0px darken(#505050, 10%) !important);
+                @include box-shadow(inset 0 2px 0px color.adjust(#505050, $lightness: -10%) !important);
             }
 
             &:hover {
@@ -2417,7 +2419,7 @@ sd-multi-image-edit {
 // Margin
 .sd-margin-start {
     &--0-5 {
-        margin-inline-start: $sd-base-increment / 2;
+        margin-inline-start: math.div($sd-base-increment, 2);
     }
     &--1 {
         margin-inline-start: $sd-base-increment * 1;
@@ -2443,7 +2445,7 @@ sd-multi-image-edit {
 }
 .sd-margin-end {
     &--0-5 {
-        margin-inline-end: $sd-base-increment / 2;
+        margin-inline-end: math.div($sd-base-increment, 2);
     }
     &--1 {
         margin-inline-end: $sd-base-increment * 1;
@@ -2471,7 +2473,7 @@ sd-multi-image-edit {
 // Padding
 .sd-padding-start {
     &--0-5 {
-        padding-inline-start: $sd-base-increment / 2;
+        padding-inline-start: math.div($sd-base-increment, 2);
     }
     &--1 {
         padding-inline-start: $sd-base-increment * 1;
@@ -2494,7 +2496,7 @@ sd-multi-image-edit {
 }
 .sd-padding-end {
     &--0-5 {
-        padding-inline-end: $sd-base-increment / 2;
+        padding-inline-end: math.div($sd-base-increment, 2);
     }
     &--1 {
         padding-inline-end: $sd-base-increment * 1;

--- a/styles/sass/type.scss
+++ b/styles/sass/type.scss
@@ -1,13 +1,14 @@
 // Typography.scss
 // Headings, body text, lists, code, and more for a versatile and durable typography system
 // ----------------------------------------------------------------------------------------
+@use "sass:math";
 
 
 // BODY TEXT
 // ---------
 
 p {
-    margin: 0 0 $baseLineHeight / 2;
+    margin: 0 0 math.div($baseLineHeight, 2);
     font-family: $baseFontFamily;
     font-size: $baseFontSize;
     line-height: $baseLineHeight;
@@ -144,7 +145,7 @@ dt {
     line-height: $baseLineHeight - 1; // fix jank Helvetica Neue font bug
 }
 dd {
-    margin-inline-start: $baseLineHeight / 2;
+    margin-inline-start: math.div($baseLineHeight, 2);
 }
 // Horizontal layout (like forms)
 .dl-horizontal {

--- a/styles/sass/variables/_colors.scss
+++ b/styles/sass/variables/_colors.scss
@@ -1,5 +1,6 @@
 // variables/colors.scss
 // -----------------------------------------------------
+@use "sass:color";
 
 $superdesk-green:       rgba(30,176,108,1);
 
@@ -60,7 +61,7 @@ $state-border--locked:          rgb(229, 28, 35);
 $state-border--published:       rgb(94, 141, 50);
 $state-border--killed:          rgb(48, 48, 48);
 $item-background-killed:        rgb(255, 249, 248);
-$item-background-published:     lighten($state-border--published, 60%);
+$item-background-published:     color.adjust($state-border--published, $lightness: 60%);
 
 // Links
 // -------------------------
@@ -120,7 +121,7 @@ $navbarLinkBackgroundActive:    $navbarBackground;
 // -------------------------
 $warningText:          #c09853;
 $warningBackground:    #fcf8e3;
-$warningBorder:        darken(adjust-hue($warningBackground, -10), 3%);
+$warningBorder:        color.adjust(color.adjust($warningBackground, $hue: -10), $lightness: -3%);
 
 :root {
     --error-text-color: #E51C23;
@@ -128,15 +129,15 @@ $warningBorder:        darken(adjust-hue($warningBackground, -10), 3%);
 
 $errorText:            var(--error-text-color);
 $errorBackground:      #f2dede;
-$errorBorder:          darken(adjust-hue($errorBackground, -10), 3%);
+$errorBorder:          color.adjust(color.adjust($errorBackground, $hue: -10), $lightness: -3%);
 
 $successText:          #468847;
 $successBackground:    #dff0d8;
-$successBorder:        darken(adjust-hue($successBackground, -10), 5%);
+$successBorder:        color.adjust(color.adjust($successBackground, $hue: -10), $lightness: -5%);
 
 $infoText:             #3a87ad;
 $infoBackground:       #d9edf7;
-$infoBorder:           darken(adjust-hue($infoBackground, -10), 7%);
+$infoBorder:           color.adjust(color.adjust($infoBackground, $hue: -10), $lightness: -7%);
 
 // Theme
 // -------------------------


### PR DESCRIPTION
### Purpose
Clear four Dart Sass deprecation categories (`color-functions`, `global-builtin`, `slash-div`, `function-units`) so the dev console stops emitting them. Roughly `500` of the `~800` deprecation warnings the dev build emits today come from these four. Every change is a documented byte-identical equivalent per the Dart Sass migration guide; compiled CSS is unchanged.

### What has changed
Swaps the deprecated Sass functions for the modern ones that replace them. They produce exactly the same CSS, just written the new way. The touched files get a `@use "sass:color"` and/or `@use "sass:math"` at the top so the new function names are in scope.

### Out of scope
Two more deprecation categories still show up (about `300` warnings between them). They need bigger changes and will come as separate PRs:
- `[import]`: the `@import` to `@use` migration. That's a structural refactor.
- `[legacy-js-api]`: bumping `sass-loader` from 10 to 16. It needs the `~` prefix stripped from imports here and in planning, analytics, and publisher, so it has to be coordinated.

### Steps to test
- Run `npm run start`. The `color-functions`, `global-builtin`, `slash-div`, and `function-units` warnings should be gone. `[import]` and `[legacy-js-api]` are still there on purpose.
- Click around the areas these files touch (authoring, dashboard tasks, search, desks, editor3, menu, notifications, plus the global form, label, table, and button styles) and make sure nothing looks off.

### Checklist
- [x] I reviewed my code
- [ ] I tested all affected functionality and made sure it works

First PR for [SDESK-7852]

[SDESK-7852]: https://sofab.atlassian.net/browse/SDESK-7852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ