### PR TITLE
Upgrade superdesk-ui-framework to 7.0.0-dev3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
         "sass-loader": "^16.0.8",
         "shallow-equal": "^3.1.0",
         "shortid": "2.2.8",
-        "superdesk-ui-framework": "7.0.0-dev1",
+        "superdesk-ui-framework": "7.0.0-dev2",
         "ts-loader": "^8.4.0",
         "typescript": "~4.9.5",
         "uuid": "8.3.1",
@@ -15464,9 +15464,9 @@
       }
     },
     "node_modules/superdesk-ui-framework": {
-      "version": "7.0.0-dev1",
-      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-7.0.0-dev1.tgz",
-      "integrity": "sha512-OvxLn57ASeJQ3fTqIUCxjF+3L690OCav7G68cFV/2YVSGLLPmyERDr5g3SzVa/aC7I+FUnkqqtEoNtKc5acjiw==",
+      "version": "7.0.0-dev2",
+      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-7.0.0-dev2.tgz",
+      "integrity": "sha512-qrOo00GWW771C9qDI2y+yryu7VX6uRSiyGOeRDgKyF59owZf1qtQeGlCbNURJ+E0+E4kDXcIWOkY7pwiCYkJHQ==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@hello-pangea/dnd": "^16.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
         "sass-loader": "^16.0.8",
         "shallow-equal": "^3.1.0",
         "shortid": "2.2.8",
-        "superdesk-ui-framework": "7.0.0-dev2",
+        "superdesk-ui-framework": "7.0.0-dev3",
         "ts-loader": "^8.4.0",
         "typescript": "~4.9.5",
         "uuid": "8.3.1",
@@ -15464,9 +15464,9 @@
       }
     },
     "node_modules/superdesk-ui-framework": {
-      "version": "7.0.0-dev2",
-      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-7.0.0-dev2.tgz",
-      "integrity": "sha512-qrOo00GWW771C9qDI2y+yryu7VX6uRSiyGOeRDgKyF59owZf1qtQeGlCbNURJ+E0+E4kDXcIWOkY7pwiCYkJHQ==",
+      "version": "7.0.0-dev3",
+      "resolved": "https://registry.npmjs.org/superdesk-ui-framework/-/superdesk-ui-framework-7.0.0-dev3.tgz",
+      "integrity": "sha512-hDscOwvXUaY2TyWI839yR0H5MpzvSSJdKqF+QbRafPSsvBQ73ps1UUQ+eOOlnpSRB/TvNAxZDsx38pmsfgi51w==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@hello-pangea/dnd": "^16.6.0",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "sass-loader": "^16.0.8",
     "shallow-equal": "^3.1.0",
     "shortid": "2.2.8",
-    "superdesk-ui-framework": "7.0.0-dev2",
+    "superdesk-ui-framework": "7.0.0-dev3",
     "ts-loader": "^8.4.0",
     "typescript": "~4.9.5",
     "uuid": "8.3.1",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "sass-loader": "^16.0.8",
     "shallow-equal": "^3.1.0",
     "shortid": "2.2.8",
-    "superdesk-ui-framework": "7.0.0-dev1",
+    "superdesk-ui-framework": "7.0.0-dev2",
     "ts-loader": "^8.4.0",
     "typescript": "~4.9.5",
     "uuid": "8.3.1",


### PR DESCRIPTION
This pull request includes a minor dependency update in the `package.json` file, upgrading the `superdesk-ui-framework` package from version `7.0.0-dev1` to `7.0.0-dev3`.