### PR TITLE
Automate Open items icon (1308524865)

### DIFF
--- a/e2e/client/playwright/open-items-icon.spec.ts
+++ b/e2e/client/playwright/open-items-icon.spec.ts
@@ -1,0 +1,71 @@
+import {test, expect} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {OpenedArticles} from './page-object-models/opened-articles';
+import {restoreDatabaseSnapshot} from './utils';
+
+/**
+ * QA case "Open items icon" (1308524865).
+ *
+ * The Open Items icon in the opened-articles bar opens a fullscreen view listing
+ * every article the user currently has open. Picking one there returns to the
+ * workspace with that article in the editor; the X in the top right corner
+ * leaves the view without changing what is open.
+ *
+ * The main snapshot already ships two articles locked by the admin, so they sit
+ * in the opened-articles bar from the start. Neither has a headline, and the
+ * dashboard cards are labelled by headline alone, so the spec opens
+ * "test sports story" as the article it picks in the dashboard and uses one of
+ * the snapshot ones only as the article the editor is switched away from.
+ */
+test.describe('open items icon', () => {
+    const SELECTED_ARTICLE = 'test sports story';
+    const OTHER_ARTICLE = 'Finances Story';
+    const TOTAL_OPEN_ARTICLES = 3;
+
+    test('lists every open article, reopens the selected one and closes on X', {
+        annotation: [
+            {type: 'confluence', description: '1308524865 complete'}, // Open items icon
+        ],
+    }, async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const monitoring = new Monitoring(page);
+        const openedArticles = new OpenedArticles(page);
+        const slugline = page.getByTestId('authoring').getByTestId('field-slugline');
+
+        await page.goto('/#/workspace/monitoring');
+        await monitoring.selectDeskOrWorkspace('Sports');
+
+        await expect(openedArticles.getBarItem(OTHER_ARTICLE)).toBeVisible();
+
+        await monitoring.getArticleLocator(SELECTED_ARTICLE).dblclick();
+        await expect(slugline).toHaveValue(SELECTED_ARTICLE);
+        await expect(openedArticles.getBarItems()).toHaveCount(TOTAL_OPEN_ARTICLES);
+
+        // Leave the editor on a different article, so opening one from the
+        // dashboard has an observable effect.
+        await openedArticles.getBarItem(OTHER_ARTICLE).click();
+        await expect(slugline).toHaveValue(OTHER_ARTICLE);
+
+        await expect(openedArticles.getOpenItemsIcon()).toBeVisible();
+        await openedArticles.openDashboard();
+
+        await expect(openedArticles.getDashboardItems()).toHaveCount(TOTAL_OPEN_ARTICLES);
+        await expect(openedArticles.getDashboardItem(SELECTED_ARTICLE)).toBeVisible();
+
+        await openedArticles.getDashboardItem(SELECTED_ARTICLE).click();
+
+        await expect(openedArticles.getDashboard()).not.toBeVisible();
+        await expect(page).toHaveURL(/#\/workspace\/monitoring/);
+        await expect(monitoring.getArticleLocator(SELECTED_ARTICLE)).toBeVisible();
+        await expect(slugline).toHaveValue(SELECTED_ARTICLE);
+
+        await openedArticles.openDashboard();
+        await openedArticles.closeDashboard();
+
+        // Leaving through the X only dismisses the view: nothing is closed and the
+        // editor keeps the article that was selected.
+        await expect(slugline).toHaveValue(SELECTED_ARTICLE);
+        await expect(openedArticles.getBarItems()).toHaveCount(TOTAL_OPEN_ARTICLES);
+    });
+});

--- a/e2e/client/playwright/page-object-models/opened-articles.ts
+++ b/e2e/client/playwright/page-object-models/opened-articles.ts
@@ -1,0 +1,65 @@
+import {Locator, Page, expect} from '@playwright/test';
+
+/**
+ * The bar at the bottom of the workspace listing the articles the current user
+ * has open, and the fullscreen "Currently working on" view its Open Items icon
+ * opens.
+ */
+export class OpenedArticles {
+    private page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    getBar(): Locator {
+        return this.page.getByTestId('opened-articles-bar');
+    }
+
+    getOpenItemsIcon(): Locator {
+        return this.getBar().getByTestId('open-items');
+    }
+
+    getBarItems(): Locator {
+        return this.getBar().getByTestId('item');
+    }
+
+    /**
+     * Bar entries are labelled with the article's headline, falling back to its
+     * slugline and then to "Untitled".
+     */
+    getBarItem(label: string): Locator {
+        return this.getBarItems().filter({hasText: label});
+    }
+
+    /**
+     * sd-modal moves the dialog to <body>, so it is not a descendant of the
+     * workqueue bar; locate it from the page root.
+     */
+    getDashboard(): Locator {
+        return this.page.getByTestId('opened-articles-dashboard');
+    }
+
+    getDashboardItems(): Locator {
+        return this.getDashboard().getByTestId('item');
+    }
+
+    /**
+     * Dashboard cards are labelled with the article's headline only, and show
+     * "Untitled" when there is none, so only articles that have a headline can
+     * be picked out this way.
+     */
+    getDashboardItem(headline: string): Locator {
+        return this.getDashboardItems().filter({hasText: headline});
+    }
+
+    async openDashboard(): Promise<void> {
+        await this.getOpenItemsIcon().click();
+        await expect(this.getDashboard()).toBeVisible();
+    }
+
+    async closeDashboard(): Promise<void> {
+        await this.getDashboard().getByTestId('close').click();
+        await expect(this.getDashboard()).not.toBeVisible();
+    }
+}

--- a/scripts/apps/authoring/views/dashboard-articles.html
+++ b/scripts/apps/authoring/views/dashboard-articles.html
@@ -1,13 +1,13 @@
 <div sd-modal data-model="active" data-close="closeDashboard()"
-    class="modal--fullscreen animate-zoom__from-bottom-left">
+    class="modal--fullscreen animate-zoom__from-bottom-left" data-test-id="'opened-articles-dashboard'">
     <div class="modal__header">
-        <button ng-click="closeDashboard()" title="{{ :: 'Close'|translate}}" class="modal__close pull-right animate-slide-in__from-right"><i class="icon-close-thick"></i></button>
+        <button ng-click="closeDashboard()" title="{{ :: 'Close'|translate}}" class="modal__close pull-right animate-slide-in__from-right" data-test-id="close"><i class="icon-close-thick"></i></button>
         <h3 class="modal__heading" translate>Currently working on</h3>        
     </div>
 
     <div class="modal__body">
         <div class="flex-grid box wrap-items small-2 medium-3 large-5 xlarge-6">
-            <div class="flex-item card-box card-box--with-click card-box--flex" ng-repeat="article in items track by article._id"  ng-class="{active: article === active}">
+            <div class="flex-item card-box card-box--with-click card-box--flex" ng-repeat="article in items track by article._id"  ng-class="{active: article === active}" data-test-id="item">
                 <a class="card-box__full-click" ng-click="edit(article, $event)" ng-href="{{ :: link(article)}}"></a>
                 <span class="close cardbox__close" ng-click="closeItem(article)"><i class="icon-close-small icon--white"></i></span>
                 <div class="card-box__header card-box__header--padded-flex">

--- a/scripts/apps/authoring/views/opened-articles.html
+++ b/scripts/apps/authoring/views/opened-articles.html
@@ -1,5 +1,5 @@
 <div class="opened-articles-bar" ng-class="{'menu-open': flags.menu}" data-test-id="opened-articles-bar">
-    <button class="opened-articles-bar__quick-actions" ng-click="openDashboard()" title="{{ 'All opened items' | translate }}"><i class="icon-th-large icon--white"></i></button>
+    <button class="opened-articles-bar__quick-actions" ng-click="openDashboard()" title="{{ 'All opened items' | translate }}" data-test-id="open-items"><i class="icon-th-large icon--white"></i></button>
 
     <ul ng-if="workqueue.items.length" class="opened-articles-bar__list">
         <li


### PR DESCRIPTION
### Purpose
Automates the QA case [Open items icon](https://sofab.atlassian.net/wiki/spaces/SET/pages/1308524865) as a Playwright spec so it runs in CI instead of being tested by hand.

### What has changed
- New spec `e2e/client/playwright/open-items-icon.spec.ts` covering the scenario below
- Annotated with `{type: 'confluence', description: '1308524865 complete'}` per the coverage convention
- Adds `data-test-id` attributes to product source: `open-items` (`scripts/apps/authoring/views/opened-articles.html`, the Open Items quick-action button), `opened-articles-dashboard` (`scripts/apps/authoring/views/dashboard-articles.html`, the `sd-modal` root; angular-expression form because `sd-modal` binds `testId` with `'='`), `close` (`scripts/apps/authoring/views/dashboard-articles.html`, the modal X button), `item` (`scripts/apps/authoring/views/dashboard-articles.html`, each article card) (needs developer eyes)

### Steps to test
**Given** the Sports desk monitoring view, with three articles open for editing: the two the `main` snapshot ships already locked by the admin ("Finances Story" and an untitled one) plus "test sports story", and the editor currently showing "Finances Story".

**When**
1. Click the Open Items icon in the opened-articles bar at the bottom of the workspace.
2. Click the "test sports story" card in the "Currently working on" view.
3. Click the Open Items icon again, then click the X in the top right corner of the view.

**Then**
- The "Currently working on" view opens and lists all three open articles.
- Picking "test sports story" closes the view, returns to the monitoring workspace and loads that article in the editor.
- The X closes the view again, leaves the editor on "test sports story" and keeps all three articles open.

The spec also checks that the Open Items icon itself is visible, that the card count matches the number of entries in the opened-articles bar, and that the URL is back on `#/workspace/monitoring` after picking an article.

Run it: `cd e2e/client && npx playwright test open-items-icon.spec.ts`

The spec passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
