### PR TITLE
Add e2e test for extended headline length validation on publish

### DIFF
--- a/e2e/client/playwright/page-object-models/authoring.ts
+++ b/e2e/client/playwright/page-object-models/authoring.ts
@@ -44,6 +44,34 @@ export class Authoring {
         }
     }
 
+    /**
+     * Clicks the authoring-react topbar Save button and waits for the save to
+     * settle (the button disables once there are no unsaved changes).
+     */
+    async saveInAuthoringReact(): Promise<void> {
+        const saveButton = this.page.getByTestId('authoring').getByRole('button', {name: 'Save', exact: true});
+
+        await saveButton.click();
+        await expect(saveButton).toBeDisabled();
+    }
+
+    /**
+     * Opens the "Send to / Publish" side widget and confirms publish.
+     * authoring-react exposes publish through the right-rail side widget
+     * (interactive-article-actions-widget), not the legacy topbar pane that
+     * {@link publish} drives.
+     */
+    async publishInAuthoringReact(): Promise<void> {
+        const {page} = this;
+
+        await page.getByTestId('widget-icon')
+            .and(page.locator('[data-test-value="interactive-article-actions-widget"]'))
+            .click();
+
+        // Publish tab is active by default in the panel.
+        await page.getByTestId('publish').click();
+    }
+
     async sendTo(destination: {desk: string; stage: string}): Promise<void> {
         const {page} = this;
 

--- a/e2e/client/playwright/page-object-models/settings/content-profile.ts
+++ b/e2e/client/playwright/page-object-models/settings/content-profile.ts
@@ -42,6 +42,45 @@ export class ContentProfileSettings {
         await expect(this.page.locator(s('content-profile-edit-view'))).not.toBeVisible();
     }
 
+    /**
+     * Adds an existing custom text field to a content profile and sets its
+     * character-length limits (Minimum / Maximum length). getByTestId-based
+     * (current convention), unlike the sibling s()-based helpers above.
+     */
+    async addTextFieldWithLengthLimits(options: {
+        profileName: string;
+        tabName: string;
+        fieldName: string;
+        minLength: number;
+        maxLength: number;
+    }): Promise<void> {
+        const {page} = this;
+        const card = page.getByTestId('content-profile')
+            .and(page.locator(`[data-test-value="${options.profileName}"]`));
+
+        await page.goto('/#/settings/content-profiles');
+        await card.getByTestId('content-profile-actions').click();
+        await page.getByTestId('content-profile-actions--options').getByRole('button', {name: 'Edit'}).click();
+
+        const editModal = page.getByTestId('content-profile-editing-modal');
+
+        await editModal.getByTestId('content-profile-tabs')
+            .getByRole('tab', {name: `${options.tabName} fields`}).click();
+        await editModal.getByRole('button', {name: 'Add new field'}).first().click();
+        await page.getByTestId('tree-menu-popover')
+            .getByRole('treeitem', {name: `${options.fieldName} (text)`, exact: true}).click();
+
+        const fieldEdit = page.getByTestId('item-view-edit');
+
+        await fieldEdit.getByTestId('gform-input--minlength').fill(String(options.minLength));
+        await fieldEdit.getByTestId('gform-input--maxlength').fill(String(options.maxLength));
+        await fieldEdit.getByTestId('gform-input--sdWidth').selectOption('full');
+        await fieldEdit.getByRole('button', {name: 'apply'}).click();
+
+        await editModal.getByRole('button', {name: 'Save'}).click();
+        await expect(editModal).not.toBeVisible();
+    }
+
     async addFieldsToContentProfile(
         contentProfile: string,
         fields: Array<{tabName: string; fieldId: string, fieldType?: string}>,

--- a/e2e/client/playwright/page-object-models/settings/metadata.ts
+++ b/e2e/client/playwright/page-object-models/settings/metadata.ts
@@ -1,0 +1,31 @@
+import {Page, expect} from '@playwright/test';
+
+export class MetadataSettings {
+    private page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    /**
+     * Creates a custom text field under Settings -> Metadata -> Custom text fields.
+     * The field can then be added to a content profile (see
+     * {@link ContentProfileSettings.addTextFieldWithLengthLimits}).
+     */
+    async createCustomTextField(field: {id: string; name: string}): Promise<void> {
+        const {page} = this;
+        const modal = page.getByTestId('vocabulary-modal');
+
+        await page.goto('/#/settings/vocabularies');
+        await page.getByTestId('metadata-tabs').getByRole('button', {name: 'Custom text fields'}).click();
+        await page.getByTestId('metadata-content').getByRole('button', {name: 'Add new'}).click();
+
+        await modal.getByLabel('id').fill(field.id);
+        await modal.getByLabel('name').fill(field.name);
+        await modal.getByRole('button', {name: 'Save'}).click();
+
+        await expect(
+            page.getByTestId('metadata-content').getByTestId('vocabulary-item').filter({hasText: field.name}),
+        ).toBeVisible();
+    }
+}

--- a/e2e/client/playwright/publish-validation.extended-headline-length.authoring-react.spec.ts
+++ b/e2e/client/playwright/publish-validation.extended-headline-length.authoring-react.spec.ts
@@ -1,0 +1,93 @@
+import {test, expect, type Page} from '@playwright/test';
+import {Authoring} from './page-object-models/authoring';
+import {Monitoring} from './page-object-models/monitoring';
+import {MetadataSettings} from './page-object-models/settings/metadata';
+import {ContentProfileSettings} from './page-object-models/settings/content-profile';
+import {restoreDatabaseSnapshot} from './utils';
+import {setEditor3FieldValue} from './utils/editor3';
+import {getStorageState} from './utils/storage-state';
+
+/**
+ * QA case: a custom text field ("extended headline") configured with min/max
+ * character limits in the content profile of a desk has those limits enforced at
+ * publish time. When the saved value is shorter than the minimum or longer than
+ * the maximum, publishing is blocked (the item stays in Draft) and a red error
+ * toast names the offending limit.
+ *
+ * The message text comes from the backend content-profile validator
+ * (apps/validate/validate.py): custom fields report "<display name> <cerberus
+ * message>", e.g. "extended headline max length is 20" / "... min length is 10".
+ */
+test.use({storageState: getStorageState({}, {authoringReact: true})});
+
+const FIELD = {id: 'extended-headline', name: 'extended headline'};
+const MIN_LENGTH = 10;
+const MAX_LENGTH = 20;
+const BELOW_MIN = 'abc'; // 3 chars < MIN_LENGTH
+const ABOVE_MAX = 'x'.repeat(MAX_LENGTH + 5); // 25 chars > MAX_LENGTH
+
+// Adds the "extended headline" custom text field to the Story profile with limits.
+async function configureExtendedHeadlineLimits(page: Page): Promise<void> {
+    await new MetadataSettings(page).createCustomTextField(FIELD);
+    await new ContentProfileSettings(page).addTextFieldWithLengthLimits({
+        profileName: 'Story',
+        tabName: 'Content',
+        fieldName: FIELD.name,
+        minLength: MIN_LENGTH,
+        maxLength: MAX_LENGTH,
+    });
+}
+
+// Opens "test sports story" (Sports desk, Story profile) in authoring-react.
+async function openTestSportsStory(page: Page): Promise<void> {
+    const monitoring = new Monitoring(page);
+
+    await page.goto('/#/workspace/monitoring');
+    await monitoring.selectDeskOrWorkspace('Sports');
+    await monitoring.getArticleLocator('test sports story').dblclick();
+    await new Authoring(page).waitForAuthoringReactToInitialize();
+}
+
+test.describe('extended headline length limits are enforced on publish (authoring-react)', () => {
+    test('below the minimum blocks publishing and shows a red message', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await configureExtendedHeadlineLimits(page);
+        await openTestSportsStory(page);
+
+        const authoring = new Authoring(page);
+
+        await setEditor3FieldValue(authoring.field(`authoring-field=${FIELD.id}`), BELOW_MIN);
+        await authoring.saveInAuthoringReact();
+        await authoring.publishInAuthoringReact();
+
+        // A red error toast names the required minimum length.
+        await expect(
+            page.getByTestId('notification--error')
+                .filter({hasText: `${FIELD.name} min length is ${MIN_LENGTH}`}),
+        ).toBeVisible();
+
+        // Publishing was prevented: the article is still open as a draft (the
+        // publish panel stays open instead of the article closing on success).
+        await expect(page.getByTestId('publish')).toBeVisible();
+    });
+
+    test('above the maximum blocks publishing and shows a red message', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await configureExtendedHeadlineLimits(page);
+        await openTestSportsStory(page);
+
+        const authoring = new Authoring(page);
+
+        await setEditor3FieldValue(authoring.field(`authoring-field=${FIELD.id}`), ABOVE_MAX);
+        await authoring.saveInAuthoringReact();
+        await authoring.publishInAuthoringReact();
+
+        // A red error toast names the allowed maximum length.
+        await expect(
+            page.getByTestId('notification--error')
+                .filter({hasText: `${FIELD.name} max length is ${MAX_LENGTH}`}),
+        ).toBeVisible();
+
+        await expect(page.getByTestId('publish')).toBeVisible();
+    });
+});


### PR DESCRIPTION
Playwright e2e spec (authoring-react) covering that a custom text field's min/max length, configured in the content profile, is enforced on publish: an out-of-bounds value blocks publishing, keeps the item in draft, and surfaces the backend validation error toast.

- below-min and above-max cases
- adds `MetadataSettings` PO and `addTextFieldWithLengthLimits` / `saveInAuthoringReact` / `publishInAuthoringReact` helpers

Verified stable (12/12 across repeats).