### PR TITLE
[STT-1673] Preserve trailing whitespace in custom editor tag preview (backport to 3.5)

### DIFF
--- a/scripts/core/editor3/components/customStyleMap.tsx
+++ b/scripts/core/editor3/components/customStyleMap.tsx
@@ -8,8 +8,14 @@ export function applyCustomEditorTagStyles(element: HTMLElement, tagId: string):
     const style = customEditorTagStyleMap[tagId];
 
     if (style != null) {
-        element.style.display = 'inline-block';
         for (const [prop, value] of Object.entries(style)) {
+            // Keep the span inline: under the preview's default white-space, an
+            // inline-block box trims edge whitespace and would drop a trailing space
+            // that is part of the styled range. The border renders fine inline.
+            if (prop === 'display') {
+                continue;
+            }
+
             element.style[prop] = value as string;
         }
     }

--- a/scripts/core/editor3/components/tests/customStyleMap.spec.tsx
+++ b/scripts/core/editor3/components/tests/customStyleMap.spec.tsx
@@ -1,0 +1,43 @@
+import {applyCustomEditorTagStyles, customEditorTagStyleMap} from '../customStyleMap';
+
+describe('applyCustomEditorTagStyles', () => {
+    const TEST_TAG = 'EDITOR_TAG_TEST';
+
+    beforeEach(() => {
+        customEditorTagStyleMap[TEST_TAG] = {
+            display: 'inline-block',
+            borderBlockEnd: '4px double blue',
+        };
+    });
+
+    afterEach(() => {
+        delete customEditorTagStyleMap[TEST_TAG];
+    });
+
+    it('applies the visual style from the style map', () => {
+        const element = document.createElement('span');
+
+        applyCustomEditorTagStyles(element, TEST_TAG);
+
+        expect(element.style.borderBlockEnd).toBe('4px double blue');
+    });
+
+    it('applies no display override so the span stays inline and preserves trailing whitespace', () => {
+        // Any block-level display (inline-block, block, flex, grid, table) trims its
+        // own edge whitespace under the preview's default white-space, dropping a
+        // trailing space that was part of the styled range. The span must stay inline.
+        const element = document.createElement('span');
+
+        applyCustomEditorTagStyles(element, TEST_TAG);
+
+        expect(element.style.display).toBe('');
+    });
+
+    it('leaves the element untouched for an unknown tag', () => {
+        const element = document.createElement('span');
+
+        applyCustomEditorTagStyles(element, 'UNKNOWN_TAG');
+
+        expect(element.getAttribute('style')).toBeNull();
+    });
+});


### PR DESCRIPTION
### Purpose
Backport of #5256 to `release/3.5`. Custom editor tag styles [STT-1590] rendered in the article preview dropped a trailing space that was part of the styled range. This fixes that so the preview matches the editor.

Resolves: [STT-1673]

[STT-1673]: https://sofab.atlassian.net/browse/STT-1673


[STT-1590]: https://sofab.atlassian.net/browse/STT-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ