### PR TITLE
Resolve sass-loader via require.resolve so nested installs work

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -299,7 +299,7 @@ module.exports = function makeConfig(grunt) {
                             },
                         },
                         {
-                            loader: 'sass-loader',
+                            loader: require.resolve('sass-loader'),
                             options: {
                                 sassOptions: {
                                     loadPaths: [


### PR DESCRIPTION
### Purpose
Consumer `superdesk/client` docker build broke after #5260 with `Can't resolve 'sass-loader' in '/tmp/client'`. See https://github.com/superdesk/superdesk/actions/runs/30033896644/job/89296874513.

### Why it broke
npm nests sass-loader under `client/node_modules/superdesk-core/node_modules/sass-loader` instead of hoisting it to `client/node_modules/` (v16 declares more optional peers, so npm plays it safe). Webpack's default loader resolver walks up from the build context and never reaches the nested path.

### Fix
`'sass-loader'` -> `require.resolve('sass-loader')`. Node's resolver, anchored to this file, finds core's own sass-loader wherever npm puts it.

### Steps to test
- Fresh docker build of `superdesk/client` against develop of core. Being verified via the branch `test/sass-loader-hotfix-verify` in the superdesk repo.