### PR TITLE
[SDESK-8005] Declare @swc/helpers as a regular dependency

### DIFF
--- a/e2e/client/package-lock.json
+++ b/e2e/client/package-lock.json
@@ -30,6 +30,7 @@
         "@sourcefabric/date-fns-tz": "^1.2.1",
         "@sourcefabric/draft-js": "^0.11.5",
         "@swc/core": "^1.15.47",
+        "@swc/helpers": "^0.5.23",
         "@types/angular": "~1.6.0",
         "@types/draft-js": "0.11.20",
         "@types/enzyme": "3.10.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@sourcefabric/date-fns-tz": "^1.2.1",
         "@sourcefabric/draft-js": "^0.11.5",
         "@swc/core": "^1.15.47",
+        "@swc/helpers": "^0.5.23",
         "@types/angular": "~1.6.0",
         "@types/draft-js": "0.11.20",
         "@types/enzyme": "3.10.19",
@@ -2316,6 +2317,15 @@
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@swc/types": {
       "version": "0.1.28",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@sourcefabric/date-fns-tz": "^1.2.1",
     "@sourcefabric/draft-js": "^0.11.5",
     "@swc/core": "^1.15.47",
+    "@swc/helpers": "^0.5.23",
     "@types/angular": "~1.6.0",
     "@types/draft-js": "0.11.20",
     "@types/enzyme": "3.10.19",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -264,6 +264,14 @@ module.exports = function makeConfig(grunt) {
     // tsc's default at target es5: without it, declaration-only class fields
     // (`scope: any;`) are defined as undefined after super() returns, wiping
     // values that parent constructors assigned.
+    //
+    // @swc/helpers is declared in dependencies although nothing imports it directly
+    // (swc only emits imports of it with externalHelpers enabled, which is not used
+    // here). Repos that consume superdesk-core as a git dependency get @swc/helpers
+    // in their tree anyway through @swc/core's optional peer dependency, and
+    // Dependabot's lockfile regeneration drops optional-peer entries, leaving a lock
+    // that fails `npm ci` there. A regular dependency stays a hard lock entry that
+    // survives regeneration. Do not remove it as unused.
     const swcOptions = (parser) => ({
         isModule: 'unknown',
         module: {type: 'commonjs'},


### PR DESCRIPTION
### Purpose
Since the swc-loader switch, every Dependabot bump of a client git dep in the superdesk repo produces a `client/package-lock.json` that fails `npm ci` (superdesk/superdesk#4251, superdesk/superdesk#4252). The consumer tree needs a nested `@swc/helpers` because `@swc/core` declares it as an optional peer and another copy in the tree activates it, but Dependabot's lock regeneration drops peer-flagged entries.

### What has changed
- `@swc/helpers` is declared in `dependencies`, so consumer lockfiles carry it as a hard entry instead of a peer-flagged one, which survives Dependabot's regeneration.
- A comment next to the swc config in `webpack.config.js` explains why the dependency exists, so it does not get removed as unused later (nothing imports it directly; swc only needs it with `externalHelpers`, which we do not use).
- `e2e/client/package-lock.json` regenerated, since it embeds the repo's dependency list through the `file:../..` link.

### Steps to test
- CI passing is enough here; both locks validate with `npm ci --dry-run`.
- The real validation happens in the superdesk repo: the next Dependabot "Bump superdesk-core" PR should keep the `client / install` job green. Until this lands there via a bump, superdesk/superdesk#4253 unblocks the current failures.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works