### PR TITLE
[SDESK-7811] Reflect external `marked_desks` changes in the open editor

### DIFF
--- a/e2e/client/playwright/mark-for-desks.authoring-react.spec.ts
+++ b/e2e/client/playwright/mark-for-desks.authoring-react.spec.ts
@@ -86,3 +86,49 @@ test('mark for desks: clear-all unmarks every desk, not just one (authoring-reac
     await expect(bell).toHaveCount(0);
     expect(await desksSelect.getValues()).toEqual([]);
 });
+
+test('mark for desks: editor reflects a desk unmarked from the monitoring list (authoring-react)', async ({
+    page,
+}) => {
+    await restoreDatabaseSnapshot();
+    const monitoring = new Monitoring(page);
+    const authoring = new Authoring(page);
+
+    await page.goto('/#/workspace/monitoring');
+    await monitoring.selectDeskOrWorkspace('Sports');
+
+    const listItem = page.locator(s('monitoring-group=Sports / Working Stage', 'article-item=test sports story'));
+
+    await monitoring.executeActionOnMonitoringItem(listItem, 'Edit');
+    await authoring.waitForAuthoringReactToInitialize();
+
+    // Mark a desk from the editor.
+    await page.getByRole('button', {name: 'Actions menu'}).click();
+    await page.getByText('Marked for desks', {exact: true}).click();
+
+    const modal = page.locator(s('modal-mark-for-desks'));
+
+    await expect(modal).toBeVisible();
+    await new TreeSelectDriver(page, modal.locator(s('desks-select'))).addValues('Education');
+
+    const bell = page.locator('#marked-for-desks');
+
+    await expect(bell).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(modal).toBeHidden();
+
+    // Unmark it from the monitoring list, a surface outside the open, locked editor.
+    const listBell = listItem.locator(s('mark-for-desk--bell'));
+
+    await expect(listBell).toBeVisible();
+    await listBell.click();
+
+    const listMarks = page.locator(s('marked-desk-list'));
+
+    await expect(listMarks).toBeVisible();
+    await listMarks.getByRole('button', {name: 'remove'}).click();
+
+    // The editor must reflect the external change: its marked-for-desks bell disappears.
+    await expect(bell).toHaveCount(0);
+});

--- a/scripts/apps/authoring-react/authoring-react.tsx
+++ b/scripts/apps/authoring-react/authoring-react.tsx
@@ -33,7 +33,7 @@ import {
 import {AuthoringWidgetLayoutComponent} from './widget-layout-component';
 import {WidgetHeaderComponent} from './widget-header-component';
 import {registerToReceivePatches, unregisterFromReceivingPatches} from 'apps/authoring-bridge/receive-patches';
-import {addInternalEventListener} from 'core/internal-events';
+import {addInternalEventListener, dispatchInternalEvent} from 'core/internal-events';
 import {
     showUnsavedChangesPrompt,
     IUnsavedChangesActionWithSaving,
@@ -872,6 +872,46 @@ export class AuthoringReact<T extends IBaseRestApiResponse>
                         state.allThemes.default,
                         state.allThemes.proofreading,
                     ));
+                });
+            }),
+        );
+
+        /**
+         * marked_desks can change from outside this editor (the monitoring list, or another
+         * session). The reload handler above bails while the item is locked here or has unsaved
+         * edits, so it never picks those changes up and the editor keeps showing stale marks.
+         * Apply the toggle from the event rather than re-reading the item: right after a toggle the
+         * server read is stale (eventual consistency), so a re-fetch would reconcile to old marks.
+         */
+        this.cleanupFunctionsToRunBeforeUnmounting.push(
+            addInternalWebsocketEventListener('item:marked_desks', (event) => {
+                const {item_id, mark_id, marked} = event.extra;
+                const state = this.state;
+
+                if (state.initialized !== true || state.itemOriginal._id !== item_id) {
+                    return;
+                }
+
+                const current = (state.itemWithChanges as unknown as IArticle).marked_desks ?? [];
+                const alreadyMarked = current.some((desk) => desk.desk_id === mark_id);
+                const shouldMark = marked === 1;
+
+                if (shouldMark === alreadyMarked) {
+                    return;
+                }
+
+                const nextMarkedDesks = shouldMark
+                    ? [...current, {
+                        desk_id: mark_id,
+                        // Event includes only desk id. user_marked/date_marked are placeholders, replaced
+                        // on next item load and excluded from save diff so they are never sent to server
+                        date_marked: new Date().toISOString(),
+                        user_marked: sdApi.user.getCurrentUserId(),
+                    }]
+                    : current.filter((desk) => desk.desk_id !== mark_id);
+
+                dispatchInternalEvent('dangerouslyOverwriteAuthoringData', {
+                    item: {_id: item_id, marked_desks: nextMarkedDesks},
                 });
             }),
         );

--- a/scripts/apps/authoring-react/authoring-react.tsx
+++ b/scripts/apps/authoring-react/authoring-react.tsx
@@ -878,10 +878,7 @@ export class AuthoringReact<T extends IBaseRestApiResponse>
 
         /**
          * marked_desks can change from outside this editor (the monitoring list, or another
-         * session). The reload handler above bails while the item is locked here or has unsaved
-         * edits, so it never picks those changes up and the editor keeps showing stale marks.
-         * Apply the toggle from the event rather than re-reading the item: right after a toggle the
-         * server read is stale (eventual consistency), so a re-fetch would reconcile to old marks.
+         * session). Listen to 'item:marked_desks' and update here to avoid having stale marks.
          */
         this.cleanupFunctionsToRunBeforeUnmounting.push(
             addInternalWebsocketEventListener('item:marked_desks', (event) => {

--- a/scripts/apps/authoring-react/authoring-react.tsx
+++ b/scripts/apps/authoring-react/authoring-react.tsx
@@ -885,7 +885,7 @@ export class AuthoringReact<T extends IBaseRestApiResponse>
          */
         this.cleanupFunctionsToRunBeforeUnmounting.push(
             addInternalWebsocketEventListener('item:marked_desks', (event) => {
-                const {item_id, mark_id, marked} = event.extra;
+                const {item_id, mark_id, marked, user_marked, date_marked} = event.extra;
                 const state = this.state;
 
                 if (state.initialized !== true || state.itemOriginal._id !== item_id) {
@@ -900,14 +900,10 @@ export class AuthoringReact<T extends IBaseRestApiResponse>
                     return;
                 }
 
+                // A mark carries the real marker and timestamp (an unmark does not), so store the
+                // true values instead of fabricating ones that could later overwrite the marker on save.
                 const nextMarkedDesks = shouldMark
-                    ? [...current, {
-                        desk_id: mark_id,
-                        // Event includes only desk id. user_marked/date_marked are placeholders, replaced
-                        // on next item load and excluded from save diff so they are never sent to server
-                        date_marked: new Date().toISOString(),
-                        user_marked: sdApi.user.getCurrentUserId(),
-                    }]
+                    ? [...current, {desk_id: mark_id, user_marked: user_marked!, date_marked: date_marked!}]
                     : current.filter((desk) => desk.desk_id !== mark_id);
 
                 dispatchInternalEvent('dangerouslyOverwriteAuthoringData', {

--- a/scripts/apps/authoring-react/authoring-react.tsx
+++ b/scripts/apps/authoring-react/authoring-react.tsx
@@ -900,8 +900,6 @@ export class AuthoringReact<T extends IBaseRestApiResponse>
                     return;
                 }
 
-                // A mark carries the real marker and timestamp (an unmark does not), so store the
-                // true values instead of fabricating ones that could later overwrite the marker on save.
                 const nextMarkedDesks = shouldMark
                     ? [...current, {desk_id: mark_id, user_marked: user_marked!, date_marked: date_marked!}]
                     : current.filter((desk) => desk.desk_id !== mark_id);

--- a/scripts/core/notification/notification.ts
+++ b/scripts/core/notification/notification.ts
@@ -60,7 +60,14 @@ interface IInternalWebsocketMessages { // not exposed to client API
     'item:spike': IWebsocketMessage<never>;
     'item:unspike': IWebsocketMessage<never>;
     'item:highlights': IWebsocketMessage<{item_id?: string; mark_id?: string; marked: number}>;
-    'item:marked_desks': IWebsocketMessage<{item_id: string; mark_id: string; marked: number}>;
+    'item:marked_desks': IWebsocketMessage<{
+        item_id: string;
+        mark_id: string;
+        marked: number;
+        // present on a mark (older servers omit them); absent on an unmark
+        user_marked?: string;
+        date_marked?: string;
+    }>;
     'item:publish': IWebsocketMessage<any>;
 }
 

--- a/scripts/core/notification/notification.ts
+++ b/scripts/core/notification/notification.ts
@@ -64,7 +64,6 @@ interface IInternalWebsocketMessages { // not exposed to client API
         item_id: string;
         mark_id: string;
         marked: number;
-        // present on a mark (older servers omit them); absent on an unmark
         user_marked?: string;
         date_marked?: string;
     }>;

--- a/scripts/core/notification/notification.ts
+++ b/scripts/core/notification/notification.ts
@@ -27,6 +27,7 @@ const internalWebsocketMessageNames: IInternalWebsocketMessages = {
     'item:spike': undefined,
     'item:unspike': undefined,
     'item:highlights': undefined,
+    'item:marked_desks': undefined,
     'item:publish': undefined,
 };
 
@@ -59,6 +60,7 @@ interface IInternalWebsocketMessages { // not exposed to client API
     'item:spike': IWebsocketMessage<never>;
     'item:unspike': IWebsocketMessage<never>;
     'item:highlights': IWebsocketMessage<{item_id?: string; mark_id?: string; marked: number}>;
+    'item:marked_desks': IWebsocketMessage<{item_id: string; mark_id: string; marked: number}>;
     'item:publish': IWebsocketMessage<any>;
 }
 


### PR DESCRIPTION
### Purpose

Fixes a `marked_desks` desync in the authoring-react editor. When an item's marked desks change from outside the open editor (from the monitoring list, or another session), the editor did not react and kept showing stale marks. Adding a desk on top then produced a set that diverged from the server: the list showed one set of desks, the editor another.

Reference comment: https://sofab.atlassian.net/browse/SDESK-7811?focusedCommentId=165766

### What has changed

The editor had no way to hear about `marked_desks` changes it did not make itself. `item:marked_desks` was only broadcast to Angular, so it never picked those changes up.

- Register `item:marked_desks` as an internal websocket message so React can listen to it.
- Add a listener in authoring-react that applies the toggle delta to `marked_desks` in place. It runs regardless of the lock/unsaved-changes guards, which is safe because `marked_desks` has no editor input.


### Steps to test

1. Enable authoring-react (`localStorage.setItem('auth-react', true)`).
2. Open an item in the editor and mark it for two desks via the Actions menu, Marked for desks.
3. In the monitoring list, open the item's marked-desks bell and Remove one of those desks.
4. Without reloading, the editor must reflect it: the removed desk disappears from the editor's marked-for-desks bell and modal. Reopening Marked for desks shows only the desk that is still marked.
5. Regression to watch: adding another desk in the editor after an external change must not resurrect the removed desk, and the list and editor must agree.

### Checklist

- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7811]


[SDESK-7811]: https://sofab.atlassian.net/browse/SDESK-7811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ