### PR TITLE
chore: remove fallback since superdesk-planning now uses IAuthouringGroup too

### DIFF
--- a/scripts/apps/authoring-react/subcomponents/authoring-actions-menu.tsx
+++ b/scripts/apps/authoring-react/subcomponents/authoring-actions-menu.tsx
@@ -82,17 +82,12 @@ export class AuthoringActionsMenu extends React.PureComponent<IProps, IState> {
                 'Migrate to the "group" attribute.',
             );
 
-            // TODO: Remove this fallback once superdesk-planning migrates from groupId to group.
-            const isPlanning = action.groupId === 'planning-actions';
-            const fallbackLabel = isPlanning ? gettext('Planning') : undefined;
-            const fallbackPriority = isPlanning ? 10 : 0;
-
             const existing = groupsMap.get(action.groupId);
 
             if (existing == null) {
                 groupsMap.set(action.groupId, {
-                    label: fallbackLabel,
-                    priority: fallbackPriority,
+                    label: undefined,
+                    priority: 0,
                     actions: [action],
                 });
             } else {


### PR DESCRIPTION
### Purpose
This PR removes the planning-specific fallback in the React authoring actions menu grouping logic, since the superdesk-planning extension has the new group attribute in this [PR](https://github.com/superdesk/superdesk-planning/pull/2875)

### What has changed
- Removed the `isPlanning` fallback and it's related variables in authoring actions menu

### Steps to test
1. Open an article in React authoring with the planning extension enabled
2. Open the three-dot actions menu
3. Verify the planning actions ("Add to Planning", "Unlink as Coverage", "Link to Assignment") still appear under a labeled "PLANNING" group header

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7802](https://sofab.atlassian.net/browse/SDESK-7802)


[SDESK-7802]: https://sofab.atlassian.net/browse/SDESK-7802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ