### PR TITLE
Automate Filter buttons (1308524887)

### DIFF
--- a/e2e/client/playwright/monitoring-filter-buttons.spec.ts
+++ b/e2e/client/playwright/monitoring-filter-buttons.spec.ts
@@ -1,0 +1,132 @@
+import {test, expect} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+
+/**
+ * The active toggle is only expressed as a CSS class; these anchors carry no
+ * aria-pressed or other state attribute.
+ */
+const ACTIVE = /toggle-button--active/;
+
+/**
+ * Internal item type and its button label, in the order the buttons are rendered.
+ */
+const ITEM_TYPES: Array<[string, string]> = [
+    ['all', 'all'],
+    ['text', 'text'],
+    ['picture', 'picture'],
+    ['graphic', 'graphic'],
+    ['composite', 'package'],
+    ['highlight-pack', 'highlights package'],
+    ['video', 'video'],
+    ['audio', 'audio'],
+];
+
+/**
+ * How many items each filter leaves in the Sports monitoring groups, given the `main` snapshot.
+ * It holds four text items ("test sports story", "story 2", "Story 3" and the published
+ * "Story 5") plus "Package Highlight 1", a package carrying a highlight, which the `composite`
+ * filter deliberately excludes (`CardsService.setQueryFiltersForFileType` matches non-highlight
+ * packages only). The snapshot has no picture, graphic, video or audio item, so those filters
+ * can only be shown to empty the list, never to select items of their own type.
+ */
+const LISTED: Record<string, number> = {
+    'all': 5,
+    'text': 4,
+    'picture': 0,
+    'graphic': 0,
+    'composite': 0,
+    'highlight-pack': 1,
+    'video': 0,
+    'audio': 0,
+};
+
+/**
+ * Well above the default 30s: opening monitoring can cost a reload (see
+ * `Monitoring.openMonitoringForDesk`) and each of the 14 filter changes below waits out the
+ * group's 1s query debounce plus the round trip.
+ */
+test.setTimeout(120000);
+
+test.describe('monitoring item type filter buttons', {
+    annotation: [
+        // partial: the snapshot has no picture/graphic/video/audio item, so those filters are
+        // only shown to exclude everything else, not to select items of their own type
+        {type: 'confluence', description: '1308524887 partial'}, // Filter buttons
+    ],
+}, () => {
+    test('one button per item type is offered, in a fixed order', async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const monitoring = new Monitoring(page);
+
+        await monitoring.openMonitoringForDesk('Sports');
+
+        const buttons = monitoring.getFileTypeFilterButtons();
+
+        await expect(buttons).toHaveCount(ITEM_TYPES.length);
+
+        for (const [index, [itemType, label]] of ITEM_TYPES.entries()) {
+            await expect(buttons.nth(index)).toHaveAttribute('data-test-id', `file-type-filter--${itemType}`);
+            await expect(buttons.nth(index)).toHaveAttribute('aria-label', label);
+        }
+    });
+
+    /**
+     * Selecting a type does not re-render the list synchronously: the monitoring group schedules a
+     * debounced query (1s) and leaves the previously rendered items in the DOM until the new
+     * response lands. Asserting that an already visible item is still visible would therefore pass
+     * against the stale list, so each step below waits on the resulting item count, which can only
+     * settle once the filtered query has landed, before checking which items survived.
+     */
+    test('the list is filtered by item type, with ALL selected by default', async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const monitoring = new Monitoring(page);
+
+        await monitoring.openMonitoringForDesk('Sports');
+
+        const articles = monitoring.getListedArticles();
+        const all = monitoring.getFileTypeFilterButton('all');
+        const text = monitoring.getFileTypeFilterButton('text');
+
+        const textArticle = monitoring.getListedArticle('story 2');
+        const packageArticle = monitoring.getListedArticle('Package Highlight 1');
+
+        await expect(all).toHaveClass(ACTIVE);
+        await expect(articles).toHaveCount(LISTED.all);
+        await expect(textArticle).toBeVisible();
+        await expect(packageArticle).toBeVisible();
+
+        for (const [itemType] of ITEM_TYPES.filter(([type]) => type !== 'all')) {
+            const button = monitoring.getFileTypeFilterButton(itemType);
+
+            await button.click();
+
+            await expect(button).toHaveClass(ACTIVE);
+            await expect(all).not.toHaveClass(ACTIVE);
+            await expect(articles).toHaveCount(LISTED[itemType]);
+            await expect(textArticle).toBeVisible({visible: itemType === 'text'});
+            await expect(packageArticle).toBeVisible({visible: itemType === 'highlight-pack'});
+
+            // clicking an active type toggle clears it, which is the same state as ALL
+            await button.click();
+
+            await expect(all).toHaveClass(ACTIVE);
+            await expect(button).not.toHaveClass(ACTIVE);
+            await expect(articles).toHaveCount(LISTED.all);
+        }
+
+        await text.click();
+
+        await expect(articles).toHaveCount(LISTED.text);
+
+        await all.click();
+
+        await expect(all).toHaveClass(ACTIVE);
+        await expect(text).not.toHaveClass(ACTIVE);
+        await expect(articles).toHaveCount(LISTED.all);
+        await expect(textArticle).toBeVisible();
+        await expect(packageArticle).toBeVisible();
+    });
+});

--- a/e2e/client/playwright/page-object-models/monitoring.ts
+++ b/e2e/client/playwright/page-object-models/monitoring.ts
@@ -26,6 +26,36 @@ export class Monitoring {
     }
 
     /**
+     * Opens the monitoring view on a desk and waits for its groups to render.
+     *
+     * `AggregateCtrl.getDefaultGroups` reads `desks.getCurrentDesk()._id`, and the
+     * workspace watcher that calls it sometimes fires before the current desk is
+     * resolved. The resulting TypeError aborts the digest, leaving the view with a
+     * working subnav but no groups and no item query, and nothing re-runs that
+     * query later, so reloading is the only recovery.
+     *
+     * The retry budget has to stay well under the caller's test timeout: `toPass` cannot
+     * interrupt an attempt that is already running, so a budget equal to the test timeout would
+     * be spent inside the last attempt and surface as a bare test timeout instead of this
+     * assertion, with no time left for the test body.
+     */
+    async openMonitoringForDesk(deskName: string): Promise<void> {
+        let loaded = false;
+
+        await expect(async () => {
+            if (loaded) {
+                await this.page.reload();
+            } else {
+                await this.page.goto('/#/workspace/monitoring');
+                loaded = true;
+            }
+
+            await this.selectDeskOrWorkspace(deskName);
+            await expect(this.page.getByTestId('monitoring-group').first()).toBeVisible({timeout: 10000});
+        }).toPass({timeout: 45000});
+    }
+
+    /**
      * opens 3-dot menu for an article and clicks on an action(supports nested actions)
      */
     async executeActionOnMonitoringItem(item: Locator, ...actionPath: Array<string>): Promise<void> {
@@ -122,6 +152,33 @@ export class Monitoring {
 
     getArticleLocator(headline: string): Locator {
         return this.page.locator(s('article-item=' + headline));
+    }
+
+    /**
+     * All article items currently listed in the monitoring groups.
+     */
+    getListedArticles(): Locator {
+        return this.page.getByTestId('monitoring-view').getByTestId('article-item');
+    }
+
+    getListedArticle(label: string): Locator {
+        return this.getListedArticles().and(this.page.locator(`[data-test-value="${label}"]`));
+    }
+
+    /**
+     * All item type toggles in the monitoring subnav, in render order.
+     */
+    getFileTypeFilterButtons(): Locator {
+        return this.page.getByTestId('monitoring-filter-buttons').getByTestId(/^file-type-filter--/);
+    }
+
+    /**
+     * One of the item type toggles in the monitoring subnav.
+     * `fileType` is the internal type, not the label: all, text, picture,
+     * graphic, composite (package), highlight-pack, video, audio.
+     */
+    getFileTypeFilterButton(fileType: string): Locator {
+        return this.page.getByTestId('monitoring-filter-buttons').getByTestId(`file-type-filter--${fileType}`);
     }
 
     getPreviewPane(): Locator {

--- a/scripts/apps/monitoring/views/monitoring-view.html
+++ b/scripts/apps/monitoring/views/monitoring-view.html
@@ -135,8 +135,8 @@
                     <div ng-hide="hideMonitoringToolbar2 === true" sd-media-query min-width="700" class="subnav">
 
                         <!-- filtering by file type not implemented for usage with custom data source -->
-                        <div ng-if="(!elementState || elementState === 'comfort') && customDataSource == null" class="button-list button-list--padded">
-                            <a href="" ng-repeat="fileType in aggregate.fileTypes" ng-click="aggregate.setFileFilter(fileType.type)" class="toggle-button" ng-class="{'toggle-button--active': aggregate.hasFileType(fileType.type)}" title="{{ fileType.label }}" aria-label="{{ fileType.label }}">
+                        <div ng-if="(!elementState || elementState === 'comfort') && customDataSource == null" class="button-list button-list--padded" data-test-id="monitoring-filter-buttons">
+                            <a href="" ng-repeat="fileType in aggregate.fileTypes" ng-click="aggregate.setFileFilter(fileType.type)" class="toggle-button" ng-class="{'toggle-button--active': aggregate.hasFileType(fileType.type)}" title="{{ fileType.label }}" aria-label="{{ fileType.label }}" data-test-id="{{'file-type-filter--' + fileType.type}}">
                                 <span ng-if="fileType.type === 'all'" class="toggle-button__text toggle-button__text--all">{{ fileType.label }}</span>
                                 <i ng-if="fileType.type !== 'all'" class="toggle-button__icon filetype-icon-{{fileType.type}}" aria-hidden="true"></i>
                             </a>


### PR DESCRIPTION
### Purpose
Automates the QA case [Filter buttons](https://sofab.atlassian.net/wiki/spaces/SET/pages/1308524887) as a Playwright spec so it runs in CI instead of being tested by hand.

### What has changed
- New spec `e2e/client/playwright/monitoring-filter-buttons.spec.ts` covering the scenario below
- Annotated with `{type: 'confluence', description: '1308524887 partial'}` per the coverage convention
- Adds `data-test-id` attributes to product source: `monitoring-filter-buttons`, `file-type-filter--{type}` (all, text, picture, graphic, composite, highlight-pack, video, audio) (needs developer eyes)

### Steps to test
**Given** the `main` snapshot restored and monitoring open on the Sports desk.

**When**
1. Inspect the item type filter buttons
2. Click each of the seven type toggles (text, picture, graphic, package, highlights package, video, audio)
3. Click each toggle again to clear it

**Then**
- Eight buttons render in a fixed order with the documented labels, with ALL active by default
- Each clicked toggle becomes active while ALL deselects
- The listed items narrow to that type: 4 text items including "story 2"; 1 highlights package, "Package Highlight 1"; nothing for the types the snapshot has no items of (package included, since the only package carries a highlight)
- Clearing the toggle or clicking ALL restores the full list of 5

Run it: `cd e2e/client && npx playwright test monitoring-filter-buttons.spec.ts`
The spec passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
