### PR TITLE
Automate User roles (1311834342)

### DIFF
--- a/e2e/client/playwright/page-object-models/settings/user-roles.ts
+++ b/e2e/client/playwright/page-object-models/settings/user-roles.ts
@@ -1,0 +1,102 @@
+import {Locator, Page, expect} from '@playwright/test';
+
+export class UserRolesSettings {
+    private page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    async open(): Promise<void> {
+        await this.page.goto('/#/settings/user-roles');
+        await expect(this.page.getByTestId('add-role')).toBeVisible();
+    }
+
+    /**
+     * Drops all client-side state and re-queries the API. page.goto() cannot do
+     * this: the settings route is a hash, so navigating to the URL the page is
+     * already on is a same-document no-op and the tab stays where it was.
+     */
+    async reload(): Promise<void> {
+        await this.page.reload();
+
+        // Booting the whole application takes noticeably longer than a route
+        // change, so this one assertion gets a longer budget.
+        await expect(this.page.getByTestId('add-role')).toBeVisible({timeout: 60000});
+    }
+
+    getRole(roleName: string): Locator {
+        return this.withValue(this.page.getByTestId('role-item'), roleName);
+    }
+
+    async createRole(options: {name: string; description?: string}): Promise<void> {
+        await this.page.getByTestId('add-role').click();
+
+        const modal = this.page.getByTestId('role-modal');
+
+        await modal.getByTestId('field--name').fill(options.name);
+
+        if (options.description != null) {
+            await modal.getByTestId('field--description').fill(options.description);
+        }
+
+        await modal.getByTestId('save').click();
+
+        // sd-modal keeps its content in the DOM and only hides it, so wait for
+        // the hidden state instead of for detachment.
+        await expect(modal.getByTestId('field--name')).toBeHidden();
+    }
+
+    async openPrivilegesTab(): Promise<void> {
+        await this.page.getByTestId('roles-privileges-tab').click();
+        await expect(this.page.getByTestId('roles-privileges-form')).toBeVisible();
+    }
+
+    /**
+     * Privilege identifiers (the `data-test-value` of every table row), in table
+     * order. The set is whatever the backend's /api/privileges returns, so read
+     * it rather than hardcoding it when an assertion should span all privileges.
+     */
+    async getPrivilegeNames(): Promise<Array<string>> {
+        const rows = this.page.getByTestId('privilege-row');
+
+        // ng-repeat attaches the rows before Angular interpolates
+        // data-test-value, so an unguarded read returns empty strings. Every row
+        // is interpolated in the same digest, so the first one settling means
+        // they all have.
+        await expect(rows.first()).toHaveAttribute('data-test-value', /\S/);
+
+        return rows.evaluateAll(
+            (elements) => elements
+                .map((row) => row.getAttribute('data-test-value'))
+                .filter((name): name is string => name != null && name !== ''),
+        );
+    }
+
+    getPrivilegeCheckbox(privilege: string, roleName: string): Locator {
+        return this.withValue(
+            this.withValue(this.page.getByTestId('privilege-row'), privilege).getByTestId('privilege-checkbox'),
+            roleName,
+        );
+    }
+
+    async grantAllPrivileges(roleName: string): Promise<void> {
+        await this.withValue(this.page.getByTestId('role-column'), roleName)
+            .getByTestId('toggle-all-privileges')
+            .check();
+    }
+
+    async savePrivileges(): Promise<void> {
+        const saveButton = this.page.getByTestId('save-privileges');
+
+        await saveButton.click();
+
+        // The directive marks the form pristine only once every role PATCH has
+        // resolved, which re-disables the button; that is the save's completion.
+        await expect(saveButton).toBeDisabled();
+    }
+
+    private withValue(locator: Locator, value: string): Locator {
+        return locator.and(this.page.locator(`[data-test-value="${value}"]`));
+    }
+}

--- a/e2e/client/playwright/user-roles.spec.ts
+++ b/e2e/client/playwright/user-roles.spec.ts
@@ -1,0 +1,134 @@
+import {test, expect} from '@playwright/test';
+import {restoreDatabaseSnapshot} from './utils';
+import {UserRolesSettings} from './page-object-models/settings/user-roles';
+
+/**
+ * QA case "User roles" (Confluence 1311834342).
+ *
+ * A new role is granted every privilege except a documented restricted set, and
+ * a user assigned that role inherits exactly that split: the granted privileges
+ * come from the role and cannot be edited per user, the restricted ones are not
+ * granted.
+ *
+ * Documented expectations not covered here:
+ *
+ * - Four of the eleven restricted privileges the case names are contributed by
+ *   superdesk-planning (featured stories, global filters, planning item
+ *   management, planning - manage locations). That app is not installed in the
+ *   client-core e2e stack, so /api/privileges does not return them and the rows
+ *   do not exist in the table.
+ * - That the restrictions actually block the actions (no unlock / spike /
+ *   publish / unpublish control for a user holding the role). A user created
+ *   through the UI has no password, client-core has no per-test fixture API,
+ *   and the `main` snapshot carries no non-admin user with known credentials,
+ *   so there is no way to log in as the restricted user.
+ */
+
+const ROLE_NAME = 'Editor';
+
+/**
+ * The privileges the case withholds from the role that exist in this backend,
+ * by their `/api/privileges` name. UI labels, in the same order: Unlock content,
+ * Spike, Publish, Unpublish, Roles Management, Mark items for users, Master Desk.
+ */
+const RESTRICTED_PRIVILEGES = [
+    'unlock',
+    'spike',
+    'publish',
+    'unpublish',
+    'roles',
+    'mark_for_user',
+    'masterdesk',
+];
+
+test('a role granted every privilege but the restricted ones, applied to a user', {
+    annotation: [
+        {type: 'confluence', description: '1311834342 partial'}, // User roles
+    ],
+}, async ({page}) => {
+    await restoreDatabaseSnapshot();
+
+    const userRoles = new UserRolesSettings(page);
+
+    await userRoles.open();
+    await expect(userRoles.getRole(ROLE_NAME)).toHaveCount(0);
+
+    await userRoles.createRole({name: ROLE_NAME, description: 'Editor without publishing rights'});
+    await expect(userRoles.getRole(ROLE_NAME)).toBeVisible();
+
+    await userRoles.openPrivilegesTab();
+
+    const privilegeNames = await userRoles.getPrivilegeNames();
+
+    for (const privilege of RESTRICTED_PRIVILEGES) {
+        expect(privilegeNames).toContain(privilege);
+    }
+
+    await userRoles.grantAllPrivileges(ROLE_NAME);
+
+    for (const privilege of RESTRICTED_PRIVILEGES) {
+        await userRoles.getPrivilegeCheckbox(privilege, ROLE_NAME).uncheck();
+    }
+
+    await userRoles.savePrivileges();
+
+    // Reload to prove the split was persisted server-side, not just held in the
+    // directive's scope.
+    await userRoles.reload();
+    await userRoles.openPrivilegesTab();
+
+    for (const privilege of privilegeNames) {
+        const checkbox = userRoles.getPrivilegeCheckbox(privilege, ROLE_NAME);
+
+        if (RESTRICTED_PRIVILEGES.includes(privilege)) {
+            await expect(checkbox).not.toBeChecked();
+        } else {
+            await expect(checkbox).toBeChecked();
+        }
+    }
+
+    await page.goto('/#/users');
+    await page.getByTestId('user-filter').selectOption('All');
+    await page.getByTestId('create-user-button').click();
+
+    const userForm = page.getByTestId('user-details-form');
+
+    await userForm.getByTestId('field--first_name').fill('Jane');
+    await userForm.getByTestId('field--last_name').fill('Editor');
+    await userForm.getByTestId('field--username').fill('janeeditor');
+    await userForm.getByTestId('field--email').fill('janeeditor@example.com');
+    await userForm.getByTestId('field--role').selectOption({label: ROLE_NAME});
+    await userForm.getByTestId('save').click();
+
+    const newUser = page.getByTestId('users-list').getByTestId('users-list-item').filter({hasText: 'janeeditor'});
+
+    await expect(newUser).toBeVisible();
+
+    await newUser.click();
+    await page.getByTestId('view-full-profile').click();
+
+    await page.getByTestId('page-sections')
+        .getByTestId('page-section')
+        .and(page.locator('[data-test-value="privileges"]'))
+        .click();
+
+    const userPrivileges = page.getByTestId('user-privileges-form');
+
+    await expect(userPrivileges).toBeVisible();
+
+    for (const privilege of privilegeNames) {
+        const row = userPrivileges.getByTestId('privilege-row')
+            .and(page.locator(`[data-test-value="${privilege}"]`));
+        const checkbox = row.getByTestId('privilege-checkbox');
+
+        if (RESTRICTED_PRIVILEGES.includes(privilege)) {
+            await expect(checkbox).not.toBeChecked();
+            await expect(checkbox).toBeEnabled();
+            await expect(row.getByTestId('privilege-granted-by-role')).toHaveCount(0);
+        } else {
+            await expect(checkbox).toBeChecked();
+            await expect(checkbox).toBeDisabled();
+            await expect(row.getByTestId('privilege-granted-by-role')).toHaveText(ROLE_NAME);
+        }
+    }
+});

--- a/scripts/apps/users/views/edit-form.html
+++ b/scripts/apps/users/views/edit-form.html
@@ -159,6 +159,7 @@
                                             ng-model="user.role"
                                             name="user_role"
                                             id="user_role"
+                                            data-test-id="field--role"
                                             ng-options="role._id as role.name for role in roles">
                                     </select>
                                 </div>

--- a/scripts/apps/users/views/edit.html
+++ b/scripts/apps/users/views/edit.html
@@ -16,7 +16,7 @@
             <header>
                 <ul class="nav nav-tabs" data-test-id="page-sections">
                     <li ng-repeat="section in sections track by section.id" ng-class="{active: selectedSection.id === section.id}">
-                        <button translate ng-click="setSelectedSection(section)"">{{section.label}}</button>
+                        <button translate data-test-id="page-section" data-test-value="{{section.id}}" ng-click="setSelectedSection(section)"">{{section.label}}</button>
                     </li>
                 </ul>
             </header>

--- a/scripts/apps/users/views/settings-privileges.html
+++ b/scripts/apps/users/views/settings-privileges.html
@@ -1,17 +1,17 @@
 <div class="sd-page__flex-helper">
     <div class="sd-page__header">
         <span class="sd-page__element-grow"></span>
-        <button class="btn btn--primary" ng-click="saveAll(rolesForm)" ng-disabled="!rolesForm.$dirty" translate>Save</button>
+        <button class="btn btn--primary" ng-click="saveAll(rolesForm)" data-test-id="save-privileges" ng-disabled="!rolesForm.$dirty" translate>Save</button>
     </div>
 
     <div class="sd-page__content privileges-settings">
-        <form name="rolesForm">
+        <form name="rolesForm" data-test-id="roles-privileges-form">
             <table class="table table--fixed-header">
                 <thead>
                     <tr>
                         <th class="name"></th>
-                        <th ng-repeat="role in roles">
-                            <input type="checkbox" ng-click="toggleAll(role, selectAll)" ng-true-value="1" ng-false-value="0" ng-model="selectAll">
+                        <th ng-repeat="role in roles" data-test-id="role-column" data-test-value="{{role.name}}">
+                            <input type="checkbox" ng-click="toggleAll(role, selectAll)" ng-true-value="1" ng-false-value="0" ng-model="selectAll" data-test-id="toggle-all-privileges">
                             {{ :: role.name | translate }}
                             <span class="label label--primary" ng-if="role.is_default" translate>default</span>
                         </th>
@@ -19,7 +19,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr ng-repeat="p in privileges">
+                    <tr ng-repeat="p in privileges" data-test-id="privilege-row" data-test-value="{{::p.name}}">
                         <td class="name">
                             <div>
                                 <span>{{ :: p.label | translate }}</span>
@@ -36,7 +36,8 @@
                             </div>
                         </td>
                         <td ng-repeat="role in roles">
-                            <input type="checkbox" ng-true-value="1" ng-false-value="0" ng-model="role.privileges[p.name]">
+                            <input type="checkbox" ng-true-value="1" ng-false-value="0" ng-model="role.privileges[p.name]"
+                                   data-test-id="privilege-checkbox" data-test-value="{{role.name}}">
                         </td>
                         <td class="blank-field"></td>
                     </tr>

--- a/scripts/apps/users/views/settings-roles.html
+++ b/scripts/apps/users/views/settings-roles.html
@@ -2,20 +2,20 @@
     <div class="sd-page__header">
         <sd-search-handler ng-model="query.name" data-debounce="200"></sd-search-handler>
         <span class="sd-page__element-grow"></span>
-        <button class="btn btn--primary" ng-click="edit({})">
+        <button class="btn btn--primary" ng-click="edit({})" data-test-id="add-role">
             <i class="icon-plus-sign icon--white"></i> {{:: 'Add New' | translate}}
         </button>
     </div>
 
     <div class="sd-page__content user-roles-settings">
         <ul class="pills-list">
-            <li ng-repeat="role in roles | filter: query" class="clearfix">
+            <li ng-repeat="role in roles | filter: query" class="clearfix" data-test-id="role-item" data-test-value="{{role.name}}">
                 <div class="header">
                     <h6>{{role.name}}</h6>
-                    <span class="label label--primary label--hollow" ng-if="role.is_default" translate>default</span>
+                    <span class="label label--primary label--hollow" ng-if="role.is_default" data-test-id="role-default-label" translate>default</span>
                     <div class="actions">
-                        <button ng-click="edit(role)" title="{{:: 'Edit role' | translate }}"><i class="icon-pencil"></i></button>
-                        <button ng-click="remove(role)" title="{{:: 'Remove role' | translate }}"><i class="icon-trash"></i></button>
+                        <button ng-click="edit(role)" data-test-id="role-edit" title="{{:: 'Edit role' | translate }}"><i class="icon-pencil"></i></button>
+                        <button ng-click="remove(role)" data-test-id="role-remove" title="{{:: 'Remove role' | translate }}"><i class="icon-trash"></i></button>
                     </div>
                 </div>
             </li>
@@ -23,7 +23,7 @@
         </ul>
     </div>
 
-    <div sd-modal data-model="editRole">
+    <div sd-modal data-model="editRole" data-test-id="'role-modal'">
         <div class="modal__header modal__header--flex">
             
             <h3 class="modal__heading" ng-show="editRole._id" translate>Edit Role</h3>
@@ -36,14 +36,14 @@
                     <div class="form__row">
                         <div class="sd-line-input" ng-class="{'sd-line-input--invalid': roleForm.$error.unique}">
                             <label class="sd-line-input__label">{{ 'Role Name'|translate }}</label>
-                            <input class="sd-line-input__input" type="text" ng-model="editRole.name" required sd-role-unique>
+                            <input class="sd-line-input__input" type="text" ng-model="editRole.name" required sd-role-unique data-test-id="field--name">
                             <div class="sd-line-input__message" ng-show="roleForm.$error.unique" sd-valid-error translate>Sorry, this role name already exists.</div>
                         </div>
                     </div>
                     <div class="form__row">
                         <div class="sd-line-input">
                             <label class="sd-line-input__label">{{ 'Role Description'|translate }}</label>
-                            <textarea class="sd-line-input__input" sd-auto-height ng-model="editRole.description"></textarea>
+                            <textarea class="sd-line-input__input" sd-auto-height ng-model="editRole.description" data-test-id="field--description"></textarea>
                         </div>
                     </div>
                     <div class="form__row">
@@ -84,8 +84,8 @@
             </form>
         </div>
         <div class="modal__footer">
-            <button class="btn" ng-click="cancel()" translate>Cancel</button>
-            <button class="btn btn--primary" ng-click="save(editRole)" ng-disabled="!roleForm.$valid || !roleForm.$dirty" translate>Ok</button>
+            <button class="btn" ng-click="cancel()" data-test-id="cancel" translate>Cancel</button>
+            <button class="btn btn--primary" ng-click="save(editRole)" data-test-id="save" ng-disabled="!roleForm.$valid || !roleForm.$dirty" translate>Ok</button>
         </div>
     </div>
 </div>

--- a/scripts/apps/users/views/settings.html
+++ b/scripts/apps/users/views/settings.html
@@ -6,10 +6,10 @@
         <div class="sd-page__header">
             <ul class="nav nav-tabs">
                 <li ng-class="{active: rolesTab}">
-                    <button ng-click="rolesTab = true" translate>Roles</button>
+                    <button ng-click="rolesTab = true" data-test-id="roles-tab" translate>Roles</button>
                 </li>
                 <li ng-class="{active: !rolesTab}">
-                    <button ng-click="rolesTab = false" translate>Roles privileges</button>
+                    <button ng-click="rolesTab = false" data-test-id="roles-privileges-tab" translate>Roles privileges</button>
                 </li>
             </ul>
         </div>

--- a/scripts/apps/users/views/user-privileges.html
+++ b/scripts/apps/users/views/user-privileges.html
@@ -22,7 +22,7 @@
                 </tr>
             </thead>
             <tbody>
-                <tr ng-repeat="p in privileges track by p.name">
+                <tr ng-repeat="p in privileges track by p.name" data-test-id="privilege-row" data-test-value="{{::p.name}}">
                     <td class="name">
                         <div>
                             <span>{{ :: p.label | translate }}</span>
@@ -46,7 +46,7 @@
                                ng-disabled="true"
                                ng-if="role.privileges[p.name]" />
                     </td>
-                    <td><span ng-if="role.privileges[p.name]" class="label">{{:: role.name | translate }}</span></td>
+                    <td><span ng-if="role.privileges[p.name]" class="label" data-test-id="privilege-granted-by-role">{{:: role.name | translate }}</span></td>
                     <td class="blank-field"></td>
                 </tr>
             </tbody>


### PR DESCRIPTION
### Purpose
Automates the QA case [User roles](https://sofab.atlassian.net/wiki/spaces/SET/pages/1311834342) as a Playwright spec so it runs in CI instead of being tested by hand.

### What has changed
- New spec `e2e/client/playwright/user-roles.spec.ts` covering the scenario below
- Annotated with `{type: 'confluence', description: '1311834342 partial'}` per the coverage convention
- Adds `data-test-id` attributes to product source: `roles-tab` (`scripts/apps/users/views/settings.html`), `roles-privileges-tab` (`scripts/apps/users/views/settings.html`), `add-role` (`scripts/apps/users/views/settings-roles.html`), `role-item` + `data-test-value`=role name (`scripts/apps/users/views/settings-roles.html`), `role-default-label` (`scripts/apps/users/views/settings-roles.html`), `role-edit` (`scripts/apps/users/views/settings-roles.html`), `role-remove` (`scripts/apps/users/views/settings-roles.html`), `role-modal` (`scripts/apps/users/views/settings-roles.html`), `field--name` (`scripts/apps/users/views/settings-roles.html`), `field--description` (`scripts/apps/users/views/settings-roles.html`), `save` (role modal, `scripts/apps/users/views/settings-roles.html`), `cancel` (role modal, `scripts/apps/users/views/settings-roles.html`), `save-privileges` (`scripts/apps/users/views/settings-privileges.html`), `roles-privileges-form` (`scripts/apps/users/views/settings-privileges.html`), `role-column` + `data-test-value`=role name (`scripts/apps/users/views/settings-privileges.html`), `toggle-all-privileges` (`scripts/apps/users/views/settings-privileges.html`), `privilege-row` + `data-test-value`=privilege name (`scripts/apps/users/views/settings-privileges.html`), `privilege-checkbox` + `data-test-value`=role name (`scripts/apps/users/views/settings-privileges.html`), `privilege-row` + `data-test-value`=privilege name (`scripts/apps/users/views/user-privileges.html`), `privilege-granted-by-role` (`scripts/apps/users/views/user-privileges.html`), `field--role` (`scripts/apps/users/views/edit-form.html`), `page-section` + `data-test-value`=section id (`scripts/apps/users/views/edit.html`) (needs developer eyes)

### Steps to test
**Given** a clean `main` snapshot with no user roles defined, logged in as the admin user.

**When**
1. Open Settings > User Roles and create a new role named `Editor`.
2. Switch to the "Roles privileges" tab and tick the column's select-all checkbox to grant `Editor` every privilege.
3. Untick the privileges the case restricts: Unlock content, Spike, Publish, Unpublish, Roles Management, Mark items for users, Master Desk.
4. Save, then reload the page and reopen the "Roles privileges" tab.
5. Go to User Management, create user `janeeditor` with role `Editor`, then open their full profile and the Privileges section.

**Then**
- The `Editor` role appears in the roles list right after it is created.
- After the reload, every privilege in the table is still ticked for `Editor` except the seven restricted ones, which are unticked.
- On the new user's Privileges tab, each granted privilege is ticked, read-only, and labelled as coming from the `Editor` role.
- Each restricted privilege is unticked, still editable per user, and carries no role label.

The privilege list is read from the rendered table rather than hardcoded, so the "all the rest are granted" assertion spans every privilege the backend exposes (71 in this stack).

Run it: `cd e2e/client && npx playwright test user-roles.spec.ts`

The spec passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
