### PR TITLE
Automate Find and replace (1310294123)

### DIFF
--- a/e2e/client/playwright/find-and-replace.spec.ts
+++ b/e2e/client/playwright/find-and-replace.spec.ts
@@ -1,0 +1,83 @@
+import {test, expect} from '@playwright/test';
+import {Authoring} from './page-object-models/authoring';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+import {setEditor3FieldValue} from './utils/editor3';
+
+/**
+ * QA case "Find and replace" (Authoring widgets, 1310294123).
+ *
+ * The widget finds every occurrence of the text typed in Find, replaces the
+ * currently selected one with the text typed in Replace with, and replaces the
+ * remaining ones in a single step through Replace All.
+ *
+ * Every documented expected result is covered. Case sensitivity and the
+ * previous/next match controls are not part of the documented scenario and are
+ * left out on purpose.
+ *
+ * The widget is exercised in authoring-angular, the default implementation, which
+ * is what the case describes: it selects the first match as soon as a search term
+ * is typed, so Replace acts on it right away.
+ */
+test.describe('find and replace widget', () => {
+    const WIDGET = 'Find and Replace';
+    const ORIGINAL_BODY = 'one apple two apple three apple four';
+    const AFTER_SINGLE_REPLACE = 'one orange two apple three apple four';
+    const AFTER_REPLACE_ALL = 'one orange two orange three orange four';
+
+    /**
+     * Matches are marked with editor3's HIGHLIGHT / HIGHLIGHT_STRONG styles, which
+     * draft-js applies as an inline background colour on the leaf span. Those spans
+     * carry no id of their own, so the colour is the only DOM signal that a match was
+     * found; the opaque variant marks the currently selected match.
+     */
+    const MATCH_BACKGROUND = 'rgba(255, 235, 59';
+    const SELECTED_MATCH_BACKGROUND = 'rgba(255, 235, 59, 0.8)';
+
+    test('finds every occurrence, replaces the selected one, and replaces the rest at once', {
+        annotation: [
+            {type: 'confluence', description: '1310294123 complete'}, // Find and replace
+        ],
+    }, async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const monitoring = new Monitoring(page);
+        const authoring = new Authoring(page);
+
+        await page.goto('/#/workspace/monitoring');
+        await monitoring.selectDeskOrWorkspace('Sports');
+        await monitoring.getArticleLocator('test sports story').dblclick();
+
+        const bodyField = page.getByTestId('authoring')
+            .getByTestId('authoring-field')
+            .and(page.locator('[data-test-value="body_html"]'));
+        const body = bodyField.getByRole('textbox');
+
+        await expect(body).toBeVisible();
+
+        await setEditor3FieldValue(body, ORIGINAL_BODY);
+
+        const widget = await authoring.openWidget(WIDGET);
+        const matches = bodyField.locator(`span[style*="${MATCH_BACKGROUND}"]`);
+        const selectedMatch = bodyField.locator(`span[style*="${SELECTED_MATCH_BACKGROUND}"]`);
+
+        await widget.getByTestId('find-replace-find').fill('apple');
+
+        // The Find field is debounced by 500ms in ng-model-options, so the highlights
+        // only appear once that has elapsed; the retrying count assertion absorbs it.
+        await expect(matches).toHaveCount(3);
+        await expect(selectedMatch).toHaveCount(1);
+        await expect(selectedMatch).toHaveText('apple');
+
+        await widget.getByTestId('find-replace-replace-with').fill('orange');
+        await widget.getByTestId('find-replace-replace').click();
+
+        await expect(body).toHaveText(AFTER_SINGLE_REPLACE);
+        await expect(matches).toHaveCount(2);
+
+        await widget.getByTestId('find-replace-replace-all').click();
+
+        await expect(body).toHaveText(AFTER_REPLACE_ALL);
+        await expect(matches).toHaveCount(0);
+    });
+});

--- a/e2e/client/playwright/page-object-models/authoring.ts
+++ b/e2e/client/playwright/page-object-models/authoring.ts
@@ -64,6 +64,23 @@ export class Authoring {
     }
 
     /**
+     * Opens a right-side widget from the authoring-angular widget bar by its label and
+     * returns the opened panel. authoring-react renders the same bar differently
+     * (`widget-icon` keyed by widget id), so this is not usable there.
+     */
+    async openWidget(label: string): Promise<Locator> {
+        const {page} = this;
+
+        await page.getByTestId('authoring-widget').and(page.locator(`[data-test-value="${label}"]`)).click();
+
+        const panel = page.getByTestId('authoring-widget-panel').and(page.locator(`[data-test-value="${label}"]`));
+
+        await expect(panel).toBeVisible();
+
+        return panel;
+    }
+
+    /**
      * editor3 field takes quite some time to initialize in authoring-react.
      * Until it initializes - typing inside it doesn't update `fieldsData` in authoring-react state.
      */

--- a/scripts/apps/authoring/editor/views/find-replace.html
+++ b/scripts/apps/authoring/editor/views/find-replace.html
@@ -7,11 +7,13 @@
                 ng-model="from"
                 sd-autofocus
                 ng-trim="false"
+                data-test-id="find-replace-find"
                 ng-model-options="{debounce: 500}">
         </div>
         <div class="form__row">
             <label class="form-label form-label--marg-b10" for="find-replace-with" translate>Replace with</label>
-            <input type="text" class="basic-input form-control" id="find-replace-with" ng-model="to" ng-trim="false">
+            <input type="text" class="basic-input form-control" id="find-replace-with" ng-model="to" ng-trim="false"
+                data-test-id="find-replace-replace-with">
         </div>
 
         <div class="form__row">
@@ -25,8 +27,10 @@
             </div>
     
             <div class="btn-group ml-auto" role="group">
-                <button type="button" class="btn" ng-click="replace()" ng-disabled="!from" translate>Replace</button>
-                <button type="button" class="btn" ng-click="replaceAll()" ng-disabled="!from" translate>Replace All</button>
+                <button type="button" class="btn" ng-click="replace()" ng-disabled="!from"
+                    data-test-id="find-replace-replace" translate>Replace</button>
+                <button type="button" class="btn" ng-click="replaceAll()" ng-disabled="!from"
+                    data-test-id="find-replace-replace-all" translate>Replace All</button>
             </div>
         </div>
 


### PR DESCRIPTION
### Purpose
Automates the QA case [Find and replace](https://sofab.atlassian.net/wiki/spaces/SET/pages/1310294123) as a Playwright spec so it runs in CI instead of being tested by hand.

### What has changed
- New spec `e2e/client/playwright/find-and-replace.spec.ts` covering the scenario below
- Annotated with `{type: 'confluence', description: '1310294123 complete'}` per the coverage convention
- Adds `data-test-id` attributes to product source: `find-replace-find` (`scripts/apps/authoring/editor/views/find-replace.html`), `find-replace-replace-with` (`scripts/apps/authoring/editor/views/find-replace.html`), `find-replace-replace` (`scripts/apps/authoring/editor/views/find-replace.html`), `find-replace-replace-all` (`scripts/apps/authoring/editor/views/find-replace.html`) (needs developer eyes)

### Steps to test
**Given** the "test sports story" article from Sports / Working Stage is open in authoring with a body of `one apple two apple three apple four`.

**When**
1. Open the "Find and Replace" widget from the authoring widget bar
2. Type `apple` in the Find field
3. Type `orange` in the Replace with field and click Replace
4. Click Replace All

**Then**
- All three occurrences of `apple` are highlighted in the body, with the first one marked as the currently selected match
- Replace changes only the selected occurrence: the body reads `one orange two apple three apple four` and two highlighted matches remain
- Replace All changes every remaining occurrence: the body reads `one orange two orange three orange four` and no highlighted matches remain

The spec also checks that the selected match highlight covers exactly the searched word.

Run it: `cd e2e/client && npx playwright test find-and-replace.spec.ts`

The spec passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
