### PR TITLE
[SDESK-7955] Preserve authoring view when toggling full width

### DIFF
--- a/e2e/client/playwright/full-width-toggle.authoring-react.spec.ts
+++ b/e2e/client/playwright/full-width-toggle.authoring-react.spec.ts
@@ -1,0 +1,52 @@
+import {test, expect} from '@playwright/test';
+import {Authoring} from './page-object-models/authoring';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+import {getStorageState} from './utils/storage-state';
+import {setEditor3FieldValue} from './utils/editor3';
+
+test.use({
+    storageState: getStorageState({}, {authoringReact: true}),
+});
+
+test.describe('full width toggle in authoring-react', () => {
+    const BODY = 'unsaved body that must survive';
+
+    test('keeps unsaved article content that was never autosaved', async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        // Failing every autosave leaves no server-side copy, so surviving text can
+        // only mean the editor kept its in-memory state across the toggle. It also
+        // covers the toolbar flushing autosave before it toggles, which must not
+        // leave the button waiting on a request that never succeeds.
+        await page.route('**/archive_autosave**', (route) => route.abort());
+
+        const monitoring = new Monitoring(page);
+        const authoring = new Authoring(page);
+
+        await page.goto('/#/workspace/monitoring');
+        await monitoring.selectDeskOrWorkspace('Sports');
+        await monitoring.createArticleFromDefaultTemplate();
+
+        await authoring.waitForAuthoringReactToInitialize();
+
+        const body = page.getByTestId('authoring')
+            .getByTestId('authoring-field')
+            .and(page.locator('[data-test-value="body_html"]'))
+            .getByRole('textbox');
+
+        await expect(body).toBeVisible();
+        await setEditor3FieldValue(body, BODY);
+
+        const toggleFullWidth = page.getByTestId('toggle-full-width');
+        const mainContainer = page.locator('#main-container');
+
+        await toggleFullWidth.click();
+        await expect(mainContainer).toHaveClass(/hideMonitoring/);
+        await expect(body).toHaveText(BODY);
+
+        await toggleFullWidth.click();
+        await expect(mainContainer).not.toHaveClass(/hideMonitoring/);
+        await expect(body).toHaveText(BODY);
+    });
+});

--- a/e2e/client/playwright/full-width-toggle.spec.ts
+++ b/e2e/client/playwright/full-width-toggle.spec.ts
@@ -1,0 +1,38 @@
+import {test, expect} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+
+test.describe('full width toggle in authoring', () => {
+    const HEADLINE = 'unsaved headline that must survive';
+
+    test('keeps unsaved article content that was never autosaved', async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        // Failing every autosave leaves no server-side copy, so surviving text can
+        // only mean the editor kept its in-memory state across the toggle.
+        await page.route('**/archive_autosave**', (route) => route.abort());
+
+        const monitoring = new Monitoring(page);
+
+        await page.goto('/#/workspace/monitoring');
+        await monitoring.selectDeskOrWorkspace('Sports');
+        await monitoring.createArticleFromDefaultTemplate();
+
+        const headline = page.getByTestId('field--headline').getByRole('textbox');
+
+        await expect(headline).toBeVisible();
+        await headline.fill(HEADLINE);
+        await expect(headline).toHaveText(HEADLINE);
+
+        const toggleFullWidth = page.getByTestId('authoring-topbar').getByTestId('toggle-full-width');
+        const mainContainer = page.locator('#main-container');
+
+        await toggleFullWidth.click();
+        await expect(mainContainer).toHaveClass(/hideMonitoring/);
+        await expect(headline).toHaveText(HEADLINE);
+
+        await toggleFullWidth.click();
+        await expect(mainContainer).not.toHaveClass(/hideMonitoring/);
+        await expect(headline).toHaveText(HEADLINE);
+    });
+});

--- a/e2e/client/playwright/page-object-models/monitoring.ts
+++ b/e2e/client/playwright/page-object-models/monitoring.ts
@@ -110,6 +110,11 @@ export class Monitoring {
         }
     }
 
+    async createArticleFromDefaultTemplate(): Promise<void> {
+        await this.page.getByTestId('content-create').click();
+        await this.page.getByTestId('content-create-dropdown').getByTestId('default-desk-template').click();
+    }
+
     async openMediaUploadView(): Promise<void> {
         await this.page.locator(s('content-create')).click();
         await this.page.locator(s('content-create-dropdown')).getByRole('button', {name: 'Upload media'}).click();

--- a/scripts/apps/authoring-react/auto-save-http.ts
+++ b/scripts/apps/authoring-react/auto-save-http.ts
@@ -1,4 +1,5 @@
 import {httpRequestJsonLocal, httpRequestRawLocal} from 'core/helpers/network';
+import {logger} from 'core/services/logger';
 import {Cancelable, throttle} from 'lodash';
 import {IArticle, IAuthoringAutoSave} from 'superdesk-api';
 import {omitFields} from './data-layer';
@@ -19,6 +20,9 @@ export class AutoSaveHttp implements IAuthoringAutoSave<IArticle> {
                 }).then((res) => {
                     this.autosavePromise = null;
                     callback(res);
+                }).catch((error) => {
+                    this.autosavePromise = null;
+                    logger.error(new Error('Autosave request failed.'), error);
                 });
             },
             delay,

--- a/scripts/apps/authoring/authoring/components/toggleFullWithEditor.tsx
+++ b/scripts/apps/authoring/authoring/components/toggleFullWithEditor.tsx
@@ -23,6 +23,7 @@ export class ToggleFullWidth extends React.Component<IProps> {
                 <button
                     className={classes}
                     onClick={this.props.setFullWidth}
+                    data-test-id="toggle-full-width"
                 >
                     <Icon name="chevron-left-thin" />
                 </button>

--- a/scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringEmbeddedDirective.ts
@@ -4,7 +4,6 @@ import {gettext} from 'core/utils';
 import {appConfig, authoringReactViewEnabled} from 'appConfig';
 import {canPrintPreview} from 'apps/search/helpers';
 import {IFullWidthPageCapabilityConfiguration} from 'superdesk-api';
-import {closedIntentionally} from 'apps/authoring/widgets/widgets';
 
 AuthoringEmbeddedDirective.$inject = ['superdeskFlags', 'api', 'notify', '$filter'];
 export function AuthoringEmbeddedDirective(superdeskFlags, api, notify, $filter) {
@@ -30,9 +29,13 @@ export function AuthoringEmbeddedDirective(superdeskFlags, api, notify, $filter)
             scope.canPrintPreview = canPrintPreview;
             scope.fullWidth = superdeskFlags.flags.hideMonitoring;
             scope.setFullWidth = () => {
-                closedIntentionally.value = true;
                 scope.hideMonitoring(true, new Event('click'));
             };
+
+            // The directive is no longer re-linked on toggle, so mirror the flag instead.
+            scope.$watch(() => superdeskFlags.flags.hideMonitoring, (value) => {
+                scope.fullWidth = value;
+            });
 
             // This function is duplicated from the directive `WorkspaceSidenavDirective.ts`.
             scope.hideMonitoring = function(state, e) {

--- a/scripts/apps/authoring/authoring/directives/AuthoringTopbarDirective.ts
+++ b/scripts/apps/authoring/authoring/directives/AuthoringTopbarDirective.ts
@@ -8,7 +8,6 @@ import {ITEM_STATE} from 'apps/archive/constants';
 import {IArticleActionInteractive} from 'core/interactive-article-actions-panel/interfaces';
 import {IFullWidthPageCapabilityConfiguration} from 'superdesk-api';
 import {sdApi} from 'api';
-import {closedIntentionally} from 'apps/authoring/widgets/widgets';
 import {partition} from 'lodash';
 
 /**
@@ -167,7 +166,6 @@ export function AuthoringTopbarDirective(
 
             scope.setFullWidth = () => {
                 scope.$applyAsync(() => {
-                    closedIntentionally.value = true;
                     scope.hideMonitoring(true, new Event('click'));
                 });
             };

--- a/scripts/core/menu/menu.ts
+++ b/scripts/core/menu/menu.ts
@@ -110,7 +110,15 @@ angular.module('superdesk.core.menu', [
                 }
 
                 this.currentRoute = route;
-                this.flags.workspace = !!route.sideTemplateUrl;
+
+                const isWorkspaceRoute = !!route.sideTemplateUrl;
+
+                // Leaving a workspace route with full width still on would render no container at all.
+                if (!isWorkspaceRoute) {
+                    this.flags.hideMonitoring = false;
+                }
+
+                this.flags.workspace = isWorkspaceRoute;
                 this.flags.workqueue = this.flags.workqueue || true;
             });
 

--- a/scripts/core/menu/views/superdesk-view.html
+++ b/scripts/core/menu/views/superdesk-view.html
@@ -16,20 +16,22 @@
 
 <div class="loading" ng-if="loading"></div>
 
+<!--
+    `renderMonitoring` gates only the monitoring parts. Gating `#main-container` would
+    destroy and rebuild authoring on every full width toggle, losing unsaved changes.
+    It cannot be `!popup` either: popups open a workspace route with `renderMonitoring`
+    false, so that would render nothing at all.
+-->
 <div
     id="main-container"
     ng-class="superdesk.flags"
-    ng-if="renderMonitoring && superdesk.flags.workspace === true"
+    ng-if="superdesk.flags.workspace === true"
 >
-    <div id="workspace-container" ng-view sd-splitter-widget></div>
-    <div id="authoring-container" ng-show="superdesk.flags.authoring" ng-if="superdesk.flags.workspace" sd-authoring-container></div>
-    <div id="superdesk-workqueue" ng-if="superdesk.flags.workspace === true && superdesk.flags.workqueue === true" sd-workqueue></div>
+    <div id="workspace-container" ng-if="renderMonitoring" ng-view sd-splitter-widget></div>
+    <div id="authoring-container" ng-show="superdesk.flags.authoring" sd-authoring-container></div>
+    <div id="superdesk-workqueue" ng-if="renderMonitoring && superdesk.flags.workqueue === true" sd-workqueue></div>
 
     <div ng-if="itemsForExport != null" sd-export></div>
-</div>
-
-<div id="main-container" ng-class="superdesk.flags" ng-if="!renderMonitoring">
-    <div id="authoring-container" sd-authoring-container></div>
 </div>
 
 <div id="main-container" ng-class="superdesk.flags" ng-if="renderMonitoring && superdesk.flags.workspace === false" ng-view></div>


### PR DESCRIPTION
### Purpose

Switching an article to full width (and back) wiped out any changes you had not saved yet. This was reported twice before, SDESK-7340 and SDESK-7341, and both attempts fixed it by flushing autosave before the toggle. That could never satisfy this ticket, which explicitly asks for unsaved *and* non-autosaved changes to survive.

The real cause is older than either ticket. Since #4043 (Jan 2022) the full width flag drove two mutually exclusive `ng-if` blocks in `superdesk-view.html`, and each one had its own `sd-authoring-container`. Toggling destroyed the whole authoring subtree and built a new one, so the editor reloaded from the last saved version. Before that PR the toggle was pure CSS.

### What has changed

`renderMonitoring` now applies to the monitoring parts only, not the whole `#main-container`, so the authoring element survives the toggle. Nothing moves on screen: the existing `.hideMonitoring` CSS already handled the layout, and the resulting DOM matches what the removed block produced.

`!popup` is deliberately left out of the outer condition. Popups open a workspace route with `renderMonitoring` false, so including it would leave an empty window.

Falling out of that:
- Removed the two `closedIntentionally.value = true` writes in the toggle handlers, which only existed to carry widget state through the remount.
- `hideMonitoring` resets when leaving a workspace route, otherwise Back out of full width rendered nothing.
- `AuthoringEmbeddedDirective` mirrors the flag with a watcher, since it is no longer re-linked.
- `AutoSaveHttp.flush()` no longer hangs when an autosave POST fails. One failure left it pending forever and poisoned later flushes, which could kill the toggle button.

### Steps to test

1. Start a new article, type a headline, do not save and do not wait for autosave
2. Toggle full width on, the text should still be there
3. Toggle it back off, still there
4. Worth also checking: open an article in a new window (Actions, open in new window), and browser Back out of full width authoring

Two specs cover 1 to 3, one per editor:
- `full-width-toggle.spec.ts` for the AngularJS editor, still the default
- `full-width-toggle.authoring-react.spec.ts` for authoring-react

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: SDESK-7955
