### PR TITLE
Automate Upload a single image by drag and drop (1315931215)

### DIFF
--- a/e2e/client/playwright/page-object-models/upload.ts
+++ b/e2e/client/playwright/page-object-models/upload.ts
@@ -1,6 +1,9 @@
-import {Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 import {s} from '../utils';
+import fs from 'fs';
 import path from 'path';
+
+const TEST_FILE_DIR = 'test-files';
 
 export class MediaUpload {
     private page: Page;
@@ -17,5 +20,68 @@ export class MediaUpload {
 
     async startUpload(): Promise<void> {
         await this.page.locator(s('file-upload', 'multi-image-edit--start-upload')).click();
+    }
+
+    getModal(): Locator {
+        return this.page.getByTestId('file-upload');
+    }
+
+    getDropArea(): Locator {
+        return this.getModal().getByTestId('drag-area');
+    }
+
+    getUploadButton(): Locator {
+        return this.getModal().getByTestId('multi-image-edit--start-upload');
+    }
+
+    getSelectedDesk(): Locator {
+        return this.getModal().getByTestId('upload-selected-desk');
+    }
+
+    /**
+     * Items already added to the upload, one per file waiting to be uploaded.
+     */
+    getItems(): Locator {
+        return this.getModal().getByTestId('media-grid-item');
+    }
+
+    /**
+     * Adds a file to the upload by dropping it on the drop area.
+     *
+     * A real OS drag-and-drop cannot be driven from Playwright, so the file is
+     * constructed inside the page and handed to a synthetic `drop` event. The
+     * bytes cross the boundary base64-encoded because `evaluateHandle` arguments
+     * are JSON-serialised. ng-file-upload's `ngf-drop` reads
+     * `dataTransfer.items`, which is what `DataTransfer.items.add(file)` fills.
+     */
+    async dropFile(filename: string, mimeType: string = 'image/jpeg'): Promise<void> {
+        const contents = fs.readFileSync(path.join(TEST_FILE_DIR, filename)).toString('base64');
+
+        const dataTransfer = await this.page.evaluateHandle(({base64, name, type}) => {
+            const bytes = Uint8Array.from(atob(base64), (character) => character.charCodeAt(0));
+            const transfer = new DataTransfer();
+
+            transfer.items.add(new File([bytes], name, {type}));
+
+            return transfer;
+        }, {base64: contents, name: filename, type: mimeType});
+
+        await this.getDropArea().dispatchEvent('drop', {dataTransfer});
+
+        await dataTransfer.dispose();
+    }
+
+    /**
+     * Picks the desk the uploaded media will be sent to.
+     */
+    async selectDesk(deskName: string): Promise<void> {
+        await this.getSelectedDesk().click();
+
+        await this.getModal()
+            .getByTestId('upload-select-desk-options')
+            .getByRole('button', {name: deskName, exact: true})
+            .click();
+
+        await expect(this.getSelectedDesk()).toContainText(deskName);
     }
 }

--- a/e2e/client/playwright/upload-media-drag-and-drop.spec.ts
+++ b/e2e/client/playwright/upload-media-drag-and-drop.spec.ts
@@ -1,0 +1,75 @@
+import {test, expect} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {MediaUpload} from './page-object-models/upload';
+import {MediaEditor} from './page-object-models/media-editor';
+import {PictureAuthoring} from './page-object-models/authoring';
+import {restoreDatabaseSnapshot} from './utils';
+import {setEditor3FieldValue} from './utils/editor3';
+
+/**
+ * QA case "Upload a single image by drag and drop".
+ *
+ * Opens the Upload media screen from the Monitoring create menu, drops one image
+ * on the drop area, retargets the upload at another desk, fills metadata and
+ * uploads. The image must end up on the desk that was picked, with the metadata
+ * entered before the upload preserved.
+ */
+test('uploading a single image by drag and drop', {
+    annotation: [
+        {type: 'confluence', description: '1315931215 partial'}, // Upload a single image by drag and drop
+    ],
+}, async ({page}) => {
+    const HEADLINE = 'dropped image';
+    const DESCRIPTION = 'dropped image description';
+
+    await restoreDatabaseSnapshot();
+
+    const monitoring = new Monitoring(page);
+    const upload = new MediaUpload(page);
+    const mediaEditor = new MediaEditor(page);
+    const pictureAuthoring = new PictureAuthoring(page);
+
+    await page.goto('/#/workspace/monitoring');
+
+    await monitoring.selectDeskOrWorkspace('Sports');
+    await monitoring.openMediaUploadView();
+
+    await expect(upload.getModal()).toBeVisible();
+    await expect(upload.getModal().getByTestId('drag-files-here')).toBeVisible();
+    await expect(upload.getModal().getByTestId('select-file-button')).toBeVisible();
+    await expect(upload.getSelectedDesk()).toContainText('Sports');
+    await expect(upload.getUploadButton()).toBeDisabled();
+
+    await upload.dropFile('image-red.jpg');
+
+    await expect(upload.getItems()).toHaveCount(1);
+
+    // the thumbnail is rendered from the dropped file's bytes, so it only shows
+    // once the file itself was read, not merely once an item was added
+    await expect(upload.getItems().locator('img')).toBeVisible();
+    await expect(upload.getModal().getByTestId('drag-files-here')).toBeHidden();
+    await expect(upload.getUploadButton()).toBeEnabled();
+
+    await upload.selectDesk('Education');
+
+    await setEditor3FieldValue(mediaEditor.field('field--headline'), HEADLINE);
+    await setEditor3FieldValue(mediaEditor.field('field--description_text'), DESCRIPTION);
+
+    await upload.startUpload();
+
+    await expect(upload.getModal()).toBeHidden();
+
+    await monitoring.selectDeskOrWorkspace('Education');
+
+    const uploadedItem = page.getByTestId('monitoring-group')
+        .and(page.locator('[data-test-value="Education / Working Stage"]'))
+        .getByTestId('article-item')
+        .filter({hasText: HEADLINE});
+
+    await expect(uploadedItem).toBeVisible();
+
+    await monitoring.executeActionOnMonitoringItem(uploadedItem, 'Edit');
+
+    await expect(pictureAuthoring.field('field--headline')).toHaveText(HEADLINE);
+    await expect(pictureAuthoring.field('field--description_text')).toHaveText(DESCRIPTION);
+});

--- a/scripts/apps/archive/views/upload.html
+++ b/scripts/apps/archive/views/upload.html
@@ -14,13 +14,13 @@
 >
     <sd-multi-edit-select-desk>
         <div ng-if="deskSelectionAllowed === true && desks !== null" class="dropdown dropdown--boxed" dropdown is-open="isOpen">
-            <button class="dropdown__toggle dropdown__toggle--small dropdown__toggle--hollow dropdown-toggle" dropdown__toggle aria-haspopup="true" aria-expanded="false">
+            <button class="dropdown__toggle dropdown__toggle--small dropdown__toggle--hollow dropdown-toggle" dropdown__toggle aria-haspopup="true" aria-expanded="false" data-test-id="upload-selected-desk">
                 <span class="dropdown__button-label">
                     Send to:</span> <span>{{selectedDesk.name}}</span>
                     <b class="dropdown__caret white"></b>
             </button>
             <!-- TODO: fix dropdown2 component so height adjusts according to available space-->
-            <ul class="dropdown__menu dropdown--align-right" style="max-height: 400px; overflow: auto;">
+            <ul class="dropdown__menu dropdown--align-right" style="max-height: 400px; overflow: auto;" data-test-id="upload-select-desk-options">
                 <li ng-repeat="desk in desks track by desk._id"><button ng-click="selectDesk(desk)">{{desk.name}}</button></li>
             </ul>
         </div>
@@ -28,13 +28,14 @@
 
     <sd-multi-edit-additional-content>
         <div class="drag-area"
+            data-test-id="drag-area"
             ngf-drop="addFiles($files)"
             ngf-multiple="!uniqueUpload"
             ngf-drag="drag($isDragging, $class, $event)">
             <div ng-if="isDragging" class="upload__target" style="display: block"></div>
             <div ng-if="(!items.length) && canUpload()" class="upload__info">
                 <div class="upload__info-icon"></div>
-                <h3 class="upload__info-heading" translate>Drag Your Files Here</h3>
+                <h3 class="upload__info-heading" translate data-test-id="drag-files-here">Drag Your Files Here</h3>
                 <div class="upload__info-label" translate>or</div>
                 <button ng-click="invokeImagesInput()" data-test-id="select-file-button" class="btn btn--hollow upload__info-button" translate>Select them from folder</button>
                 <input ng-if="uniqueUpload" id="images-input" type="file" ngf-select="addFiles($files)" class="hide" data-test-id="image-upload-input">

--- a/scripts/apps/search/views/multi-image-edit.html
+++ b/scripts/apps/search/views/multi-image-edit.html
@@ -44,6 +44,7 @@
                 <div class="sd-photo-preview__thumb-strip">
                     <div class="sd-grid-list">
                         <div class="sd-grid-item sd-grid-item--with-click"
+                             data-test-id="media-grid-item"
                              ng-click="handleItemClick($event, image)"
                              ng-repeat="image in images track by image._id"
                              ng-class="{'sd-grid-item--selected' : image.selected}"


### PR DESCRIPTION
### Purpose
Automates the QA case [Upload a single image by drag and drop](https://sofab.atlassian.net/wiki/spaces/SET/pages/1315931215) as a Playwright spec so it runs in CI instead of being tested by hand.

### What has changed
- New spec `e2e/client/playwright/upload-media-drag-and-drop.spec.ts` covering the scenario below
- Annotated with `{type: 'confluence', description: '1315931215 partial'}` per the coverage convention
- Adds `data-test-id` attributes to product source: `drag-area`, `drag-files-here`, `upload-selected-desk`, `upload-select-desk-options`, `media-grid-item` (needs developer eyes)

### Steps to test
**Given** the Sports desk is selected in Monitoring.

**When**
1. Open Upload media from the create menu
2. Drop a single JPEG on the drop area
3. Switch the target desk to Education
4. Fill headline and description
5. Click Upload

**Then**
- The Upload media screen closes
- The image appears in Education / Working Stage
- Opening it in the editor shows the headline and description entered before the upload

The spec also checks the drop-area contents ("Drag your files here" text plus "Select them from folder" button), the current desk being preselected, and the Upload button being disabled while no file is selected.

Run it: `cd e2e/client && npx playwright test upload-media-drag-and-drop.spec.ts`
The spec passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
