### PR TITLE
[SDBELGA-1110] Fix wrong author role used when fetching ingested items

### DIFF
--- a/scripts/apps/authoring/authoring/controllers/PopulateAuthorsController.ts
+++ b/scripts/apps/authoring/authoring/controllers/PopulateAuthorsController.ts
@@ -15,7 +15,8 @@ interface IScope extends ng.IScope {
 }
 
 const isNewItem = (item: IArticle): boolean =>
-    item._current_version === 0 || (item.authors || []).length === 0;
+    item._current_version === 0 ||
+    (item.assignment_id != null && (item.authors || []).length === 0);
 
 /**
  * It will populate item.authors with current user when item is opened for authoring.


### PR DESCRIPTION
### Purpose
Fetching an ingested agency item prefilled the Authors field with the Content Creation role instead of the Content Editing role.

### What has changed
The [SDBELGA-1054] fix treated any item with no authors as a new item. But fetched ingest items also have no authors, so they were wrongly seen as new and got the author role. We now tell items apart by `assignment_id`: items started from an assignment keep the author role, and fetched items get the editor role.

Related PR https://github.com/superdesk/superdesk-client-core/pull/5118

Resolves: [SDBELGA-1110](https://sofab.atlassian.net/browse/SDBELGA-1110)

[SDBELGA-1110]: https://sofab.atlassian.net/browse/SDBELGA-1110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SDBELGA-1054]: https://sofab.atlassian.net/browse/SDBELGA-1054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ