### PR TITLE
[SDESK-7980] - Image upload dialogue does not clear

### DIFF
--- a/scripts/apps/archive/controllers/UploadController.ts
+++ b/scripts/apps/archive/controllers/UploadController.ts
@@ -9,8 +9,29 @@ import {fileUploadErrorModal} from './file-upload-error-modal';
 import {showModal} from '@sourcefabric/common';
 import {sdApi} from 'api';
 import {getMetadata} from 'apps/archive/parse-metadata';
+import {COMPANION_FIELD_IDS, FIELD_ID_TO_STORED_FIELD} from 'apps/authoring-react/data-layer';
 
 const isNotEmptyString = (value: any) => value != null && value !== '';
+
+/**
+ * Drop synthetic/companion profile fields the archive schema rejects, mirroring `data-layer.ts`:
+ * COMPANION_FIELD_IDS have no backing field; FIELD_ID_TO_STORED_FIELD ids are stored elsewhere.
+ */
+function sanitizeUploadMeta(meta: Partial<IArticle>): Partial<IArticle> {
+    const sanitized: Record<string, any> = {...meta};
+
+    for (const [fieldId, storedField] of Object.entries(FIELD_ID_TO_STORED_FIELD)) {
+        if (sanitized[fieldId] != null && sanitized[storedField] == null) {
+            sanitized[storedField] = sanitized[fieldId];
+        }
+        delete sanitized[fieldId];
+    }
+    for (const fieldId of COMPANION_FIELD_IDS) {
+        delete sanitized[fieldId];
+    }
+
+    return sanitized;
+}
 
 /* eslint-disable complexity */
 
@@ -383,7 +404,7 @@ export function UploadController(
         return $scope.upload().then(() => {
             $q.all(_.map($scope.items, (item) => {
                 archiveService.addTaskToArticle(item.meta, $scope.selectedDesk);
-                return api.archive.update(item.model, item.meta);
+                return api.archive.update(item.model, sanitizeUploadMeta(item.meta));
             })).then((results) => {
                 $scope.resolve(results);
             });

--- a/scripts/apps/archive/controllers/UploadController.ts
+++ b/scripts/apps/archive/controllers/UploadController.ts
@@ -9,7 +9,7 @@ import {fileUploadErrorModal} from './file-upload-error-modal';
 import {showModal} from '@sourcefabric/common';
 import {sdApi} from 'api';
 import {getMetadata} from 'apps/archive/parse-metadata';
-import {COMPANION_FIELD_IDS, FIELD_ID_TO_STORED_FIELD} from 'apps/authoring-react/data-layer';
+import {COMPANION_FIELD_IDS, FIELD_ID_TO_STORED_FIELD} from 'apps/authoring-react/data-layer-constants';
 
 const isNotEmptyString = (value: any) => value != null && value !== '';
 

--- a/scripts/apps/authoring-react/data-layer-constants.ts
+++ b/scripts/apps/authoring-react/data-layer-constants.ts
@@ -1,0 +1,15 @@
+import {IArticle} from 'superdesk-api';
+
+/**
+ * Content-profile field ids that don't map 1:1 to a stored article field. They can be enabled in
+ * profiles but are not part of the `archive` resource schema, so they must not be sent verbatim in
+ * a PATCH or the server rejects the request with "unknown field".
+ *
+ * Kept in a dependency-light module so it can be imported without dragging in the full data-layer.
+ */
+
+// companion/unused fields with no backing data of their own; drop them before saving
+export const COMPANION_FIELD_IDS = ['footer', 'media_description'];
+
+// profile field id -> the article field its value is actually stored in
+export const FIELD_ID_TO_STORED_FIELD: Partial<Record<string, keyof IArticle>> = {sms: 'sms_message'};

--- a/scripts/apps/authoring-react/data-layer.ts
+++ b/scripts/apps/authoring-react/data-layer.ts
@@ -28,6 +28,16 @@ import {description_text} from './field-adapters/description_text';
 import {formatDateTime} from 'core/get-superdesk-api-implementation';
 
 /**
+ * Content-profile field ids that don't map 1:1 to a stored article field. They can be enabled in
+ * profiles but are not part of the `archive` resource schema, so they must not be sent verbatim in
+ * a PATCH or the server rejects the request with "unknown field".
+ */
+// companion/unused fields with no backing data of their own; drop them before saving
+export const COMPANION_FIELD_IDS = ['footer', 'media_description'];
+// profile field id -> the article field its value is actually stored in
+export const FIELD_ID_TO_STORED_FIELD: {[fieldId: string]: keyof IArticle} = {sms: 'sms_message'};
+
+/**
  * Field `section` ('header' | 'content') is an authoring-react concept. Profiles created before it
  * (e.g. the stock "Text" profile) have none, and treating that as an error stopped authoring-react
  * from opening or switching to them. Default to "content" (legacy just rendered such fields) and warn.
@@ -65,14 +75,8 @@ export function getArticleContentProfile<T>(
      * and this restructuring code dropped.
      */
     function adjustId(fieldId: string): string {
-        switch (fieldId) {
-            case 'sms':
-            // in content profile the field ID is "sms"
-            // but value is written to `IArticle['sms_message']`
-                return 'sms_message';
-            default:
-                return fieldId;
-        }
+        // some profile field ids (e.g. "sms") store their value under a different article field
+        return FIELD_ID_TO_STORED_FIELD[fieldId] ?? fieldId;
     }
 
     return Promise.all([
@@ -97,20 +101,12 @@ export function getArticleContentProfile<T>(
             };
         }
 
-        const fieldsToOmit = [
-            /**
-             * Avoid having unnecessary adapters for fields to which we do not write data e.g. 'footer'.
-             * authoring-react doesn't support companion fields like 'footer' that don't have data on
-             * their own but simply modify the data of other fields.
-             */
-            'footer',
-
-            /**
-             * `media_description` isn't used anywhere. It might still be present in content profiles, so
-             * I'm omitting it here to prevent authoring-react from crashing trying to render it.
-             */
-            'media_description',
-        ];
+        /**
+         * Companion fields (e.g. 'footer', 'media_description') have no data of their own and would
+         * otherwise need unnecessary adapters / crash authoring-react while rendering. See
+         * COMPANION_FIELD_IDS for the shared list.
+         */
+        const fieldsToOmit = COMPANION_FIELD_IDS;
 
         const fieldsOrdered =
             Object.keys(editor)

--- a/scripts/apps/authoring-react/data-layer.ts
+++ b/scripts/apps/authoring-react/data-layer.ts
@@ -26,16 +26,7 @@ import {gettext} from 'core/utils';
 import {PACKAGE_ITEMS_FIELD_ID} from './fields/package-items';
 import {description_text} from './field-adapters/description_text';
 import {formatDateTime} from 'core/get-superdesk-api-implementation';
-
-/**
- * Content-profile field ids that don't map 1:1 to a stored article field. They can be enabled in
- * profiles but are not part of the `archive` resource schema, so they must not be sent verbatim in
- * a PATCH or the server rejects the request with "unknown field".
- */
-// companion/unused fields with no backing data of their own; drop them before saving
-export const COMPANION_FIELD_IDS = ['footer', 'media_description'];
-// profile field id -> the article field its value is actually stored in
-export const FIELD_ID_TO_STORED_FIELD: {[fieldId: string]: keyof IArticle} = {sms: 'sms_message'};
+import {COMPANION_FIELD_IDS, FIELD_ID_TO_STORED_FIELD} from './data-layer-constants';
 
 /**
  * Field `section` ('header' | 'content') is an authoring-react concept. Profiles created before it


### PR DESCRIPTION
### Purpose
This PR fixes the image upload dialogue not clearing on instances whose picture content profile enables synthetic/companion fields (e.g. `media_description`, `footer`, `sms`). The legacy upload modal PATCHed these fields verbatim, but they are not part of the `archive` resource schema, so the server rejected the whole request with `"unknown field"` and the dialogue stayed open.

### What has changed
- `scripts/apps/archive/controllers/UploadController.ts`: before saving, the uploaded item's metadata is passed through a new `sanitizeUploadMeta()` helper that drops the companion/unused fields (`footer`, `media_description`) and maps `sms` to its stored field `sms_message`. This mirrors the handling authoring-react already performs in `data-layer.ts`.

### Steps to test
1. Use an instance whose picture profile enables `media_description`, `footer` or `sms` (e.g. STT).
2. Upload an image, fill in the metadata including those fields, and save.
3. The item saves successfully and the upload dialogue closes. The request no longer contains `media_description`, `footer` or `sms`.

Companion PR: https://github.com/superdesk/superdesk-core/pull/3281

Resolves: https://sofab.atlassian.net/browse/SDESK-7980
