### PR TITLE
Annotate e2e specs with Confluence QA case coverage

### DIFF
--- a/e2e/client/playwright/article-send-to.spec.ts
+++ b/e2e/client/playwright/article-send-to.spec.ts
@@ -4,7 +4,11 @@ import {Monitoring} from './page-object-models/monitoring';
 import {restoreDatabaseSnapshot, s} from './utils';
 
 test.describe('sending an article', async () => {
-    test('sending an article to another desk', async ({page}) => {
+    test('sending an article to another desk', {
+        annotation: [
+            {type: 'confluence', description: '1308524834 complete'}, // 🤖 Send item to another desk (AUTOMATED)
+        ],
+    }, async ({page}) => {
         const monitoring = new Monitoring(page);
         const authoring = new Authoring(page);
 
@@ -28,7 +32,11 @@ test.describe('sending an article', async () => {
         ).toBeVisible();
     });
 
-    test('sending an article to another stage of the same desk', async ({page}) => {
+    test('sending an article to another stage of the same desk', {
+        annotation: [
+            {type: 'confluence', description: '1308524832 complete'}, // 🤖 Send item to another stage (AUTOMATED)
+        ],
+    }, async ({page}) => {
         const monitoring = new Monitoring(page);
         const authoring = new Authoring(page);
 

--- a/e2e/client/playwright/article-versions.spec.ts
+++ b/e2e/client/playwright/article-versions.spec.ts
@@ -3,7 +3,14 @@ import {Monitoring} from './page-object-models/monitoring';
 import {restoreDatabaseSnapshot, s} from './utils';
 
 test.describe('article versions', async () => {
-    test('reverting to a previous article version', async ({page}) => {
+    test('reverting to a previous article version', {
+        annotation: [
+            {type: 'confluence', description: '1310294128 partial'}, // Versioning
+            {type: 'confluence', description: '1308524923 partial'}, // Item versions (Mikayel)
+            {type: 'confluence', description: '1308524925 partial'}, // Check item history
+            {type: 'confluence', description: '1308524929 partial'}, // Revert to a previous version
+        ],
+    }, async ({page}) => {
         const monitoring = new Monitoring(page);
 
         await restoreDatabaseSnapshot();

--- a/e2e/client/playwright/authoring.custom-fields.spec.ts
+++ b/e2e/client/playwright/authoring.custom-fields.spec.ts
@@ -22,7 +22,16 @@ async function addFieldsToContentProfile(
     await contentProfileSettings.addFieldsToContentProfile('Story', fields);
 }
 
-test('creating a custom text field', async ({page}) => {
+test('creating a custom text field', {
+    annotation: [
+        {type: 'confluence', description: '1311835044 partial'}, // Add new custom text field (AUTOMATED)
+        {type: 'confluence', description: '1344443809 partial'}, // Custom text
+        // Edit content profile content fields - PASS Mikayel 13.10
+        {type: 'confluence', description: '1311834985 complete'},
+        // Create New Article utilizing new CP-template with custom fields added - PASS - 20.10
+        {type: 'confluence', description: '1344443857 complete'},
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/settings/vocabularies');
 
@@ -36,7 +45,12 @@ test('creating a custom text field', async ({page}) => {
     await expectFieldToBeVisibleInAuthoring(page, 'custom text field 2');
 });
 
-test('creating a custom date field', async ({page}) => {
+test('creating a custom date field', {
+    annotation: [
+        {type: 'confluence', description: '1311835054 partial'}, // Add new custom date field (AUTOMATED)
+        {type: 'confluence', description: '1344443799 partial'}, // Custom date
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/settings/vocabularies');
 
@@ -50,7 +64,12 @@ test('creating a custom date field', async ({page}) => {
     await expectFieldToBeVisibleInAuthoring(page, 'custom date field 2');
 });
 
-test('creating a custom embed field', async ({page}) => {
+test('creating a custom embed field', {
+    annotation: [
+        {type: 'confluence', description: '1311835062 partial'}, // Add new custom embed field (AUTOMATED)
+        {type: 'confluence', description: '1344443803 partial'}, // Custom embed
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/settings/vocabularies');
 
@@ -64,7 +83,13 @@ test('creating a custom embed field', async ({page}) => {
     await expectFieldToBeVisibleInAuthoring(page, 'custom embed field 2');
 });
 
-test('creating a related content field', async ({page}) => {
+test('creating a related content field', {
+    annotation: [
+        {type: 'confluence', description: '1311835070 partial'}, // Add new related content field (AUTOMATED)
+        {type: 'confluence', description: '1344443805 partial'}, // Custom related content
+        {type: 'confluence', description: '1344443807 partial'}, // Custom related content (media gall)
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/settings/vocabularies');
 
@@ -83,7 +108,12 @@ test('creating a related content field', async ({page}) => {
     await expectFieldToBeVisibleInAuthoring(page, 'related content field 2');
 });
 
-test('creating a custom URL field', async ({page}) => {
+test('creating a custom URL field', {
+    annotation: [
+        {type: 'confluence', description: '1311835079 partial'}, // Add new URL field (AUTOMATED)
+        {type: 'confluence', description: '1344443811 partial'}, // Custom URL
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/settings/vocabularies');
 
@@ -100,7 +130,12 @@ test('creating a custom URL field', async ({page}) => {
     await expectFieldToBeVisibleInAuthoring(page, 'custom url field 2');
 });
 
-test('creating a field based on a vocabulary', async ({page}) => {
+test('creating a field based on a vocabulary', {
+    annotation: [
+        {type: 'confluence', description: '1311835040 partial'}, // Add new vocabulary (AUTOMATED)
+        {type: 'confluence', description: '10815143953 partial'}, // Vocabularies
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/settings/vocabularies');
 

--- a/e2e/client/playwright/authoring.legacy.media-gallery.spec.ts
+++ b/e2e/client/playwright/authoring.legacy.media-gallery.spec.ts
@@ -52,7 +52,11 @@ test.describe('media gallery (legacy)', () => {
         await login(page);
     });
 
-    test('uploading an image with default crops adds it to the gallery', async ({page}) => {
+    test('uploading an image with default crops adds it to the gallery', {
+        annotation: [
+            {type: 'confluence', description: '1344444010 complete'}, // Media functionality for Body Editor3 (Mikayel)
+        ],
+    }, async ({page}) => {
         const monitoring = new Monitoring(page);
 
         await page.goto('/#/workspace/monitoring');

--- a/e2e/client/playwright/authoring.picture.spec.ts
+++ b/e2e/client/playwright/authoring.picture.spec.ts
@@ -11,7 +11,14 @@ import {setEditor3FieldValue} from './utils/editor3';
  * edit metadata
  * test metadata changes from modal are visible in the editor
  */
-test('media metadata editor', async ({page}) => {
+test('media metadata editor', {
+    annotation: [
+        {type: 'confluence', description: '1311834322 partial'}, // Edit image metadata
+        {type: 'confluence', description: '1315931673 partial'}, // Edit values in metadata fields
+        {type: 'confluence', description: '1315931211 partial'}, // Upload a single image by selecting from folder
+        {type: 'confluence', description: '1311835200 partial'}, // Upload image to Personal space
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
 
     const upload = new MediaUpload(page);

--- a/e2e/client/playwright/authoring.spec.ts
+++ b/e2e/client/playwright/authoring.spec.ts
@@ -5,7 +5,12 @@ import {restoreDatabaseSnapshot, s} from './utils';
 const defaultPriorityValue = '6';
 const defaultUrgencyValue = '3';
 
-test('applying "populate abstract" macro', async ({page}) => {
+test('applying "populate abstract" macro', {
+    annotation: [
+        {type: 'confluence', description: '1332117825 complete'}, // Populate Abstract
+        {type: 'confluence', description: '1344443792 complete'}, // Macros
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
 
     const monitoring = new Monitoring(page);
@@ -42,7 +47,13 @@ test('applying "populate abstract" macro', async ({page}) => {
     ).toHaveText('test sport story body');
 });
 
-test('cancel and ignore buttons from unsaved changes modal', async ({page}) => {
+test('cancel and ignore buttons from unsaved changes modal', {
+    annotation: [
+        {type: 'confluence', description: '1310851153 complete'}, // Create new article (AUTOMATED)
+        {type: 'confluence', description: '1310851164 partial'}, // Create, save and close new article
+        {type: 'confluence', description: '1308524765 partial'}, // Edit existing item
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();
@@ -83,7 +94,12 @@ test('save button from unsaved changes modal', async ({page}) => {
     await expect(page.locator(s('monitoring-view', 'article-item=new article'))).toBeVisible();
 });
 
-test('setting embargo', async ({page}) => {
+test('setting embargo', {
+    annotation: [
+        {type: 'confluence', description: '1308524955 partial'}, // Set embargo (Nareg)
+        {type: 'confluence', description: '1344443874 complete'}, // Setting embargo (AUTOMATED)
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();

--- a/e2e/client/playwright/compare-versions.authoring-react.spec.ts
+++ b/e2e/client/playwright/compare-versions.authoring-react.spec.ts
@@ -8,7 +8,11 @@ test.use({
     storageState: getStorageState({}, {authoringReact: true}),
 });
 
-test('compare versions renders dateline and custom field differences (authoring-react)', async ({page}) => {
+test('compare versions renders dateline and custom field differences (authoring-react)', {
+    annotation: [
+        {type: 'confluence', description: '1308524931 partial'}, // Compare versions (AUTOMATED)
+    ],
+}, async ({page}) => {
     // `compare-fields` clones the default snapshot and adds urls/boolean/dropdown custom fields plus
     // a populated dateline on the Story profile, with two versions carrying differing values.
     await restoreDatabaseSnapshot({snapshotName: 'compare-fields'});

--- a/e2e/client/playwright/content-filters.spec.ts
+++ b/e2e/client/playwright/content-filters.spec.ts
@@ -129,7 +129,16 @@ test.describe('content filters', () => {
         await login(page);
     });
 
-    test('can manage filter conditions', async ({page}) => {
+    test('can manage filter conditions', {
+        annotation: [
+            {type: 'confluence', description: '1311834375 complete'}, // Content filters (AUTOMATED)
+            // Defining Publishing routes (Mikayel) - BEING AUTOMATED SDESK-7561
+            {type: 'confluence', description: '1344443878 partial'},
+            {type: 'confluence', description: '1311835278 partial'}, // Add new filter condition
+            {type: 'confluence', description: '1311835310 complete'}, // Remove filter condition
+            {type: 'confluence', description: '1344444313 complete'}, // Content filters_PASS
+        ],
+    }, async ({page}) => {
         await openFilterConditionsTab(page);
 
         await addFilterCondition(page, {
@@ -196,7 +205,11 @@ test.describe('content filters', () => {
         ).toBeVisible();
     });
 
-    test('can contain complex statements', async ({page}) => {
+    test('can contain complex statements', {
+        annotation: [
+            {type: 'confluence', description: '1311835280 complete'}, // Add new filter
+        ],
+    }, async ({page}) => {
         await openFilterConditionsTab(page);
 
         await addFilterCondition(page, {

--- a/e2e/client/playwright/content-profile.spec.ts
+++ b/e2e/client/playwright/content-profile.spec.ts
@@ -59,6 +59,14 @@ async function openTemplateEdit(page: Page, name: string): Promise<void> {
 
 test(
     'content profile auto-creates matching template; deleting blanks template profile',
+    {
+        annotation: [
+            // Create new content profile (Mikayel) - PASS 13.10 (AUTOMATED)
+            {type: 'confluence', description: '1308524961 complete'},
+            // Use content profile in a template - PASS - Mikayel 20.10
+            {type: 'confluence', description: '1311834555 complete'},
+        ],
+    },
     async ({page}) => {
         const PROFILE_NAME = 'Simple';
 
@@ -108,7 +116,12 @@ test(
     },
 );
 
-test('content profile required field blocks publish', async ({page}) => {
+test('content profile required field blocks publish', {
+    annotation: [
+        // Edit content profile header fields - PASS Mikayel 13.10
+        {type: 'confluence', description: '1311834983 complete'},
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();

--- a/e2e/client/playwright/correct-item-corrections-workflow.spec.ts
+++ b/e2e/client/playwright/correct-item-corrections-workflow.spec.ts
@@ -10,7 +10,11 @@ test.use({
 
 test.setTimeout(60000);
 
-test('can correct published item using corrections workflow', async ({page}) => {
+test('can correct published item using corrections workflow', {
+    annotation: [
+        {type: 'confluence', description: '1344443358 partial'}, // 🤖 Corrections workflow (AUTOMATED)
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();

--- a/e2e/client/playwright/correct-item.spec.ts
+++ b/e2e/client/playwright/correct-item.spec.ts
@@ -2,7 +2,11 @@ import {test, expect} from '@playwright/test';
 import {Monitoring} from './page-object-models/monitoring';
 import {restoreDatabaseSnapshot, s} from './utils';
 
-test('can correct published item', async ({page}) => {
+test('can correct published item', {
+    annotation: [
+        {type: 'confluence', description: '1310851139 complete'}, // 🤖 Correct item (AUTOMATED)
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();

--- a/e2e/client/playwright/dashboard.monitor-widget-config.spec.ts
+++ b/e2e/client/playwright/dashboard.monitor-widget-config.spec.ts
@@ -35,7 +35,11 @@ async function selectDesk(page: Page, deskName: string) {
         .click();
 }
 
-test('configures a custom label for a monitor widget', async ({page}) => {
+test('configures a custom label for a monitor widget', {
+    annotation: [
+        {type: 'confluence', description: '1308524881 complete'}, // Monitoring Widget Settings
+    ],
+}, async ({page}) => {
     await selectDesk(page, 'Politic Desk');
     await addMonitorWidget(page);
 

--- a/e2e/client/playwright/dashboard.monitoring-widget.spec.ts
+++ b/e2e/client/playwright/dashboard.monitoring-widget.spec.ts
@@ -1,7 +1,13 @@
 import {test, expect} from '@playwright/test';
 import {restoreDatabaseSnapshot, s} from './utils';
 
-test('can add saved search to monitoring widget', async ({page}) => {
+test('can add saved search to monitoring widget', {
+    annotation: [
+        // Use private saved search in the Monitoring widget (only in workspace)
+        {type: 'confluence', description: '1318322990 partial'},
+        {type: 'confluence', description: '1318322988 partial'}, // Use global saved search in Monitoring widget
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/workspace');
 

--- a/e2e/client/playwright/dashboard.spec.ts
+++ b/e2e/client/playwright/dashboard.spec.ts
@@ -2,7 +2,11 @@ import {test, expect} from '@playwright/test';
 import {Monitoring} from './page-object-models/monitoring';
 import {restoreDatabaseSnapshot, s} from './utils';
 
-test('adding a widget to a dashboard', async ({page}) => {
+test('adding a widget to a dashboard', {
+    annotation: [
+        {type: 'confluence', description: '1308524869 partial'}, // Add widget to Dashboard of the desk
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();

--- a/e2e/client/playwright/desks.spec.ts
+++ b/e2e/client/playwright/desks.spec.ts
@@ -2,7 +2,12 @@ import {test, expect, Page} from '@playwright/test';
 import {login, restoreDatabaseSnapshot, s, withTestContext} from './utils';
 import {Monitoring} from './page-object-models/monitoring';
 
-test('adding a desk', async ({page}) => {
+test('adding a desk', {
+    annotation: [
+        {type: 'confluence', description: '1311834267 partial'}, // Add new desk (AUTOMATED)
+        {type: 'confluence', description: '1344443818 complete'}, // Desks and stages
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
 
     await page.goto('/#/settings/desks');
@@ -21,7 +26,11 @@ test('adding a desk', async ({page}) => {
     await expect(page.locator(s('desk--desk 7'))).toBeVisible();
 });
 
-test('deleting a desk', async ({page}) => {
+test('deleting a desk', {
+    annotation: [
+        {type: 'confluence', description: '1311834334 complete'}, // Deleting desk (AUTOMATED)
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
 
     await page.goto('/#/settings/desks');
@@ -103,7 +112,12 @@ test('desk notifications', async ({page}) => {
     ).toContainText('1');
 });
 
-test('can mark/unmark for desk', async ({page}) => {
+test('can mark/unmark for desk', {
+    annotation: [
+        {type: 'confluence', description: '1315931720 complete'}, // Unmark item from desk (AUTOMATED)
+        {type: 'confluence', description: '1311835247 partial'}, // Mark article for desk from the list view (AUTOMATED)
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();
@@ -141,7 +155,11 @@ test('can mark/unmark for desk', async ({page}) => {
     ).not.toBeVisible();
 });
 
-test('Switching between desks', async ({page}) => {
+test('Switching between desks', {
+    annotation: [
+        {type: 'confluence', description: '1344443825 complete'}, // Desk switching (AUTOMATED)
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();
@@ -232,7 +250,13 @@ test.describe('desks - legacy snapshot', () => {
         await expiryRow.locator('input[ng-model="contentExpiry.minutes"]').fill(String(minutes));
     }
 
-    test('edit desk', async ({page}) => {
+    test('edit desk', {
+        annotation: [
+            {type: 'confluence', description: '1311834275 complete'}, // Edit general desk settings
+            {type: 'confluence', description: '1311834273 partial'}, // Edit stage
+            {type: 'confluence', description: '1335329041 complete'}, // Remove stage
+        ],
+    }, async ({page}) => {
         await restoreDatabaseSnapshot({snapshotName: 'legacy'});
         await login(page);
         await openDesksSettings(page);
@@ -337,7 +361,11 @@ test.describe('desks - legacy snapshot', () => {
         await closeDeskModal(page);
     });
 
-    test('can set stage macro for new desk', async ({page}) => {
+    test('can set stage macro for new desk', {
+        annotation: [
+            {type: 'confluence', description: '1311834271 partial'}, // Create new stage
+        ],
+    }, async ({page}) => {
         await restoreDatabaseSnapshot({snapshotName: 'legacy'});
         await login(page);
         await openDesksSettings(page);
@@ -407,7 +435,11 @@ test.describe('desks - legacy snapshot', () => {
         await closeDeskModal(page);
     });
 
-    test('can enforce incoming, outgoing and onstage rules', async ({page}) => {
+    test('can enforce incoming, outgoing and onstage rules', {
+        annotation: [
+            {type: 'confluence', description: '1311834259 partial'}, // Assign user to a desk
+        ],
+    }, async ({page}) => {
         const monitoring = new Monitoring(page);
         const deskName = `Rule Desk ${Date.now()}`;
 

--- a/e2e/client/playwright/dictionaries.spec.ts
+++ b/e2e/client/playwright/dictionaries.spec.ts
@@ -9,7 +9,13 @@ async function openAddDictionaryMenu(page: Page): Promise<void> {
     await expect(page.locator(s('create-personal-dictionary'))).toBeVisible();
 }
 
-test('create, edit, add and remove a word in, and delete a dictionary', async ({page}) => {
+test('create, edit, add and remove a word in, and delete a dictionary', {
+    annotation: [
+        {type: 'confluence', description: '1311835017 complete'}, // Remove global dictionary
+        {type: 'confluence', description: '1311835015 complete'}, // Edit global dictionary
+        {type: 'confluence', description: '1311834994 complete'}, // Add new global dictionary
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/settings/dictionaries');
 
@@ -53,7 +59,11 @@ test('create, edit, add and remove a word in, and delete a dictionary', async ({
     await expect(page.locator(s('dictionary-row=Test Dict 2'))).not.toBeVisible();
 });
 
-test('create a personal dictionary', async ({page}) => {
+test('create a personal dictionary', {
+    annotation: [
+        {type: 'confluence', description: '1311834997 complete'}, // Add new personal dictionary
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/settings/dictionaries');
 

--- a/e2e/client/playwright/edit-embed.spec.ts
+++ b/e2e/client/playwright/edit-embed.spec.ts
@@ -43,7 +43,11 @@ test.describe('editing an embed in the article body', () => {
         });
     }
 
-    test('hover controls open the edit dialog; Cancel discards, Submit persists across reopen', async ({page}) => {
+    test('hover controls open the edit dialog; Cancel discards, Submit persists across reopen', {
+        annotation: [
+            {type: 'confluence', description: '1327759385 complete'}, // Edit embed (AUTOMATED)
+        ],
+    }, async ({page}) => {
         await restoreDatabaseSnapshot();
         await stubIframely(page);
 

--- a/e2e/client/playwright/editor3.spec.ts
+++ b/e2e/client/playwright/editor3.spec.ts
@@ -4,7 +4,11 @@ import {restoreDatabaseSnapshot, s} from './utils';
 import {getEditor3FormattingOptions, getEditor3Paragraphs} from './utils/editor3';
 import {TreeSelectDriver} from './utils/tree-select-driver';
 
-test('can add embeds', async ({page}) => {
+test('can add embeds', {
+    annotation: [
+        {type: 'confluence', description: '1308524917 complete'}, // Add embed (AUTOMATED)
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
 
     const monitoring = new Monitoring(page);
@@ -122,7 +126,11 @@ test('adding word marked as a spellchecker issue to dictionary', async ({page}) 
  * FYI undo/redo isn't working the same as in the main editor outside tables
  * and it's not great that it's character based.
  */
-test('tables maintaining cursor position at the start when executing "undo" action', async ({page}) => {
+test('tables maintaining cursor position at the start when executing "undo" action', {
+    annotation: [
+        {type: 'confluence', description: '1308524921 partial'}, // Add table
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot({snapshotName: 'editor3-tables'});

--- a/e2e/client/playwright/fetching.spec.ts
+++ b/e2e/client/playwright/fetching.spec.ts
@@ -48,7 +48,12 @@ test('fetching an article to selected desk', async ({page}) => {
     ).toBeVisible();
 });
 
-test('fetching an article', async ({page}) => {
+test('fetching an article', {
+    annotation: [
+        {type: 'confluence', description: '1308524853 partial'}, // Fetch item (AUTOMATED)
+        {type: 'confluence', description: '1311834953 complete'}, // Go to items from ingest source
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();

--- a/e2e/client/playwright/hightlights.spec.ts
+++ b/e2e/client/playwright/hightlights.spec.ts
@@ -3,7 +3,11 @@ import {Monitoring} from './page-object-models/monitoring';
 import {restoreDatabaseSnapshot, s} from './utils';
 
 test.describe('highlights', async () => {
-    test('creating a global highlight', async ({page}) => {
+    test('creating a global highlight', {
+        annotation: [
+            {type: 'confluence', description: '1311834311 complete'}, // 🤖 Add a new (automated)
+        ],
+    }, async ({page}) => {
         const monitoring = new Monitoring(page);
 
         await restoreDatabaseSnapshot();
@@ -25,7 +29,11 @@ test.describe('highlights', async () => {
         await expect(page.locator(s('workspace-navigation')).getByRole('button', {name: 'Highlight 2'})).toBeVisible();
     });
 
-    test('creating a desk highlight', async ({page}) => {
+    test('creating a desk highlight', {
+        annotation: [
+            {type: 'confluence', description: '1311834309 complete'}, // 🤖 Test desk-specific highlights (automated)
+        ],
+    }, async ({page}) => {
         const monitoring = new Monitoring(page);
 
         await restoreDatabaseSnapshot();
@@ -49,7 +57,11 @@ test.describe('highlights', async () => {
         ).not.toBeVisible();
     });
 
-    test('adding an item to a highlights list', async ({page}) => {
+    test('adding an item to a highlights list', {
+        annotation: [
+            {type: 'confluence', description: '1311834313 complete'}, // 🤖 Add item to highlight list (automated)
+        ],
+    }, async ({page}) => {
         const monitoring = new Monitoring(page);
 
         await restoreDatabaseSnapshot();
@@ -69,7 +81,11 @@ test.describe('highlights', async () => {
         await expect(page.locator(s('articles-list', 'article-item=test sports story'))).toBeVisible();
     });
 
-    test('creating a highlights package', async ({page}) => {
+    test('creating a highlights package', {
+        annotation: [
+            {type: 'confluence', description: '1311834315 complete'}, // 🤖 Create highlights package (automated)
+        ],
+    }, async ({page}) => {
         // requires an article created on today's date for highlight inclusion
 
         const monitoring = new Monitoring(page);
@@ -105,7 +121,14 @@ test.describe('highlights', async () => {
         await expect(page.locator(s('monitoring-view', 'article-item=Package Highlight 2'))).toBeVisible();
     });
 
-    test('publishing a highlights package', async ({page}) => {
+    test('publishing a highlights package', {
+        annotation: [
+            {type: 'confluence', description: '1328906283 complete'}, // Publishing package
+            // Check Publishing a package (Nareg) - BEING AUTOMATED SDESK-7596
+            {type: 'confluence', description: '1344443870 partial'},
+            {type: 'confluence', description: '1311834317 complete'}, // 🤖 Publish highlights package (automated)
+        ],
+    }, async ({page}) => {
         const monitoring = new Monitoring(page);
 
         await restoreDatabaseSnapshot();
@@ -135,7 +158,11 @@ test.describe('highlights', async () => {
         ).toBeVisible();
     });
 
-    test('exporting a highlight', async ({page}) => {
+    test('exporting a highlight', {
+        annotation: [
+            {type: 'confluence', description: '1311834319 complete'}, // 🤖 Export highlights (automated)
+        ],
+    }, async ({page}) => {
         // requires an article created on today's date for highlight inclusion
 
         const monitoring = new Monitoring(page);

--- a/e2e/client/playwright/ingest-provider.spec.ts
+++ b/e2e/client/playwright/ingest-provider.spec.ts
@@ -68,7 +68,11 @@ test.describe('ingest provider', () => {
         await expect(page.locator(s('ingest-dashboard-list', 'ingest-dashboard-widget'))).toHaveCount(0);
     });
 
-    test('change settings for ingest provider widget', async ({page}) => {
+    test('change settings for ingest provider widget', {
+        annotation: [
+            {type: 'confluence', description: '1308524883 complete'}, // Ingest Widget Settings
+        ],
+    }, async ({page}) => {
         await addProviderToDashboard(page);
 
         const widget = page.locator(s('ingest-dashboard-list', `ingest-dashboard-widget=${PROVIDER_NAME}`));
@@ -92,7 +96,13 @@ test.describe('ingest provider', () => {
         await expect(page.locator(s('ingest-settings'))).toBeVisible();
     });
 
-    test('open edit source dialog from ingest settings', async ({page}) => {
+    test('open edit source dialog from ingest settings', {
+        annotation: [
+            {type: 'confluence', description: '1311834976 complete'}, // Add source
+            {type: 'confluence', description: '1311834949 complete'}, // Add ingest source
+            {type: 'confluence', description: '1311834951 complete'}, // Edit ingest source
+        ],
+    }, async ({page}) => {
         await addProviderToDashboard(page);
 
         const widget = page.locator(s('ingest-dashboard-list', `ingest-dashboard-widget=${PROVIDER_NAME}`));

--- a/e2e/client/playwright/ingest-settings.spec.ts
+++ b/e2e/client/playwright/ingest-settings.spec.ts
@@ -17,14 +17,25 @@ async function startNewSchemeWithFetchPublishRule(page: Page, schemeName: string
     await page.locator(s('rule-handler--desk_fetch_publish')).click();
 }
 
-test.describe('ingest_settings', () => {
+test.describe('ingest_settings', {
+    annotation: [
+        {type: 'confluence', description: '1311834968 partial'}, // Add new routing scheme
+    ],
+}, () => {
     test.beforeEach(async ({page}) => {
         await restoreDatabaseSnapshot({snapshotName: 'legacy'});
         await login(page);
         await openRoutingTab(page);
     });
 
-    test('contains the Schedule tab for editing routing schedules', async ({page}) => {
+    test('contains the Schedule tab for editing routing schedules', {
+        annotation: [
+            {type: 'confluence', description: '1315934696 complete'}, // Add new rule
+            {type: 'confluence', description: '1315934702 complete'}, // Add Fetch action
+            {type: 'confluence', description: '1315934704 complete'}, // Add Publish action
+            {type: 'confluence', description: '1315934706 complete'}, // Schedule
+        ],
+    }, async ({page}) => {
         await startNewSchemeWithFetchPublishRule(page, 'My Routing Scheme');
 
         await page.locator('[placeholder="Rule name"]').fill('Routing Rule 1');

--- a/e2e/client/playwright/internal-destinations.crud.spec.ts
+++ b/e2e/client/playwright/internal-destinations.crud.spec.ts
@@ -3,7 +3,11 @@ import {restoreDatabaseSnapshot, s} from './utils';
 
 test.use({storageState: {cookies: [], origins: []}});
 
-test.describe('internal destinations - CRUD, preview & sort', () => {
+test.describe('internal destinations - CRUD, preview & sort', {
+    annotation: [
+        {type: 'confluence', description: '1332117815 complete'}, // Internal destinations
+    ],
+}, () => {
     test.beforeEach(async ({page}) => {
         await restoreDatabaseSnapshot({snapshotName: 'legacy'});
 

--- a/e2e/client/playwright/internal-destinations.spec.ts
+++ b/e2e/client/playwright/internal-destinations.spec.ts
@@ -1,7 +1,12 @@
 import {test, expect} from '@playwright/test';
 import {restoreDatabaseSnapshot, s} from './utils';
 
-test.describe('internal destinations', async () => {
+test.describe('internal destinations', {
+    annotation: [
+        // Internal Destination for a Smoke test (PASS 27.10.25)
+        {type: 'confluence', description: '10545135631 partial'},
+    ],
+}, async () => {
     test('display and removal of active filters', async ({page}) => {
         await restoreDatabaseSnapshot();
 

--- a/e2e/client/playwright/legal-archive.spec.ts
+++ b/e2e/client/playwright/legal-archive.spec.ts
@@ -2,7 +2,11 @@ import {test, expect} from '@playwright/test';
 import {restoreDatabaseSnapshot, s, login} from './utils';
 import {Monitoring} from './page-object-models/monitoring';
 
-test.describe('legal archive', () => {
+test.describe('legal archive', {
+    annotation: [
+        {type: 'confluence', description: '1311834385 complete'}, // Legal archive
+    ],
+}, () => {
     test('shows Legal Archive entry in the hamburger menu', async ({page}) => {
         await restoreDatabaseSnapshot();
         await page.goto('/#/workspace/monitoring');

--- a/e2e/client/playwright/mark-for-desks.authoring-react.spec.ts
+++ b/e2e/client/playwright/mark-for-desks.authoring-react.spec.ts
@@ -9,7 +9,11 @@ test.use({
     storageState: getStorageState({}, {authoringReact: true}),
 });
 
-test('mark for desks: per-action toggle via modal (authoring-react)', async ({page}) => {
+test('mark for desks: per-action toggle via modal (authoring-react)', {
+    annotation: [
+        {type: 'confluence', description: '1315931717 complete'}, // Mark open article for desk (AUTOMATED)
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     const monitoring = new Monitoring(page);
     const authoring = new Authoring(page);

--- a/e2e/client/playwright/monitoring.custom-workspace.spec.ts
+++ b/e2e/client/playwright/monitoring.custom-workspace.spec.ts
@@ -2,7 +2,11 @@ import {test, expect} from '@playwright/test';
 import {Monitoring} from './page-object-models/monitoring';
 import {restoreDatabaseSnapshot, s} from './utils';
 
-test('creating a custom workspace', async ({page}) => {
+test('creating a custom workspace', {
+    annotation: [
+        {type: 'confluence', description: '1315930206 complete'}, // Create new custom workspace (AUTOMATED)
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/workspace/monitoring');
 
@@ -35,7 +39,12 @@ test('cancelling creation of a custom workspace', async ({page}) => {
     ).not.toBeVisible();
 });
 
-test('creating an article from a custom workspace', async ({page}) => {
+test('creating an article from a custom workspace', {
+    annotation: [
+        // Create, save and close new article in custom workspace (AUTOMATED)
+        {type: 'confluence', description: '1318323005 partial'},
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();

--- a/e2e/client/playwright/monitoring.desk-output.spec.ts
+++ b/e2e/client/playwright/monitoring.desk-output.spec.ts
@@ -57,7 +57,11 @@ test('article appears in destination desk working stage after Send to', async ({
  * When the user edits and publishes it,
  * Then the article shows up under Sports desk output.
  */
-test('published article appears in source desk output', async ({page}) => {
+test('published article appears in source desk output', {
+    annotation: [
+        {type: 'confluence', description: '1308524957 partial'}, // Publish article
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();

--- a/e2e/client/playwright/monitoring.duplication-extensions.spec.ts
+++ b/e2e/client/playwright/monitoring.duplication-extensions.spec.ts
@@ -10,7 +10,11 @@ import {TreeSelectDriver} from './utils/tree-select-driver';
  * When the user duplicates it to Finance / Working Stage,
  * Then the article is visible in Finance / Working Stage.
  */
-test('duplicate to a different desk and stage', async ({page}) => {
+test('duplicate to a different desk and stage', {
+    annotation: [
+        {type: 'confluence', description: '1311835243 complete'}, // Duplicate article to another place (AUTOMATED)
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
     const articleSelector = s('monitoring-group=Sports / Working Stage', 'article-item=test sports story');
 

--- a/e2e/client/playwright/monitoring.duplication.spec.ts
+++ b/e2e/client/playwright/monitoring.duplication.spec.ts
@@ -2,7 +2,11 @@ import {test, expect} from '@playwright/test';
 import {Monitoring} from './page-object-models/monitoring';
 import {restoreDatabaseSnapshot, s} from './utils';
 
-test('duplicate in place action', async ({page}) => {
+test('duplicate in place action', {
+    annotation: [
+        {type: 'confluence', description: '1311835241 complete'}, // Duplicate article in place (AUTOMATED)
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
     const articleSelector = s('monitoring-group=Sports / Working Stage', 'article-item=test sports story');
 

--- a/e2e/client/playwright/monitoring.misc.spec.ts
+++ b/e2e/client/playwright/monitoring.misc.spec.ts
@@ -72,7 +72,11 @@ test('open upload-media modal from the content-create menu', async ({page}) => {
 /**
  * Searching the monitoring list narrows results across all groups to matching items.
  */
-test('searching the monitoring list filters items across groups', async ({page}) => {
+test('searching the monitoring list filters items across groups', {
+    annotation: [
+        {type: 'confluence', description: '1308524885 complete'}, // Search field (AUTOMATED)
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();

--- a/e2e/client/playwright/monitoring.personal-space.spec.ts
+++ b/e2e/client/playwright/monitoring.personal-space.spec.ts
@@ -2,7 +2,13 @@ import {test, expect} from '@playwright/test';
 import {Monitoring} from './page-object-models/monitoring';
 import {restoreDatabaseSnapshot, s} from './utils';
 
-test('creating an article in personal space', async ({page}) => {
+test('creating an article in personal space', {
+    annotation: [
+        {type: 'confluence', description: '1311835196 complete'}, // Create new article in Personal space (AUTOMATED)
+        // Create new article from a template in Personal space
+        {type: 'confluence', description: '1311835206 complete'},
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();
@@ -13,7 +19,11 @@ test('creating an article in personal space', async ({page}) => {
     await expect(page.locator(s('monitoring-group=Personal Items', 'article-item=article 1'))).toBeVisible();
 });
 
-test('editing an article in personal space', async ({page}) => {
+test('editing an article in personal space', {
+    annotation: [
+        {type: 'confluence', description: '1311835208 complete'}, // Edit article in Personal space (AUTOMATED)
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();
@@ -33,7 +43,11 @@ test('editing an article in personal space', async ({page}) => {
     ).toBeVisible();
 });
 
-test('copying an article in personal space', async ({page}) => {
+test('copying an article in personal space', {
+    annotation: [
+        {type: 'confluence', description: '1311835212 complete'}, // Copy article in Personal space (AUTOMATED)
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();
@@ -49,7 +63,11 @@ test('copying an article in personal space', async ({page}) => {
     await expect(page.locator(s('article-item=personal space article 1'))).toHaveCount(2);
 });
 
-test('sending an item from personal space', async ({page}) => {
+test('sending an item from personal space', {
+    annotation: [
+        {type: 'confluence', description: '1311835216 complete'}, // Send item from Personal space (AUTOMATED)
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();

--- a/e2e/client/playwright/monitoring.preview.spec.ts
+++ b/e2e/client/playwright/monitoring.preview.spec.ts
@@ -14,14 +14,22 @@ import {restoreDatabaseSnapshot} from './utils';
  * has related items (see ItemPreview's showRelatedTab), which the snapshot's
  * "test sports story" does not have.
  */
-test.describe('opening an article in preview mode', () => {
+test.describe('opening an article in preview mode', {
+    annotation: [
+        {type: 'confluence', description: '1333690440 complete'}, // Item preview
+    ],
+}, () => {
     const ARTICLE = 'test sports story';
 
     test.beforeEach(async () => {
         await restoreDatabaseSnapshot();
     });
 
-    test('single click previews the item read-only and the close icon dismisses it', async ({page}) => {
+    test('single click previews the item read-only and the close icon dismisses it', {
+        annotation: [
+            {type: 'confluence', description: '1311835227 partial'}, // 🤖 Open article in preview mode (AUTOMATED)
+        ],
+    }, async ({page}) => {
         const monitoring = new Monitoring(page);
 
         await page.goto('/#/workspace/monitoring');

--- a/e2e/client/playwright/monitoring.publishing.spec.ts
+++ b/e2e/client/playwright/monitoring.publishing.spec.ts
@@ -3,7 +3,12 @@ import {Monitoring} from './page-object-models/monitoring';
 import {restoreDatabaseSnapshot, s} from './utils';
 import {TreeSelectDriver} from './utils/tree-select-driver';
 
-test('publishing an article from a different desk', async ({page}) => {
+test('publishing an article from a different desk', {
+    annotation: [
+        // Sending items between desks_ (PASS 20.10) (AUTOMATED)
+        {type: 'confluence', description: '1344443827 complete'},
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();

--- a/e2e/client/playwright/monitoring.settings.spec.ts
+++ b/e2e/client/playwright/monitoring.settings.spec.ts
@@ -15,7 +15,12 @@ import {restoreDatabaseSnapshot, s} from './utils';
  * rendered when a desk is the active selection. The per-desk entry point lives on the
  * desks settings page (`desk-actions--monitoring-settings`).
  */
-test('enabling a global saved search shows it on the monitoring view', async ({page}) => {
+test('enabling a global saved search shows it on the monitoring view', {
+    annotation: [
+        // Saved searches tab in Monitoring settings of the desk
+        {type: 'confluence', description: '1315934715 partial'},
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();
@@ -60,7 +65,11 @@ test('enabling a global saved search shows it on the monitoring view', async ({p
  * behaviour after switching desks is what users care about and what `main` supports
  * without extra fixture work.)
  */
-test('switching between desks shows the selected desk monitoring groups', async ({page}) => {
+test('switching between desks shows the selected desk monitoring groups', {
+    annotation: [
+        {type: 'confluence', description: '1315934713 partial'}, // Desks tab in Monitoring settings
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();

--- a/e2e/client/playwright/monitoring.spiking.spec.ts
+++ b/e2e/client/playwright/monitoring.spiking.spec.ts
@@ -2,7 +2,12 @@ import {test, expect} from '@playwright/test';
 import {Monitoring} from './page-object-models/monitoring';
 import {restoreDatabaseSnapshot, s} from './utils';
 
-test('spiking and unspiking an article', async ({page}) => {
+test('spiking and unspiking an article', {
+    annotation: [
+        {type: 'confluence', description: '1311834144 complete'}, // Unspike item (AUTOMATED)
+        {type: 'confluence', description: '1308524774 complete'}, // Spike item (AUTOMATED)
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();

--- a/e2e/client/playwright/multiedit.spec.ts
+++ b/e2e/client/playwright/multiedit.spec.ts
@@ -6,7 +6,11 @@ import {restoreDatabaseSnapshot, s} from './utils';
 import {clearInput} from './utils/inputs';
 
 test.describe('Multiedit', async () => {
-    test('editing articles in multi-edit mode', async ({page}) => {
+    test('editing articles in multi-edit mode', {
+        annotation: [
+            {type: 'confluence', description: '1311834330 complete'}, // 🤖 Multiedit (AUTOMATED)
+        ],
+    }, async ({page}) => {
         const monitoring = new Monitoring(page);
         const multiedit = new MultiEdit(page);
 

--- a/e2e/client/playwright/notifications.spec.ts
+++ b/e2e/client/playwright/notifications.spec.ts
@@ -7,7 +7,12 @@ import {login, restoreDatabaseSnapshot, s} from './utils';
 // so we override it and log in fresh.
 test.use({storageState: {cookies: [], origins: []}});
 
-test('user mention notifies the mentioned user and clearing the badge', async ({page, browser}) => {
+test('user mention notifies the mentioned user and clearing the badge', {
+    annotation: [
+        {type: 'confluence', description: '1344443904 partial'}, // Comments
+        {type: 'confluence', description: '1311834891 complete'}, // Comments
+    ],
+}, async ({page, browser}) => {
     await restoreDatabaseSnapshot({snapshotName: 'legacy'});
 
     // log in as the author and post a mention of admin1

--- a/e2e/client/playwright/package.spec.ts
+++ b/e2e/client/playwright/package.spec.ts
@@ -29,7 +29,11 @@ function packageGroupItems(page: Page, groupId: string): Locator {
 }
 
 test.describe('package', () => {
-    test('increment package version', async ({page}) => {
+    test('increment package version', {
+        annotation: [
+            {type: 'confluence', description: '1310294142 partial'}, // Add single item to existing package (AUTOMATED)
+        ],
+    }, async ({page}) => {
         const monitoring = new Monitoring(page);
 
         await restoreDatabaseSnapshot();
@@ -93,7 +97,11 @@ test.describe('package', () => {
         ).toHaveCount(0);
     });
 
-    test('create package from multiple items via bulk action', async ({page}) => {
+    test('create package from multiple items via bulk action', {
+        annotation: [
+            {type: 'confluence', description: '1308524947 partial'}, // Create package from multiple items
+        ],
+    }, async ({page}) => {
         const monitoring = new Monitoring(page);
 
         await restoreDatabaseSnapshot();
@@ -133,7 +141,12 @@ test.describe('package', () => {
         await expect(packageGroupItems(page, 'main')).toHaveCount(2);
     });
 
-    test('add multiple items to the currently open package via bulk action', async ({page}) => {
+    test('add multiple items to the currently open package via bulk action', {
+        annotation: [
+            // Add multiple items to existing package (AUTOMATED)
+            {type: 'confluence', description: '1310294139 partial'},
+        ],
+    }, async ({page}) => {
         const monitoring = new Monitoring(page);
 
         await restoreDatabaseSnapshot();
@@ -160,7 +173,11 @@ test.describe('package', () => {
         await expect(page.locator(s('authoring', 'package-items=story 2'))).toBeVisible();
     });
 
-    test('create package from a published item via global search', async ({page}) => {
+    test('create package from a published item via global search', {
+        annotation: [
+            {type: 'confluence', description: '1310294136 partial'}, // Create a package from a single item
+        ],
+    }, async ({page}) => {
         await restoreDatabaseSnapshot();
         await page.goto('/#/search?repo=published');
 

--- a/e2e/client/playwright/publish-queue.spec.ts
+++ b/e2e/client/playwright/publish-queue.spec.ts
@@ -5,7 +5,12 @@ import {getCellValueByColumTitle, restoreDatabaseSnapshot, s} from './utils';
 
 test.setTimeout(50000);
 
-test('item appearing in publish queue after publishing with subscriber', async ({page}) => {
+test('item appearing in publish queue after publishing with subscriber', {
+    annotation: [
+        {type: 'confluence', description: '1311834383 partial'}, // 🤖 Publish Queue (Nareg) (AUTOMATED)
+        {type: 'confluence', description: '1344443868 complete'}, // Check Publish Queue (Nareg) (AUTOMATED)
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
     const authoring = new Authoring(page);
 

--- a/e2e/client/playwright/remove-embed.spec.ts
+++ b/e2e/client/playwright/remove-embed.spec.ts
@@ -61,7 +61,11 @@ test.describe('removing an embed from the article body', () => {
         return EMBEDS.find((embed) => srcdoc.includes(embed.marker))!.marker;
     }
 
-    test('removing one embed deletes only it and preserves the other across reopen', async ({page}) => {
+    test('removing one embed deletes only it and preserves the other across reopen', {
+        annotation: [
+            {type: 'confluence', description: '1327759390 complete'}, // Remove embed (AUTOMATED)
+        ],
+    }, async ({page}) => {
         await restoreDatabaseSnapshot();
         await stubIframely(page);
 

--- a/e2e/client/playwright/saved-search.spec.ts
+++ b/e2e/client/playwright/saved-search.spec.ts
@@ -29,7 +29,11 @@ function priorityFilters(page: Page) {
     return page.locator('[ng-repeat="(key,value) in aggregations.priority"]');
 }
 
-test('can save a private search', async ({page}) => {
+test('can save a private search', {
+    annotation: [
+        {type: 'confluence', description: '1318322985 complete'}, // Create a new private saved search
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot({snapshotName: 'legacy'});
     await login(page);
     await openGlobalSearchListView(page);
@@ -57,7 +61,11 @@ test('can save a private search', async ({page}) => {
     await expect(userSavedSearches.first().locator('.search-name')).toContainText('A Search');
 });
 
-test('can save a global search and another user sees it', async ({browser, page}) => {
+test('can save a global search and another user sees it', {
+    annotation: [
+        {type: 'confluence', description: '1318322983 complete'}, // Create a new global saved search
+    ],
+}, async ({browser, page}) => {
     await restoreDatabaseSnapshot({snapshotName: 'legacy'});
     await login(page);
     await openGlobalSearchListView(page);

--- a/e2e/client/playwright/search.spec.ts
+++ b/e2e/client/playwright/search.spec.ts
@@ -51,7 +51,12 @@ test.describe('global search (legacy snapshot)', () => {
         await openGlobalSearchListView(page);
     });
 
-    test('searches by free-text, byline, slugline, creator and ingest provider', async ({page}) => {
+    test('searches by free-text, byline, slugline, creator and ingest provider', {
+        annotation: [
+            {type: 'confluence', description: '1308524892 partial'}, // Advanced Search (Alice)
+            {type: 'confluence', description: '1308524890 partial'}, // Search function
+        ],
+    }, async ({page}) => {
         await expect(items(page)).toHaveCount(16);
 
         await page.locator('#search-input').click();

--- a/e2e/client/playwright/spike.spec.ts
+++ b/e2e/client/playwright/spike.spec.ts
@@ -31,7 +31,11 @@ async function clickBulkAction(page: import('@playwright/test').Page, label: str
     }
 }
 
-test('can spike item from personal workspace', async ({page}) => {
+test('can spike item from personal workspace', {
+    annotation: [
+        {type: 'confluence', description: '1311835214 partial'}, // Spike item from Personal space
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/workspace/personal');
 

--- a/e2e/client/playwright/subscribers.spec.ts
+++ b/e2e/client/playwright/subscribers.spec.ts
@@ -7,7 +7,13 @@ test.describe('subscribers', () => {
         await page.goto('/#/settings/publish');
     });
 
-    test('lists the default subscriber', async ({page}) => {
+    test('lists the default subscriber', {
+        annotation: [
+            {type: 'confluence', description: '1311834381 complete'}, // Subscribers
+            {type: 'confluence', description: '1344443887 complete'}, // Creating Subscribers and Associating Products
+            {type: 'confluence', description: '1344444319 partial'}, // Subscribers_ PASS
+        ],
+    }, async ({page}) => {
         const subscriberItems = page.locator(s('subscriber-item'));
 
         await expect(subscriberItems).toHaveCount(1);

--- a/e2e/client/playwright/templates.auto-create.spec.ts
+++ b/e2e/client/playwright/templates.auto-create.spec.ts
@@ -3,7 +3,12 @@ import {restoreDatabaseSnapshot, s} from './utils';
 
 const TEMPLATE_NAME = 'Auto Created Template';
 
-test('creating an automatic-item-creation template persists schedule on reload', async ({page}) => {
+test('creating an automatic-item-creation template persists schedule on reload', {
+    annotation: [
+        {type: 'confluence', description: '1311835102 complete'}, // Automatically create item
+        {type: 'confluence', description: '1311835104 complete'}, // Add new schedule
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/settings/templates');
 

--- a/e2e/client/playwright/templates.spec.ts
+++ b/e2e/client/playwright/templates.spec.ts
@@ -3,7 +3,11 @@ import {Monitoring} from './page-object-models/monitoring';
 import {Authoring} from './page-object-models/authoring';
 import {restoreDatabaseSnapshot, s} from './utils';
 
-test('creating new template', async ({page}) => {
+test('creating new template', {
+    annotation: [
+        {type: 'confluence', description: '1309835271 complete'}, // Create new template
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/settings/templates');
 
@@ -22,7 +26,11 @@ test('creating new template', async ({page}) => {
     await expect(page.locator(s('template-content', 'content-template=template 1'))).toBeVisible();
 });
 
-test('editing template name', async ({page}) => {
+test('editing template name', {
+    annotation: [
+        {type: 'confluence', description: '1311835108 partial'}, // Edit template
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/settings/templates');
 
@@ -34,7 +42,11 @@ test('editing template name', async ({page}) => {
     await expect(page.locator(s('template-content', 'content-template=story 1.1'))).toBeVisible();
 });
 
-test('removing template', async ({page}) => {
+test('removing template', {
+    annotation: [
+        {type: 'confluence', description: '1309835275 complete'}, // Remove template
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/settings/templates');
 
@@ -44,7 +56,11 @@ test('removing template', async ({page}) => {
     await expect(page.locator(s('template-content', 'content-template=story 2'))).not.toBeVisible();
 });
 
-test('assigning template to a desk', async ({page}) => {
+test('assigning template to a desk', {
+    annotation: [
+        {type: 'confluence', description: '1308524963 complete'}, // Assign template to a desk
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();
@@ -135,7 +151,12 @@ test('legal-flag toggle on a template persists across edit', async ({page}) => {
     ).toHaveClass(/checked/);
 });
 
-test('default content template', async ({page}) => {
+test('default content template', {
+    annotation: [
+        {type: 'confluence', description: '10542284955 complete'}, // default value saved in templates Mikayel - PASS
+        {type: 'confluence', description: '1311834559 partial'}, // Default content template
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();
@@ -153,7 +174,11 @@ test('default content template', async ({page}) => {
     await expect(page.locator(s('content-create-dropdown', 'default-desk-template'))).toHaveText('story 2');
 });
 
-test('new article prefilling with content set in template', async ({page}) => {
+test('new article prefilling with content set in template', {
+    annotation: [
+        {type: 'confluence', description: '1311834557 partial'}, // Prefill template
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
 
     await restoreDatabaseSnapshot();
@@ -165,7 +190,11 @@ test('new article prefilling with content set in template', async ({page}) => {
     await expect(page.locator(s('authoring', 'field-slugline'))).toHaveValue('article 1');
 });
 
-test('performing "save as" action on a template', async ({page}) => {
+test('performing "save as" action on a template', {
+    annotation: [
+        {type: 'confluence', description: '1308524933 partial'}, // Save as template
+    ],
+}, async ({page}) => {
     const monitoring = new Monitoring(page);
     const authoring = new Authoring(page);
 

--- a/e2e/client/playwright/user-management.spec.ts
+++ b/e2e/client/playwright/user-management.spec.ts
@@ -1,7 +1,11 @@
 import {test, expect} from '@playwright/test';
 import {restoreDatabaseSnapshot, s} from './utils';
 
-test('creating a new user', async ({page}) => {
+test('creating a new user', {
+    annotation: [
+        {type: 'confluence', description: '1311834344 complete'}, // Add user (PASS 01.11.22)
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
 
     await page.goto('/#/users');

--- a/e2e/client/playwright/user-profile.spec.ts
+++ b/e2e/client/playwright/user-profile.spec.ts
@@ -19,7 +19,12 @@ test('switching system language', async ({page}) => {
     await expect(page.locator(s('page-title'))).toHaveText('Mein Profil');
 });
 
-test('can edit my profile', async ({page}) => {
+test('can edit my profile', {
+    annotation: [
+        {type: 'confluence', description: '1308524836 partial'}, // User profile (Mikayel)
+        {type: 'confluence', description: '1311834352 complete'}, // Profile settings
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/profile');
 
@@ -76,7 +81,11 @@ test('can disable a user', async ({page}) => {
     await expect(user).toBeVisible();
 });
 
-test('can reset password', async ({page}) => {
+test('can reset password', {
+    annotation: [
+        {type: 'confluence', description: '1311834356 complete'}, // Reset users password (pass 02.11)
+    ],
+}, async ({page}) => {
     await restoreDatabaseSnapshot();
     await page.goto('/#/profile');
 

--- a/e2e/client/playwright/vocabularies.spec.ts
+++ b/e2e/client/playwright/vocabularies.spec.ts
@@ -1,7 +1,15 @@
 import {test, expect} from '@playwright/test';
 import {restoreDatabaseSnapshot, s} from './utils';
 
-test('can restore vocabulary data when editing is cancelled', async ({page}) => {
+test('can restore vocabulary data when editing is cancelled', {
+    annotation: [
+        {type: 'confluence', description: '1311835056 partial'}, // Edit custom date field (AUTOMATED)
+        {type: 'confluence', description: '1311835064 partial'}, // Edit custom embed field (AUTOMATED)
+        {type: 'confluence', description: '1311835072 partial'}, // Edit related content field (AUTOMATED)
+        {type: 'confluence', description: '1311835046 partial'}, // Edit custom text field (AUTOMATED)
+        {type: 'confluence', description: '1311835042 partial'}, // Edit vocabulary (AUTOMATED)
+    ],
+}, async ({page}) => {
     const originalName = 'Categories';
     const updatedName = 'Categories test';
     const originalVocabularyItemSelector = s('metadata-content', `vocabulary-item=${originalName}`);


### PR DESCRIPTION
### Purpose
Baseline that links our existing Playwright e2e tests to their Confluence QA cases, so the QA coverage dashboard can track what's automated vs the backlog and show progress over time.

### What has changed
Adds `confluence` annotations to existing e2e tests, tagging each with the QA case id and whether coverage is complete or partial. Purely additive: no test logic changed, none added or removed. Format on the test's details object:
`{type: 'confluence', description: '<confluencePageId> complete|partial'}`

### Steps to test
Lint and type-check pass. Annotations render in the Playwright HTML report as `confluence: <id> ...`. No behavioural change to any test.