### PR TITLE
Automate Send item to Personal space (1344443788)

### DIFF
--- a/e2e/client/playwright/page-object-models/interactive-actions-panel.ts
+++ b/e2e/client/playwright/page-object-models/interactive-actions-panel.ts
@@ -1,0 +1,49 @@
+import {Locator, Page, expect} from '@playwright/test';
+
+/**
+ * Drives the interactive actions panel (Send to / Duplicate to / Fetch to).
+ * The same markup is rendered whether the panel is opened from the authoring
+ * topbar, from a monitoring item's context menu or from the multi action bar,
+ * so one driver covers all three entry points.
+ */
+export class InteractiveActionsPanel {
+    private page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    get root(): Locator {
+        return this.page.getByTestId('interactive-actions-panel');
+    }
+
+    async openSendToFromAuthoring(): Promise<void> {
+        await this.page.getByTestId('authoring-topbar').getByTestId('open-send-publish-pane').click();
+        await this.root.getByTestId('tabs').getByRole('tab', {name: 'Send to'}).click();
+    }
+
+    /**
+     * Opens the destination dropdown and returns the option list. The list lives in a
+     * portal outside the panel, hence it is located from the page and not from `root`.
+     */
+    async openDestinationOptions(): Promise<Locator> {
+        await this.root.getByTestId('destination-select').getByTestId('open-popover').click();
+
+        const options = this.page.getByTestId('tree-select-popover').getByTestId('options');
+
+        await expect(options).toBeVisible();
+
+        return options;
+    }
+
+    async selectDestination(destination: string): Promise<void> {
+        const options = await this.openDestinationOptions();
+
+        await options.getByRole('treeitem', {name: destination, exact: true}).click();
+    }
+
+    async send(): Promise<void> {
+        await this.root.getByTestId('send').click();
+        await expect(this.root).toBeHidden();
+    }
+}

--- a/e2e/client/playwright/send-item-to-personal-space.spec.ts
+++ b/e2e/client/playwright/send-item-to-personal-space.spec.ts
@@ -1,0 +1,193 @@
+import {test, expect, type Locator, type Page} from '@playwright/test';
+import {InteractiveActionsPanel} from './page-object-models/interactive-actions-panel';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+import {getStorageState} from './utils/storage-state';
+
+/**
+ * QA case "Send item to Personal space" (Confluence 1344443788), whose expected results
+ * come from the tickets it links: SDANSA-424, SDANSA-466 and SDESK-5609.
+ *
+ * Covered:
+ *  - the feature is off unless `features.sendToPersonal` is configured (SDANSA-424);
+ *  - "Personal space" is offered as a destination in the Send to panel opened from the
+ *    monitoring context menu, from authoring and from a multi selection (SDANSA-424, SDANSA-466);
+ *  - sending removes the item from the desk and leaves it available only in the personal
+ *    space (SDANSA-424);
+ *  - the shortcut action "Send to Personal Space" in the item context menu (SDANSA-424);
+ *  - items already in the personal space offer neither the shortcut action nor the
+ *    "Personal space" destination (SDESK-5609).
+ *
+ * Not covered:
+ *  - the `send_to_personal` user privilege gate (SDANSA-424: "I expect to have a user privilege
+ *    for Send items to personal space"). Blocker: missing fixture. The `main` snapshot ships no
+ *    roles and its only usable login is the administrator, who implicitly holds every privilege,
+ *    so there is no way to log in as a user that has the ordinary authoring privileges but not
+ *    `send_to_personal`.
+ */
+
+const PERSONAL_SPACE = 'Personal space';
+const SPORTS_WORKING_STAGE = 'Sports / Working Stage';
+const PERSONAL_ITEMS = 'Personal Items';
+
+function articleInGroup(page: Page, group: string, article: string): Locator {
+    return page.getByTestId('monitoring-group').and(page.locator(`[data-test-value="${group}"]`))
+        .getByTestId('article-item').and(page.locator(`[data-test-value="${article}"]`));
+}
+
+test.describe('sending an item to the personal space', {
+    annotation: [
+        {type: 'confluence', description: '1344443788 partial'}, // Send item to Personal space
+    ],
+}, () => {
+    test.describe('with the feature enabled', () => {
+        test.use({storageState: getStorageState({features: {sendToPersonal: true}})});
+
+        test('sends an item from a desk to the personal space via the Send to panel', async ({page}) => {
+            const monitoring = new Monitoring(page);
+            const panel = new InteractiveActionsPanel(page);
+
+            await restoreDatabaseSnapshot();
+            await page.goto('/#/workspace/monitoring');
+            await monitoring.selectDeskOrWorkspace('Sports');
+
+            await monitoring.executeActionOnMonitoringItem(
+                articleInGroup(page, SPORTS_WORKING_STAGE, 'story 2'),
+                'Send to',
+            );
+
+            const destinations = await panel.openDestinationOptions();
+            const personalSpace = destinations.getByRole('treeitem', {name: PERSONAL_SPACE, exact: true});
+
+            await expect(personalSpace).toBeVisible();
+            await personalSpace.click();
+
+            // the stage picker only applies to desk destinations
+            await expect(panel.root.getByTestId('stage-select')).toBeHidden();
+
+            await panel.send();
+
+            await expect(articleInGroup(page, SPORTS_WORKING_STAGE, 'story 2')).toBeHidden();
+
+            await page.goto('/#/workspace/personal');
+            await expect(articleInGroup(page, PERSONAL_ITEMS, 'story 2')).toBeVisible();
+        });
+
+        test('sends an item from a desk to the personal space from the authoring send panel', async ({page}) => {
+            const monitoring = new Monitoring(page);
+            const panel = new InteractiveActionsPanel(page);
+
+            await restoreDatabaseSnapshot();
+            await page.goto('/#/workspace/monitoring');
+            await monitoring.selectDeskOrWorkspace('Sports');
+
+            await monitoring.executeActionOnMonitoringItem(
+                articleInGroup(page, SPORTS_WORKING_STAGE, 'test sports story'),
+                'Edit',
+            );
+
+            await panel.openSendToFromAuthoring();
+            await panel.selectDestination(PERSONAL_SPACE);
+            await panel.send();
+
+            // sending the item that is currently open closes authoring
+            await expect(page.getByTestId('authoring-topbar')).toBeHidden();
+            await expect(articleInGroup(page, SPORTS_WORKING_STAGE, 'test sports story')).toBeHidden();
+
+            await page.goto('/#/workspace/personal');
+            await expect(articleInGroup(page, PERSONAL_ITEMS, 'test sports story')).toBeVisible();
+        });
+
+        test('sends a multi selection to the personal space', async ({page}) => {
+            const monitoring = new Monitoring(page);
+            const panel = new InteractiveActionsPanel(page);
+
+            await restoreDatabaseSnapshot();
+            await page.goto('/#/workspace/monitoring');
+            await monitoring.selectDeskOrWorkspace('Sports');
+
+            await monitoring.executeBulkAction('Send to', ['story 2', 'test sports story']);
+
+            await panel.selectDestination(PERSONAL_SPACE);
+            await panel.send();
+
+            await expect(articleInGroup(page, SPORTS_WORKING_STAGE, 'story 2')).toBeHidden();
+            await expect(articleInGroup(page, SPORTS_WORKING_STAGE, 'test sports story')).toBeHidden();
+
+            await page.goto('/#/workspace/personal');
+            await expect(articleInGroup(page, PERSONAL_ITEMS, 'story 2')).toBeVisible();
+            await expect(articleInGroup(page, PERSONAL_ITEMS, 'test sports story')).toBeVisible();
+        });
+
+        test('sends an item to the personal space with the context menu shortcut', async ({page}) => {
+            const monitoring = new Monitoring(page);
+
+            await restoreDatabaseSnapshot();
+            await page.goto('/#/workspace/monitoring');
+            await monitoring.selectDeskOrWorkspace('Sports');
+
+            await monitoring.executeActionOnMonitoringItem(
+                articleInGroup(page, SPORTS_WORKING_STAGE, 'story 2'),
+                'Send to Personal Space',
+            );
+
+            await expect(articleInGroup(page, SPORTS_WORKING_STAGE, 'story 2')).toBeHidden();
+
+            await page.goto('/#/workspace/personal');
+            await expect(articleInGroup(page, PERSONAL_ITEMS, 'story 2')).toBeVisible();
+        });
+
+        test('does not offer the personal space for an item that is already there', async ({page}) => {
+            const panel = new InteractiveActionsPanel(page);
+            const article = articleInGroup(page, PERSONAL_ITEMS, 'personal space article 1');
+
+            await restoreDatabaseSnapshot();
+            await page.goto('/#/workspace/personal');
+
+            await article.hover();
+            await article.getByTestId('context-menu-button').click();
+
+            const contextMenu = page.getByTestId('context-menu');
+            const sendTo = contextMenu.getByRole('button', {name: 'Send to', exact: true});
+
+            await expect(sendTo).toBeVisible();
+            await expect(
+                contextMenu.getByRole('button', {name: 'Send to Personal Space', exact: true}),
+            ).toHaveCount(0);
+
+            await sendTo.click();
+
+            const destinations = await panel.openDestinationOptions();
+
+            await expect(destinations.getByRole('treeitem', {name: 'Education', exact: true})).toBeVisible();
+            await expect(destinations.getByRole('treeitem', {name: PERSONAL_SPACE, exact: true})).toHaveCount(0);
+        });
+    });
+
+    test('does not offer the personal space when the feature is not enabled', async ({page}) => {
+        const monitoring = new Monitoring(page);
+        const panel = new InteractiveActionsPanel(page);
+
+        await restoreDatabaseSnapshot();
+        await page.goto('/#/workspace/monitoring');
+        await monitoring.selectDeskOrWorkspace('Sports');
+
+        const article = articleInGroup(page, SPORTS_WORKING_STAGE, 'story 2');
+
+        await article.hover();
+        await article.getByTestId('context-menu-button').click();
+
+        const contextMenu = page.getByTestId('context-menu');
+        const sendTo = contextMenu.getByRole('button', {name: 'Send to', exact: true});
+
+        await expect(sendTo).toBeVisible();
+        await expect(contextMenu.getByRole('button', {name: 'Send to Personal Space', exact: true})).toHaveCount(0);
+
+        await sendTo.click();
+
+        const destinations = await panel.openDestinationOptions();
+
+        await expect(destinations.getByRole('treeitem', {name: 'Education', exact: true})).toBeVisible();
+        await expect(destinations.getByRole('treeitem', {name: PERSONAL_SPACE, exact: true})).toHaveCount(0);
+    });
+});

--- a/e2e/client/playwright/utils/storage-state.ts
+++ b/e2e/client/playwright/utils/storage-state.ts
@@ -1,8 +1,28 @@
+import fs from 'fs';
+import path from 'path';
 import {BrowserContextOptions} from '@playwright/test';
 import {ISuperdeskGlobalConfig} from 'superdesk-api';
-import storageState from '../.auth/user.json';
+import committedStorageState from '../.auth/user.json';
 
 type StorageState = BrowserContextOptions['storageState'];
+
+/**
+ * localStorage is keyed by origin, and the committed storage state is keyed to
+ * http://localhost:9000. A slot serves the client from another port, so e2e-up.sh
+ * writes an origin-rewritten copy and points `PLAYWRIGHT_STORAGE_STATE` at it
+ * (playwright.config.ts resolves it relative to e2e/client). Patching the committed
+ * copy instead would put both the session and the config patch under an origin the
+ * browser never visits, leaving the test stuck on the login screen.
+ */
+function getBaseStorageState(): {origins: Array<{origin: string; localStorage: Array<unknown>}>} {
+    const slotStorageState = process.env.PLAYWRIGHT_STORAGE_STATE;
+
+    if (slotStorageState != null && slotStorageState !== '') {
+        return JSON.parse(fs.readFileSync(path.resolve(__dirname, '../..', slotStorageState), 'utf-8'));
+    }
+
+    return JSON.parse(JSON.stringify(committedStorageState));
+}
 
 /**
  * Allows to set custom application configs while preserving values defined in .auth/user.json
@@ -11,7 +31,7 @@ export function getStorageState(
     appConfigPatch: Partial<ISuperdeskGlobalConfig>,
     otherOptions?: {authoringReact?: boolean},
 ): StorageState {
-    const storageStateCopy = JSON.parse(JSON.stringify(storageState));
+    const storageStateCopy = getBaseStorageState();
 
     storageStateCopy['origins'][0].localStorage.push({name: 'TEST_APP_CONFIG', value: JSON.stringify(appConfigPatch)});
 
@@ -19,5 +39,5 @@ export function getStorageState(
         storageStateCopy['origins'][0].localStorage.push({name: 'auth-react', value: 'true'});
     }
 
-    return storageStateCopy;
+    return storageStateCopy as StorageState;
 }


### PR DESCRIPTION
### Purpose
Automates the QA case [Send item to Personal space](https://sofab.atlassian.net/wiki/spaces/SET/pages/1344443788) as a Playwright spec so it runs in CI instead of being tested by hand.

### What has changed
- New spec `e2e/client/playwright/send-item-to-personal-space.spec.ts` covering the scenario below
- Annotated with `{type: 'confluence', description: '1344443788 partial'}` per the coverage convention

### Steps to test
**Given** the `main` snapshot, with `features.sendToPersonal` enabled through the test app config, and "story 2" / "test sports story" sitting in Sports / Working Stage.

**When**
1. Open Monitoring and switch to the Sports desk.
2. Open an item's 3-dot menu and choose "Send to".
3. Open the destination dropdown and pick "Personal space".
4. Click Send.

**Then**
- "Personal space" is offered as a destination, and no stage picker is shown for it.
- The item disappears from Sports / Working Stage.
- The item appears in the Personal Items group of the personal workspace.

The spec also covers the same send from the authoring send panel, from a multi selection (both items move), and the "Send to Personal Space" 3-dot shortcut. It asserts the negative cases too: with the feature flag off, neither the shortcut nor the "Personal space" destination is offered; and for an item that is already in the personal space, neither is offered either.

Run it: `cd e2e/client && npx playwright test send-item-to-personal-space.spec.ts`

The spec passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
