### PR TITLE
[SDESK-7852] Bump sass-loader to 16 (modern API), strip tilde imports, add loadPaths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
         "redux-logger": "^3.0.6",
         "redux-thunk": "^2.3.0",
         "sass": "^1.97.2",
-        "sass-loader": "^10.5.2",
+        "sass-loader": "^16.0.8",
         "shallow-equal": "^3.1.0",
         "shortid": "2.2.8",
         "superdesk-ui-framework": "7.0.0-dev1",
@@ -10153,15 +10153,6 @@
         "graceful-fs": "^4.1.11"
       }
     },
-    "node_modules/klona": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
-      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/launch-editor": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
@@ -13849,38 +13840,41 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.5.2.tgz",
-      "integrity": "sha512-vMUoSNOUKJILHpcNCCyD23X34gve1TS7Rjd9uXHeKqhvBG39x6XbswFDtpbTElj6XdMFezoWhkh5vtKudf2cgQ==",
+      "version": "16.0.8",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.8.tgz",
+      "integrity": "sha512-hcov4ZwZJIGbEuyNr9EmiTmZueyrxSToE6GOzoZnq5JM7ecRO7ttyvilPn+VmRsqiP16+VYZzVnGZj/hzZgKBA==",
       "license": "MIT",
       "dependencies": {
-        "klona": "^2.0.4",
-        "loader-utils": "^2.0.0",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.0.0",
-        "semver": "^7.3.2"
+        "neo-async": "^2.6.2"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": ">= 18.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "fibers": ">= 3.1.0",
+        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
         "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "sass": "^1.3.0",
-        "webpack": "^4.36.0 || ^5.0.0"
+        "sass-embedded": "*",
+        "webpack": "^5.0.0"
       },
       "peerDependenciesMeta": {
-        "fibers": {
+        "@rspack/core": {
           "optional": true
         },
         "node-sass": {
           "optional": true
         },
         "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "webpack": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
     "sass": "^1.97.2",
-    "sass-loader": "^10.5.2",
+    "sass-loader": "^16.0.8",
     "shallow-equal": "^3.1.0",
     "shortid": "2.2.8",
     "superdesk-ui-framework": "7.0.0-dev1",

--- a/scripts/apps/archive/styles/html-preview.scss
+++ b/scripts/apps/archive/styles/html-preview.scss
@@ -1,4 +1,4 @@
-@import '~variables.scss';
+@import 'variables.scss';
 
 .html-preview {
     .annotation-text {

--- a/scripts/apps/archive/styles/related-item.scss
+++ b/scripts/apps/archive/styles/related-item.scss
@@ -1,5 +1,5 @@
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .related-item-list {
   .relate-item-label {

--- a/scripts/apps/authoring/attachments/attachments.scss
+++ b/scripts/apps/authoring/attachments/attachments.scss
@@ -1,4 +1,4 @@
-@import '~variables.scss';
+@import 'variables.scss';
 
 
 .field .attachments-pane {

--- a/scripts/apps/authoring/comments/comments.scss
+++ b/scripts/apps/authoring/comments/comments.scss
@@ -1,8 +1,8 @@
 // comments.scss
 // Styling for COMMENTS - editor widget
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 
 .sd-widget.comments {

--- a/scripts/apps/authoring/compare-versions/compare-versions.scss
+++ b/scripts/apps/authoring/compare-versions/compare-versions.scss
@@ -1,8 +1,8 @@
 // compare-versions.scss
 // Styling for the superdesk compare-versions screen
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .close-compare-versions {
     position: absolute;

--- a/scripts/apps/authoring/metadata/metadata.scss
+++ b/scripts/apps/authoring/metadata/metadata.scss
@@ -1,8 +1,8 @@
 // comments.scss
 // Styling for COMMENTS - editor widget
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .sd-widget.metadata {
     .widget-content {

--- a/scripts/apps/authoring/packages/packages.scss
+++ b/scripts/apps/authoring/packages/packages.scss
@@ -1,8 +1,8 @@
 // packaging.scss
 // Styling for making packages - editor widget
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .sd-widget.packages {
 

--- a/scripts/apps/authoring/styles/authoring.scss
+++ b/scripts/apps/authoring/styles/authoring.scss
@@ -3,9 +3,9 @@
 // ----------------------------------------------------------------------------------------
 @use "sass:color";
 @use "sass:math";
-@import '~mixins.scss';
-@import '~variables.scss';
-@import "~sf-additional.scss";
+@import 'mixins.scss';
+@import 'variables.scss';
+@import "sf-additional.scss";
 
 #main-container.authoring {
     .authoring-embedded {

--- a/scripts/apps/authoring/styles/multiedit.scss
+++ b/scripts/apps/authoring/styles/multiedit.scss
@@ -1,8 +1,8 @@
 // multiedit.scss
 // Styling for the superdesk multiedit screen
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 $create-board-pane: 64px;
 $top-offset: 48px;

--- a/scripts/apps/authoring/styles/themes.scss
+++ b/scripts/apps/authoring/styles/themes.scss
@@ -1,7 +1,7 @@
 // Styling for authoring screen editor
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 $main-article-padding : 3.2rem 4rem $bottom-view-padding 4rem;
 

--- a/scripts/apps/authoring/suggest/styles.scss
+++ b/scripts/apps/authoring/suggest/styles.scss
@@ -1,5 +1,5 @@
-@import '~variables.scss';
-@import '~mixins.scss';
+@import 'variables.scss';
+@import 'mixins.scss';
 
 $panel-width: 550px;
 

--- a/scripts/apps/authoring/track-changes/styles.scss
+++ b/scripts/apps/authoring/track-changes/styles.scss
@@ -1,4 +1,4 @@
-@import '~variables.scss';
+@import 'variables.scss';
 
 .sd-widget.inline-comments, .sd-widget.suggestions {
     .form__row {

--- a/scripts/apps/authoring/versioning/history/history.scss
+++ b/scripts/apps/authoring/versioning/history/history.scss
@@ -1,5 +1,5 @@
 // history.scss
 // Styling for article versions
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';

--- a/scripts/apps/authoring/versioning/versions/versions.scss
+++ b/scripts/apps/authoring/versioning/versions/versions.scss
@@ -1,8 +1,8 @@
 // versions.scss
 // Styling for article versions
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 
 .sd-widget.versioning {

--- a/scripts/apps/authoring/widgets/widgets-article.scss
+++ b/scripts/apps/authoring/widgets/widgets-article.scss
@@ -1,8 +1,8 @@
 // widgets-article.scss
 // Widget styling for article edit and packaging screen
 // ----------------------------------------------------------------------------------------
-@import "~variables.scss";
-@import "~superdesk-ui-framework/app/styles/_mixins.scss";
+@import "variables.scss";
+@import "superdesk-ui-framework/app/styles/_mixins.scss";
 
 .widget-wrapper {
     position: absolute;

--- a/scripts/apps/contacts/components/Form/SelectFieldSearchInput/style.scss
+++ b/scripts/apps/contacts/components/Form/SelectFieldSearchInput/style.scss
@@ -1,5 +1,5 @@
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .field-search__popup {
     margin-block-start: 1px;

--- a/scripts/apps/contacts/components/Popup/style.scss
+++ b/scripts/apps/contacts/components/Popup/style.scss
@@ -1,5 +1,5 @@
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .popup {
     &__menu {

--- a/scripts/apps/contacts/styles/contacts.scss
+++ b/scripts/apps/contacts/styles/contacts.scss
@@ -1,8 +1,8 @@
 // contacts.scss
 // Styling for the superdesk media contacts management page
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 /*
 ====================================================

--- a/scripts/apps/content-filters/styles/content-filters.scss
+++ b/scripts/apps/content-filters/styles/content-filters.scss
@@ -2,8 +2,8 @@
 // Styling for the superdesk content filters module
 // ----------------------------------------------------------------------------------------
 
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 
 .padded--sides10 {

--- a/scripts/apps/dashboard/styles/dashboard.scss
+++ b/scripts/apps/dashboard/styles/dashboard.scss
@@ -1,8 +1,8 @@
 // dashboard.scss
 // Styling for the superdesk dashboard page (gridster, widgets)
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .dashboard-container {
     position: absolute;

--- a/scripts/apps/dashboard/styles/widgets.scss
+++ b/scripts/apps/dashboard/styles/widgets.scss
@@ -1,8 +1,8 @@
 // world-clock.scss
 // Styling for ingest widget
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 .sd-widget {
     &.ingest, &.archive, &.related-item, &.aggregate, &.package-manager, &.packages, &.user-activity {
         .widget-header {

--- a/scripts/apps/dashboard/workspace-tasks/styles/tasks.scss
+++ b/scripts/apps/dashboard/workspace-tasks/styles/tasks.scss
@@ -2,8 +2,8 @@
 // Styling for the superdesk dashboard page (gridster, widgets)
 // ----------------------------------------------------------------------------------------
 @use "sass:color";
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 /*
 ---------------------------------------------

--- a/scripts/apps/dashboard/world-clock/world-clock.scss
+++ b/scripts/apps/dashboard/world-clock/world-clock.scss
@@ -1,8 +1,8 @@
 // world-clock.scss
 // Styling for world clock widget
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .world-clock {
 

--- a/scripts/apps/desks/styles/desks.scss
+++ b/scripts/apps/desks/styles/desks.scss
@@ -2,9 +2,9 @@
 // Styling for the superdesk desk module
 // ----------------------------------------------------------------------------------------
 @use "sass:color";
-@import '~mixins.scss';
-@import '~variables.scss';
-@import '~labels.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
+@import 'labels.scss';
 
 
 $main-desk-color:  #ffffff;

--- a/scripts/apps/dictionaries/styles/dictionaries.scss
+++ b/scripts/apps/dictionaries/styles/dictionaries.scss
@@ -1,6 +1,6 @@
 
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .words-list {
     margin-block-start: 4px;

--- a/scripts/apps/highlights/styles/highlights.scss
+++ b/scripts/apps/highlights/styles/highlights.scss
@@ -1,8 +1,8 @@
 // highlights.scss
 // Styling for the highlights functionality
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 
 

--- a/scripts/apps/ingest/styles/dashboard.scss
+++ b/scripts/apps/ingest/styles/dashboard.scss
@@ -1,7 +1,7 @@
 // Styling for the ingest dashboard
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 
 // Ingest dashboard

--- a/scripts/apps/ingest/styles/settings.scss
+++ b/scripts/apps/ingest/styles/settings.scss
@@ -2,8 +2,8 @@
 // Styling for the superdesk ingest settings
 // ----------------------------------------------------------------------------------------
 @use "sass:color";
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 // Ingest sources
 // -------------------------------------

--- a/scripts/apps/monitoring/styles/aggregate.scss
+++ b/scripts/apps/monitoring/styles/aggregate.scss
@@ -1,7 +1,7 @@
 // search(aggregate) widget.scss
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 $search-widget-width: $tabpane-extended-width;
 $search-widget-preview-width: 440px;

--- a/scripts/apps/monitoring/styles/monitoring.scss
+++ b/scripts/apps/monitoring/styles/monitoring.scss
@@ -1,5 +1,5 @@
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .monitoring {
     position: absolute;

--- a/scripts/apps/packaging/styles/packaging.scss
+++ b/scripts/apps/packaging/styles/packaging.scss
@@ -1,8 +1,8 @@
 // packaging.scss
 // Styling for making packages - editor widget
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 
 .package-item {

--- a/scripts/apps/products/styles/products.scss
+++ b/scripts/apps/products/styles/products.scss
@@ -1,8 +1,8 @@
 // product.scss
 // Styling for the superdesk product module
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 
 /* 	============================

--- a/scripts/apps/profiling/styles/profiling.scss
+++ b/scripts/apps/profiling/styles/profiling.scss
@@ -2,8 +2,8 @@
 // Styling for the superdesk profiling module
 // ----------------------------------------------------------------------------------------
 
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .profiling-data {
     inset-block-start: $subnav-height;

--- a/scripts/apps/publish/styles/publish.scss
+++ b/scripts/apps/publish/styles/publish.scss
@@ -2,8 +2,8 @@
 // Styling for the superdesk publish module
 // ----------------------------------------------------------------------------------------
 
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .filter-result-modal {
     position: absolute;

--- a/scripts/apps/search/styles/search.scss
+++ b/scripts/apps/search/styles/search.scss
@@ -2,9 +2,9 @@
 // Styling for search page, and search functionalities
 // ----------------------------------------------------------------------------------------
 @use "sass:math";
-@import '~mixins.scss';
-@import '~variables.scss';
-@import '~animation.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
+@import 'animation.scss';
 
 .search-page-container {
     .archive-content {

--- a/scripts/apps/settings/styles/settings.scss
+++ b/scripts/apps/settings/styles/settings.scss
@@ -1,8 +1,8 @@
 // settings.scss
 // Styling for the superdesk settings page (vertical tabs)
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .settings-page {
     position: absolute;

--- a/scripts/apps/templates/styles/templates.scss
+++ b/scripts/apps/templates/styles/templates.scss
@@ -1,5 +1,5 @@
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .template-card {
     .card-box__header--dark {

--- a/scripts/apps/users/activity-widget/widget-activity.scss
+++ b/scripts/apps/users/activity-widget/widget-activity.scss
@@ -1,8 +1,8 @@
 // world-clock.scss
 // Styling for ingest widget
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .sd-widget.activity {
     .activity-holder {

--- a/scripts/apps/users/styles/change-avatar.scss
+++ b/scripts/apps/users/styles/change-avatar.scss
@@ -1,8 +1,8 @@
 // planning.scss
 // Styling for the superdesk content planing modules
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .upload-avatar {
 

--- a/scripts/apps/users/styles/settings.scss
+++ b/scripts/apps/users/styles/settings.scss
@@ -1,8 +1,8 @@
 // users.scss
 // Styling for the superdesk users page (list, prevew, profile)
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 // User roles
 // -------------------------------------

--- a/scripts/apps/users/styles/users.scss
+++ b/scripts/apps/users/styles/users.scss
@@ -1,8 +1,8 @@
 // users.scss
 // Styling for the superdesk users page (list, prevew, profile)
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .users {    //page styles
     .users-subnav {

--- a/scripts/apps/vocabularies/styles/vocabularies.scss
+++ b/scripts/apps/vocabularies/styles/vocabularies.scss
@@ -1,6 +1,6 @@
 
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 .vocabularyForm {
     button.del {

--- a/scripts/apps/workspace/content/styles/profiles.scss
+++ b/scripts/apps/workspace/content/styles/profiles.scss
@@ -1,5 +1,5 @@
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 sd-content-schema-editor {
     .schema-editor {

--- a/scripts/core/auth/styles/auth.scss
+++ b/scripts/core/auth/styles/auth.scss
@@ -1,8 +1,8 @@
 // login-screen.scss
 // Styling for login (auth) screen
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 
 .login-screen {

--- a/scripts/core/editor3/styles.scss
+++ b/scripts/core/editor3/styles.scss
@@ -2,10 +2,10 @@
 
 @use "sass:color";
 @use "sass:math";
-@import '~mixins.scss';
-@import '~variables/_typography.scss';
-@import '~variables/_colors.scss';
-@import '~draft-js/dist/Draft.css';
+@import 'mixins.scss';
+@import 'variables/_typography.scss';
+@import 'variables/_colors.scss';
+@import 'draft-js/dist/Draft.css';
 
 // colors
 $editor-neutral-border: 			var(--sd-editor-colour__controls-border);

--- a/scripts/core/menu/styles/menu.scss
+++ b/scripts/core/menu/styles/menu.scss
@@ -2,8 +2,8 @@
 // Styling for the superdesk top menu and sidebar main menu
 // ----------------------------------------------------------------------------------------
 @use "sass:math";
-@import '~variables.scss';
-@import '~mixins.scss';
+@import 'variables.scss';
+@import 'mixins.scss';
 
 
 /*

--- a/scripts/core/notify/styles/notify.scss
+++ b/scripts/core/notify/styles/notify.scss
@@ -2,8 +2,8 @@
 // Styling for notifications displayed on top of the page
 // ----------------------------------------------------------------------------------------
 @use "sass:math";
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 
 $notif-holder-w : 340px;

--- a/scripts/core/ui/components/Form/ColouredValueInput/style.scss
+++ b/scripts/core/ui/components/Form/ColouredValueInput/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/_variables.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/_variables.scss';
 
 .select-coloured-value {
     &__input {

--- a/scripts/core/ui/components/Form/DateInput/style.scss
+++ b/scripts/core/ui/components/Form/DateInput/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/_variables.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/_variables.scss';
 
 .date-popup {
     width: 260px;

--- a/scripts/core/ui/components/Form/DateTimeInput/style.scss
+++ b/scripts/core/ui/components/Form/DateTimeInput/style.scss
@@ -1,4 +1,4 @@
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
 
 .date-time-input__row {
     &--required {

--- a/scripts/core/ui/components/Form/SelectMetaTermsInput/style.scss
+++ b/scripts/core/ui/components/Form/SelectMetaTermsInput/style.scss
@@ -1,5 +1,5 @@
-// @import '~superdesk-ui-framework/app/styles/_mixins.scss';
-// @import '~superdesk-ui-framework/app/styles/_variables.scss';
+// @import 'superdesk-ui-framework/app/styles/_mixins.scss';
+// @import 'superdesk-ui-framework/app/styles/_variables.scss';
 
 // .Select {
 // 	&__dropdownToggle {

--- a/scripts/core/ui/components/Form/SelectTagInput/style.scss
+++ b/scripts/core/ui/components/Form/SelectTagInput/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/_variables.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/_variables.scss';
 
 .select-tag__popup {
     margin-block-start: 1px;

--- a/scripts/core/ui/components/Form/TimeInput/style.scss
+++ b/scripts/core/ui/components/Form/TimeInput/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/_variables.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/_variables.scss';
 
 // .time-popup {
 //     width: 200px;

--- a/scripts/core/ui/components/Form/ToggleInput/style.scss
+++ b/scripts/core/ui/components/Form/ToggleInput/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/_variables.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/_variables.scss';
 
 .sd-line-input__toggle {
     .sd-line-input__label {

--- a/scripts/core/ui/components/Form/style.scss
+++ b/scripts/core/ui/components/Form/style.scss
@@ -1,4 +1,4 @@
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
 
 // Add some padding to the right for long filenames
 // so that the trash icon is still visible

--- a/scripts/core/ui/components/Popup/style.scss
+++ b/scripts/core/ui/components/Popup/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/_variables.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/_variables.scss';
 
 .popup {
     &__menu {

--- a/scripts/core/ui/components/SubNav/style.scss
+++ b/scripts/core/ui/components/SubNav/style.scss
@@ -1,4 +1,4 @@
-@import '~superdesk-ui-framework/app/styles/_variables.scss';
+@import 'superdesk-ui-framework/app/styles/_variables.scss';
 
 .sliding-toolbar__info-tools {
     a { cursor: pointer; }

--- a/scripts/core/ui/components/Toggle/style.scss
+++ b/scripts/core/ui/components/Toggle/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
-@import '~superdesk-ui-framework/app/styles/_variables.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/_variables.scss';
 
 .sd-toggle {
     &--disabled {

--- a/scripts/core/ui/components/ToggleBox/style.scss
+++ b/scripts/core/ui/components/ToggleBox/style.scss
@@ -1,4 +1,4 @@
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
 
 .toggle-box {
 

--- a/scripts/core/ui/components/style.scss
+++ b/scripts/core/ui/components/style.scss
@@ -1,5 +1,5 @@
-@import '~superdesk-ui-framework/app/styles/_variables.scss';
-@import '~superdesk-ui-framework/app/styles/_mixins.scss';
+@import 'superdesk-ui-framework/app/styles/_variables.scss';
+@import 'superdesk-ui-framework/app/styles/_mixins.scss';
 
 time.Datetime {
     padding-inline-start: 0;

--- a/scripts/core/upload/styles/upload.scss
+++ b/scripts/core/upload/styles/upload.scss
@@ -1,9 +1,9 @@
 // uploader.scss
 // Styling for the superdesk upload submodule (avatar upload, media upload)
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
-@import "~sf-additional.scss";
+@import 'mixins.scss';
+@import 'variables.scss';
+@import "sf-additional.scss";
 
 @mixin generic-upload-progress($height:2px) {
     position: absolute;

--- a/styles/sass/app.scss
+++ b/styles/sass/app.scss
@@ -7,7 +7,7 @@
 @import url(//fonts.googleapis.com/css?family=Roboto:400,300,300italic,400italic,500,500italic,700,700italic&subset=latin,latin-ext);
 
 @import '../extension-styles.generated.css';
-@import '~@sourcefabric/common/dist/src/index.css';
+@import '@sourcefabric/common/dist/src/index.css';
 
 // Core variables and mixins
 @import 'variables'; // Modify this for custom colors, font-sizes, etc

--- a/styles/sass/archive-filtering.scss
+++ b/styles/sass/archive-filtering.scss
@@ -1,9 +1,9 @@
 // archive-filtering.scss
 // Styling for content archive filtering
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
-@import '~animation.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
+@import 'animation.scss';
 
 .archive-sidebar {
     position:absolute;

--- a/styles/sass/archive-preview.scss
+++ b/styles/sass/archive-preview.scss
@@ -1,8 +1,8 @@
 // archive-preview.scss
 // Styling for the superdesk media archive and ingest
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 // SIDE PREVIEW
 

--- a/styles/sass/forms.scss
+++ b/styles/sass/forms.scss
@@ -1,6 +1,6 @@
 
 @use "sass:color";
-@import '~mixins.scss';
+@import 'mixins.scss';
 // Forms.scss
 // Base styles for various input types, form layouts, and states
 // -------------------------------------------------------------

--- a/styles/sass/media-archive.scss
+++ b/styles/sass/media-archive.scss
@@ -3,8 +3,8 @@
 // ----------------------------------------------------------------------------------------
 @use "sass:color";
 @use "sass:math";
-@import '~mixins.scss';
-@import '~variables.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
 
 
 /* ====================================== */

--- a/styles/sass/modals.scss
+++ b/styles/sass/modals.scss
@@ -1,5 +1,5 @@
 @use "sass:math";
-@import '~variables.scss';
+@import 'variables.scss';
 
 // // MODALS
 // // ------

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -298,7 +298,18 @@ module.exports = function makeConfig(grunt) {
                                 modules: 'global',
                             },
                         },
-                        {loader: 'sass-loader'},
+                        {
+                            loader: 'sass-loader',
+                            options: {
+                                sassOptions: {
+                                    loadPaths: [
+                                        path.join(__dirname, 'styles', 'sass'),
+                                        path.join(__dirname, 'node_modules'),
+                                        path.join(process.cwd(), 'node_modules'),
+                                    ],
+                                },
+                            },
+                        },
                     ],
                 },
                 {


### PR DESCRIPTION
### Purpose
Finish the Dart Sass modernisation started in #5234. Get rid of the last two deprecation classes (`legacy-js-api` and `~`-imports) so `npm run start` and the CI build stop shouting.

### What has changed
- `sass-loader` `^10.5.2` -> `^16.0.8`. The v16 line uses the modern API and drops the legacy tilde (`~`) shim.
- Strip the `~` prefix from every `@import` in this repo's SCSS (131 lines across 67 files). Targets like `mixins.scss` or `superdesk-ui-framework/app/styles/_variables.scss` are unchanged; they resolve via the new `sassOptions.loadPaths` instead.
- Add `sassOptions.loadPaths` to the sass-loader rule in `webpack.config.js` pointing at `styles/sass`, this package's `node_modules`, and `process.cwd()/node_modules`. The last one keeps the dev-linked build alive: when core is symlinked into `superdesk/client`, `superdesk-ui-framework` and the other siblings live under `client/node_modules`, not core's own.

Sibling repos have already landed matching PRs so the integrated `superdesk/client` build has no `~`-imports left to break: https://github.com/superdesk/superdesk-planning/pull/2868, https://github.com/superdesk/superdesk-ui-framework/pull/1036, https://github.com/superdesk/superdesk-analytics/pull/212, https://github.com/superdesk/superdesk-publisher/pull/378, and the byte-identical prep PR #5234 in this repo. This is the last one in the chain.

Out of scope: a handful of `url('~images/...')` references in a few SCSS files. Those are a css-loader concern (css-loader v7 dropped `~` a while ago), separate follow-up.

### Steps to test
- `npm install`, `npm run start`, load the app. Expect no `legacy-js-api` or `[import]` "prefix `~` is deprecated" lines in the console.
- Visual smoke: dashboard, monitoring, authoring, media archive filters, contacts, users settings. These pull the largest chunks of migrated SCSS.
- If dev-linking core into `superdesk/client`, confirm the sibling repos also resolve (they will use `client/node_modules` via the third loadPath).
