### PR TITLE
Automate Related items (1310294133)

### DIFF
--- a/e2e/client/playwright/related-items-widget.spec.ts
+++ b/e2e/client/playwright/related-items-widget.spec.ts
@@ -1,0 +1,104 @@
+import {test, expect, Page} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+
+/**
+ * QA case "Related items" (Authoring widgets, 1310294133).
+ *
+ * The widget only ever searches on slugline: the keyword typed into its search box is matched
+ * against `slugline` (exact phrase by default), so "same slugline or keywords" from the case
+ * description is a single behaviour in the product, covered here as one search round trip.
+ *
+ * The `authoring-header` snapshot is used because the widget also filters on
+ * `versioncreated >= today`, and that snapshot is the only one carrying an item recent enough to
+ * survive it: "Story 3 sibling", dated 2099 and sharing the slugline "Story 3". Under the `main`
+ * snapshot every item predates the current day, so any search returns nothing.
+ */
+
+const ARTICLE = 'Story 3';
+const SLUGLINE = 'Story 3';
+const MATCHING_ITEM = 'Story 3 sibling';
+
+function relatedItemsTab(page: Page) {
+    return page.getByTestId('authoring-widget').and(page.locator('[data-test-value="Related Items"]'));
+}
+
+async function openFromSportsWorkingStage(page: Page, label: string): Promise<void> {
+    const monitoring = new Monitoring(page);
+
+    await page.goto('/#/workspace/monitoring');
+    await monitoring.selectDeskOrWorkspace('Sports');
+
+    // matched on data-test-value rather than hasText: the fixture holds items whose labels are
+    // prefixes of one another ("Story 3" / "Story 3 rewrite")
+    await monitoring.executeActionOnMonitoringItem(
+        page
+            .getByTestId('monitoring-group')
+            .and(page.locator('[data-test-value="Sports / Working Stage"]'))
+            .getByTestId('article-item')
+            .and(page.locator(`[data-test-value="${label}"]`)),
+        'Edit',
+    );
+
+    await expect(page.getByTestId('authoring')).toBeVisible();
+}
+
+test.describe('related items widget', () => {
+    test('lists same-slugline items and re-lists them from a keyword typed in the search box', {
+        annotation: [
+            {type: 'confluence', description: '1310294133 complete'}, // Related items
+        ],
+    }, async ({page}) => {
+        await restoreDatabaseSnapshot({snapshotName: 'authoring-header'});
+        await openFromSportsWorkingStage(page, ARTICLE);
+
+        // the tab label flips to "Relate an item" once the widget has loaded and found no
+        // existing relations, so it can only be selected by its initial label
+        await expect(relatedItemsTab(page)).toBeVisible();
+        await relatedItemsTab(page).click();
+
+        const widget = page.getByTestId('authoring-widget-panel').getByTestId('related-items-widget');
+        const searchInput = widget.getByTestId('related-items-search-input');
+        const searchButton = widget.getByTestId('related-items-search-button');
+        const results = widget.getByTestId('related-items-list-item');
+
+        await expect(widget.getByTestId('related-items-search')).toBeVisible();
+        await expect(searchInput).toHaveValue(SLUGLINE);
+
+        await expect(results).toHaveCount(1);
+        await expect(results).toHaveAttribute('data-test-value', SLUGLINE);
+        await expect(results).toContainText(MATCHING_ITEM);
+
+        await searchInput.fill('slugline nothing shares');
+        await searchButton.click();
+        await expect(results).toHaveCount(0);
+
+        // the widget refuses to search on fewer than two characters
+        await searchInput.fill('S');
+        await expect(searchButton).toBeDisabled();
+
+        await searchInput.fill(SLUGLINE);
+        await expect(searchButton).toBeEnabled();
+        await searchButton.click();
+
+        await expect(results).toHaveCount(1);
+        await expect(results).toContainText(MATCHING_ITEM);
+    });
+
+    test('is not offered while editing a package', {
+        annotation: [
+            {type: 'confluence', description: '1310294133 complete'}, // Related items
+        ],
+    }, async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await openFromSportsWorkingStage(page, 'Package Highlight 1');
+
+        // an unrelated tab of the same bar, to tell "no Related Items tab" apart from
+        // "the widget bar has not rendered yet"
+        await expect(
+            page.getByTestId('authoring-widget').and(page.locator('[data-test-value="Versions/History"]')),
+        ).toBeVisible();
+
+        await expect(relatedItemsTab(page)).toHaveCount(0);
+    });
+});

--- a/scripts/core/itemList/views/relatedItem-list-widget.html
+++ b/scripts/core/itemList/views/relatedItem-list-widget.html
@@ -1,16 +1,16 @@
-<div class="main-list" ng-class="{wrap: selected, 'existing-items': !options.searchEnabled}" sd-loading="loading">
+<div class="main-list" ng-class="{wrap: selected, 'existing-items': !options.searchEnabled}" sd-loading="loading" data-test-id="related-items-widget">
 
-    <div class="search-box" ng-class="{blank: related}" ng-show="options.searchEnabled">
+    <div class="search-box" ng-class="{blank: related}" ng-show="options.searchEnabled" data-test-id="related-items-search">
         <i class="icon-search search-box__icon"></i>
         <input type="text" placeholder="{{ :: 'Search' | translate }}" ng-keypress="($event.which === 13)?refresh():null"
-            ng-model="itemListOptions.keyword">
-        <button id="search-related-items" type="button" class="btn btn--small search-box__btn" ng-click="refresh()" ng-disabled="!hasKeywords()" translate>Search</button>
+            ng-model="itemListOptions.keyword" data-test-id="related-items-search-input">
+        <button id="search-related-items" type="button" class="btn btn--small search-box__btn" ng-click="refresh()" ng-disabled="!hasKeywords()" data-test-id="related-items-search-button" translate>Search</button>
     </div>
 
     <div class="ingest-list-holder" ng-class="{'mode-detailed': options.mode === 'detailed'}">
         <div sd-shadow>
-            <ul class="boxed-list sd-margin-all--2 sd-padding-b--4">
-                <li ng-repeat="item in processedItems track by $index" class="boxed-list__item boxed-list__item--clickable boxed-list__item--comfortable" ng-class="{'boxed-list__item--selected': item._id === options.item._id}" ng-if="canDisplayItem(item)">
+            <ul class="boxed-list sd-margin-all--2 sd-padding-b--4" data-test-id="related-items-list">
+                <li ng-repeat="item in processedItems track by $index" class="boxed-list__item boxed-list__item--clickable boxed-list__item--comfortable" ng-class="{'boxed-list__item--selected': item._id === options.item._id}" ng-if="canDisplayItem(item)" data-test-id="related-items-list-item" data-test-value="{{item.slugline}}">
                     <div class="boxed-list__item-media" ng-click="view(item)">
                         <i sd-filetype-icon data-item="item"></i>
                     </div>


### PR DESCRIPTION
### Purpose
Automates the QA case [Related items](https://sofab.atlassian.net/wiki/spaces/SET/pages/1310294133) as a Playwright spec so it runs in CI instead of being tested by hand.

### What has changed
- New spec `e2e/client/playwright/related-items-widget.spec.ts` covering the scenario below
- Annotated with `{type: 'confluence', description: '1310294133 complete'}` per the coverage convention
- Adds `data-test-id` attributes to product source: `related-items-widget`, `related-items-search`, `related-items-search-input`, `related-items-search-button`, `related-items-list`, `related-items-list-item` (with `data-test-value="{{item.slugline}}"`) (needs developer eyes)

### Steps to test
**Given** the `authoring-header` snapshot, whose Sports working stage holds "Story 3" and whose Finance working stage holds "Story 3 sibling" (same slugline, dated in the future so it survives the widget's "created since midnight" filter).

**When**
1. Open "Story 3" from the Sports working stage for editing
2. Click the Related Items icon in the authoring widget bar
3. Type a slugline nobody shares into the widget's search box and press Search
4. Type "Story 3" back into the search box and press Search

**Then**
- The Related Items tab is offered for the plain text item and its panel opens with a search box
- The search box is pre-filled with the open item's slugline and the list shows exactly one item, "Story 3 sibling", carrying the same slugline
- Searching the unmatched slugline empties the list
- Searching "Story 3" again brings "Story 3 sibling" back

The spec also checks that the Search button stays disabled for a single-character keyword, and a second test opens the "Package Highlight 1" package and asserts the Related Items tab is absent while the rest of the widget bar (Versions/History) is present.

Run it: `cd e2e/client && npx playwright test related-items-widget.spec.ts`

The spec passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
