### PR TITLE
Pin `@types/node` and `date-fns` in extensions to fix build against drifted transitive deps

### DIFF
--- a/scripts/extensions/availability-manager/package-lock.json
+++ b/scripts/extensions/availability-manager/package-lock.json
@@ -102,6 +102,15 @@
       "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
+    "@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -2015,6 +2024,12 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "util-deprecate": {

--- a/scripts/extensions/availability-manager/package.json
+++ b/scripts/extensions/availability-manager/package.json
@@ -13,10 +13,11 @@
     "mocha": "8.4.0",
     "superdesk-code-style": "1.3.0",
     "ts-node": "10.9.1",
-    "typescript": "~4.9.5"
+    "typescript": "~4.9.5",
+    "@types/node": "~20"
   },
   "dependencies": {
     "@sourcefabric/common": "0.0.66",
-    "date-fns": "^4.1.0"
+    "date-fns": "4.1.0"
   }
 }

--- a/scripts/extensions/broadcasting/package-lock.json
+++ b/scripts/extensions/broadcasting/package-lock.json
@@ -94,6 +94,15 @@
       "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
+    "@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -2294,6 +2303,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/scripts/extensions/broadcasting/package.json
+++ b/scripts/extensions/broadcasting/package.json
@@ -13,7 +13,8 @@
     "mocha": "8.4.0",
     "superdesk-code-style": "1.3.0",
     "ts-node": "10.9.1",
-    "typescript": "~4.9.5"
+    "typescript": "~4.9.5",
+    "@types/node": "~20"
   },
   "dependencies": {
     "@sourcefabric/common": "0.0.66"

--- a/scripts/extensions/helloWorld/package-lock.json
+++ b/scripts/extensions/helloWorld/package-lock.json
@@ -63,6 +63,15 @@
       "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
+    "@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -1910,6 +1919,12 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "util-deprecate": {

--- a/scripts/extensions/helloWorld/package.json
+++ b/scripts/extensions/helloWorld/package.json
@@ -13,6 +13,7 @@
     "mocha": "8.4.0",
     "superdesk-code-style": "1.3.0",
     "ts-node": "10.9.1",
-    "typescript": "~4.9.5"
+    "typescript": "~4.9.5",
+    "@types/node": "~20"
   }
 }


### PR DESCRIPTION
## Problem

`npm run build` in consumer repos (e.g. superdesk-belga) fails while installing/compiling bundled extensions, with dozens of parse errors originating in `node_modules/@types/node/ffi.d.ts`:

```
node_modules/@types/node/ffi.d.ts(206,81): error TS1434: Unexpected keyword or identifier.
...
Command failed: cd .../scripts/extensions/availability-manager && npm install --no-audit && npm run compile
```

## Root cause

Two overlapping breakages, both surfaced by open ranges in extensions that pin `typescript@~4.9.5`:

1. **`@types/node@26.1.0` (published 2026-07-01)** added `ffi.d.ts`, which uses TypeScript 5.0 `<const T>` (const type parameter) syntax. TypeScript 4.9.5's parser cannot read it, so `tsc` fails. `skipLibCheck` does not help: this is a parse error, not a type check. `@types/node` is pulled transitively via `ts-node@10.9.1`, which declares `@types/node: "*"`. Affected extensions: the three that depend on `ts-node` (`availability-manager`, `broadcasting`, `helloWorld`).

2. **`date-fns@4.3.0` (published 2026-05-22)** restructured its type entrypoint so named exports (`format`, `addMonths`, etc.) no longer resolve under the extensions' classic-node module resolution, producing `TS2305` errors. This was masked because `tsc` died on cause 1 first. Affected extension: `availability-manager` (the only one with a direct `date-fns` dependency).

