### PR TITLE
[SDESK-7804] Render the send to / publish widget dark and remove the leftover panel

### DIFF
--- a/e2e/client/index.js
+++ b/e2e/client/index.js
@@ -31,6 +31,10 @@ setTimeout(() => {
                 id: 'availability-manager',
                 load: () => import('superdesk-core/scripts/extensions/availability-manager'),
             },
+            {
+                id: 'publishing-sections',
+                load: () => import('./test-extensions/publishing-sections'),
+            },
         ],
         {}
     );

--- a/e2e/client/playwright/page-object-models/authoring.ts
+++ b/e2e/client/playwright/page-object-models/authoring.ts
@@ -71,6 +71,18 @@ export class Authoring {
         await this.page.waitForTimeout(2000);
     }
 
+    /**
+     * Opens an authoring-react side widget from the sidebar.
+     * The sidebar buttons all share the `widget-icon` test id and are told apart by
+     * `data-test-value`, which carries the widget id.
+     */
+    async openSideWidget(widgetId: string): Promise<void> {
+        await this.page
+            .getByTestId('widget-icon')
+            .and(this.page.locator(`[data-test-value="${widgetId}"]`))
+            .click();
+    }
+
     field(field: string): Locator {
         return this.page.locator(s('authoring', field)).getByRole('textbox');
     }

--- a/e2e/client/playwright/send-to-publish-widget.authoring-react.spec.ts
+++ b/e2e/client/playwright/send-to-publish-widget.authoring-react.spec.ts
@@ -1,0 +1,120 @@
+import {test, expect, Locator, Page} from '@playwright/test';
+import {Authoring} from './page-object-models/authoring';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot, s} from './utils';
+import {getStorageState} from './utils/storage-state';
+import {TreeSelectDriver} from './utils/tree-select-driver';
+
+test.use({
+    storageState: getStorageState({}, {authoringReact: true}),
+});
+
+const SEND_TO_PUBLISH_WIDGET_ID = 'interactive-article-actions-widget';
+
+function sendToPublishWidget(page: Page): Locator {
+    return page.getByTestId('interactive-actions-widget');
+}
+
+function sportsWorkingStageItem(page: Page): Locator {
+    return page.locator(s('monitoring-group=Sports / Working Stage', 'article-item=test sports story'));
+}
+
+async function openTestSportsStory(page: Page): Promise<void> {
+    const monitoring = new Monitoring(page);
+    const authoring = new Authoring(page);
+
+    await page.goto('/#/workspace/monitoring');
+    await monitoring.selectDeskOrWorkspace('Sports');
+    await monitoring.executeActionOnMonitoringItem(sportsWorkingStageItem(page), 'Edit');
+    await authoring.waitForAuthoringReactToInitialize();
+}
+
+/**
+ * WCAG relative luminance. Asserting on it rather than on a class name or a token
+ * keeps the test tied to what the user sees, so it still fails if the theme is
+ * applied through a different mechanism that ends up light.
+ */
+function relativeLuminance(cssColor: string): number {
+    const components = cssColor.match(/[\d.]+/g);
+
+    if (components == null || components.length < 3) {
+        throw new Error(`unexpected colour format: ${cssColor}`);
+    }
+
+    const [red, green, blue] = components.slice(0, 3).map(Number);
+
+    const channel = (value: number) => {
+        const normalized = value / 255;
+
+        return normalized <= 0.03928
+            ? normalized / 12.92
+            : Math.pow((normalized + 0.055) / 1.055, 2.4);
+    };
+
+    return (0.2126 * channel(red)) + (0.7152 * channel(green)) + (0.0722 * channel(blue));
+}
+
+test('send to / publish widget renders on a dark surface', async ({page}) => {
+    const authoring = new Authoring(page);
+
+    await restoreDatabaseSnapshot();
+    await openTestSportsStory(page);
+    await authoring.openSideWidget(SEND_TO_PUBLISH_WIDGET_ID);
+
+    const widget = sendToPublishWidget(page);
+
+    await expect(widget).toBeVisible();
+
+    // The theme attribute sits on the panel container, but the surface the user sees is
+    // painted by the `.side-panel` inside it, so that is the element worth measuring.
+    const background = await widget.locator('.side-panel').first()
+        .evaluate((element) => window.getComputedStyle(element).backgroundColor);
+
+    expect(relativeLuminance(background)).toBeLessThan(0.2);
+
+    // the surface is dark because the theme tokens inherit from here
+    await expect(widget).toHaveAttribute('data-theme', 'dark-ui');
+});
+
+test('article can be sent to another desk from the send to / publish widget', async ({page}) => {
+    const monitoring = new Monitoring(page);
+    const authoring = new Authoring(page);
+
+    await restoreDatabaseSnapshot();
+    await openTestSportsStory(page);
+    await authoring.openSideWidget(SEND_TO_PUBLISH_WIDGET_ID);
+
+    const widget = sendToPublishWidget(page);
+
+    await expect(widget).toBeVisible();
+    await widget.getByTestId('tabs').getByRole('tab', {name: 'Send to'}).click();
+
+    // the tree select renders its popup in a portal outside the widget
+    await new TreeSelectDriver(page, page.locator(s('destination-select'))).setValues('Finance');
+
+    // Radio inputs are visually hidden behind sd-check-button labels.
+    await widget.getByTestId('stage-select').getByRole('radio', {name: 'Working Stage'}).check({force: true});
+    await widget.getByTestId('send').click();
+
+    await monitoring.selectDeskOrWorkspace('Finance');
+
+    await expect(
+        page.locator(s('monitoring-group=Finance / Working Stage', 'article-item=test sports story')),
+    ).toBeVisible();
+});
+
+test('Send to from the monitoring list opens the widget for the article being edited', async ({page}) => {
+    const monitoring = new Monitoring(page);
+
+    await restoreDatabaseSnapshot();
+    await openTestSportsStory(page);
+
+    await expect(sendToPublishWidget(page)).toHaveCount(0);
+
+    await monitoring.executeActionOnMonitoringItem(sportsWorkingStageItem(page), 'Send to');
+
+    const widget = sendToPublishWidget(page);
+
+    await expect(widget).toBeVisible();
+    await expect(widget.getByTestId('tabs').getByRole('tab', {name: 'Send to', selected: true})).toBeVisible();
+});

--- a/e2e/client/playwright/send-to-publish-widget.authoring-react.spec.ts
+++ b/e2e/client/playwright/send-to-publish-widget.authoring-react.spec.ts
@@ -118,3 +118,118 @@ test('Send to from the monitoring list opens the widget for the article being ed
     await expect(widget).toBeVisible();
     await expect(widget.getByTestId('tabs').getByRole('tab', {name: 'Send to', selected: true})).toBeVisible();
 });
+
+/**
+ * The publishing body is adaptive: it grows a column for every section contributed
+ * through the `publishingSections` extension point. No extension in this repository
+ * contributes one, so these tests enable a test extension that does. Without it the
+ * column count is always 1 and the adaptive layout cannot be observed.
+ */
+test.describe('with a contributed publishing section', () => {
+    test.use({
+        storageState: getStorageState({}, {authoringReact: true, publishingSections: true}),
+
+        // two columns need more than the default 1280px, as they would in a real deployment
+        viewport: {width: 1920, height: 1080},
+    });
+
+    async function getBox(locator: Locator): Promise<{width: number, height: number}> {
+        const box = await locator.boundingBox();
+
+        if (box == null) {
+            throw new Error('cannot measure an element that is not rendered');
+        }
+
+        return box;
+    }
+
+    /**
+     * The panel container transitions its width, so a measurement taken right after the
+     * widget opens or the tab changes can land mid-animation.
+     */
+    async function getSettledWidth(locator: Locator): Promise<number> {
+        let previous = NaN;
+
+        await expect.poll(async () => {
+            const {width} = await getBox(locator);
+            const settled = width === previous;
+
+            previous = width;
+
+            return settled;
+        }).toBe(true);
+
+        return previous;
+    }
+
+    async function openPublishTab(page: Page): Promise<Locator> {
+        const authoring = new Authoring(page);
+
+        await restoreDatabaseSnapshot();
+        await openTestSportsStory(page);
+        await authoring.openSideWidget(SEND_TO_PUBLISH_WIDGET_ID);
+
+        const widget = sendToPublishWidget(page);
+
+        await expect(widget.getByTestId('publish')).toBeVisible();
+        await getSettledWidth(widget);
+
+        return widget;
+    }
+
+    function publishingColumns(widget: Locator): Locator {
+        return widget.getByTestId('publishing-section').locator('> div');
+    }
+
+    test('the section is rendered next to the standard publishing options', async ({page}) => {
+        const widget = await openPublishTab(page);
+
+        await expect(publishingColumns(widget)).toHaveCount(2);
+
+        // proves the contribution point hands the section the article being published
+        await expect(widget.getByTestId('extra-publishing-section--slugline'))
+            .toHaveText('test sports story');
+    });
+
+    test('the publish tab is substantially wider than the send to tab', async ({page}) => {
+        const widget = await openPublishTab(page);
+        const publishTabWidth = await getSettledWidth(widget);
+
+        await widget.getByTestId('tabs').getByRole('tab', {name: 'Send to'}).click();
+        await expect(widget.getByTestId('send')).toBeVisible();
+
+        // send to contributes no sections, so it stays at a single column
+        const sendToTabWidth = await getSettledWidth(sendToPublishWidget(page));
+
+        /**
+         * One contributed section means two columns against send to's one. Comparing the
+         * two tabs rather than a pixel width keeps this tied to the behaviour: it survives
+         * a change to the column width, and still fails when the widget ignores
+         * `columnCount`, which leaves both tabs exactly the same width.
+         */
+        expect(publishTabWidth / sendToTabWidth).toBeGreaterThan(1.6);
+    });
+
+    test('the publish tab does not scroll horizontally', async ({page}) => {
+        const widget = await openPublishTab(page);
+
+        await expect(publishingColumns(widget)).toHaveCount(2);
+
+        const overflow = await widget.locator('.side-panel__content').evaluate(
+            (element) => element.scrollWidth - element.clientWidth,
+        );
+
+        // the reported symptom: columns squeezed into a single column width overflow it
+        expect(overflow).toBeLessThanOrEqual(1);
+    });
+
+    test('the contributed column fills the height of the panel', async ({page}) => {
+        const widget = await openPublishTab(page);
+
+        const contentHeight = (await getBox(widget.locator('.side-panel__content'))).height;
+        const sectionHeight = (await getBox(widget.getByTestId('extra-publishing-section'))).height;
+
+        // the section asks for `height: 100%`, which only resolves if the body has a definite height
+        expect(sectionHeight).toBeGreaterThan(contentHeight * 0.9);
+    });
+});

--- a/e2e/client/playwright/utils/storage-state.ts
+++ b/e2e/client/playwright/utils/storage-state.ts
@@ -1,6 +1,7 @@
 import {BrowserContextOptions} from '@playwright/test';
 import {ISuperdeskGlobalConfig} from 'superdesk-api';
 import storageState from '../.auth/user.json';
+import {PUBLISHING_SECTIONS_ENABLED} from '../../test-extensions/publishing-sections/extension';
 
 type StorageState = BrowserContextOptions['storageState'];
 
@@ -9,7 +10,7 @@ type StorageState = BrowserContextOptions['storageState'];
  */
 export function getStorageState(
     appConfigPatch: Partial<ISuperdeskGlobalConfig>,
-    otherOptions?: {authoringReact?: boolean},
+    otherOptions?: {authoringReact?: boolean, publishingSections?: boolean},
 ): StorageState {
     const storageStateCopy = JSON.parse(JSON.stringify(storageState));
 
@@ -17,6 +18,10 @@ export function getStorageState(
 
     if (otherOptions?.authoringReact === true) {
         storageStateCopy['origins'][0].localStorage.push({name: 'auth-react', value: 'true'});
+    }
+
+    if (otherOptions?.publishingSections === true) {
+        storageStateCopy['origins'][0].localStorage.push({name: PUBLISHING_SECTIONS_ENABLED, value: 'true'});
     }
 
     return storageStateCopy;

--- a/e2e/client/test-extensions/publishing-sections/extension.tsx
+++ b/e2e/client/test-extensions/publishing-sections/extension.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {IArticle, IExtension, IExtensionActivationResult} from 'superdesk-api';
+
+/**
+ * Stands in for a deployment that contributes extra columns to the publishing panel.
+ * No extension in this repository does, so without one the adaptive layout of the
+ * publishing panel and of the send to / publish widget cannot be exercised at all.
+ *
+ * It stays inert unless a spec opts in, because the number of contributed sections
+ * changes the width of both hosts for every other spec in the suite.
+ */
+export const PUBLISHING_SECTIONS_ENABLED = 'e2e-publishing-sections';
+
+function ExtraPublishingSection({item}: {item: IArticle}) {
+    return (
+        <div data-test-id="extra-publishing-section" style={{height: '100%'}}>
+            <h4>Extra publishing section</h4>
+
+            <div data-test-id="extra-publishing-section--slugline">{item.slugline}</div>
+        </div>
+    );
+}
+
+const extension: IExtension = {
+    activate: () => {
+        const contributions: IExtensionActivationResult =
+            localStorage.getItem(PUBLISHING_SECTIONS_ENABLED) === 'true'
+                ? {contributions: {publishingSections: [{component: ExtraPublishingSection}]}}
+                : {};
+
+        return Promise.resolve(contributions);
+    },
+};
+
+export default extension;

--- a/e2e/client/test-extensions/publishing-sections/package.json
+++ b/e2e/client/test-extensions/publishing-sections/package.json
@@ -1,0 +1,4 @@
+{
+    "private": true,
+    "main": "extension.tsx"
+}

--- a/scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx
+++ b/scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx
@@ -11,12 +11,22 @@ import {SendToAction} from 'core/interactive-article-actions-panel/actions/send-
 import {DuplicateToAction} from 'core/interactive-article-actions-panel/actions/duplicate-to-action';
 import {UnspikeAction} from 'core/interactive-article-actions-panel/actions/unspike-action';
 import {FetchToAction} from 'core/interactive-article-actions-panel/actions/fetch-to-action';
-import {PublishAction} from 'core/interactive-article-actions-panel/actions/publish-action';
+import {PublishAction, singleColumnWidthRem} from 'core/interactive-article-actions-panel/actions/publish-action';
 import {Text} from 'superdesk-ui-framework/react';
 
 export const INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID = 'interactive-article-actions-widget';
 
 const getLabel = () => gettext('Send to / Publish');
+
+/**
+ * This widget hosts the actions that the standalone panel hosts in authoring-angular,
+ * and sizes itself the same way so the two stay visually equivalent: one column budget
+ * per section contributed through the `publishingSections` extension point. Only the
+ * publishing tabs are adaptive; every other tab has a single column.
+ */
+export function getWidgetWidth(columnCount: number): string {
+    return `${singleColumnWidthRem * columnCount}rem`;
+}
 
 interface IState {
     tabs: Array<IArticleActionInteractive>;
@@ -90,10 +100,18 @@ export class SendToPublishWidget extends React.Component<IArticleSideWidgetCompo
         footer: JSX.Element,
         tabs: Array<IArticleActionInteractive>,
         activeTab: IArticleActionInteractive,
+        columnCount: number = 1,
     ) {
         return (
             <AuthoringWidgetLayout
                 theme="dark"
+                width={getWidgetWidth(columnCount)}
+
+                /**
+                 * The action bodies lay their columns out against the full height,
+                 * the same way the standalone panel does.
+                 */
+                fillBodyHeight
                 data-test-id="interactive-actions-widget"
                 header={(
                     <AuthoringWidgetHeading
@@ -157,11 +175,11 @@ export class SendToPublishWidget extends React.Component<IArticleSideWidgetCompo
                     onError={this.handleError}
                     onDataChange={this.handleDataChange}
                 >
-                    {({body, footer, loading}) => {
+                    {({body, footer, columnCount, loading}) => {
                         if (loading) {
                             return this.renderWithLayout(null, null, tabs, activeTab);
                         }
-                        return this.renderWithLayout(body, footer, tabs, activeTab);
+                        return this.renderWithLayout(body, footer, tabs, activeTab, columnCount);
                     }}
                 </PublishAction>
             );
@@ -175,12 +193,12 @@ export class SendToPublishWidget extends React.Component<IArticleSideWidgetCompo
                     onDataChange={this.handleDataChange}
                     action="correct"
                 >
-                    {({body, footer, loading}) => {
+                    {({body, footer, columnCount, loading}) => {
                         if (loading) {
                             return this.renderWithLayout(null, null, tabs, activeTab);
                         }
 
-                        return this.renderWithLayout(body, footer, tabs, activeTab);
+                        return this.renderWithLayout(body, footer, tabs, activeTab, columnCount);
                     }}
                 </PublishAction>
             );

--- a/scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx
+++ b/scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx
@@ -90,6 +90,8 @@ export class SendToPublishWidget extends React.Component<IArticleSideWidgetCompo
     ) {
         return (
             <AuthoringWidgetLayout
+                theme="dark"
+                data-test-id="interactive-actions-widget"
                 header={(
                     <AuthoringWidgetHeading
                         widgetId={INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID}
@@ -111,44 +113,6 @@ export class SendToPublishWidget extends React.Component<IArticleSideWidgetCompo
                 bodyPadding="small"
             />
         );
-    }
-
-    renderActiveTabContent(): {body: JSX.Element; footer: JSX.Element} {
-        const {activeTab} = this.state;
-
-        if (activeTab === 'send_to') {
-            return {
-                body: null,
-                footer: null,
-            };
-        } else if (activeTab === 'publish') {
-            return {
-                body: null,
-                footer: null,
-            };
-        } else if (activeTab === 'correct') {
-            return {
-                body: null,
-                footer: null,
-            };
-        } else if (activeTab === 'duplicate_to') {
-            return {
-                body: null,
-                footer: null,
-            };
-        } else if (activeTab === 'unspike') {
-            return {
-                body: null,
-                footer: null,
-            };
-        } else if (activeTab === 'fetch_to') {
-            return {
-                body: null,
-                footer: null,
-            };
-        } else {
-            assertNever(activeTab);
-        }
     }
 
     render() {

--- a/scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx
+++ b/scripts/apps/authoring-react/article-widgets/send-to-publish/send-to-publish-widget.tsx
@@ -72,7 +72,10 @@ export class SendToPublishWidget extends React.Component<IArticleSideWidgetCompo
 
     handleError(error: IPanelError) {
         if (error.kind === 'publishing-error') {
-            // The parent handles validation errors through the widget props if needed
+            this.props.setValidationErrors?.({
+                ...(this.props.getValidationErrors?.() ?? {}),
+                ...error.fields,
+            });
         } else {
             assertNever(error.kind);
         }

--- a/scripts/apps/authoring-react/article-widgets/send-to-publish/tests/publish-tab-width.spec.ts
+++ b/scripts/apps/authoring-react/article-widgets/send-to-publish/tests/publish-tab-width.spec.ts
@@ -1,0 +1,21 @@
+import {getWidgetWidth} from '../send-to-publish-widget';
+import {singleColumnWidthRem} from 'core/interactive-article-actions-panel/actions/publish-action';
+
+describe('send to / publish widget width', () => {
+    it('is one column wide for the tabs that have a single column', () => {
+        expect(getWidgetWidth(1)).toBe(`${singleColumnWidthRem}rem`);
+    });
+
+    it('allocates a full column to every contributed publishing section', () => {
+        expect(getWidgetWidth(2)).toBe(`${singleColumnWidthRem * 2}rem`);
+        expect(getWidgetWidth(3)).toBe(`${singleColumnWidthRem * 3}rem`);
+    });
+
+    it('widens by exactly one column per section', () => {
+        const widthInRem = (columnCount: number) => parseFloat(getWidgetWidth(columnCount));
+
+        expect(widthInRem(2) - widthInRem(1)).toBe(singleColumnWidthRem);
+        expect(widthInRem(3) - widthInRem(2)).toBe(singleColumnWidthRem);
+        expect(widthInRem(4) - widthInRem(3)).toBe(singleColumnWidthRem);
+    });
+});

--- a/scripts/apps/authoring-react/authoring-angular-integration.tsx
+++ b/scripts/apps/authoring-react/authoring-angular-integration.tsx
@@ -24,10 +24,6 @@ import {
     authoringStorageIArticleCorrect,
     getAuthoringStorageIArticleKillOrTakedown,
 } from './data-layer';
-import {
-    IStateInteractiveActionsPanelHOC,
-    IActionsInteractiveActionsPanelHOC,
-} from 'core/interactive-article-actions-panel/index-hoc';
 import {IArticleActionInteractive} from 'core/interactive-article-actions-panel/interfaces';
 import {dispatchInternalEvent} from 'core/internal-events';
 import {getSendAndDuplicateTarget} from 'apps/authoring/authoring/get-send-and-duplicate-target';

--- a/scripts/apps/authoring-react/authoring-integration-wrapper.tsx
+++ b/scripts/apps/authoring-react/authoring-integration-wrapper.tsx
@@ -24,12 +24,11 @@ import {sdApi} from 'api';
 import ng from 'core/services/ng';
 import {notify} from 'core/notify/notify';
 import {getSpellchecker} from 'core/editor3/components/spellchecker/default-spellcheckers';
+import {IArticleActionInteractive} from 'core/interactive-article-actions-panel/interfaces';
+import {addInternalEventListener} from 'core/internal-events';
 import {
-    IActionsInteractiveActionsPanelHOC,
-    IStateInteractiveActionsPanelHOC,
-    WithInteractiveArticleActionsPanel,
-} from 'core/interactive-article-actions-panel/index-hoc';
-import {InteractiveArticleActionsPanel} from 'core/interactive-article-actions-panel/index-ui';
+    INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID,
+} from './article-widgets/send-to-publish/send-to-publish-widget';
 
 import {ARTICLE_RELATED_RESOURCE_NAMES} from 'core/constants';
 import {showModal} from '@sourcefabric/common';
@@ -46,7 +45,6 @@ import {TemplateModal} from './toolbar/template-modal';
 import {WidgetStatePersistenceHOC, widgetState} from './widget-persistance-hoc';
 import {PINNED_WIDGET_USER_PREFERENCE_SETTINGS, closedIntentionally} from 'apps/authoring/widgets/widgets';
 import {AuthoringIntegrationWrapperSidebar} from './authoring-integration-wrapper-sidebar';
-import {assertNever} from 'core/helpers/typescript-helpers';
 import {
     PrintPreviewButton,
     ToggleThemeButton,
@@ -293,10 +291,7 @@ const getMarkedForDesksModal = (getItem: IExposedFromAuthoring<IArticle>['getLat
 
 interface IPropsWrapper extends IProps {
     onClose?(): void;
-    getAuthoringPrimaryToolbarWidgets?: (
-        panelState: IStateInteractiveActionsPanelHOC,
-        panelActions: IActionsInteractiveActionsPanelHOC,
-    ) => Array<ITopBarWidget<IArticle>>;
+    getAuthoringPrimaryToolbarWidgets?: () => Array<ITopBarWidget<IArticle>>;
     getInlineToolbarActions?(options: IExposedFromAuthoring<IArticle>): {
         readOnly: boolean;
         actions: Array<ITopBarWidget<IArticle>>;
@@ -324,10 +319,21 @@ interface IPropsWrapper extends IProps {
 interface IState {
     sidebarMode: boolean | 'hidden';
     sideWidget: ISideWidget;
+
+    /**
+     * Set when an article action is started from outside authoring (monitoring, search, ingest).
+     * It is handed to the send to / publish widget as its initial state so the widget opens
+     * on the requested tab instead of its own default.
+     */
+    interactiveActionsWidgetState: {
+        tabs: Array<IArticleActionInteractive>;
+        activeTab: IArticleActionInteractive;
+    } | null;
 }
 
 export class AuthoringIntegrationWrapper extends React.PureComponent<IPropsWrapper, IState> {
     private authoringReactRef: AuthoringReact<IArticle> | null;
+    private eventListenersToRemoveBeforeUnmounting: Array<() => void>;
 
     constructor(props: IPropsWrapper) {
         super(props);
@@ -341,16 +347,49 @@ export class AuthoringIntegrationWrapper extends React.PureComponent<IPropsWrapp
                 pinnedId: widgetId,
                 activeId: widgetId,
             },
+            interactiveActionsWidgetState: null,
         };
+
+        this.eventListenersToRemoveBeforeUnmounting = [];
 
         this.prepareForUnmounting = this.prepareForUnmounting.bind(this);
         this.handleUnsavedChanges = this.handleUnsavedChanges.bind(this);
         this.toggleSidebar = this.toggleSidebar.bind(this);
         this.loadWidgetFromPreferences = this.loadWidgetFromPreferences.bind(this);
+        this.setSideWidget = this.setSideWidget.bind(this);
     }
 
     componentDidMount(): void {
         this.loadWidgetFromPreferences();
+
+        this.eventListenersToRemoveBeforeUnmounting.push(
+            addInternalEventListener('interactiveArticleActionStart', (event) => {
+                const {items, tabs, activeTab} = event.detail;
+
+                // `getSidePanel` renders whichever widget is active, so pointing it at a widget
+                // this article is not allowed to use would render `undefined` and throw.
+                const widgetAvailable = items.length === 1 && getWidgetsFromExtensions(items[0])
+                    .some((widget) => widget._id === INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID);
+
+                if (widgetAvailable && items[0]._id === this.props.itemId) {
+                    this.setState({
+                        interactiveActionsWidgetState: {tabs, activeTab},
+                        sideWidget: {
+                            ...this.state.sideWidget,
+                            activeId: INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID,
+                        },
+                    });
+
+                    closedIntentionally.value = false;
+                }
+            }),
+        );
+    }
+
+    componentWillUnmount(): void {
+        this.eventListenersToRemoveBeforeUnmounting.forEach((removeListener) => {
+            removeListener();
+        });
     }
 
     componentDidUpdate(_prevProps: IPropsWrapper, prevState: IState): void {
@@ -373,6 +412,19 @@ export class AuthoringIntegrationWrapper extends React.PureComponent<IPropsWrapp
                 },
             });
         }
+    }
+
+    private setSideWidget(sideWidget: ISideWidget | null) {
+        this.setState({
+            sideWidget,
+
+            // the pending action only applies to the widget it was requested for
+            interactiveActionsWidgetState: sideWidget?.activeId === INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID
+                ? this.state.interactiveActionsWidgetState
+                : null,
+        });
+
+        closedIntentionally.value = false;
     }
 
     public toggleSidebar() {
@@ -436,288 +488,261 @@ export class AuthoringIntegrationWrapper extends React.PureComponent<IPropsWrapp
             .flatMap(({activationResult}) => activationResult?.contributions?.authoringTopbar2Widgets ?? []);
 
         return (
-            <WithInteractiveArticleActionsPanel location="authoring">
-                {(panelState, panelActions) => (
-                    <AuthoringReact
-                        onFieldChange={this.props.onFieldChange}
-                        ref={(component) => {
-                            this.authoringReactRef = component;
-                        }}
-                        itemId={this.props.itemId}
-                        resourceNames={ARTICLE_RELATED_RESOURCE_NAMES}
-                        onClose={() => this.props.onClose()}
-                        authoringStorage={this.props.authoringStorage}
-                        fieldsAdapter={getFieldsAdapter(this.props.authoringStorage)}
-                        storageAdapter={{
-                            storeValue: (value, fieldId, article) => {
-                                return {
-                                    ...article,
-                                    extra: {
-                                        ...(article.extra ?? {}),
-                                        [fieldId]: value,
-                                    },
-                                };
+            <AuthoringReact
+                onFieldChange={this.props.onFieldChange}
+                ref={(component) => {
+                    this.authoringReactRef = component;
+                }}
+                itemId={this.props.itemId}
+                resourceNames={ARTICLE_RELATED_RESOURCE_NAMES}
+                onClose={() => this.props.onClose()}
+                authoringStorage={this.props.authoringStorage}
+                fieldsAdapter={getFieldsAdapter(this.props.authoringStorage)}
+                storageAdapter={{
+                    storeValue: (value, fieldId, article) => {
+                        return {
+                            ...article,
+                            extra: {
+                                ...(article.extra ?? {}),
+                                [fieldId]: value,
                             },
-                            retrieveStoredValue: (item: IArticle, fieldId) => item.extra?.[fieldId] ?? null,
-                        }}
-                        headerToolbar={() => {
-                            // Context is provided by AuthoringReact, so no need to update refs here
-                            return headerToolbarWidgetsStable;
-                        }}
-                        getLanguage={(article) => article.language ?? 'en'}
-                        onEditingStart={(article) => {
-                            dispatchCustomEvent('articleEditStart', article);
-                        }}
-                        onEditingEnd={(article) => {
-                            dispatchCustomEvent('articleEditEnd', article);
-                        }}
-                        getActions={({
-                            item,
-                            contentProfile,
-                            fieldsData,
+                        };
+                    },
+                    retrieveStoredValue: (item: IArticle, fieldId) => item.extra?.[fieldId] ?? null,
+                }}
+                headerToolbar={() => {
+                    // Context is provided by AuthoringReact, so no need to update refs here
+                    return headerToolbarWidgetsStable;
+                }}
+                getLanguage={(article) => article.language ?? 'en'}
+                onEditingStart={(article) => {
+                    dispatchCustomEvent('articleEditStart', article);
+                }}
+                onEditingEnd={(article) => {
+                    dispatchCustomEvent('articleEditEnd', article);
+                }}
+                getActions={({
+                    item,
+                    contentProfile,
+                    fieldsData,
+                    getLatestItem,
+                    handleUnsavedChanges,
+                    hasUnsavedChanges,
+                    authoringStorage,
+                    fieldsAdapter,
+                    storageAdapter,
+                    spellchecker,
+                }) => {
+                    const authoringActionsFromExtensions = getAuthoringActionsFromExtensions(
+                        item,
+                        contentProfile,
+                        fieldsData,
+                    );
+
+                    const actions = [
+                        getSaveAsTemplate(getLatestItem),
+                        ...(
+                            appConfig.features?.hideLiveSuggestions === true
+                                ? []
+                                : [getLiveSuggestionsAction()]
+                        ),
+                        getCompareVersionsModal(
                             getLatestItem,
-                            handleUnsavedChanges,
-                            hasUnsavedChanges,
                             authoringStorage,
                             fieldsAdapter,
                             storageAdapter,
-                            spellchecker,
-                        }) => {
-                            const authoringActionsFromExtensions = getAuthoringActionsFromExtensions(
-                                item,
-                                contentProfile,
-                                fieldsData,
-                            );
+                        ),
+                        getMultiEditModal(getLatestItem),
+                        getHighlightsAction(getLatestItem),
+                        getMarkedForDesksModal(getLatestItem),
+                        getExportModal(getLatestItem, handleUnsavedChanges, hasUnsavedChanges),
+                        getTranslateModal(getLatestItem),
+                        ...authoringActionsFromExtensions,
+                    ];
 
-                            const actions = [
-                                getSaveAsTemplate(getLatestItem),
-                                ...(
-                                    appConfig.features?.hideLiveSuggestions === true
-                                        ? []
-                                        : [getLiveSuggestionsAction()]
-                                ),
-                                getCompareVersionsModal(
-                                    getLatestItem,
-                                    authoringStorage,
-                                    fieldsAdapter,
-                                    storageAdapter,
-                                ),
-                                getMultiEditModal(getLatestItem),
-                                getHighlightsAction(getLatestItem),
-                                getMarkedForDesksModal(getLatestItem),
-                                getExportModal(getLatestItem, handleUnsavedChanges, hasUnsavedChanges),
-                                getTranslateModal(getLatestItem),
-                                ...authoringActionsFromExtensions,
-                            ];
-
-                            const getSpellcheckerAction = (): IAuthoringAction | null => {
-                                if (appConfig.features.useTansaProofing !== true) {
-                                    return {
-                                        label: spellchecker.enabled
-                                            ? gettext('Disable spellchecker')
-                                            : gettext('Enable spellchecker'),
-                                        group: {id: 'spellchecker', label: gettext('Spell Checker'), priority: 40},
-                                        onTrigger: () => {
-                                            spellchecker.setSpellcheckerStatus(!spellchecker.enabled);
-                                        },
-                                    } satisfies IAuthoringAction;
-                                }
-
-                                return null;
-                            };
-
-                            const getCheckSpellingAction = (): IAuthoringAction | null => {
-                                if (appConfig.features.useTansaProofing === true) {
-                                    return null;
-                                }
-
-                                const runCheck = () => {
-                                    // Must match the editor3 `getLanguage` fallback, or this can
-                                    // report "no dictionary" while the editor spellchecks with 'en'.
-                                    const language = getLatestItem().language ?? 'en';
-                                    const spellcheck = ng.get('spellcheck');
-                                    const dictAvailable =
-                                        spellcheck.isActiveDictionary
-                                        || getSpellchecker(language) != null;
-
-                                    if (!dictAvailable) {
-                                        notify.error(gettext('No dictionary available for spell checking.'));
-                                        return;
-                                    }
-
-                                    // Mirrors legacy SpellcheckMenuController.runSpellchecker: enables
-                                    // auto-mode and re-runs the check. Calling with `true` when already
-                                    // enabled re-dispatches the editor3 spellcheck via the existing event.
-                                    spellchecker.setSpellcheckerStatus(true);
-                                };
-
-                                return {
-                                    label: gettext('Check spelling'),
-                                    group: {id: 'spellchecker', label: gettext('Spell Checker'), priority: 40},
-                                    onTrigger: runCheck,
-                                    keyBindings: {
-                                        'ctrl+shift+y': runCheck,
-                                    },
-                                } satisfies IAuthoringAction;
-                            };
-
-                            const spellcheckerAction = getSpellcheckerAction();
-
-                            if (spellcheckerAction != null) {
-                                actions.push(spellcheckerAction);
-                            }
-
-                            const checkSpellingAction = getCheckSpellingAction();
-
-                            if (checkSpellingAction != null) {
-                                actions.push(checkSpellingAction);
-                            }
-
-                            return actions;
-                        }}
-                        getSidebarWidgetsCount={({item}) => getWidgetsFromExtensions(item).length}
-                        sideWidget={this.state.sideWidget}
-                        onSideWidgetChange={(sideWidget) => {
-                            this.setState({sideWidget});
-                            closedIntentionally.value = false;
-                        }}
-                        getInlineToolbarActions={this.props.getInlineToolbarActions}
-                        getAuthoringPrimaryToolbarWidgets={
-                            this.props.getAuthoringPrimaryToolbarWidgets != null
-                                ? () => this.props.getAuthoringPrimaryToolbarWidgets(panelState, panelActions)
-                                : undefined
+                    const getSpellcheckerAction = (): IAuthoringAction | null => {
+                        if (appConfig.features.useTansaProofing !== true) {
+                            return {
+                                label: spellchecker.enabled
+                                    ? gettext('Disable spellchecker')
+                                    : gettext('Enable spellchecker'),
+                                group: {id: 'spellchecker', label: gettext('Spell Checker'), priority: 40},
+                                onTrigger: () => {
+                                    spellchecker.setSpellcheckerStatus(!spellchecker.enabled);
+                                },
+                            } satisfies IAuthoringAction;
                         }
-                        getSidePanel={({
-                            item,
-                            getLatestItem,
-                            contentProfile,
-                            fieldsData,
-                            handleFieldsDataChange,
-                            fieldsAdapter,
-                            storageAdapter,
-                            authoringStorage,
-                            handleUnsavedChanges,
-                            sideWidget,
-                            onItemChange,
-                            getValidationErrors,
-                            setValidationErrors,
-                        }, readOnly) => {
-                            if (panelState.active === true) {
-                                return (
-                                    <InteractiveArticleActionsPanel
-                                        items={panelState.items}
-                                        tabs={panelState.tabs}
-                                        activeTab={panelState.activeTab}
-                                        handleUnsavedChanges={
-                                            () => handleUnsavedChanges().then((res) => [res])
+
+                        return null;
+                    };
+
+                    const getCheckSpellingAction = (): IAuthoringAction | null => {
+                        if (appConfig.features.useTansaProofing === true) {
+                            return null;
+                        }
+
+                        const runCheck = () => {
+                            // Must match the editor3 `getLanguage` fallback, or this can
+                            // report "no dictionary" while the editor spellchecks with 'en'.
+                            const language = getLatestItem().language ?? 'en';
+                            const spellcheck = ng.get('spellcheck');
+                            const dictAvailable =
+                                spellcheck.isActiveDictionary
+                                || getSpellchecker(language) != null;
+
+                            if (!dictAvailable) {
+                                notify.error(gettext('No dictionary available for spell checking.'));
+                                return;
+                            }
+
+                            // Mirrors legacy SpellcheckMenuController.runSpellchecker: enables
+                            // auto-mode and re-runs the check. Calling with `true` when already
+                            // enabled re-dispatches the editor3 spellcheck via the existing event.
+                            spellchecker.setSpellcheckerStatus(true);
+                        };
+
+                        return {
+                            label: gettext('Check spelling'),
+                            group: {id: 'spellchecker', label: gettext('Spell Checker'), priority: 40},
+                            onTrigger: runCheck,
+                            keyBindings: {
+                                'ctrl+shift+y': runCheck,
+                            },
+                        } satisfies IAuthoringAction;
+                    };
+
+                    const spellcheckerAction = getSpellcheckerAction();
+
+                    if (spellcheckerAction != null) {
+                        actions.push(spellcheckerAction);
+                    }
+
+                    const checkSpellingAction = getCheckSpellingAction();
+
+                    if (checkSpellingAction != null) {
+                        actions.push(checkSpellingAction);
+                    }
+
+                    return actions;
+                }}
+                getSidebarWidgetsCount={({item}) => getWidgetsFromExtensions(item).length}
+                sideWidget={this.state.sideWidget}
+                onSideWidgetChange={this.setSideWidget}
+                getInlineToolbarActions={this.props.getInlineToolbarActions}
+                getAuthoringPrimaryToolbarWidgets={this.props.getAuthoringPrimaryToolbarWidgets}
+                getSidePanel={({
+                    item,
+                    getLatestItem,
+                    contentProfile,
+                    fieldsData,
+                    handleFieldsDataChange,
+                    fieldsAdapter,
+                    storageAdapter,
+                    authoringStorage,
+                    handleUnsavedChanges,
+                    sideWidget,
+                    onItemChange,
+                    getValidationErrors,
+                    setValidationErrors,
+                }, readOnly) => {
+                    if (sideWidget == null) {
+                        return null;
+                    }
+
+                    const WidgetComponent = getWidgetsFromExtensions(item)
+                        .find((widget) => sideWidget === widget._id)?.component;
+
+                    // the active widget id can outlive the article it was chosen for,
+                    // for example when it is restored from local storage
+                    if (WidgetComponent == null) {
+                        return null;
+                    }
+
+                    return (
+                        <WidgetStatePersistenceHOC sideWidgetId={sideWidget}>
+                            {(widgetRef) => (
+                                <WidgetComponent
+                                    ref={widgetRef}
+                                    initialState={(() => {
+                                        if (
+                                            sideWidget === INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID
+                                            && this.state.interactiveActionsWidgetState != null
+                                        ) {
+                                            return this.state.interactiveActionsWidgetState;
                                         }
-                                        onClose={panelActions.closePanel}
-                                        onError={(error) => {
-                                            if (error.kind === 'publishing-error') {
-                                                setValidationErrors({
-                                                    ...getValidationErrors(),
-                                                    ...error.fields,
-                                                });
-                                            } else {
-                                                assertNever(error.kind);
-                                            }
-                                        }}
-                                        onDataChange={(item) => {
-                                            onItemChange(item);
-                                        }}
-                                        markupV2
-                                    />
-                                );
-                            }
 
-                            if (sideWidget == null) {
-                                return null;
-                            }
+                                        const localStorageWidgetState =
+                                            JSON.parse(localStorage.getItem('SIDE_WIDGET') ?? 'null');
 
-                            const WidgetComponent = getWidgetsFromExtensions(item)
-                                .find((widget) => sideWidget === widget._id)?.component;
+                                        if (localStorageWidgetState?.id != null) {
+                                            const initialState = localStorageWidgetState?.initialState;
 
-                            return (
-                                <WidgetStatePersistenceHOC sideWidgetId={sideWidget}>
-                                    {(widgetRef) => (
-                                        <WidgetComponent
-                                            ref={widgetRef}
-                                            initialState={(() => {
-                                                const localStorageWidgetState =
-                                                    JSON.parse(localStorage.getItem('SIDE_WIDGET') ?? 'null');
+                                            sdApi.preferences.update(
+                                                PINNED_WIDGET_USER_PREFERENCE_SETTINGS,
+                                                {type: 'string', _id: localStorageWidgetState?.id},
+                                            );
 
-                                                if (localStorageWidgetState?.id != null) {
-                                                    const initialState = localStorageWidgetState?.initialState;
+                                            // Once a user switches the widget, authoring gets
+                                            // re-rendered 3-4 times, causing this logic to run more
+                                            // than once. To prevent wrong widget state its
+                                            // deleted after 5 seconds.
+                                            setTimeout(() => {
+                                                localStorage.removeItem('SIDE_WIDGET');
+                                            }, 5000);
 
-                                                    sdApi.preferences.update(
-                                                        PINNED_WIDGET_USER_PREFERENCE_SETTINGS,
-                                                        {type: 'string', _id: localStorageWidgetState?.id},
-                                                    );
+                                            closedIntentionally.value = false;
+                                            return initialState;
+                                        }
 
-                                                    // Once a user switches the widget, authoring gets
-                                                    // re-rendered 3-4 times, causing this logic to run more
-                                                    // than once. To prevent wrong widget state its
-                                                    // deleted after 5 seconds.
-                                                    setTimeout(() => {
-                                                        localStorage.removeItem('SIDE_WIDGET');
-                                                    }, 5000);
+                                        if (
+                                            localStorageWidgetState == null
+                                            && closedIntentionally.value === true
+                                            && widgetState[this.state.sideWidget?.activeId] != null
+                                        ) {
+                                            return widgetState[this.state.sideWidget?.activeId];
+                                        }
 
-                                                    closedIntentionally.value = false;
-                                                    return initialState;
-                                                }
-
-                                                if (
-                                                    localStorageWidgetState == null
-                                                    && closedIntentionally.value === true
-                                                    && widgetState[this.state.sideWidget?.activeId] != null
-                                                ) {
-                                                    return widgetState[this.state.sideWidget?.activeId];
-                                                }
-
-                                                return undefined;
-                                            })()}
-                                            article={item}
-                                            getLatestArticle={getLatestItem}
-                                            contentProfile={contentProfile}
-                                            fieldsData={fieldsData}
-                                            authoringStorage={authoringStorage}
-                                            fieldsAdapter={fieldsAdapter}
-                                            storageAdapter={storageAdapter}
-                                            onFieldsDataChange={handleFieldsDataChange}
-                                            readOnly={readOnly}
-                                            handleUnsavedChanges={() => handleUnsavedChanges()}
-                                            onItemChange={onItemChange}
-                                        />
-                                    )}
-                                </WidgetStatePersistenceHOC>
-                            );
-                        }}
-                        getSidebar={this.state.sidebarMode !== true ? null : (options) => (
-                            <AuthoringIntegrationWrapperSidebar
-                                options={options}
-                                sideWidget={this.state.sideWidget}
-                                setSideWidget={(sideWidget) => {
-                                    this.setState({sideWidget});
-                                    closedIntentionally.value = false;
-                                }}
-                            />
-                        )}
-                        getSecondaryToolbarWidgets={(exposed) => {
-                            // Context is provided by AuthoringReact, so no need to update refs here
-                            return [
-                                ...secondaryToolbarWidgetsStable,
-                                ...secondaryToolbarWidgetsFromExtensions,
-                                ...getAuthoringCosmeticActions(exposed),
-                            ];
-                        }}
-                        validateBeforeSaving={false}
-                        getSideWidgetIdAtIndex={(article, index) => {
-                            return getWidgetsFromExtensions(article)[index]._id;
-                        }}
-                        autoFocus={this.props.autoFocus}
+                                        return undefined;
+                                    })()}
+                                    article={item}
+                                    getLatestArticle={getLatestItem}
+                                    contentProfile={contentProfile}
+                                    fieldsData={fieldsData}
+                                    authoringStorage={authoringStorage}
+                                    fieldsAdapter={fieldsAdapter}
+                                    storageAdapter={storageAdapter}
+                                    onFieldsDataChange={handleFieldsDataChange}
+                                    readOnly={readOnly}
+                                    handleUnsavedChanges={() => handleUnsavedChanges()}
+                                    onItemChange={onItemChange}
+                                    getValidationErrors={getValidationErrors}
+                                    setValidationErrors={setValidationErrors}
+                                />
+                            )}
+                        </WidgetStatePersistenceHOC>
+                    );
+                }}
+                getSidebar={this.state.sidebarMode !== true ? null : (options) => (
+                    <AuthoringIntegrationWrapperSidebar
+                        options={options}
+                        sideWidget={this.state.sideWidget}
+                        setSideWidget={this.setSideWidget}
                     />
                 )}
-            </WithInteractiveArticleActionsPanel>
+                getSecondaryToolbarWidgets={(exposed) => {
+                    // Context is provided by AuthoringReact, so no need to update refs here
+                    return [
+                        ...secondaryToolbarWidgetsStable,
+                        ...secondaryToolbarWidgetsFromExtensions,
+                        ...getAuthoringCosmeticActions(exposed),
+                    ];
+                }}
+                validateBeforeSaving={false}
+                getSideWidgetIdAtIndex={(article, index) => {
+                    return getWidgetsFromExtensions(article)[index]._id;
+                }}
+                autoFocus={this.props.autoFocus}
+            />
         );
     }
 }

--- a/scripts/apps/authoring-react/authoring-integration-wrapper.tsx
+++ b/scripts/apps/authoring-react/authoring-integration-wrapper.tsx
@@ -372,13 +372,14 @@ export class AuthoringIntegrationWrapper extends React.PureComponent<IPropsWrapp
                     .some((widget) => widget._id === INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID);
 
                 if (widgetAvailable && items[0]._id === this.props.itemId) {
-                    this.setState({
+                    // keeps whatever the pinned state is when a pin change is still pending
+                    this.setState((previousState) => ({
                         interactiveActionsWidgetState: {tabs, activeTab},
                         sideWidget: {
-                            ...this.state.sideWidget,
+                            ...previousState.sideWidget,
                             activeId: INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID,
                         },
-                    });
+                    }));
 
                     closedIntentionally.value = false;
                 }
@@ -415,14 +416,14 @@ export class AuthoringIntegrationWrapper extends React.PureComponent<IPropsWrapp
     }
 
     private setSideWidget(sideWidget: ISideWidget | null) {
-        this.setState({
+        this.setState((previousState) => ({
             sideWidget,
 
             // the pending action only applies to the widget it was requested for
             interactiveActionsWidgetState: sideWidget?.activeId === INTERACTIVE_ARTICLE_ACTIONS_WIDGET_ID
-                ? this.state.interactiveActionsWidgetState
+                ? previousState.interactiveActionsWidgetState
                 : null,
-        });
+        }));
 
         closedIntentionally.value = false;
     }

--- a/scripts/apps/authoring-react/authoring-react.scss
+++ b/scripts/apps/authoring-react/authoring-react.scss
@@ -13,6 +13,15 @@
     padding: 1rem;
 }
 
+/**
+ * `.side-panel__content-block` is auto height, which leaves `height: 100%` inside a
+ * widget body unresolvable. Widgets that lay their body out against the full panel
+ * height opt into a definite height here.
+ */
+.sd-authoring-widget-body--fill-height {
+    height: 100%;
+}
+
 .authoring-toolbar-1 {
     display: flex;
     width: 100%;

--- a/scripts/apps/authoring-react/widget-layout-component.tsx
+++ b/scripts/apps/authoring-react/widget-layout-component.tsx
@@ -20,7 +20,7 @@ export class AuthoringWidgetLayoutComponent extends React.PureComponent<IAuthori
             <Layout.Panel
                 side="right"
                 open={true}
-                size="x-small"
+                size={this.props.width == null ? 'x-small' : {custom: this.props.width}}
                 background={this.props.background ?? 'light'}
                 theme={this.props.theme}
                 data-test-id={this.props['data-test-id']}
@@ -28,7 +28,15 @@ export class AuthoringWidgetLayoutComponent extends React.PureComponent<IAuthori
                 {header && <React.Fragment>{header}</React.Fragment>}
 
                 <Layout.PanelContent>
-                    <Layout.PanelContentBlock flex={bodyPadding === 'none'} padding={paddingMap[bodyPadding]}>
+                    <Layout.PanelContentBlock
+                        flex={bodyPadding === 'none'}
+                        padding={paddingMap[bodyPadding]}
+                        className={
+                            this.props.fillBodyHeight === true
+                                ? 'sd-authoring-widget-body--fill-height'
+                                : undefined
+                        }
+                    >
                         {body}
                     </Layout.PanelContentBlock>
                 </Layout.PanelContent>

--- a/scripts/apps/authoring-react/widget-layout-component.tsx
+++ b/scripts/apps/authoring-react/widget-layout-component.tsx
@@ -17,7 +17,14 @@ export class AuthoringWidgetLayoutComponent extends React.PureComponent<IAuthori
         };
 
         return (
-            <Layout.Panel side="right" open={true} size="x-small" background={this.props.background ?? 'light'}>
+            <Layout.Panel
+                side="right"
+                open={true}
+                size="x-small"
+                background={this.props.background ?? 'light'}
+                theme={this.props.theme}
+                data-test-id={this.props['data-test-id']}
+            >
                 {header && <React.Fragment>{header}</React.Fragment>}
 
                 <Layout.PanelContent>

--- a/scripts/core/interactive-article-actions-panel/actions/duplicate-to-tab.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/duplicate-to-tab.tsx
@@ -7,7 +7,6 @@ import {DuplicateToAction} from './duplicate-to-action';
 interface IProps {
     items: Array<IArticle>;
     closeDuplicateToView(): void;
-    markupV2: boolean;
 }
 
 /**
@@ -15,7 +14,7 @@ interface IProps {
  */
 export class DuplicateToTab extends React.PureComponent<IProps> {
     render() {
-        const {items, markupV2, closeDuplicateToView} = this.props;
+        const {items, closeDuplicateToView} = this.props;
 
         return (
             <DuplicateToAction
@@ -24,10 +23,10 @@ export class DuplicateToTab extends React.PureComponent<IProps> {
             >
                 {({body, footer}) => (
                     <>
-                        <PanelContent markupV2={markupV2}>
+                        <PanelContent>
                             {body}
                         </PanelContent>
-                        <PanelFooter markupV2={markupV2}>
+                        <PanelFooter>
                             {footer}
                         </PanelFooter>
                     </>

--- a/scripts/core/interactive-article-actions-panel/actions/fetch-to-tab.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/fetch-to-tab.tsx
@@ -7,7 +7,6 @@ import {FetchToAction} from './fetch-to-action';
 interface IProps {
     items: Array<IArticle>;
     closeFetchToView(): void;
-    markupV2: boolean;
     handleUnsavedChanges(items: Array<IArticle>): Promise<Array<IArticle>>;
 }
 
@@ -16,7 +15,7 @@ interface IProps {
  */
 export class FetchToTab extends React.PureComponent<IProps> {
     render() {
-        const {items, markupV2, closeFetchToView, handleUnsavedChanges} = this.props;
+        const {items, closeFetchToView, handleUnsavedChanges} = this.props;
 
         return (
             <FetchToAction
@@ -26,10 +25,10 @@ export class FetchToTab extends React.PureComponent<IProps> {
             >
                 {({body, footer}) => (
                     <>
-                        <PanelContent markupV2={markupV2}>
+                        <PanelContent>
                             {body}
                         </PanelContent>
-                        <PanelFooter markupV2={markupV2}>
+                        <PanelFooter>
                             {footer}
                         </PanelFooter>
                     </>

--- a/scripts/core/interactive-article-actions-panel/actions/publish-action.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/publish-action.tsx
@@ -27,6 +27,12 @@ import {PreviewModal} from 'apps/publish-preview/previewModal';
 import {notify} from 'core/notify/notify';
 import {sdApi} from 'api';
 
+/**
+ * Width budget of a single publishing column. `columnCount` below says how many
+ * of them there are, so every host of this action sizes itself the same way.
+ */
+export const singleColumnWidthRem = 40;
+
 export interface IPublishConfig {
     item: IArticle;
     closePublishView(): void;

--- a/scripts/core/interactive-article-actions-panel/actions/publish-tab.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/publish-tab.tsx
@@ -9,7 +9,6 @@ interface IProps extends IPropsHocInteractivePanelTab {
     item: IArticle;
     closePublishView(): void;
     handleUnsavedChanges(): Promise<IArticle>;
-    markupV2: boolean;
     onError: (error: IPanelError) => void;
     onDataChange: (item: IArticle) => void;
     action?: 'publish' | 'correct';
@@ -22,7 +21,7 @@ interface IProps extends IPropsHocInteractivePanelTab {
  */
 export class WithPublishTab extends React.PureComponent<IProps> {
     render() {
-        const {item, markupV2, closePublishView, handleUnsavedChanges, onError, onDataChange, action} = this.props;
+        const {item, closePublishView, handleUnsavedChanges, onError, onDataChange, action} = this.props;
 
         return (
             <PublishAction
@@ -42,10 +41,10 @@ export class WithPublishTab extends React.PureComponent<IProps> {
                         columnCount,
                         content: (
                             <>
-                                <PanelContent markupV2={markupV2}>
+                                <PanelContent>
                                     {body}
                                 </PanelContent>
-                                <PanelFooter markupV2={markupV2}>
+                                <PanelFooter>
                                     {footer}
                                 </PanelFooter>
                             </>

--- a/scripts/core/interactive-article-actions-panel/actions/send-correction-tab.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/send-correction-tab.tsx
@@ -8,7 +8,6 @@ interface IProps {
     item: IArticle;
     closePublishView(): void;
     handleUnsavedChanges(): Promise<IArticle>;
-    markupV2: boolean;
     onDataChange(changes: IArticle): void;
 }
 
@@ -17,7 +16,7 @@ interface IProps {
  */
 export class SendCorrectionTab extends React.Component<IProps> {
     render() {
-        const {item, markupV2, closePublishView, handleUnsavedChanges, onDataChange} = this.props;
+        const {item, closePublishView, handleUnsavedChanges, onDataChange} = this.props;
 
         return (
             <SendCorrectionAction
@@ -28,10 +27,10 @@ export class SendCorrectionTab extends React.Component<IProps> {
             >
                 {({body, footer}) => (
                     <>
-                        <PanelContent markupV2={markupV2}>
+                        <PanelContent>
                             {body}
                         </PanelContent>
-                        <PanelFooter markupV2={markupV2}>
+                        <PanelFooter>
                             {footer}
                         </PanelFooter>
                     </>

--- a/scripts/core/interactive-article-actions-panel/actions/send-to-tab.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/send-to-tab.tsx
@@ -9,7 +9,6 @@ import {SendToAction} from './send-to-action';
 interface IProps {
     items: Array<IArticle>;
     closeSendToView(): void;
-    markupV2: boolean;
     handleUnsavedChanges(items: Array<IArticle>): Promise<Array<IArticle>>;
 }
 
@@ -18,7 +17,7 @@ interface IProps {
  */
 export class SendToTab extends React.PureComponent<IProps> {
     render() {
-        const {items, markupV2, closeSendToView, handleUnsavedChanges} = this.props;
+        const {items, closeSendToView, handleUnsavedChanges} = this.props;
 
         return (
             <SendToAction
@@ -45,10 +44,10 @@ export class SendToTab extends React.PureComponent<IProps> {
 
                     return (
                         <>
-                            <PanelContent markupV2={markupV2}>
+                            <PanelContent>
                                 {body}
                             </PanelContent>
-                            <PanelFooter markupV2={markupV2}>
+                            <PanelFooter>
                                 {footer}
                             </PanelFooter>
                         </>

--- a/scripts/core/interactive-article-actions-panel/actions/unspike-tab.tsx
+++ b/scripts/core/interactive-article-actions-panel/actions/unspike-tab.tsx
@@ -7,7 +7,6 @@ import {UnspikeAction} from './unspike-action';
 interface IProps {
     items: Array<IArticle>;
     closeUnspikeView(): void;
-    markupV2: boolean;
 }
 
 /**
@@ -15,7 +14,7 @@ interface IProps {
  */
 export class UnspikeTab extends React.PureComponent<IProps> {
     render() {
-        const {items, markupV2, closeUnspikeView} = this.props;
+        const {items, closeUnspikeView} = this.props;
 
         return (
             <UnspikeAction
@@ -24,10 +23,10 @@ export class UnspikeTab extends React.PureComponent<IProps> {
             >
                 {({body, footer}) => (
                     <>
-                        <PanelContent markupV2={markupV2}>
+                        <PanelContent>
                             {body}
                         </PanelContent>
-                        <PanelFooter markupV2={markupV2}>
+                        <PanelFooter>
                             {footer}
                         </PanelFooter>
                     </>

--- a/scripts/core/interactive-article-actions-panel/index-combined.tsx
+++ b/scripts/core/interactive-article-actions-panel/index-combined.tsx
@@ -11,7 +11,6 @@ interface IProps {
      */
     location: 'authoring' | 'list-view';
     handleUnsavedChanges?(items: Array<IArticle>): Promise<Array<IArticle>>;
-    markupV2?: boolean;
     onError: (error: IPanelError) => void;
     onDataChange: (item: IArticle) => void;
 }
@@ -33,7 +32,6 @@ export class InteractiveArticleActionsPanelCombined extends React.PureComponent<
                             tabs={state.tabs}
                             activeTab={state.activeTab}
                             handleUnsavedChanges={this.props.handleUnsavedChanges}
-                            markupV2={this.props.markupV2}
                             onClose={actions.closePanel}
                         />
                     );

--- a/scripts/core/interactive-article-actions-panel/index-ui.tsx
+++ b/scripts/core/interactive-article-actions-panel/index-ui.tsx
@@ -14,8 +14,7 @@ import {FetchToTab} from './actions/fetch-to-tab';
 import {UnspikeTab} from './actions/unspike-tab';
 import {IArticleActionInteractive, IPanelAction} from './interfaces';
 import {ActionTabs} from './action-tabs';
-
-const singleColumnWidthRem = 40; // rem
+import {singleColumnWidthRem} from './actions/publish-action';
 
 const handleUnsavedChangesDefault = (items: Array<IArticle>) => Promise.resolve(items);
 

--- a/scripts/core/interactive-article-actions-panel/index-ui.tsx
+++ b/scripts/core/interactive-article-actions-panel/index-ui.tsx
@@ -6,7 +6,7 @@ import {Button} from 'superdesk-ui-framework/react';
 import {gettext} from 'core/utils';
 import {Panel} from './panel/panel-main';
 import {PanelHeader} from './panel/panel-header';
-import {authoringReactViewEnabled, appConfig} from 'appConfig';
+import {appConfig} from 'appConfig';
 import {DuplicateToTab} from './actions/duplicate-to-tab';
 import {WithPublishTab} from './actions/publish-tab';
 import {logger} from 'core/services/logger';
@@ -25,7 +25,6 @@ export interface IPropsInteractiveArticleActionsPanelStateless extends IPanelAct
      * `location` is added in order to be able to determine which one should be activated.
      */
     handleUnsavedChanges?(items: Array<IArticle>): Promise<Array<IArticle>>;
-    markupV2?: boolean;
     onClose(): void;
     onDataChange?(item: IArticle): void;
 }
@@ -53,11 +52,10 @@ export class InteractiveArticleActionsPanel
     render() {
         const {items, tabs, onClose, onError, onDataChange} = this.props;
         const {activeTab} = this.state;
-        const markupV2 = authoringReactViewEnabled && this.props.markupV2 === true;
         const handleUnsavedChanges = this.props.handleUnsavedChanges ?? handleUnsavedChangesDefault;
 
         const panelHeader = (
-            <PanelHeader markupV2={markupV2}>
+            <PanelHeader>
                 <div className="space-between" style={{width: '100%', paddingInlineEnd: 10}}>
                     <ActionTabs
                         tabs={tabs}
@@ -87,7 +85,6 @@ export class InteractiveArticleActionsPanel
             return (
                 <Panel
                     width={`${singleColumnWidthRem * columnCount}rem`}
-                    markupV2={markupV2}
                     data-test-id="interactive-actions-panel"
                 >
                     {panelHeader}
@@ -117,7 +114,6 @@ export class InteractiveArticleActionsPanel
                     onError={onError}
                     item={item}
                     closePublishView={onClose}
-                    markupV2={markupV2}
                     handleUnsavedChanges={
                         () => handleUnsavedChanges([item]).then((res) => res[0])
                     }
@@ -150,7 +146,6 @@ export class InteractiveArticleActionsPanel
                     onError={onError}
                     item={item}
                     closePublishView={onClose}
-                    markupV2={markupV2}
                     handleUnsavedChanges={
                         () => handleUnsavedChanges([item]).then((res) => res[0])
                     }
@@ -170,7 +165,6 @@ export class InteractiveArticleActionsPanel
                         items={items}
                         closeSendToView={onClose}
                         handleUnsavedChanges={handleUnsavedChanges}
-                        markupV2={markupV2}
                     />
                 </PanelWithHeader>
             );
@@ -181,7 +175,6 @@ export class InteractiveArticleActionsPanel
                         items={items}
                         closeFetchToView={onClose}
                         handleUnsavedChanges={handleUnsavedChanges}
-                        markupV2={markupV2}
                     />
                 </PanelWithHeader>
             );
@@ -191,7 +184,6 @@ export class InteractiveArticleActionsPanel
                     <DuplicateToTab
                         items={items}
                         closeDuplicateToView={onClose}
-                        markupV2={markupV2}
                     />
                 </PanelWithHeader>
             );
@@ -201,7 +193,6 @@ export class InteractiveArticleActionsPanel
                     <UnspikeTab
                         items={items}
                         closeUnspikeView={onClose}
-                        markupV2={markupV2}
                     />
                 </PanelWithHeader>
             );

--- a/scripts/core/interactive-article-actions-panel/panel/panel-content.tsx
+++ b/scripts/core/interactive-article-actions-panel/panel/panel-content.tsx
@@ -1,25 +1,14 @@
 import React from 'react';
-import * as Layout from 'superdesk-ui-framework/react/components/Layouts';
 import {IPropsSendToPanel} from './panel-main';
 
 export class PanelContent extends React.PureComponent<IPropsSendToPanel> {
     render() {
-        if (this.props.markupV2) {
-            return (
-                <Layout.PanelContent>
-                    <Layout.PanelContentBlock>
-                        {this.props.children}
-                    </Layout.PanelContentBlock>
-                </Layout.PanelContent>
-            );
-        } else {
-            return (
-                <div className="side-panel__content" data-test-id={this.props['data-test-id']}>
-                    <div className="side-panel__content-block" style={{height: '100%'}}>
-                        {this.props.children}
-                    </div>
+        return (
+            <div className="side-panel__content" data-test-id={this.props['data-test-id']}>
+                <div className="side-panel__content-block" style={{height: '100%'}}>
+                    {this.props.children}
                 </div>
-            );
-        }
+            </div>
+        );
     }
 }

--- a/scripts/core/interactive-article-actions-panel/panel/panel-footer.tsx
+++ b/scripts/core/interactive-article-actions-panel/panel/panel-footer.tsx
@@ -1,25 +1,14 @@
 import React from 'react';
-import * as Layout from 'superdesk-ui-framework/react/components/Layouts';
 import {IPropsSendToPanel} from './panel-main';
 
 export class PanelFooter extends React.PureComponent<IPropsSendToPanel> {
     render() {
-        if (this.props.markupV2) {
-            return (
-                <Layout.PanelFooter>
-                    <div style={{width: '100%', display: 'flex', flexDirection: 'column', gap: 8}}>
-                        {this.props.children}
-                    </div>
-                </Layout.PanelFooter>
-            );
-        } else {
-            return (
-                <div className="side-panel__footer side-panel__footer--button-box-large">
-                    <div style={{width: '100%', display: 'flex', flexDirection: 'column', gap: 8}}>
-                        {this.props.children}
-                    </div>
+        return (
+            <div className="side-panel__footer side-panel__footer--button-box-large">
+                <div style={{width: '100%', display: 'flex', flexDirection: 'column', gap: 8}}>
+                    {this.props.children}
                 </div>
-            );
-        }
+            </div>
+        );
     }
 }

--- a/scripts/core/interactive-article-actions-panel/panel/panel-header.tsx
+++ b/scripts/core/interactive-article-actions-panel/panel/panel-header.tsx
@@ -1,21 +1,12 @@
 import React from 'react';
-import * as Layout from 'superdesk-ui-framework/react/components/Layouts';
 import {IPropsSendToPanel} from './panel-main';
 
 export class PanelHeader extends React.PureComponent<IPropsSendToPanel> {
     render() {
-        if (this.props.markupV2) {
-            return (
-                <Layout.PanelHeader>
-                    {this.props.children}
-                </Layout.PanelHeader>
-            );
-        } else {
-            return (
-                <div className="side-panel__header">
-                    {this.props.children}
-                </div>
-            );
-        }
+        return (
+            <div className="side-panel__header">
+                {this.props.children}
+            </div>
+        );
     }
 }

--- a/scripts/core/interactive-article-actions-panel/panel/panel-main.tsx
+++ b/scripts/core/interactive-article-actions-panel/panel/panel-main.tsx
@@ -1,41 +1,22 @@
 import React from 'react';
-import * as Layout from 'superdesk-ui-framework/react/components/Layouts';
 
 export interface IPropsSendToPanel {
-    /**
-     * Whether panel markup from ui-framework v3 RC should be used.
-     * It should be used when {@see authoringReactViewEnabled},
-     * but not when send-to panel is opened outside of authoring.
-     */
-    markupV2: boolean;
     'data-test-id'?: string;
     width?: React.CSSProperties['width'];
 }
 
 export class Panel extends React.PureComponent<IPropsSendToPanel> {
     render() {
-        if (this.props.markupV2) {
-            return (
-                <Layout.Panel
-                    side="right"
-                    open={true}
-                    size={this.props.width == null ? 'x-small' : {custom: this.props.width}}
-                >
+        return (
+            <div
+                className="sd-overlay-panel sd-overlay-panel--open sd-overlay-panel--dark-ui"
+                data-test-id={this.props['data-test-id']}
+                style={this.props.width == null ? undefined : {width: this.props.width}}
+            >
+                <div className="side-panel side-panel--shadow-right side-panel--dark-ui" data-theme="dark-ui">
                     {this.props.children}
-                </Layout.Panel>
-            );
-        } else {
-            return (
-                <div
-                    className="sd-overlay-panel sd-overlay-panel--open sd-overlay-panel--dark-ui"
-                    data-test-id={this.props['data-test-id']}
-                    style={this.props.width == null ? undefined : {width: this.props.width}}
-                >
-                    <div className="side-panel side-panel--shadow-right side-panel--dark-ui" data-theme="dark-ui">
-                        {this.props.children}
-                    </div>
                 </div>
-            );
-        }
+            </div>
+        );
     }
 }

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -793,6 +793,13 @@ declare module 'superdesk-api' {
          * Will prompt user to save changes. The promise will get rejected if user cancels saving.
          */
         handleUnsavedChanges(): Promise<IArticle>;
+
+        /**
+         * Lets a widget mark authoring fields as invalid, for example when the server
+         * rejects publishing because of a field that is not filled in.
+         */
+        getValidationErrors?(): IAuthoringValidationErrors;
+        setValidationErrors?(validationErrors: IAuthoringValidationErrors): void;
     }
 
     export interface IArticleSideWidget {

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -741,6 +741,19 @@ declare module 'superdesk-api' {
          * of that theme inherit to the entire widget subtree. Defaults to 'light'.
          */
         theme?: 'light' | 'dark';
+
+        /**
+         * Overrides the default side widget width, for widgets whose content is
+         * adaptive. Any CSS width. Defaults to the standard side widget width.
+         */
+        width?: React.CSSProperties['width'];
+
+        /**
+         * Gives the body a definite height instead of letting it size to its content,
+         * so that body content laid out with `height: 100%` resolves against the panel.
+         */
+        fillBodyHeight?: boolean;
+
         'data-test-id'?: string;
     }
 

--- a/scripts/core/superdesk-api.d.ts
+++ b/scripts/core/superdesk-api.d.ts
@@ -735,6 +735,13 @@ declare module 'superdesk-api' {
         // only works react based authoring
         background?: 'light' | 'grey';
         bodyPadding?: 'none' | 'small' | 'medium'; // default is 'medium'
+
+        /**
+         * Sets `data-theme` on the panel container so the design tokens
+         * of that theme inherit to the entire widget subtree. Defaults to 'light'.
+         */
+        theme?: 'light' | 'dark';
+        'data-test-id'?: string;
     }
 
     export interface IGenericSidebarComponentProps<T> {


### PR DESCRIPTION
### Purpose

A user opens an article in authoring-react and hits the purple door to send or publish it. The panel that slides in is white, while everything around it is dark. It reads as a different application bolted onto the editor.

The white panel is also a leftover. SDESK-7447 moved these actions into a side widget back in February, but its first bullet, "remove the interactive article actions panel", never happened. So authoring-react has been carrying two hosts for the same five actions, and the one the ticket screenshotted is the one that should not be there any more.

This makes the widget dark and finishes the removal.

### What has changed

- The send to / publish widget renders on a dark surface. `Layout.Panel` already accepts a `theme`, which emits `data-theme="dark-ui"`; the widget host just never passed it. The custom properties inherit to the whole subtree, so nothing else needed styling.
- The panel is no longer rendered inside authoring-react, and the `markupV2` branches that existed only to serve it are gone from `panel-main`, `panel-header`, `panel-content`, `panel-footer`, `index-ui` and the six `*-tab` files.
- **The panel component itself is untouched.** Monitoring, search and Angular authoring still render it, and they still dispatch `interactiveArticleActionStart`.

Two gaps turned up while removing it. Both would have shipped as regressions, so they are fixed here rather than filed:

- The widget never actually opened on `interactiveArticleActionStart`. Its listener only updated tabs on an already-mounted widget; nothing selected it. A "Send to" from the monitoring list against an item open in authoring-react would have gone nowhere once the panel was removed.
- Publishing validation errors were not reaching the fields. The panel fed them back through `setValidationErrors`; the widget's `handleError` was an empty stub, so field-level highlighting was silently lost. Toasts still fired, which is why it was easy to miss.

### Steps to test

With `auth-react` enabled:

1. Open an article, click the purple door. The widget should be dark, matching the rest of authoring.
2. Send the article to another desk from the widget and confirm it arrives.
3. With that article open, trigger "Send to" on the same item from the monitoring list. The widget should open on the right tab.
4. Try to publish an article that fails validation. The offending fields should highlight, not just show a toast.
5. With `auth-react` off, check the purple door in monitoring still behaves exactly as before.

### Known narrowing

For an archived or killed item that is open in authoring-react **and** actioned from the monitoring list, the action is now a no-op where the panel previously opened. The widget's `isAllowed` returns false for those states. Fixing it properly means changing `triggeredFromAuthoring` semantics in `index-hoc.tsx`, which affects Angular authoring too, so it is deliberately out of scope here.

### Checklist

- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves: SDESK-7804
