### PR TITLE
[SDCP-1195] Fix autosave failing after a manual save in authoring-react

### DIFF
--- a/scripts/apps/authoring-react/authoring-react.tsx
+++ b/scripts/apps/authoring-react/authoring-react.tsx
@@ -139,7 +139,7 @@ const ANPA_CATEGORY = {
 };
 
 function getInitialState<T extends IBaseRestApiResponse>(
-    item: {saved: T; autosaved: T},
+    item: {saved: T; autosaved: T | null},
     profile: IContentProfileV2,
     userPreferencesForFields: IStateLoaded<T>['userPreferencesForFields'],
     spellcheckerEnabled: boolean,
@@ -1040,8 +1040,11 @@ export class AuthoringReact<T extends IBaseRestApiResponse>
                     this.computeLatestEntity(),
                     state.itemOriginal,
                 ).then((item: T) => {
+                    // `cancelAutosave()` above deleted the autosave document, so there is no
+                    // autosave to reference anymore. Passing it here would leave `itemAutosaved`
+                    // pointing at a non-existent resource and make the next autosave fail.
                     const nextState = getInitialState(
-                        {saved: item, autosaved: item},
+                        {saved: item, autosaved: null},
                         state.profile,
                         state.userPreferencesForFields,
                         state.spellcheckerEnabled,
@@ -1103,6 +1106,10 @@ export class AuthoringReact<T extends IBaseRestApiResponse>
                 this.hasUnsavedChanges(),
                 () => {
                     authoringStorage.autosave.cancel();
+
+                    if (state.itemAutosaved == null) {
+                        return Promise.resolve();
+                    }
 
                     return authoringStorage.autosave.delete(state.itemOriginal._id, state.itemAutosaved._etag);
                 },


### PR DESCRIPTION
### Purpose

To fix autosave failing after a manual save in authoring-react (Related Planning > Coverages). `save()` deletes the autosave document via `cancelAutosave()`, but then reseeded the editor state with the saved item as the previous autosave (`getInitialState({saved: item, autosaved: item})`). That left `itemAutosaved` pointing at a resource that no longer exists, so the next autosave targeted a deleted document.

For POST-based autosave this is fine but for PATCH-based autosave implementations, such as planning's embedded coverage editor, it produces a 404. See [SDCP-1195].

Companion PR (planning): https://github.com/superdesk/superdesk-planning/pull/2873 . Targets `release/3.1` first (CP consumes `#release/3.1`); a develop forward-port will be handled separately. 

> [!IMPORTANT]
> Tests are already failing in branch `release/3.1` because of the broken Python 3.12 dependency. We'd have to merge this without expecting them to be green. This issue has been solved in `develop` branch where I will forward-port this fix and add a proper end to end test to cover it. 

### What has changed

- Reseed with `autosaved: null` after save so the next autosave starts fresh.
- Widen `getInitialState`'s parameter to `T | null` (the load path already passed `null` at runtime).
- Guard the close-path autosave delete against a null autosave.

### Steps to test
- Please follow the steps/video in the ticket [SDCP-1195]

Resolves: [SDCP-1195]


[SDCP-1195]: https://sofab.atlassian.net/browse/SDCP-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDCP-1195]: https://sofab.atlassian.net/browse/SDCP-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ