### PR TITLE
[STT-1694] Add spell checker toggle to authoring header with configurable shortcut

### DIFF
--- a/e2e/client/playwright/editor3.spellchecker.running-mode.spec.ts
+++ b/e2e/client/playwright/editor3.spellchecker.running-mode.spec.ts
@@ -33,7 +33,7 @@ test('configuring spellchecker to be disabled until user enables it manually', a
     await expect(page.locator(s('authoring', 'authoring-field=body_html', 'spellchecker-warning'))).toHaveCount(0);
 
     await page.locator(s('authoring-topbar', 'actions-button')).click();
-    await page.locator(s('actions-list')).getByRole('button', {name: 'Ctrl+Shift+Y Check spelling'}).click();
+    await page.locator(s('actions-list')).getByRole('button', {name: 'Check spelling'}).click();
 
     await expect(page.locator(s('authoring', 'authoring-field=body_html', 'spellchecker-warning'))).toHaveCount(2);
 });

--- a/e2e/client/specs/authoring_spec.ts
+++ b/e2e/client/specs/authoring_spec.ts
@@ -329,7 +329,7 @@ describe('authoring', () => {
         monitoring.actionOnItem('Edit', 2, 1);
 
         browser.wait(ECE.attributeEquals(
-            element(by.model('spellcheckMenu.isAuto')),
+            element(by.model('spellcheck.isAutoSpellchecker')),
             'checked',
             'true',
         ));
@@ -337,7 +337,7 @@ describe('authoring', () => {
         authoring.toggleAutoSpellCheck();
 
         browser.wait(ECE.attributeEquals(
-            element(by.model('spellcheckMenu.isAuto')),
+            element(by.model('spellcheck.isAutoSpellchecker')),
             'checked',
             null,
         ));
@@ -347,7 +347,7 @@ describe('authoring', () => {
         monitoring.actionOnItem('Edit', 2, 2);
 
         browser.wait(ECE.attributeEquals(
-            element(by.model('spellcheckMenu.isAuto')),
+            element(by.model('spellcheck.isAutoSpellchecker')),
             'checked',
             null,
         ));

--- a/e2e/client/specs/helpers/authoring.ts
+++ b/e2e/client/specs/helpers/authoring.ts
@@ -662,7 +662,7 @@ class Authoring {
 
         this.toggleAutoSpellCheck = function() {
             openAuthoringDropdown();
-            element(by.model('spellcheckMenu.isAuto')).click();
+            element(by.model('spellcheck.isAutoSpellchecker')).click();
         };
 
         this.openLiveSuggest = function() {

--- a/e2e/client/specs/send_spec.ts
+++ b/e2e/client/specs/send_spec.ts
@@ -109,7 +109,7 @@ describe('send', () => {
 
         // Skip spell check
         authoring.toggleAutoSpellCheck();
-        expect(element(by.model('spellcheckMenu.isAuto')).getAttribute('checked')).toBeFalsy();
+        expect(element(by.model('spellcheck.isAutoSpellchecker')).getAttribute('checked')).toBeFalsy();
 
         authoring.writeText('Text, that not saved yet');
         authoring.sendTo('Sports Desk', null, true);

--- a/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringDirective.ts
@@ -9,6 +9,8 @@ import {getLabelNameResolver} from 'apps/workspace/helpers/getLabelForFieldId';
 import {isMediaType} from 'core/helpers/item';
 import {copyJson} from 'core/helpers/utils';
 import {addInternalEventListener} from 'core/internal-events';
+import {getSpellchecker} from 'core/editor3/components/spellchecker/default-spellcheckers';
+import {getSpellcheckShortcutLabel, matchesSpellcheckShortcut} from 'core/spellcheck/spellcheck-shortcut';
 import {applyMiddleware as coreApplyMiddleware} from 'core/middleware';
 import {logger} from 'core/services/logger';
 import {gettext} from 'core/utils';
@@ -61,6 +63,7 @@ AuthoringDirective.$inject = [
     'embedService',
     '$injector',
     'autosave',
+    'spellcheck',
 ];
 export function AuthoringDirective(
     superdesk,
@@ -88,6 +91,7 @@ export function AuthoringDirective(
     embedService,
     $injector,
     autosave,
+    spellcheck,
 ) {
     return {
         link: function($scope, elem, attrs) {
@@ -150,6 +154,21 @@ export function AuthoringDirective(
             $scope.proofread = false;
             $scope.referrerUrl = referrer.getReferrerUrl();
             $scope.gettext = gettext;
+
+            $scope.spellcheck = spellcheck;
+            $scope.spellcheckShortcutLabel = getSpellcheckShortcutLabel();
+
+            $scope.isSpellcheckerAvailable = function() {
+                return $scope.item != null
+                    && !$scope.useTansaProofing()
+                    && getSpellchecker($scope.item.language) != null;
+            };
+
+            $scope.toggleSpellchecker = function() {
+                if ($scope.isSpellcheckerAvailable()) {
+                    spellcheck.toggleSpellcheckerStatus();
+                }
+            };
 
             /**
              * Get the Desk and Stage for the item.
@@ -1116,6 +1135,21 @@ export function AuthoringDirective(
                         }
                     },
                 ),
+            );
+
+            const spellcheckShortcutHandler = (event: KeyboardEvent) => {
+                if (matchesSpellcheckShortcut(event) && $scope._editable && $scope.isSpellcheckerAvailable()) {
+                    // preventDefault so the combo (e.g. Alt+S) does not trigger the browser menu
+                    event.preventDefault();
+                    $scope.$apply(() => {
+                        spellcheck.toggleSpellcheckerStatus();
+                    });
+                }
+            };
+
+            window.addEventListener('keydown', spellcheckShortcutHandler);
+            $scope.eventListenersToRemoveOnUnmount.push(
+                () => window.removeEventListener('keydown', spellcheckShortcutHandler),
             );
 
             $scope.$on('$destroy', () => {

--- a/scripts/apps/authoring/authoring/index.ts
+++ b/scripts/apps/authoring/authoring/index.ts
@@ -17,6 +17,7 @@ import {LineCount} from './components/line-count';
 import {PopulateAuthorsController} from './controllers/PopulateAuthorsController';
 
 import {gettext} from 'core/utils';
+import {getSpellcheckShortcutLabel} from 'core/spellcheck/spellcheck-shortcut';
 import {IArticle} from 'superdesk-api';
 import {IArticleSchema} from 'superdesk-interfaces/ArticleSchema';
 import {AuthoringTopbarReact} from './authoring-topbar-react';
@@ -470,6 +471,6 @@ angular.module('superdesk.apps.authoring', [
         keyboardManager.register('Authoring', 'ctrl + shift + s', gettext('Save current item'));
         keyboardManager.register('Authoring', 'ctrl + shift + l',
             gettext('Preview formatted article, when previewFormats feature configured'));
-        keyboardManager.register('Authoring', 'ctrl + shift + y',
-            gettext('Instant Spellchecking, when automatic spellchecking turned off'));
+        keyboardManager.register('Authoring', getSpellcheckShortcutLabel(),
+            gettext('Toggle the spell checker on/off'));
     }]);

--- a/scripts/apps/authoring/styles/themes.scss
+++ b/scripts/apps/authoring/styles/themes.scss
@@ -112,7 +112,8 @@ body, html {
     .icn-btn {
         margin-inline-start: 3px;
     }
-    .proofread-toggle {
+    .proofread-toggle,
+    .spellchecker-toggle {
         &:hover {
             background-color: rgba(152, 152, 152, 0.3);
         }

--- a/scripts/apps/authoring/views/authoring-topbar.html
+++ b/scripts/apps/authoring/views/authoring-topbar.html
@@ -362,20 +362,17 @@
                     <li ng-if="!useTansaProofing()" class="dropdown__menu-item--no-link">
                       <span class="pull-right"
                           sd-switch
-                          ng-model="spellcheckMenu.isAuto"
-                          ng-change="spellcheckMenu.pushSettings()"
+                          ng-model="spellcheck.isAutoSpellchecker"
+                          ng-change="spellcheck.toggleSpellcheckerStatus(spellcheck.isAutoSpellchecker)"
                           ng-hide="getSpellchecker(item.language) == null"
-                          tooltip="{{ spellcheckMenu.isAuto ? 'Spell checking ON' : 'Spell checking OFF'  | translate }}"
+                          tooltip="{{ spellcheck.isAutoSpellchecker ? 'Spell checking ON' : 'Spell checking OFF'  | translate }}"
                           tooltip-placement="left"></span>
                       <span translate>Run automatically</span>
                     </li>
                     <li ng-if="!useTansaProofing()">
                         <button type="button"
                             ng-click="spellcheckMenu.runSpellchecker()"
-                            ng-disabled="spellcheckMenu.isAuto"
-                            sd-hotkey="ctrl+shift+y"
-                            sd-hotkey-options="{global: true}">
-                              <span class="shortcut pull-right">Ctrl+Shift+Y</span>
+                            ng-disabled="spellcheck.isAutoSpellchecker">
                               <span translate>Check spelling</span>
                         </button>
                     </li>

--- a/scripts/apps/authoring/views/authoring.html
+++ b/scripts/apps/authoring/views/authoring.html
@@ -33,6 +33,13 @@
                                 title="{{:: 'Toggle theme' | translate}}">
                                 <i class="icon-adjust"></i>
                             </button>
+                            <button class="spellchecker-toggle icn-btn"
+                                ng-if="isSpellcheckerAvailable()"
+                                ng-class="{active: spellcheck.isAutoSpellchecker}"
+                                ng-click="toggleSpellchecker()"
+                                title="{{ (spellcheck.isAutoSpellchecker ? 'Spell checker on' : 'Spell checker off') | translate }} ({{spellcheckShortcutLabel}})">
+                                <i class="icon-font"></i>
+                            </button>
                             <span sd-theme-select
                                 ng-if="proofread"
                                 data-key="proofreadTheme"></span>

--- a/scripts/core/editor3/CustomEditorControls.ts
+++ b/scripts/core/editor3/CustomEditorControls.ts
@@ -1,54 +1,12 @@
 import React from 'react';
 import {appConfig} from 'appConfig';
-import {isMacOS} from 'core/utils';
 import {logger} from 'core/services/logger';
 import {
     IShortcutConfig,
     ICustomInlineStyle,
     ICharacterInsertion,
-    KeyModifier,
 } from 'superdesk-api';
-
-const SPECIAL_KEY_LABELS: Record<string, string> = {
-    ' ': 'Space',
-    'arrowup': 'Up',
-    'arrowdown': 'Down',
-    'arrowleft': 'Left',
-    'arrowright': 'Right',
-};
-
-/**
- * Maps KeyboardEvent.code (physical key) to the base character the key
- * represents without modifiers. This is needed because on macOS, Alt/Option
- * modifies e.key to produce alternate characters (e.g. Option+- → '–'),
- * making e.key unreliable for shortcut matching when Alt is a modifier.
- */
-function physicalKeyToChar(code: string): string | null {
-    if (code.startsWith('Digit')) {
-        return code.charAt(5).toLowerCase();
-    }
-
-    if (code.startsWith('Key')) {
-        return code.charAt(3).toLowerCase();
-    }
-
-    const codeMap: Record<string, string> = {
-        Minus: '-',
-        Equal: '=',
-        Space: ' ',
-        BracketLeft: '[',
-        BracketRight: ']',
-        Backslash: '\\',
-        Semicolon: ';',
-        Quote: "'", // eslint-disable-line
-        Comma: ',',
-        Period: '.',
-        Slash: '/',
-        Backquote: '`',
-    };
-
-    return codeMap[code] ?? null;
-}
+import {eventToShortcutKeys, formatShortcut, shortcutToKey} from './helpers/shortcuts';
 
 export interface IEditorControl {
     id: string;
@@ -153,7 +111,7 @@ class CustomEditorControlsClass {
             return;
         }
 
-        const key = this.shortcutToKey(shortcut);
+        const key = shortcutToKey(shortcut);
 
         if (this.keyBindings.has(key)) {
             const existing = this.keyBindings.get(key);
@@ -164,15 +122,6 @@ class CustomEditorControlsClass {
         }
 
         this.keyBindings.set(key, control);
-    }
-
-    private shortcutToKey(shortcut: IShortcutConfig): string {
-        const normalizedModifiers = shortcut.modifiers
-            .map((m) => (m === 'primary' ? (isMacOS() ? 'cmd' : 'ctrl') : m))
-            .sort()
-            .join('+');
-
-        return `${normalizedModifiers}+${shortcut.key.toLowerCase()}`;
     }
 
     getAllFeatures(): Array<IEditorControl> {
@@ -201,36 +150,12 @@ class CustomEditorControlsClass {
     matchKeyBinding(e: KeyboardEvent | React.KeyboardEvent): IEditorControl | null {
         this.initialize();
 
-        const modifiers: Array<KeyModifier> = [];
+        for (const key of eventToShortcutKeys(e)) {
+            const match = this.keyBindings.get(key);
 
-        if (isMacOS()) {
-            if (e.metaKey) modifiers.push('cmd');
-            if (e.ctrlKey) modifiers.push('ctrl');
-        } else {
-            if (e.ctrlKey) modifiers.push('ctrl');
-            if (e.metaKey) modifiers.push('cmd');
-        }
-        if (e.altKey) modifiers.push('alt');
-        if (e.shiftKey) modifiers.push('shift');
-
-        const modifierPrefix = modifiers.sort().join('+');
-
-        // Try e.key first (the character produced by the keypress)
-        const match = this.keyBindings.get(`${modifierPrefix}+${e.key.toLowerCase()}`);
-
-        if (match) return match;
-
-        // On macOS, Alt/Option modifies e.key (e.g. Option+- → '–' instead of '-').
-        // Fall back to the physical key via e.code so shortcuts still match.
-        // React 16 SyntheticKeyboardEvent does not expose e.code, so we read it
-        // from the native event when available.
-        const code = (e as KeyboardEvent).code ?? (e as React.KeyboardEvent).nativeEvent?.code;
-        const physicalKey = code != null ? physicalKeyToChar(code) : null;
-
-        if (physicalKey != null) {
-            const physicalMatch = this.keyBindings.get(`${modifierPrefix}+${physicalKey}`);
-
-            if (physicalMatch) return physicalMatch;
+            if (match) {
+                return match;
+            }
         }
 
         return null;
@@ -261,28 +186,7 @@ class CustomEditorControlsClass {
     }
 
     formatShortcut(shortcut: IShortcutConfig): string {
-        const mac = isMacOS();
-
-        const parts = shortcut.modifiers.map((m) => {
-            switch (m) {
-                case 'primary':
-                    return mac ? 'Cmd' : 'Ctrl';
-                case 'alt':
-                    return mac ? 'Option' : 'Alt';
-                case 'shift':
-                    return 'Shift';
-                case 'ctrl':
-                    return 'Ctrl';
-                case 'cmd':
-                    return 'Cmd';
-                default:
-                    return m;
-            }
-        });
-
-        const keyLabel = SPECIAL_KEY_LABELS[shortcut.key] ?? shortcut.key.toUpperCase();
-
-        return [...parts, keyLabel].join('+');
+        return formatShortcut(shortcut);
     }
 }
 

--- a/scripts/core/editor3/helpers/shortcuts.spec.ts
+++ b/scripts/core/editor3/helpers/shortcuts.spec.ts
@@ -1,0 +1,147 @@
+import {IShortcutConfig} from 'superdesk-api';
+import {
+    physicalKeyToChar,
+    shortcutToKey,
+    eventToShortcutKeys,
+    matchesShortcut,
+    formatShortcut,
+} from './shortcuts';
+
+function keyEvent(overrides: Partial<KeyboardEvent>): KeyboardEvent {
+    return {
+        key: '',
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        ...overrides,
+    } as unknown as KeyboardEvent;
+}
+
+// karma runs in Chrome on Linux, so isMacOS() is false by default. Shadow
+// navigator.userAgent to exercise the macOS branches, restoring afterwards.
+function withPlatform(mac: boolean, fn: () => void): void {
+    const original = navigator.userAgent;
+
+    Object.defineProperty(window.navigator, 'userAgent', {
+        value: mac
+            ? 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
+            : 'Mozilla/5.0 (X11; Linux x86_64)',
+        configurable: true,
+    });
+
+    try {
+        fn();
+    } finally {
+        Object.defineProperty(window.navigator, 'userAgent', {value: original, configurable: true});
+    }
+}
+
+describe('editor3 shortcut helpers', () => {
+    describe('physicalKeyToChar', () => {
+        it('maps letter, digit and punctuation codes to their base character', () => {
+            expect(physicalKeyToChar('KeyS')).toBe('s');
+            expect(physicalKeyToChar('Digit3')).toBe('3');
+            expect(physicalKeyToChar('Minus')).toBe('-');
+            expect(physicalKeyToChar('Space')).toBe(' ');
+        });
+
+        it('returns null for keys it does not know', () => {
+            expect(physicalKeyToChar('F7')).toBe(null);
+        });
+    });
+
+    describe('shortcutToKey', () => {
+        it('normalizes and sorts modifiers', () => {
+            expect(shortcutToKey({key: 's', modifiers: ['alt']})).toBe('alt+s');
+            expect(shortcutToKey({key: '-', modifiers: ['shift', 'alt']})).toBe('alt+shift+-');
+        });
+
+        it('resolves "primary" per platform', () => {
+            withPlatform(false, () => {
+                expect(shortcutToKey({key: 's', modifiers: ['primary']})).toBe('ctrl+s');
+            });
+            withPlatform(true, () => {
+                expect(shortcutToKey({key: 's', modifiers: ['primary']})).toBe('cmd+s');
+            });
+        });
+    });
+
+    describe('eventToShortcutKeys', () => {
+        it('includes the physical-key fallback alongside the character key', () => {
+            const keys = eventToShortcutKeys(keyEvent({key: 's', altKey: true, code: 'KeyS'}));
+
+            expect(keys).toContain('alt+s');
+        });
+
+        it('derives the key from e.code when e.key is a produced character (macOS Option)', () => {
+            // On macOS Option+S yields 'ß' as e.key; e.code stays 'KeyS'.
+            const keys = eventToShortcutKeys(keyEvent({key: 'ß', altKey: true, code: 'KeyS'}));
+
+            expect(keys).toContain('alt+s');
+        });
+    });
+
+    describe('matchesShortcut', () => {
+        it('matches Alt+S on Windows/Linux', () => {
+            expect(
+                matchesShortcut({key: 's', modifiers: ['alt']}, keyEvent({key: 's', altKey: true, code: 'KeyS'})),
+            ).toBe(true);
+        });
+
+        it('matches Option+S on macOS via the physical key even though e.key is "ß"', () => {
+            expect(
+                matchesShortcut({key: 's', modifiers: ['alt']}, keyEvent({key: 'ß', altKey: true, code: 'KeyS'})),
+            ).toBe(true);
+        });
+
+        it('does not match when an extra modifier is held', () => {
+            expect(
+                matchesShortcut(
+                    {key: 's', modifiers: ['alt']},
+                    keyEvent({key: 's', altKey: true, ctrlKey: true, code: 'KeyS'}),
+                ),
+            ).toBe(false);
+        });
+
+        it('does not match a different key', () => {
+            expect(
+                matchesShortcut({key: 's', modifiers: ['alt']}, keyEvent({key: 'a', altKey: true, code: 'KeyA'})),
+            ).toBe(false);
+        });
+
+        it('resolves "primary" to Ctrl off macOS and Cmd on macOS', () => {
+            const primary: IShortcutConfig = {key: 's', modifiers: ['primary']};
+
+            withPlatform(false, () => {
+                expect(matchesShortcut(primary, keyEvent({key: 's', ctrlKey: true, code: 'KeyS'}))).toBe(true);
+            });
+            withPlatform(true, () => {
+                expect(matchesShortcut(primary, keyEvent({key: 's', metaKey: true, code: 'KeyS'}))).toBe(true);
+            });
+        });
+    });
+
+    describe('formatShortcut', () => {
+        it('renders Windows/Linux labels', () => {
+            withPlatform(false, () => {
+                expect(formatShortcut({key: 's', modifiers: ['alt']})).toBe('Alt+S');
+                expect(formatShortcut({key: 's', modifiers: ['alt', 'shift']})).toBe('Alt+Shift+S');
+                expect(formatShortcut({key: 's', modifiers: ['primary']})).toBe('Ctrl+S');
+            });
+        });
+
+        it('renders macOS labels', () => {
+            withPlatform(true, () => {
+                expect(formatShortcut({key: 's', modifiers: ['alt']})).toBe('Option+S');
+                expect(formatShortcut({key: 's', modifiers: ['primary']})).toBe('Cmd+S');
+            });
+        });
+
+        it('uses friendly labels for special keys', () => {
+            withPlatform(false, () => {
+                expect(formatShortcut({key: ' ', modifiers: ['primary', 'alt', 'shift']})).toBe('Ctrl+Alt+Shift+Space');
+            });
+        });
+    });
+});

--- a/scripts/core/editor3/helpers/shortcuts.ts
+++ b/scripts/core/editor3/helpers/shortcuts.ts
@@ -1,0 +1,122 @@
+import React from 'react';
+import {isMacOS} from 'core/utils';
+import {IShortcutConfig, KeyModifier} from 'superdesk-api';
+
+const SPECIAL_KEY_LABELS: Record<string, string> = {
+    ' ': 'Space',
+    'arrowup': 'Up',
+    'arrowdown': 'Down',
+    'arrowleft': 'Left',
+    'arrowright': 'Right',
+};
+
+/**
+ * Maps KeyboardEvent.code (physical key) to the base character the key
+ * represents without modifiers. This is needed because on macOS, Alt/Option
+ * modifies e.key to produce alternate characters (e.g. Option+S → 'ß'),
+ * making e.key unreliable for shortcut matching when Alt is a modifier.
+ */
+export function physicalKeyToChar(code: string): string | null {
+    if (code.startsWith('Digit')) {
+        return code.charAt(5).toLowerCase();
+    }
+
+    if (code.startsWith('Key')) {
+        return code.charAt(3).toLowerCase();
+    }
+
+    const codeMap: Record<string, string> = {
+        Minus: '-',
+        Equal: '=',
+        Space: ' ',
+        BracketLeft: '[',
+        BracketRight: ']',
+        Backslash: '\\',
+        Semicolon: ';',
+        Quote: "'", // eslint-disable-line
+        Comma: ',',
+        Period: '.',
+        Slash: '/',
+        Backquote: '`',
+    };
+
+    return codeMap[code] ?? null;
+}
+
+/**
+ * Normalizes a shortcut into a canonical string key, resolving `primary` to the
+ * platform modifier (cmd on macOS, ctrl elsewhere).
+ */
+export function shortcutToKey(shortcut: IShortcutConfig): string {
+    const normalizedModifiers = shortcut.modifiers
+        .map((m) => (m === 'primary' ? (isMacOS() ? 'cmd' : 'ctrl') : m))
+        .sort()
+        .join('+');
+
+    return `${normalizedModifiers}+${shortcut.key.toLowerCase()}`;
+}
+
+/**
+ * Builds the canonical modifier+key string for a keyboard event. When the
+ * character produced by the event does not match (macOS Alt/Option case), the
+ * physical key (via e.code) is used as a fallback.
+ */
+export function eventToShortcutKeys(e: KeyboardEvent | React.KeyboardEvent): Array<string> {
+    const modifiers: Array<KeyModifier> = [];
+
+    if (e.ctrlKey) modifiers.push('ctrl');
+    if (e.metaKey) modifiers.push('cmd');
+    if (e.altKey) modifiers.push('alt');
+    if (e.shiftKey) modifiers.push('shift');
+
+    const modifierPrefix = modifiers.sort().join('+');
+    const keys = [`${modifierPrefix}+${e.key.toLowerCase()}`];
+
+    const code = (e as KeyboardEvent).code ?? (e as React.KeyboardEvent).nativeEvent?.code;
+    const physicalKey = code != null ? physicalKeyToChar(code) : null;
+
+    if (physicalKey != null) {
+        keys.push(`${modifierPrefix}+${physicalKey}`);
+    }
+
+    return keys;
+}
+
+/**
+ * Returns true when the keyboard event matches the configured shortcut, robust
+ * across platforms (handles the macOS Option-produces-a-character case).
+ */
+export function matchesShortcut(shortcut: IShortcutConfig, e: KeyboardEvent | React.KeyboardEvent): boolean {
+    const target = shortcutToKey(shortcut);
+
+    return eventToShortcutKeys(e).includes(target);
+}
+
+/**
+ * Human-readable, platform-aware label for a shortcut (e.g. "Option+S" on macOS,
+ * "Alt+S" elsewhere).
+ */
+export function formatShortcut(shortcut: IShortcutConfig): string {
+    const mac = isMacOS();
+
+    const parts = shortcut.modifiers.map((m) => {
+        switch (m) {
+            case 'primary':
+                return mac ? 'Cmd' : 'Ctrl';
+            case 'alt':
+                return mac ? 'Option' : 'Alt';
+            case 'shift':
+                return 'Shift';
+            case 'ctrl':
+                return 'Ctrl';
+            case 'cmd':
+                return 'Cmd';
+            default:
+                return m;
+        }
+    });
+
+    const keyLabel = SPECIAL_KEY_LABELS[shortcut.key] ?? shortcut.key.toUpperCase();
+
+    return [...parts, keyLabel].join('+');
+}

--- a/scripts/core/spellcheck/spellcheck-shortcut.spec.ts
+++ b/scripts/core/spellcheck/spellcheck-shortcut.spec.ts
@@ -1,0 +1,57 @@
+import {appConfig} from 'appConfig';
+import {
+    getSpellcheckShortcut,
+    getSpellcheckShortcutLabel,
+    matchesSpellcheckShortcut,
+} from './spellcheck-shortcut';
+
+function keyEvent(overrides: Partial<KeyboardEvent>): KeyboardEvent {
+    return {
+        key: '',
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        ...overrides,
+    } as unknown as KeyboardEvent;
+}
+
+describe('spellcheck-shortcut', () => {
+    let originalSpellchecking: typeof appConfig.spellchecking;
+
+    beforeEach(() => {
+        originalSpellchecking = appConfig.spellchecking;
+    });
+
+    afterEach(() => {
+        appConfig.spellchecking = originalSpellchecking;
+    });
+
+    it('defaults to Alt+S when no shortcut is configured', () => {
+        appConfig.spellchecking = {};
+
+        expect(getSpellcheckShortcut()).toEqual({key: 's', modifiers: ['alt']});
+        expect(getSpellcheckShortcutLabel()).toBe('Alt+S');
+    });
+
+    it('uses the configured shortcut when present', () => {
+        appConfig.spellchecking = {shortcut: {key: 's', modifiers: ['alt', 'shift']}};
+
+        expect(getSpellcheckShortcut()).toEqual({key: 's', modifiers: ['alt', 'shift']});
+        expect(getSpellcheckShortcutLabel()).toBe('Alt+Shift+S');
+    });
+
+    it('matches the default Alt+S event', () => {
+        appConfig.spellchecking = {};
+
+        expect(matchesSpellcheckShortcut(keyEvent({key: 's', altKey: true, code: 'KeyS'}))).toBe(true);
+        expect(matchesSpellcheckShortcut(keyEvent({key: 's', altKey: true, shiftKey: true, code: 'KeyS'}))).toBe(false);
+    });
+
+    it('matches the configured override and not the old default', () => {
+        appConfig.spellchecking = {shortcut: {key: 's', modifiers: ['alt', 'shift']}};
+
+        expect(matchesSpellcheckShortcut(keyEvent({key: 's', altKey: true, shiftKey: true, code: 'KeyS'}))).toBe(true);
+        expect(matchesSpellcheckShortcut(keyEvent({key: 's', altKey: true, code: 'KeyS'}))).toBe(false);
+    });
+});

--- a/scripts/core/spellcheck/spellcheck-shortcut.ts
+++ b/scripts/core/spellcheck/spellcheck-shortcut.ts
@@ -1,0 +1,20 @@
+import {appConfig} from 'appConfig';
+import {IShortcutConfig} from 'superdesk-api';
+import {formatShortcut, matchesShortcut} from 'core/editor3/helpers/shortcuts';
+
+const DEFAULT_SPELLCHECK_SHORTCUT: IShortcutConfig = {
+    key: 's',
+    modifiers: ['alt'],
+};
+
+export function getSpellcheckShortcut(): IShortcutConfig {
+    return appConfig.spellchecking?.shortcut ?? DEFAULT_SPELLCHECK_SHORTCUT;
+}
+
+export function getSpellcheckShortcutLabel(): string {
+    return formatShortcut(getSpellcheckShortcut());
+}
+
+export function matchesSpellcheckShortcut(e: KeyboardEvent): boolean {
+    return matchesShortcut(getSpellcheckShortcut(), e);
+}

--- a/scripts/core/spellcheck/spellcheck.ts
+++ b/scripts/core/spellcheck/spellcheck.ts
@@ -11,8 +11,8 @@ import {ISuperdeskGlobalConfig} from 'superdesk-api';
  * Spellcheck module
  */
 SpellcheckService.$inject =
-    ['$q', 'api', 'dictionaries', '$rootScope', '$location', 'lodash', 'preferencesService', 'editorResolver'];
-function SpellcheckService($q, api, dictionaries, $rootScope, $location, _, preferencesService, editorResolver) {
+    ['$q', 'api', 'dictionaries', '$rootScope', '$location', 'lodash', 'preferencesService', '$injector'];
+function SpellcheckService($q, api, dictionaries, $rootScope, $location, _, preferencesService, $injector) {
     var PREFERENCES_KEY = 'spellchecker:status',
         lang = userInterfaceLanguage,
         dict = {} as any,
@@ -514,7 +514,11 @@ function SpellcheckService($q, api, dictionaries, $rootScope, $location, _, pref
      */
     this.toggleSpellcheckerStatus = function toggleSpellcheckerStatus(explicit) {
         const enabled = explicit != null ? explicit : !self.isAutoSpellchecker;
-        const editor = editorResolver.get();
+
+        // Resolved lazily so the spellcheck service does not hard-depend on the editor3 module
+        // (editor3 already depends on spellcheck; a constructor dependency would be circular).
+        const editorResolver = $injector.has('editorResolver') ? $injector.get('editorResolver') : null;
+        const editor = editorResolver != null ? editorResolver.get() : null;
 
         if (editor != null) {
             editor.setSettings({spellcheck: enabled, language: lang});

--- a/scripts/core/spellcheck/spellcheck.ts
+++ b/scripts/core/spellcheck/spellcheck.ts
@@ -10,8 +10,9 @@ import {ISuperdeskGlobalConfig} from 'superdesk-api';
 /**
  * Spellcheck module
  */
-SpellcheckService.$inject = ['$q', 'api', 'dictionaries', '$rootScope', '$location', 'lodash', 'preferencesService'];
-function SpellcheckService($q, api, dictionaries, $rootScope, $location, _, preferencesService) {
+SpellcheckService.$inject =
+    ['$q', 'api', 'dictionaries', '$rootScope', '$location', 'lodash', 'preferencesService', 'editorResolver'];
+function SpellcheckService($q, api, dictionaries, $rootScope, $location, _, preferencesService, editorResolver) {
     var PREFERENCES_KEY = 'spellchecker:status',
         lang = userInterfaceLanguage,
         dict = {} as any,
@@ -505,6 +506,24 @@ function SpellcheckService($q, api, dictionaries, $rootScope, $location, _, pref
         };
 
         preferencesService.update(updates, PREFERENCES_KEY);
+    };
+
+    /**
+     * Toggle the spell checker on/off, re-render the current editor and persist the status.
+     * Shared by the authoring header toggle, the keyboard shortcut and the "..." menu switch.
+     */
+    this.toggleSpellcheckerStatus = function toggleSpellcheckerStatus(explicit) {
+        const enabled = explicit != null ? explicit : !self.isAutoSpellchecker;
+        const editor = editorResolver.get();
+
+        if (editor != null) {
+            editor.setSettings({spellcheck: enabled, language: lang});
+            editor.render();
+        }
+
+        self.setSpellcheckerStatus(enabled);
+
+        return enabled;
     };
 
     this.getInitialSpellcheckerStatus(lang).then((status) => {

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -3961,6 +3961,9 @@ declare module 'superdesk-api' {
                     runningMode?: 'remember-user-preference' | 'initially-disabled';
                 };
             };
+
+            // toggles the spell checker on/off; defaults to Alt+S
+            shortcut?: IShortcutConfig;
         }
 
         iMatricsFields: {


### PR DESCRIPTION
### Purpose
This PR add a dedicated spell checker toggle button in the authoring header, next to the proof-read theme toggle, and gives it a simple, configurable keyboard shortcut.

### What has changed
- Added a spell checker toggle button in the header (icon-font "A" glyph) with an active/dark state when on.
- Added a shortcut to toggle spell checking, defaulting to `Alt/Option+S`, configurable via `spellchecking.shortcut`.
- The button, shortcut, and "…" menu switch now share the same `spellcheck` service state.
- Dropped the old `Ctrl+Shift+Y` alias.
- Extracted shared cross-platform shortcut helpers and added unit tests.

### Steps to test
1. Open a story in the authoring view.
2. Click the spell checker button in the header — the button darkens (active) and spell checking turns on; click again to turn it off.
3. Press `Alt/Option+S` — it toggles the same state and the button reflects it.
4. Optionally set `spellchecking.shortcut` in the config (e.g. `{key: 's', modifiers: ['alt', 'shift']}`) and confirm the new shortcut works and the tooltip label updates.

### Screenshots
#### While Inactive
<img width="791" height="140" alt="2026-07-24_17-14-47" src="https://github.com/user-attachments/assets/ca6247b1-b769-4974-be94-6bc4e9820160" />

#### While Active
<img width="795" height="126" alt="2026-07-24_17-14-27" src="https://github.com/user-attachments/assets/9d7ed2ae-f421-4b3b-a7c6-63d1eda3ddf8" />

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: https://sofab.atlassian.net/browse/STT-1694
