### PR TITLE
Automate World Clock Widget Settings (1308524876)

### DIFF
--- a/e2e/client/playwright/dashboard.world-clock-widget-config.spec.ts
+++ b/e2e/client/playwright/dashboard.world-clock-widget-config.spec.ts
@@ -1,0 +1,255 @@
+import {test, expect, Locator, Page} from '@playwright/test';
+import {Dashboard} from './page-object-models/dashboard';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot, waitForToastMessage} from './utils';
+
+/**
+ * Documented expected results that are NOT covered here:
+ *
+ * - "When you select more than 3 clocks, you will have to adjust the size of your widget to display them all at
+ *   the same time. This can be done on the Rearrange widgets settings page."
+ *   Blocker: proving the fourth clock is clipped until the widget is resized needs a pixel-level layout check
+ *   (no visual snapshots are allowed) and a gridster drag-resize, which is inherently flaky. The spec covers the
+ *   data half of it: a fourth clock is added to the widget.
+ *
+ * - Test steps 7-8: a second user who is a member of the same desk sees the saved configuration.
+ *   Blocker: missing fixture. The `main` snapshot has admin as the only member of every desk, and the one other
+ *   user (janedoe) is not a desk member and has no password recorded anywhere in the repo.
+ */
+
+const DEFAULT_ZONES = ['Europe/London', 'Asia/Tokyo', 'Europe/Moscow'];
+
+function withTestValue(page: Page, locator: Locator, value: string): Locator {
+    return locator.and(page.locator(`[data-test-value="${value}"]`));
+}
+
+async function expectWidgetZones(widget: Locator, zones: Array<string>): Promise<void> {
+    const items = widget.getByTestId('world-clock-item');
+
+    await expect(items).toHaveCount(zones.length);
+
+    for (const [index, zone] of zones.entries()) {
+        await expect(items.nth(index)).toHaveAttribute('data-test-value', zone);
+    }
+}
+
+async function boxOf(locator: Locator): Promise<{x: number; y: number; width: number; height: number}> {
+    const box = await locator.boundingBox();
+
+    if (box == null) {
+        throw new Error('element is not rendered');
+    }
+
+    return box;
+}
+
+test.describe('world clock widget settings', {
+    annotation: [
+        // World Clock Widget Settings
+        {type: 'confluence', description: '1308524876 partial'},
+    ],
+}, () => {
+    test.beforeEach(async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await page.goto('/#/workspace');
+
+        await new Monitoring(page).selectDeskOrWorkspace('Sports');
+        await new Dashboard(page).addWidget('world-clock');
+    });
+
+    test('configuration dialog offers both tabs, a close icon and a save button', async ({page}) => {
+        const dashboard = new Dashboard(page);
+        const widget = dashboard.getWidget('world-clock');
+        const settingsButton = widget.getByRole('button', {name: 'Widget settings'});
+
+        await expect(settingsButton).toBeVisible();
+
+        const widgetBox = await boxOf(widget);
+        const settingsBox = await boxOf(settingsButton);
+
+        // "top right corner of the widget" from the QA case, asserted as geometry rather than a pixel baseline
+        expect(settingsBox.x).toBeGreaterThan(widgetBox.x + widgetBox.width / 2);
+        expect(settingsBox.y).toBeLessThan(widgetBox.y + widgetBox.height / 2);
+
+        await dashboard.openWidgetConfiguration('world-clock');
+
+        await expect(page.getByTestId('world-clock-config')).toBeVisible();
+        await expect(page.getByTestId('wizard--Your clock')).toBeVisible();
+        await expect(page.getByTestId('wizard--Available clocks')).toBeVisible();
+
+        const headerBox = await boxOf(page.getByTestId('widget-config-header'));
+        const bodyBox = await boxOf(page.getByTestId('widget-config-body'));
+        const footerBox = await boxOf(page.getByTestId('widget-config-footer'));
+        const closeBox = await boxOf(page.getByTestId('widget-config-close'));
+        const saveBox = await boxOf(page.getByTestId('widget-config-save'));
+
+        expect(headerBox.y + headerBox.height).toBeLessThanOrEqual(bodyBox.y);
+        expect(footerBox.y).toBeGreaterThanOrEqual(bodyBox.y + bodyBox.height);
+        expect(closeBox.x).toBeGreaterThan(headerBox.x + headerBox.width / 2);
+        expect(saveBox.x).toBeGreaterThan(footerBox.x + footerBox.width / 2);
+
+        await dashboard.closeWidgetConfiguration();
+
+        await expect(page.getByTestId('world-clock-config')).toBeHidden();
+        await expect(widget).toBeVisible();
+    });
+
+    test('clock type reaches the widget only after saving', async ({page}) => {
+        const dashboard = new Dashboard(page);
+        const widget = dashboard.getWidget('world-clock');
+        const analogButton = page.getByTestId('clock-type-analog');
+        const digitalButton = page.getByTestId('clock-type-digital');
+
+        await expect(widget.getByTestId('analog-clock')).toHaveCount(DEFAULT_ZONES.length);
+
+        await dashboard.openWidgetConfiguration('world-clock');
+
+        await expect(analogButton).toHaveClass(/toggle-button--active/);
+        await expect(digitalButton).not.toHaveClass(/toggle-button--active/);
+
+        await digitalButton.click();
+
+        await expect(digitalButton).toHaveClass(/toggle-button--active/);
+        await expect(analogButton).not.toHaveClass(/toggle-button--active/);
+
+        await dashboard.closeWidgetConfiguration();
+
+        await expect(widget.getByTestId('analog-clock')).toHaveCount(DEFAULT_ZONES.length);
+
+        await dashboard.openWidgetConfiguration('world-clock');
+
+        await expect(analogButton).toHaveClass(/toggle-button--active/);
+
+        await digitalButton.click();
+        await dashboard.saveWidgetConfiguration();
+
+        await expect(widget.getByTestId('analog-clock')).toHaveCount(0);
+        await expectWidgetZones(widget, DEFAULT_ZONES);
+
+        await dashboard.openWidgetConfiguration('world-clock');
+
+        await expect(digitalButton).toHaveClass(/toggle-button--active/);
+
+        await dashboard.closeWidgetConfiguration();
+    });
+
+    test('your clock lists the widget zones and removal applies only after saving', async ({page}) => {
+        const dashboard = new Dashboard(page);
+        const widget = dashboard.getWidget('world-clock');
+
+        await dashboard.openWidgetConfiguration('world-clock');
+
+        const yourClocks = page.getByTestId('your-clocks').getByTestId('clock-item');
+
+        await expect(yourClocks).toHaveCount(DEFAULT_ZONES.length);
+
+        for (const [index, zone] of DEFAULT_ZONES.entries()) {
+            await expect(yourClocks.nth(index)).toHaveAttribute('data-test-value', zone);
+            await expect(withTestValue(page, yourClocks, zone).getByTestId('remove-clock')).toBeVisible();
+        }
+
+        await withTestValue(page, yourClocks, 'Asia/Tokyo').getByTestId('remove-clock').click();
+
+        await expect(yourClocks).toHaveCount(2);
+        await expect(withTestValue(page, yourClocks, 'Asia/Tokyo')).toHaveCount(0);
+        await expectWidgetZones(widget, DEFAULT_ZONES);
+
+        await dashboard.saveWidgetConfiguration();
+
+        await expectWidgetZones(widget, ['Europe/London', 'Europe/Moscow']);
+    });
+
+    test('available clocks can be searched, cleared, scrolled and added', async ({page}) => {
+        const dashboard = new Dashboard(page);
+        const widget = dashboard.getWidget('world-clock');
+
+        await dashboard.openWidgetConfiguration('world-clock');
+        await page.getByTestId('wizard--Available clocks').click();
+
+        const availableClocks = page.getByTestId('available-clocks').getByTestId('clock-item');
+        const search = page.getByTestId('clock-search');
+        const clear = page.getByTestId('clock-search-clear');
+
+        await expect(availableClocks.first()).toBeVisible();
+
+        const availableCount = await availableClocks.count();
+
+        for (const zone of DEFAULT_ZONES) {
+            await expect(withTestValue(page, availableClocks, zone)).toHaveCount(0);
+        }
+
+        const lastClock = availableClocks.last();
+
+        await expect(lastClock).not.toBeInViewport();
+        await lastClock.scrollIntoViewIfNeeded();
+        await expect(lastClock).toBeInViewport();
+
+        await expect(clear).toBeDisabled();
+
+        await search.fill('prague');
+
+        await expect(availableClocks).toHaveCount(1);
+        await expect(withTestValue(page, availableClocks, 'Europe/Prague')).toBeVisible();
+        await expect(clear).toBeEnabled();
+
+        await clear.click();
+
+        await expect(search).toHaveValue('');
+        await expect(clear).toBeDisabled();
+        await expect(availableClocks).toHaveCount(availableCount);
+
+        await search.fill('prague');
+        await withTestValue(page, availableClocks, 'Europe/Prague').click();
+
+        await waitForToastMessage(page, 'success', 'World clock added: Europe/Prague');
+
+        await expect(availableClocks).toHaveCount(0);
+
+        await clear.click();
+
+        await expect(availableClocks).toHaveCount(availableCount - 1);
+        await expect(withTestValue(page, availableClocks, 'Europe/Prague')).toHaveCount(0);
+        await expectWidgetZones(widget, DEFAULT_ZONES);
+
+        await dashboard.saveWidgetConfiguration();
+
+        await expectWidgetZones(widget, [...DEFAULT_ZONES, 'Europe/Prague']);
+    });
+
+    test('saved configuration survives leaving and returning to the dashboard', async ({page}) => {
+        const dashboard = new Dashboard(page);
+        const widget = dashboard.getWidget('world-clock');
+        const expectedZones = ['Europe/London', 'Asia/Tokyo', 'Europe/Prague'];
+
+        await dashboard.openWidgetConfiguration('world-clock');
+        await page.getByTestId('clock-type-digital').click();
+        await withTestValue(page, page.getByTestId('your-clocks').getByTestId('clock-item'), 'Europe/Moscow')
+            .getByTestId('remove-clock')
+            .click();
+        await page.getByTestId('wizard--Available clocks').click();
+        await page.getByTestId('clock-search').fill('prague');
+        await withTestValue(page, page.getByTestId('available-clocks').getByTestId('clock-item'), 'Europe/Prague')
+            .click();
+        await dashboard.saveWidgetConfiguration();
+
+        await expectWidgetZones(widget, expectedZones);
+        await expect(widget.getByTestId('analog-clock')).toHaveCount(0);
+
+        await page.goto('/#/search');
+
+        await expect(page.getByTestId('dashboard')).toBeHidden();
+
+        await page.goto('/#/workspace');
+        await new Monitoring(page).selectDeskOrWorkspace('Sports');
+
+        await expectWidgetZones(widget, expectedZones);
+        await expect(widget.getByTestId('analog-clock')).toHaveCount(0);
+
+        // the dashboard is stored server side, so a full reload proves it was persisted and not just kept in memory
+        await page.reload();
+        await new Monitoring(page).selectDeskOrWorkspace('Sports');
+
+        await expectWidgetZones(widget, expectedZones);
+        await expect(widget.getByTestId('analog-clock')).toHaveCount(0);
+    });
+});

--- a/e2e/client/playwright/page-object-models/dashboard.ts
+++ b/e2e/client/playwright/page-object-models/dashboard.ts
@@ -1,0 +1,46 @@
+import {Page, Locator, expect} from '@playwright/test';
+
+export class Dashboard {
+    private page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    getWidget(widgetId: string): Locator {
+        return this.page
+            .getByTestId('widget-grid')
+            .getByTestId('widget')
+            .and(this.page.locator(`[data-test-value="${widgetId}"]`));
+    }
+
+    async addWidget(widgetId: string): Promise<void> {
+        const modal = this.page.getByTestId('widget-modal');
+
+        await this.page.getByRole('button', {name: 'Add widget'}).click();
+        await modal
+            .getByTestId('widget-item')
+            .and(this.page.locator(`[data-test-value="${widgetId}"]`))
+            .click();
+        await modal.getByRole('button', {name: 'Add This Widget'}).click();
+        await modal.getByRole('button', {name: 'Done'}).click();
+
+        await expect(modal).not.toBeVisible();
+        await expect(this.getWidget(widgetId)).toBeVisible();
+    }
+
+    async openWidgetConfiguration(widgetId: string): Promise<void> {
+        await this.getWidget(widgetId).getByRole('button', {name: 'Widget settings'}).click();
+        await expect(this.page.getByTestId('widget-config-body')).toBeVisible();
+    }
+
+    async saveWidgetConfiguration(): Promise<void> {
+        await this.page.getByTestId('widget-config-save').click();
+        await expect(this.page.getByTestId('widget-config-body')).toBeHidden();
+    }
+
+    async closeWidgetConfiguration(): Promise<void> {
+        await this.page.getByTestId('widget-config-close').click();
+        await expect(this.page.getByTestId('widget-config-body')).toBeHidden();
+    }
+}

--- a/scripts/apps/dashboard/views/configuration.html
+++ b/scripts/apps/dashboard/views/configuration.html
@@ -1,11 +1,11 @@
-<div ng-if="!widget.custom" class="modal__header modal__header--flex">
+<div ng-if="!widget.custom" class="modal__header modal__header--flex" data-test-id="widget-config-header">
     <h3 class="modal__heading"><span translate>{{ widget.label }}</span> <span translate>{{ 'Configuration' }}</span></h3>
-    <a class="icn-btn modal__close" ng-click="$close()"><i class="icon-close-small"></i></a>
+    <a class="icn-btn modal__close" ng-click="$close()" data-test-id="widget-config-close"><i class="icon-close-small"></i></a>
 </div>
-<div ng-if="!widget.custom" class="modal__body">
+<div ng-if="!widget.custom" class="modal__body" data-test-id="widget-config-body">
     <div ng-include="widget.configurationTemplate"></div>
 </div>
-<div ng-if="!widget.custom" class="modal__footer">
-    <button class="btn" ng-click="saveConfig()"><span translate>Save</span></button>
+<div ng-if="!widget.custom" class="modal__footer" data-test-id="widget-config-footer">
+    <button class="btn" ng-click="saveConfig()" data-test-id="widget-config-save"><span translate>Save</span></button>
 </div>
 <div ng-if="widget.custom" ng-include="widget.configurationTemplate"></div>

--- a/scripts/apps/dashboard/world-clock/configuration.html
+++ b/scripts/apps/dashboard/world-clock/configuration.html
@@ -1,20 +1,20 @@
-<div ng-controller="WorldClockConfigController" class="widget-config world-clock">
+<div ng-controller="WorldClockConfigController" class="widget-config world-clock" data-test-id="world-clock-config">
     <div sd-wizard>
         <div sd-wizard-step data-title="{{ 'Your clock' | translate }}" data-code="your-clock">
             <div class="sd-margin-b--3">
                 <label class="form-label">{{'Clock type'|translate}}</label>
                 <div class="button-group button-group--start">
-                    <button type="button" class="toggle-button" ng-class="{'toggle-button--active': !configuration.digital}" ng-click="configuration.digital = false">Analog</button>
-                    <button type="button" class="toggle-button" ng-class="{'toggle-button--active': configuration.digital}" ng-click="configuration.digital = true">Digital</button>
+                    <button type="button" class="toggle-button" ng-class="{'toggle-button--active': !configuration.digital}" ng-click="configuration.digital = false" data-test-id="clock-type-analog">Analog</button>
+                    <button type="button" class="toggle-button" ng-class="{'toggle-button--active': configuration.digital}" ng-click="configuration.digital = true" data-test-id="clock-type-digital">Digital</button>
                 </div>
             </div>
             <div class="sd-margin-b--2">
                 <label class="form-label grid__item grid__item--col-12">{{'Your clock'|translate}}</label>
                 <div class="grid__item grid__item--col-12">
-                    <ul class="list-group">
-                        <li class="list-group-item list-group-item--no-click" ng-repeat="zone in configuration.zones">
+                    <ul class="list-group" data-test-id="your-clocks">
+                        <li class="list-group-item list-group-item--no-click" ng-repeat="zone in configuration.zones" data-test-id="clock-item" data-test-value="{{ zone }}">
                             <a class="sd-margin-e--auto" href="">{{ getTimezoneLabel(zone) }}</a>
-                            <a href="" class="icn-btn" ng-click="configuration.zones.splice($index, 1); notify('remove', zone)"><i class="icon-trash"></i></a>
+                            <a href="" class="icn-btn" ng-click="configuration.zones.splice($index, 1); notify('remove', zone)" data-test-id="remove-clock"><i class="icon-trash"></i></a>
                         </li>
                     </ul>
                     <div class="alert alert-info" ng-hide="configuration.zones.length" translate>No clock here!</div>
@@ -32,15 +32,16 @@
                             ng-model="search"
                             ng-change="searchZones(search)"
                             placeholder="{{ 'Search for clock'|translate }}"
+                            data-test-id="clock-search"
                         >
                     </div>
                 </div>
                 <div class="form__item form__item--auto-width">
-                    <button class="btn btn--hollow" ng-disabled="!search" ng-click="search = ''; searchZones('')" translate>Clear</button>
+                    <button class="btn btn--hollow" ng-disabled="!search" ng-click="search = ''; searchZones('')" data-test-id="clock-search-clear" translate>Clear</button>
                 </div>
             </div>
-            <ul class="list-group">
-                <li class="list-group-item" ng-repeat="zone in availableZones|filter:notIn(configuration.zones)" ng-click="configuration.zones.push(zone); notify('add', zone)">
+            <ul class="list-group" data-test-id="available-clocks">
+                <li class="list-group-item" ng-repeat="zone in availableZones|filter:notIn(configuration.zones)" ng-click="configuration.zones.push(zone); notify('add', zone)" data-test-id="clock-item" data-test-value="{{ zone }}">
                     <a href="">{{ getTimezoneLabel(zone) }}</a>
                 </li>
             </ul>

--- a/scripts/apps/dashboard/world-clock/widget-worldclock.html
+++ b/scripts/apps/dashboard/world-clock/widget-worldclock.html
@@ -1,9 +1,9 @@
 <div>
     <div class="clock-container clearfix" ng-controller="WorldClockController">
-        <div class="clock-item" ng-repeat="zone in widget.configuration.zones track by $index">
+        <div class="clock-item" ng-repeat="zone in widget.configuration.zones track by $index" data-test-id="world-clock-item" data-test-value="{{ zone }}">
             <div class="clock-box" ng-class="{digital: widget.configuration.digital}">
                 <header>{{ zone.split('/')[1].replace('_', ' ') }}</header>
-                <div class="wclock" sd-clock data-utc="utc" data-tz="{{ zone }}" ng-if="!widget.configuration.digital"></div>
+                <div class="wclock" sd-clock data-utc="utc" data-tz="{{ zone }}" ng-if="!widget.configuration.digital" data-test-id="analog-clock"></div>
                 <time>{{ utc.tz(zone).format('HH:mm') }}</time>
                 <div class="date">{{ utc.tz(zone).format('dddd') }}</div>
             </div>


### PR DESCRIPTION
### Purpose
Automates the QA case [World Clock Widget Settings](https://sofab.atlassian.net/wiki/spaces/SET/pages/1308524876) as a Playwright spec so it runs in CI instead of being tested by hand.

### What has changed
- New spec `e2e/client/playwright/dashboard.world-clock-widget-config.spec.ts` covering the scenario below
- Annotated with `{type: 'confluence', description: '1308524876 partial'}` per the coverage convention
- Adds `data-test-id` attributes to product source (needs developer eyes):
  - `scripts/apps/dashboard/views/configuration.html`: `widget-config-header`, `widget-config-close`, `widget-config-body`, `widget-config-footer`, `widget-config-save`
  - `scripts/apps/dashboard/world-clock/configuration.html`: `world-clock-config`, `clock-type-analog`, `clock-type-digital`, `your-clocks`, `clock-item` + `data-test-value={{zone}}` (both lists), `remove-clock`, `clock-search`, `clock-search-clear`, `available-clocks`
  - `scripts/apps/dashboard/world-clock/widget-worldclock.html`: `world-clock-item` + `data-test-value={{zone}}`, `analog-clock`

### Steps to test
**Given** the `main` snapshot restored, the Sports desk dashboard open, and a World Clock widget added to it (default zones Europe/London, Asia/Tokyo, Europe/Moscow, analog clock type).

**When**
1. Click the Widget settings icon in the top right corner of the World Clock widget.
2. On the "Your clock" tab, switch the clock type between Analog and Digital.
3. Remove a clock from the "Your clock" list with its trash icon.
4. On the "Available clocks" tab, type into the search field, press Clear, scroll the list and click a clock to add it.
5. Click Save (or the close icon in the dialog header to discard).
6. Navigate to another Superdesk page and back to the desk dashboard.

**Then**
- The configuration dialog opens with a "Your clock" tab, an "Available clocks" tab, a close icon in the top right of the header and a Save button in the bottom right of the footer.
- The Analog/Digital button matching the clock type currently used by the widget is rendered active, and clicking the inactive one makes it active.
- The "Your clock" list holds exactly the zones the widget displays, each with a remove icon, and clicking the icon drops the item from the list.
- The Clear button is disabled while the search field is empty and enabled once text is typed; typing filters the available list, and Clear empties the field, restores the full list and disables itself again.
- The available list excludes zones already selected, scrolls, and clicking an item shows "World clock added: Europe/Prague" and removes it from the list.
- Clock type, removals and additions reach the widget only after Save; closing with the X discards them.
- The saved configuration is still there after leaving the dashboard and coming back.

The spec also reloads the page after returning to the dashboard, to prove the configuration was persisted server side rather than kept in memory, and asserts the analog dial element is present/absent in the widget to distinguish analog from digital rendering.

Run it: `cd e2e/client && npx playwright test dashboard.world-clock-widget-config.spec.ts`

The spec passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
