### PR TITLE
[SDESK-7800] e2e regression test for Save as template with empty keywords

### DIFF
--- a/e2e/client/playwright/page-object-models/authoring.ts
+++ b/e2e/client/playwright/page-object-models/authoring.ts
@@ -77,23 +77,16 @@ export class Authoring {
 
     /**
      * Opens the authoring-react "Save as template" modal, fills the name and saves.
-     * The actions menu renders its items in a portal; the first open occasionally
-     * does not surface the modal, so the open is retried. The guard avoids toggling
-     * an already-open menu shut on a retry.
+     * Menu items render in a portal outside the actions wrapper, so locate them by
+     * role/text rather than a test-id chain.
      */
     async saveAsTemplate(templateName: string): Promise<void> {
         const {page} = this;
         const modal = page.getByTestId('modal-save-as-template');
-        const saveAsTemplateItem = page.getByText('Save as template', {exact: true});
 
-        await expect(async () => {
-            if (!(await saveAsTemplateItem.isVisible())) {
-                await page.getByRole('button', {name: 'Actions menu'}).click();
-            }
-
-            await saveAsTemplateItem.click();
-            await expect(modal).toBeVisible({timeout: 5000});
-        }).toPass({timeout: 30000});
+        await page.getByRole('button', {name: 'Actions menu'}).click();
+        await page.getByText('Save as template', {exact: true}).click();
+        await expect(modal).toBeVisible();
 
         await modal.getByLabel('Template name').fill(templateName);
         await modal.getByRole('button', {name: 'Save'}).click();

--- a/e2e/client/playwright/page-object-models/authoring.ts
+++ b/e2e/client/playwright/page-object-models/authoring.ts
@@ -1,4 +1,4 @@
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 import {s} from '../utils';
 import {TreeSelectDriver} from '../utils/tree-select-driver';
 
@@ -73,6 +73,31 @@ export class Authoring {
 
     field(field: string): Locator {
         return this.page.locator(s('authoring', field)).getByRole('textbox');
+    }
+
+    /**
+     * Opens the authoring-react "Save as template" modal, fills the name and saves.
+     * The actions menu renders its items in a portal; the first open occasionally
+     * does not surface the modal, so the open is retried. The guard avoids toggling
+     * an already-open menu shut on a retry.
+     */
+    async saveAsTemplate(templateName: string): Promise<void> {
+        const {page} = this;
+        const modal = page.getByTestId('modal-save-as-template');
+        const saveAsTemplateItem = page.getByText('Save as template', {exact: true});
+
+        await expect(async () => {
+            if (!(await saveAsTemplateItem.isVisible())) {
+                await page.getByRole('button', {name: 'Actions menu'}).click();
+            }
+
+            await saveAsTemplateItem.click();
+            await expect(modal).toBeVisible({timeout: 5000});
+        }).toPass({timeout: 30000});
+
+        await modal.getByLabel('Template name').fill(templateName);
+        await modal.getByRole('button', {name: 'Save'}).click();
+        await expect(modal).not.toBeVisible();
     }
 }
 

--- a/e2e/client/playwright/page-object-models/monitoring.ts
+++ b/e2e/client/playwright/page-object-models/monitoring.ts
@@ -1,4 +1,4 @@
-import {Page, Locator} from '@playwright/test';
+import {Page, Locator, expect} from '@playwright/test';
 import {s} from '../utils';
 
 export class Monitoring {
@@ -10,6 +10,8 @@ export class Monitoring {
 
     async selectDeskOrWorkspace(deskName: string): Promise<void> {
         const deskSelectDropdown = this.page.locator(s('monitoring--selected-desk'));
+
+        await expect(deskSelectDropdown).toBeVisible();
 
         const selectedDeskText = await deskSelectDropdown.textContent();
 

--- a/e2e/client/playwright/templates.authoring-react.spec.ts
+++ b/e2e/client/playwright/templates.authoring-react.spec.ts
@@ -20,19 +20,34 @@ test('performing "save as" action on a template (authoring-react)', async ({page
 
     await authoring.waitForAuthoringReactToInitialize();
 
-    // Menu items render in a portal, outside the actions-list test-id wrapper.
-    await page.getByRole('button', {name: 'Actions menu'}).click();
-    await page.getByText('Save as template', {exact: true}).click();
-
-    const modal = page.locator(s('modal-save-as-template'));
-
-    await expect(modal).toBeVisible();
-
-    await modal.getByLabel('Template name').fill('story 2-react');
-    await modal.getByRole('button', {name: 'Save'}).click();
-
-    await expect(modal).not.toBeVisible();
+    await authoring.saveAsTemplate('story 2-react');
 
     await page.goto('/#/settings/templates');
     await expect(page.locator(s('template-content', 'content-template=story 2-react'))).toBeVisible();
+});
+
+test('saving an article that has no keywords as a template (authoring-react)', async ({page}) => {
+    const monitoring = new Monitoring(page);
+    const authoring = new Authoring(page);
+
+    await restoreDatabaseSnapshot();
+    await page.goto('/#/workspace/monitoring');
+    await monitoring.selectDeskOrWorkspace('Sports');
+
+    await monitoring.executeActionOnMonitoringItem(
+        page.locator(s('monitoring-group=Sports / Working Stage', 'article-item=story 2')),
+        'Edit',
+    );
+
+    await authoring.waitForAuthoringReactToInitialize();
+
+    // SDESK-7800: a null keywords value used to fail content_templates validation,
+    // leaving the modal open with an error. saveAsTemplate asserts the modal closes,
+    // so the save must now complete for an article whose keywords are null.
+    await authoring.saveAsTemplate('story 2 no-keywords');
+
+    await page.goto('/#/settings/templates');
+    await expect(
+        page.locator(s('template-content', 'content-template=story 2 no-keywords')),
+    ).toBeVisible();
 });


### PR DESCRIPTION
### Purpose
E2E regression coverage for [SDESK-7800]. Saving an article whose `keywords` are `null` as a template used to fail `content_templates` validation, leaving the modal open with an error. This locks the fix.

### What has changed
- New test in `templates.authoring-react.spec.ts`: opens an existing article with `keywords: null` and saves it as a template, asserting the modal closes (no validation error).
- Extracted the actions-menu to "Save as template" modal flow into `Authoring.saveAsTemplate`, used by both tests.
- `selectDeskOrWorkspace` waits for the desk toggle to be visible before reading it.

### Steps to test
From `e2e/client`, with the stack up (`./e2e/scripts/e2e-up.sh`):

```
npx playwright test playwright/templates.authoring-react.spec.ts
```

Both tests pass.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Refs: [SDESK-7800] (test coverage for an already-merged fix #5191)


[SDESK-7800]: https://sofab.atlassian.net/browse/SDESK-7800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ