### PR TITLE
Resolve `webpack` from the consumer in `webpack.config.js`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,8 @@
 var path = require('path');
-var webpack = require('webpack');
+// Resolve webpack from the consumer so this config builds plugins with the same copy the
+// compiler uses. In a linked dev setup the consumer and this repo have separate installs,
+// and webpack >= 5.107 rejects a compilation created by a different copy.
+var webpack = require(require.resolve('webpack', {paths: [process.cwd(), __dirname]}));
 var lodash = require('lodash');
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');


### PR DESCRIPTION
### Purpose

Local dev with a linked `superdesk-client-core` broke recently:

```bash
Running "webpack-dev-server:start" (webpack-dev-server) task
9% setup compilation DefinePluginFatal error: The 'compilation' argument must be an instance of Compilation
```

A linked setup always has two webpack installs: the consumer's and this repo's. Node resolves requires from the real path, so `webpack.config.js` built `DefinePlugin` from this repo's copy while `grunt-webpack` created the `Compilation` from the consumer's. That was harmless until webpack 5.107, which added an `instanceof Compilation` guard to `DefinePlugin.getCompilationHooks`. Since we declare `webpack: "^5.95.0"`, any fresh install now picks up the guard and the build dies.

### What has changed

One line. `webpack.config.js` resolves webpack from the consumer first, so the config builds plugins with the same copy that runs the compiler. When you build this repo standalone the cwd is this repo, so nothing changes.

This is the only place we require webpack directly. `mini-css-extract-plugin` already prefers `compiler.webpack`, and `node-polyfill-webpack-plugin` doesn't require it at all.

Aligning versions doesn't fix this, by the way: two copies of the same 5.108.3 still throw, because the guard compares classes, not versions.

### Steps to test

1. In a Superdesk template, link this branch with `dev-link`, then run `npm run start`. It should compile instead of failing at 9%.
2. Run `npm run build` in this repo on its own to confirm the standalone path is unaffected.

Worth testing with a client-core whose `node_modules/webpack` is 5.108 or newer, since older copies don't have the guard and pass either way.

