### PR TITLE
Fix release/3.5 e2e server build

### DIFF
--- a/e2e/client/playwright/user-profile.spec.ts
+++ b/e2e/client/playwright/user-profile.spec.ts
@@ -1,8 +1,6 @@
 import {test, expect} from '@playwright/test';
 import {restoreDatabaseSnapshot, s} from './utils';
 
-test.setTimeout(10000);
-
 const MAILCRAB = 'http://localhost:1080';
 
 test('switching system language', async ({page}) => {
@@ -18,7 +16,6 @@ test('switching system language', async ({page}) => {
     await page.locator(s('action-bar')).locator('[data-test-id="save"]').click();
     await page.getByRole('dialog').getByRole('button', {name: 'Confirm'}).click();
 
-    // timeout needed due to page reload
     await expect(page.locator(s('page-title'))).toHaveText('Mein Profil');
 });
 
@@ -87,26 +84,54 @@ test('can reset password', async ({page}) => {
     await page.locator(s('my-profile-dropdown')).getByRole('button', {name: 'Sign Out'}).click();
     await page.locator(s('login-page')).getByRole('link', {name: 'Forgot password?'}).click();
     await page.getByPlaceholder('Email').fill('admin@example.com');
+
+    // The next click triggers a POST that we must let finish before
+    // navigating — otherwise page.request cancels it and no email is sent.
+    const resetRequest = page.waitForResponse(
+        (resp) => resp.url().includes('/api/reset_user_password') && resp.request().method() === 'POST',
+    );
+
+    // Snapshot inbox so we can identify the email this run produced.
+    // Resetting admin's password invalidates every prior admin token, so
+    // picking a stale email between retries means the token won't validate.
+    const initialMessages = await page.request.get(`${MAILCRAB}/api/messages`)
+        .then((r) => r.json() as Promise<Array<{id: string}>>);
+
     await page.getByRole('button', {name: 'Get token'}).click();
+    await resetRequest;
 
-    // Navigate to MailCrab to get the reset email
-    await page.goto(MAILCRAB);
-    await page.getByRole('listitem')
-        .filter({hasText: 'Reset password'})
-        .first()
-        .click();
+    let newMessageId: string | null = null;
 
-    // Extract the password reset link from the iFrame email content
-    const resetPasswordLink = await page.frameLocator('iFrame')
-        .locator('p:has-text("Please use this link") a')
-        .getAttribute('href');
+    await expect.poll(async () => {
+        const messages = await page.request.get(`${MAILCRAB}/api/messages`)
+            .then((r) => r.json() as Promise<Array<{id: string; subject: string; date: string}>>);
+        const fresh = messages
+            .filter((m) => !initialMessages.find((seen) => seen.id === m.id))
+            .filter((m) => m.subject === 'Reset password')
+            .sort((a, b) => b.date.localeCompare(a.date));
 
-    if (!resetPasswordLink) throw new Error('Reset link was not found in the iFrame');
+        if (fresh.length > 0) {
+            newMessageId = fresh[0].id;
+            return true;
+        }
+        return false;
+    }, {timeout: 20000, message: 'No new reset-password email arrived in MailCrab'}).toBe(true);
+
+    const message = await page.request.get(`${MAILCRAB}/api/message/${newMessageId}`)
+        .then((r) => r.json() as Promise<{text: string}>);
+    const linkMatch = message.text.match(/(https?:\/\/[^\s]+reset-password[^\s]+)/);
+
+    if (!linkMatch) throw new Error('Reset link was not found in the email body');
+    const resetPasswordLink = linkMatch[1];
 
     await page.goto(resetPasswordLink);
 
-    // Reset password
-    await page.locator('form[name="resetForm"] input[name="password"]').fill('admin123.');
+    // The form is hidden until the controller validates the token via an
+    // async POST and flips flowStep to 3.
+    const passwordInput = page.locator('form[name="resetForm"] input[name="password"]');
+
+    await expect(passwordInput).toBeVisible({timeout: 10000});
+    await passwordInput.fill('admin123.');
     await page.locator('form[name="resetForm"] input[name="passwordConfirm"]').fill('admin123.');
     await page.getByRole('button', {name: 'Reset password'}).click();
 

--- a/e2e/server/Dockerfile
+++ b/e2e/server/Dockerfile
@@ -2,17 +2,20 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-python3 python3-dev python3-pip python3-venv git gcc curl \
-# lxml
-libxml2-dev libxslt-dev \
-# xmlsec
-pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl \
-# PIL
-libjpeg-dev zlib1g-dev \
-# magic
-libmagic-dev \
-&& rm -rf /var/lib/apt/lists/*
+RUN rm -rf /var/lib/apt/lists/* && \
+    apt-get clean && \
+    apt-get update -o Acquire::Retries=5 && \
+    apt-get install -y --no-install-recommends \
+    python3 python3-dev python3-pip python3-venv git gcc curl \
+    # lxml
+    libxml2-dev libxslt-dev \
+    # xmlsec
+    pkg-config libxmlsec1-dev libxmlsec1-openssl \
+    # PIL
+    libjpeg-dev zlib1g-dev \
+    # magic
+    libmagic-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # setup venv
 ENV VIRTUAL_ENV=/opt/venv

--- a/e2e/server/requirements.txt
+++ b/e2e/server/requirements.txt
@@ -65,7 +65,7 @@ botocore==1.37.3
     #   s3transfer
 cachetools==6.2.0
     # via flask-oidc-ex
-celery[redis]==5.4.0
+celery[redis]==5.6.2
     # via superdesk-core
 cerberus==1.3.7
     # via
@@ -186,7 +186,7 @@ jwcrypto==1.5.6
     # via
     #   flask-oidc-ex
     #   python-jwt
-kombu==5.5.4
+kombu==5.6.0
     # via
     #   celery
     #   superdesk-core


### PR DESCRIPTION
### Purpose
Fix the e2e CI on `release/3.5`.

### What has changed
Backported minimal fixes from `develop`:
- **#5187** — bump `celery` `5.4.0 → 5.6.2` and `kombu` `5.5.4 → 5.6.0` to match superdesk-core's constraint (fixes the `pip install` failure).
- **#5152** — harden the apt step in the e2e `Dockerfile`.
- **reset-password test** (from #5182) — poll MailCrab's API and await the reset POST instead of scraping the email iframe, which timed out because the request was cancelled before the email was sent.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
