### PR TITLE
[SDESK-7811] - Fix marked desks bell sync after clear-all

### DIFF
--- a/e2e/client/playwright/mark-for-desks.authoring-react.spec.ts
+++ b/e2e/client/playwright/mark-for-desks.authoring-react.spec.ts
@@ -47,7 +47,7 @@ test('mark for desks: per-action toggle via modal (authoring-react)', async ({pa
     await expect(bell).toHaveCount(0);
 });
 
-test('mark for desks: clear-all unmarks every desk, not just one (authoring-react)', async ({page}) => {
+test('mark for desks: clear-all removes every desk and keeps list bell hidden (authoring-react)', async ({page}) => {
     await restoreDatabaseSnapshot();
     const monitoring = new Monitoring(page);
     const authoring = new Authoring(page);
@@ -55,10 +55,9 @@ test('mark for desks: clear-all unmarks every desk, not just one (authoring-reac
     await page.goto('/#/workspace/monitoring');
     await monitoring.selectDeskOrWorkspace('Sports');
 
-    await monitoring.executeActionOnMonitoringItem(
-        page.locator(s('monitoring-group=Sports / Working Stage', 'article-item=test sports story')),
-        'Edit',
-    );
+    const listItem = page.locator(s('monitoring-group=Sports / Working Stage', 'article-item=test sports story'));
+
+    await monitoring.executeActionOnMonitoringItem(listItem, 'Edit');
 
     await authoring.waitForAuthoringReactToInitialize();
 
@@ -79,12 +78,30 @@ test('mark for desks: clear-all unmarks every desk, not just one (authoring-reac
 
     await expect(bell).toBeVisible();
 
+    const listBell = listItem.locator(s('mark-for-desk--bell'));
+
+    await expect(listBell).toBeVisible();
+
+    // Wait for the list re-query that will be triggered after clearing all desks.
+    const listRefresh = page.waitForResponse((response) => (
+        response.request().method() === 'GET'
+        && (
+            response.url().includes('/api/archive')
+            || response.url().includes('/api/search')
+        )
+    ));
+
     // Clear-all empties the whole selection in one change. The handler must toggle every marked
     // desk, not just the first one, so the article ends up with no marked desks.
     await desksSelect.setValues();
 
     await expect(bell).toHaveCount(0);
     expect(await desksSelect.getValues()).toEqual([]);
+
+    // After the scheduled list query returns, the bell must still be gone.
+    // This guards against stale ES data resurrecting the bell.
+    await listRefresh;
+    await expect(listBell).toHaveCount(0);
 });
 
 test('mark for desks: editor reflects a desk unmarked from the monitoring list (authoring-react)', async ({

--- a/scripts/apps/search/directives/ItemList.tsx
+++ b/scripts/apps/search/directives/ItemList.tsx
@@ -262,7 +262,11 @@ export function ItemList(
 
                     if (item) {
                         var itemId = search.generateTrackByIdentifier(item);
-                        var markedItems = item[field] || [];
+                        var markedItems = (field === 'marked_desks'
+                            && item.archive_item
+                            && item.archive_item.marked_desks)
+                            ? item.archive_item.marked_desks
+                            : (item[field] || []);
                         var changes: any;
 
                         if (field === 'marked_desks') {

--- a/scripts/apps/search/directives/ItemList.tsx
+++ b/scripts/apps/search/directives/ItemList.tsx
@@ -255,25 +255,49 @@ export function ItemList(
                 });
 
                 scope.$on('item:highlights', (_e, data) => updateMarkedItems('highlights', data));
+                scope.$on('item:marked_desks', (_e, data) => updateMarkedItems('marked_desks', data));
 
                 function updateMarkedItems(field, data) {
                     var item = listComponent.findItemByPrefix(data.item_id);
 
-                    function filterMark(mark) {
-                        return mark !== data.mark_id;
-                    }
-
                     if (item) {
                         var itemId = search.generateTrackByIdentifier(item);
                         var markedItems = item[field] || [];
+                        var changes: any;
 
-                        if (data.marked) {
-                            markedItems = markedItems.concat([data.mark_id]);
+                        if (field === 'marked_desks') {
+                            if (data.marked) {
+                                markedItems = markedItems.concat([{
+                                    desk_id: data.mark_id,
+                                    user_marked: data.user_marked,
+                                    date_marked: data.date_marked,
+                                }]);
+                            } else {
+                                markedItems = markedItems.filter((desk) => desk.desk_id !== data.mark_id);
+                            }
+
+                            changes = {marked_desks: markedItems};
+
+                            if (item.archive_item) {
+                                changes.archive_item = angular.extend({}, item.archive_item, {
+                                    marked_desks: markedItems,
+                                });
+                            }
                         } else {
-                            markedItems = markedItems.filter(filterMark);
+                            if (data.marked) {
+                                markedItems = markedItems.concat([data.mark_id]);
+                            } else {
+                                markedItems = markedItems.filter((mark) => mark !== data.mark_id);
+                            }
+
+                            changes = {[field]: markedItems};
                         }
 
-                        listComponent.updateItem(itemId, {[field]: markedItems});
+                        listComponent.updateItem(itemId, changes);
+
+                        if (field === 'marked_desks') {
+                            search.recordMarkedDesksPatch(data.item_id, markedItems);
+                        }
                     }
                 }
 

--- a/scripts/apps/search/services/SearchService.ts
+++ b/scripts/apps/search/services/SearchService.ts
@@ -130,6 +130,45 @@ export function SearchService($location, session, multi,
     var sortOptions = getArticleSortOptions();
 
     var self = this;
+    var recentMarkedDesksPatches = {};
+
+    this.recordMarkedDesksPatch = function(itemId, markedDesks) {
+        recentMarkedDesksPatches[itemId] = {
+            marked_desks: markedDesks,
+            timestamp: Date.now(),
+        };
+    };
+
+    this.getRecentMarkedDesksPatch = function(itemId) {
+        var patch = recentMarkedDesksPatches[itemId];
+
+        if (patch && (Date.now() - patch.timestamp) < 5000) {
+            return patch;
+        }
+
+        delete recentMarkedDesksPatches[itemId];
+        return null;
+    };
+
+    function getMarkedDesksPatchKey(item) {
+        return item.item_id || item._id;
+    }
+
+    function applyMarkedDesksPatchesToItems(items) {
+        items.forEach((item) => {
+            var patch = self.getRecentMarkedDesksPatch(getMarkedDesksPatchKey(item));
+
+            if (patch) {
+                item.marked_desks = patch.marked_desks;
+
+                if (item.archive_item) {
+                    item.archive_item = angular.extend({}, item.archive_item, {
+                        marked_desks: patch.marked_desks,
+                    });
+                }
+            }
+        });
+    }
 
     this.cvs = appConfig.search_cvs ||
         [{id: 'subject', name: 'Subject', field: 'subject', list: 'subjectcodes'},
@@ -754,6 +793,8 @@ export function SearchService($location, session, multi,
             newItems._items = _.map(newItems._items, this.mergeHighlightFields);
         }
 
+        applyMarkedDesksPatchesToItems(newItems._items);
+
         newItems._items.forEach((item) => {
             item.selected = multi.isSelected(item);
         });
@@ -862,19 +903,35 @@ export function SearchService($location, session, multi,
      */
     this.updateItems = function(newItems, scopeItems) {
         _.map(scopeItems._items, (item) => {
-            if (item._type === 'published') {
-                return _.extend(item, _.find(newItems._items,
-                    {_id: item._id, _current_version: item._current_version}));
-            }
-
-            // remove gone flag to prevent item remaining grey, if gone item moves back to this stage.
+            let fetched;
             let itm = item;
 
-            if (angular.isDefined(item.gone)) {
-                itm = _.omit(item, 'gone');
+            if (item._type === 'published') {
+                fetched = _.find(newItems._items,
+                    {_id: item._id, _current_version: item._current_version});
+            } else {
+                // remove gone flag to prevent item remaining grey, if gone item moves back to this stage.
+                if (angular.isDefined(item.gone)) {
+                    itm = _.omit(item, 'gone');
+                }
+
+                fetched = _.find(newItems._items, {_id: itm._id});
             }
 
-            return _.extend(itm, _.find(newItems._items, {_id: itm._id}));
+            var recentPatch = self.getRecentMarkedDesksPatch(getMarkedDesksPatchKey(item));
+
+            if (recentPatch && fetched) {
+                fetched = angular.extend({}, fetched);
+                fetched.marked_desks = recentPatch.marked_desks;
+
+                if (fetched.archive_item) {
+                    fetched.archive_item = angular.extend({}, fetched.archive_item, {
+                        marked_desks: recentPatch.marked_desks,
+                    });
+                }
+            }
+
+            return _.extend(itm, fetched);
         });
 
         // update aggregations

--- a/scripts/apps/search/services/SearchService.ts
+++ b/scripts/apps/search/services/SearchService.ts
@@ -133,6 +133,12 @@ export function SearchService($location, session, multi,
     var recentMarkedDesksPatches = {};
 
     this.recordMarkedDesksPatch = function(itemId, markedDesks) {
+        Object.keys(recentMarkedDesksPatches).forEach((key) => {
+            if (Date.now() - recentMarkedDesksPatches[key].timestamp >= 5000) {
+                delete recentMarkedDesksPatches[key];
+            }
+        });
+
         recentMarkedDesksPatches[itemId] = {
             marked_desks: markedDesks,
             timestamp: Date.now(),


### PR DESCRIPTION
### Purpose
Fix an intermittent UI sync issue where clearing all marked desks from React authoring model removed the bell in the authoring pane, but the monitoring/list view bell could stay present or reappear after the list re-query returned stale Elasticsearch data.

### What has changed
- Added local list-view handling for `item:marked_desks` websocket events, matching the existing immediate update behavior used for highlights.
- Preserved recent `marked_desks` websocket state while merging fetched list results, so stale ES responses do not restore removed desk marks.
- Updated nested `archive_item.marked_desks` when present, since list indicators can read marked desks from that object.
- Extended the React authoring marked-desks e2e coverage to assert that clear-all also removes the monitoring list bell.

### Steps to test
1. Enable React authoring with `localStorage.setItem('auth-react', true)` and reload.
2. Open Monitoring, and select an item to mark. 
3. Open Actions menu -> Marked for desks.
4. Add two or more desks.
5. Confirm the marked-for-desk bell appears in both authoring and the monitoring list row.
6. Use the clear-all X in the desks field.
7. Confirm the bell disappears from both authoring and the monitoring list row, and does not come back after the list refreshes.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: [SDESK-7811](https://sofab.atlassian.net/browse/SDESK-7811)


[SDESK-7811]: https://sofab.atlassian.net/browse/SDESK-7811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ