### PR TITLE
Automate Info button (1310294120)

### DIFF
--- a/e2e/client/playwright/authoring-info-widget.spec.ts
+++ b/e2e/client/playwright/authoring-info-widget.spec.ts
@@ -1,0 +1,178 @@
+import {test, expect, type Page} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {Authoring} from './page-object-models/authoring';
+import {restoreDatabaseSnapshot} from './utils';
+
+/**
+ * QA case "Info button" (Authoring widgets, Confluence 1310294120).
+ *
+ * The Info side widget of an article: the Not For Publication and Legal flags,
+ * the editable Usage terms / Language / Unique name fields, and the read-only
+ * Pubstatus, State and GUID lines.
+ *
+ * Documented expected results that are NOT covered here, each with its blocker:
+ *
+ * - Keywords. The widget renders keywords read-only (and under a "Word Count"
+ *   label, which is a product-side labelling bug), there is no keywords input in
+ *   it, and no article in the `main` snapshot carries keywords.
+ * - Expiry. Only the spiked articles in the `main` snapshot carry an `expiry`,
+ *   and no desk in it has content auto-expiry configured, so the Expiry line
+ *   never renders for an editable article.
+ * - Target Subscribers / Target types. Not part of the Info widget in the
+ *   current UI; the targeting controls live in the publish pane and in the
+ *   template editor.
+ *
+ * The QA page contradicts itself on Not For Publication: the field description
+ * says a publish attempt fails while the flag is on, a note at the end says the
+ * flag only tags the item. The client implements the first one (the Publish tab
+ * is not offered for a flagged item, see sdApi.article.canPublish), and that is
+ * what is asserted below.
+ */
+// Both tests open the article twice and the first one also waits for the edited
+// unique name to become searchable, which does not fit the 30s default.
+test.setTimeout(90000);
+
+test.describe('Info widget in authoring', () => {
+    const ARTICLE = 'test sports story';
+    const WORKING_STAGE = 'Sports / Working Stage';
+
+    // Lower-case single token so the Advanced Search `term` filter on
+    // `unique_name` matches regardless of whether the field is mapped as a
+    // keyword or as an analysed string.
+    const UNIQUE_NAME = 'infowidgetstory';
+    const USAGE_TERMS = 'internal briefing only';
+
+    function articleInWorkingStage(page: Page) {
+        return page.getByTestId('monitoring-group')
+            .and(page.locator(`[data-test-value="${WORKING_STAGE}"]`))
+            .getByTestId('article-item')
+            .and(page.locator(`[data-test-value="${ARTICLE}"]`));
+    }
+
+    async function openArticleInfoWidget(page: Page) {
+        const monitoring = new Monitoring(page);
+        const authoring = new Authoring(page);
+
+        await page.goto('/#/workspace/monitoring');
+        await monitoring.selectDeskOrWorkspace('Sports');
+        await articleInWorkingStage(page).dblclick();
+
+        return authoring.openWidget('Info');
+    }
+
+    /**
+     * The Advanced Search parameters live in the search view's filter panel.
+     * The panel toggle, the tab and the submit button have no test ids, so they
+     * are located the same way `search.spec.ts` already does it.
+     */
+    async function searchByUniqueName(page: Page, uniqueName: string): Promise<void> {
+        await page.goto('/#/search');
+
+        if (await page.getByTestId('repo--ingest').count() === 0) {
+            await page.locator('.filter-trigger').click();
+        }
+
+        await expect(page.getByTestId('repo--ingest')).toBeVisible();
+
+        await page.locator('#parameters-tab').click();
+        await page.locator('#search-storyname').fill(uniqueName);
+
+        // The just-saved unique name has to be indexed before the term filter can
+        // match it, and there is no client-side signal for that, so re-submit the
+        // search until the result shows up.
+        await expect(async () => {
+            await page.locator('#advanced_search_filters button.search:visible').first().click();
+            await expect(page.getByTestId('article-item')).toHaveCount(1);
+        }).toPass({timeout: 60000});
+
+        await expect(page.getByTestId('article-item')).toContainText(ARTICLE);
+    }
+
+    test('lists the article identifiers and persists edits to Usage terms, Language and Unique name', {
+        annotation: [
+            {type: 'confluence', description: '1310294120 partial'}, // Info button
+        ],
+    }, async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const authoring = new Authoring(page);
+        const infoWidget = await openArticleInfoWidget(page);
+
+        // The GUID is documented as not editable: it renders as plain text, with
+        // no form control and nothing content-editable inside it.
+        await expect(infoWidget.getByTestId('guid')).toHaveText(/^urn:newsml:/);
+        await expect(
+            infoWidget.getByTestId('guid').locator('input, select, textarea, [contenteditable="true"]'),
+        ).toHaveCount(0);
+        await expect(infoWidget.getByTestId('pubstatus')).toContainText('usable');
+        await expect(infoWidget.getByTestId('state')).toContainText(/in progress/i);
+
+        await infoWidget.getByTestId('usage-terms').fill(USAGE_TERMS);
+        await infoWidget.getByTestId('language').locator('select').selectOption({label: 'Deutsch'});
+        await infoWidget.getByTestId('unique-name').fill(UNIQUE_NAME);
+
+        await authoring.closeAndSave();
+
+        await articleInWorkingStage(page).dblclick();
+
+        const reopenedInfoWidget = await authoring.openWidget('Info');
+
+        await expect(reopenedInfoWidget.getByTestId('usage-terms')).toHaveValue(USAGE_TERMS);
+        await expect(reopenedInfoWidget.getByTestId('language').locator('option:checked')).toHaveText('Deutsch');
+        await expect(reopenedInfoWidget.getByTestId('unique-name')).toHaveValue(UNIQUE_NAME);
+
+        await authoring.close();
+
+        await searchByUniqueName(page, UNIQUE_NAME);
+    });
+
+    test('Not For Publication and Legal tag the item, and only Not For Publication blocks publishing', {
+        annotation: [
+            {type: 'confluence', description: '1310294120 partial'}, // Info button
+        ],
+    }, async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const authoring = new Authoring(page);
+        const infoWidget = await openArticleInfoWidget(page);
+
+        const notForPublication = infoWidget.getByTestId('not-for-publication');
+        const legal = infoWidget.getByTestId('legal');
+
+        // sd-switch renders a span that carries its on/off state as a class.
+        await expect(notForPublication).not.toHaveClass(/checked/);
+        await expect(legal).not.toHaveClass(/checked/);
+
+        await notForPublication.click();
+        await legal.click();
+
+        await expect(notForPublication).toHaveClass(/checked/);
+        await expect(legal).toHaveClass(/checked/);
+        await expect(infoWidget.getByTestId('state')).toContainText('Not For Publication');
+        await expect(infoWidget.getByTestId('state')).toContainText('Legal');
+
+        await authoring.save();
+
+        await expect(articleInWorkingStage(page)).toContainText('Not For Publication');
+        await expect(articleInWorkingStage(page)).toContainText('Legal');
+
+        const paneWithFlag = await authoring.openSendPublishPane();
+
+        await expect(paneWithFlag.getByTestId('tabs').getByRole('tab', {name: 'Send to'})).toBeVisible();
+        await expect(paneWithFlag.getByTestId('tabs').getByRole('tab', {name: 'Publish'})).toHaveCount(0);
+
+        await authoring.closeSendPublishPane();
+
+        await notForPublication.click();
+        await expect(notForPublication).not.toHaveClass(/checked/);
+
+        await authoring.save();
+
+        await expect(articleInWorkingStage(page)).not.toContainText('Not For Publication');
+        await expect(articleInWorkingStage(page)).toContainText('Legal');
+
+        const paneWithoutFlag = await authoring.openSendPublishPane();
+
+        await expect(paneWithoutFlag.getByTestId('tabs').getByRole('tab', {name: 'Publish'})).toBeVisible();
+    });
+});

--- a/e2e/client/playwright/authoring-info-widget.spec.ts
+++ b/e2e/client/playwright/authoring-info-widget.spec.ts
@@ -104,7 +104,11 @@ test.describe('Info widget in authoring', () => {
         await expect(
             infoWidget.getByTestId('guid').locator('input, select, textarea, [contenteditable="true"]'),
         ).toHaveCount(0);
-        await expect(infoWidget.getByTestId('pubstatus')).toContainText('usable');
+        // The documented values are "usable" and "unusable", so a substring match
+        // on "usable" would accept both. The test id sits on the whole list item,
+        // whose text is the label glued to the value ("Pubstatususable"), hence
+        // the label in the pattern.
+        await expect(infoWidget.getByTestId('pubstatus')).toHaveText(/^Pubstatus\s*usable$/);
         await expect(infoWidget.getByTestId('state')).toContainText(/in progress/i);
 
         await infoWidget.getByTestId('usage-terms').fill(USAGE_TERMS);

--- a/e2e/client/playwright/page-object-models/authoring.ts
+++ b/e2e/client/playwright/page-object-models/authoring.ts
@@ -68,16 +68,19 @@ export class Authoring {
      *
      * Both the tab and the panel carry the label in `data-test-value` while their
      * visible content is an icon, so they are matched on the attribute.
+     *
+     * The tab toggles rather than opens: clicking it while its widget is active
+     * closes the panel. The tab is therefore only clicked when the panel is not
+     * already showing, so that calling this on an open widget is a no-op.
      */
     async openWidget(label: string): Promise<Locator> {
         const {page} = this;
+        const withLabel = page.locator(`[data-test-value="${label}"]`);
+        const panel = page.getByTestId('authoring-widget-panel').and(withLabel);
 
-        await page.getByTestId('authoring-widget')
-            .and(page.locator(`[data-test-value="${label}"]`))
-            .click();
-
-        const panel = page.getByTestId('authoring-widget-panel')
-            .and(page.locator(`[data-test-value="${label}"]`));
+        if (!await panel.isVisible()) {
+            await page.getByTestId('authoring-widget').and(withLabel).click();
+        }
 
         await expect(panel).toBeVisible();
 
@@ -87,14 +90,18 @@ export class Authoring {
     /**
      * Saves from the topbar and waits for the save to land.
      *
-     * The Save button is disabled while the item is clean, so it going back to
-     * disabled is the completion signal; without it the next assertion can run
-     * against a not-yet-persisted item.
+     * The Save button is also disabled while the save is in flight, so it being
+     * disabled says nothing about the item having been persisted. The spinner
+     * inside the button is the completion signal: it is bound to the same flag
+     * the save promise clears when it settles.
      */
     async save(): Promise<void> {
         const saveButton = this.page.getByTestId('authoring-topbar').getByTestId('save');
+        const spinner = saveButton.getByTestId('loading-indicator');
 
         await saveButton.click();
+        await expect(spinner).toBeVisible();
+        await expect(spinner).toBeHidden();
         await expect(saveButton).toBeDisabled();
     }
 

--- a/e2e/client/playwright/page-object-models/authoring.ts
+++ b/e2e/client/playwright/page-object-models/authoring.ts
@@ -64,6 +64,109 @@ export class Authoring {
     }
 
     /**
+     * Opens a side widget by its label and returns the widget panel.
+     *
+     * Both the tab and the panel carry the label in `data-test-value` while their
+     * visible content is an icon, so they are matched on the attribute.
+     */
+    async openWidget(label: string): Promise<Locator> {
+        const {page} = this;
+
+        await page.getByTestId('authoring-widget')
+            .and(page.locator(`[data-test-value="${label}"]`))
+            .click();
+
+        const panel = page.getByTestId('authoring-widget-panel')
+            .and(page.locator(`[data-test-value="${label}"]`));
+
+        await expect(panel).toBeVisible();
+
+        return panel;
+    }
+
+    /**
+     * Saves from the topbar and waits for the save to land.
+     *
+     * The Save button is disabled while the item is clean, so it going back to
+     * disabled is the completion signal; without it the next assertion can run
+     * against a not-yet-persisted item.
+     */
+    async save(): Promise<void> {
+        const saveButton = this.page.getByTestId('authoring-topbar').getByTestId('save');
+
+        await saveButton.click();
+        await expect(saveButton).toBeDisabled();
+    }
+
+    /**
+     * Closes the article, discarding an autosave record if one is pending.
+     *
+     * Fields that autosave on a debounce can land a record after the item was
+     * saved, and the item then still counts as unsaved on the next close even
+     * if nothing was touched since. That makes the "Save changes?" prompt
+     * genuinely optional here, so it is answered only when it shows up.
+     */
+    async close(): Promise<void> {
+        const {page} = this;
+        const topbar = page.getByTestId('authoring-topbar');
+        const unsavedChanges = page.getByTestId('unsaved-changes-dialog');
+
+        await topbar.getByTestId('close').click();
+
+        await expect(async () => {
+            if (await unsavedChanges.isVisible()) {
+                await unsavedChanges.getByRole('button', {name: 'Ignore', exact: true}).click();
+            }
+
+            await expect(topbar).toBeHidden({timeout: 1000});
+        }).toPass({timeout: 20000});
+    }
+
+    /**
+     * Closes an article that has pending edits, answering the "Save changes?"
+     * prompt with Save.
+     *
+     * Use this instead of `save()` + `close()` after editing fields that
+     * autosave on a debounce: the debounced autosave can land after the topbar
+     * save, which raises the prompt anyway and leaves `close()` hanging on an
+     * article that never closes.
+     */
+    async closeAndSave(): Promise<void> {
+        const {page} = this;
+
+        await page.getByTestId('authoring-topbar').getByTestId('close').click();
+
+        await page.getByTestId('unsaved-changes-dialog')
+            .getByRole('button', {name: 'Save', exact: true})
+            .click();
+
+        await expect(page.getByTestId('authoring-topbar')).toBeHidden();
+    }
+
+    /**
+     * Opens the send/publish pane and returns it. Which tabs it offers depends on
+     * the article, so the caller decides what to assert or click.
+     */
+    async openSendPublishPane(): Promise<Locator> {
+        const {page} = this;
+
+        await page.getByTestId('authoring-topbar').getByTestId('open-send-publish-pane').click();
+
+        const panel = page.getByTestId('interactive-actions-panel');
+
+        await expect(panel).toBeVisible();
+
+        return panel;
+    }
+
+    async closeSendPublishPane(): Promise<void> {
+        const panel = this.page.getByTestId('interactive-actions-panel');
+
+        await panel.getByTestId('close').click();
+        await expect(panel).toBeHidden();
+    }
+
+    /**
      * editor3 field takes quite some time to initialize in authoring-react.
      * Until it initializes - typing inside it doesn't update `fieldsData` in authoring-react state.
      */

--- a/scripts/apps/authoring/metadata/views/metadata-widget.html
+++ b/scripts/apps/authoring/metadata/views/metadata-widget.html
@@ -14,7 +14,7 @@
             <li class="basic-list__item" ng-if="_isInProductionStates">
                 <label class="basic-list__item-label" ng-if="_editable" translate>Not For Publication</label>
                 <span class="basic-list__item-data" ng-if="_editable">
-                    <span ng-if="_editable" sd-switch ng-model="item.flags.marked_for_not_publication"></span>
+                    <span ng-if="_editable" sd-switch ng-model="item.flags.marked_for_not_publication" data-test-id="not-for-publication"></span>
                 </span>
                 <span ng-if="!_editable">
                     <span class="state-label not-for-publication" ng-show="item.flags.marked_for_not_publication" translate>Not For Publication</span>
@@ -25,7 +25,7 @@
             <li class="basic-list__item" ng-if="_isInProductionStates">
                 <label class="basic-list__item-label" ng-if="_editable" translate>Legal</label>
                 <span class="basic-list__item-data" ng-if="_editable">
-                    <span sd-switch ng-model="item.flags.marked_for_legal"></span>
+                    <span sd-switch ng-model="item.flags.marked_for_legal" data-test-id="legal"></span>
                 </span>
                 <span ng-if="!_editable">
                     <span class="state-label legal" ng-show="item.flags.marked_for_legal" translate>Legal</span>
@@ -33,7 +33,7 @@
             </li>
 
             <li sd-metadata-list-item data-label="'Usage terms' | translate" ng-if="!isRemovedField('usageterms')">
-                <input class="basic-input" type="text" ng-model="item.usageterms" ng-disabled="!_editable" ng-change="autosave(item)">
+                <input class="basic-input" type="text" ng-model="item.usageterms" ng-disabled="!_editable" ng-change="autosave(item)" data-test-id="usage-terms">
             </li>
 
             <li class="basic-list__item basic-list__item--stacked" ng-if="$root.config.features.alchemy">
@@ -49,11 +49,12 @@
                     data-key="qcode"
                     data-list="metadata.languages"
                     ng-disabled="!_editable"
-                    data-change="autosave(item)">
+                    data-change="autosave(item)"
+                    data-test-id="language">
                 </div>
             </li>
 
-            <li sd-metadata-list-item data-label="'Pubstatus' | translate" ng-if="item.pubstatus">
+            <li sd-metadata-list-item data-label="'Pubstatus' | translate" ng-if="item.pubstatus" data-test-id="pubstatus">
                 {{ item.pubstatus }}
             </li>
 
@@ -73,7 +74,7 @@
                 {{ item.creditline }}
             </li>
 
-            <li sd-metadata-list-item data-label="'State' | translate">
+            <li sd-metadata-list-item data-label="'State' | translate" data-test-id="state">
                 <span sd-item-state data-state=item.state data-embargo=item.embargo data-test-id="item-state"></span>
                 <span ng-if="item.flags.marked_for_not_publication" class="state-label not-for-publication" translate>Not For Publication</span>
                 <span ng-if="item.flags.marked_for_legal" class="state-label legal" translate>Legal</span>
@@ -189,13 +190,13 @@
 
             <li class="basic-list__item basic-list__item--stacked">
                 <label class="basic-list__item-label basic-list__item-label--block" translate>GUID</label>
-                <div class="basic-list__item-data" id="guid">
+                <div class="basic-list__item-data" id="guid" data-test-id="guid">
                     {{item.guid}}
                 </div>
             </li>
 
             <li sd-metadata-list-item data-label="'Unique name' | translate">
-                <input class="basic-input" type="text" ng-model="item.unique_name" ng-change="autosave(item)" ng-disabled="!_editable || !unique_name_editable">
+                <input class="basic-input" type="text" ng-model="item.unique_name" ng-change="autosave(item)" ng-disabled="!_editable || !unique_name_editable" data-test-id="unique-name">
             </li>
 
             <li sd-metadata-list-item data-label="'Type' | translate">


### PR DESCRIPTION
### Purpose
Automates the QA case [Info button](https://sofab.atlassian.net/wiki/spaces/SET/pages/1310294120) as a Playwright spec so it runs in CI instead of being tested by hand.

### What has changed
- New spec `e2e/client/playwright/authoring-info-widget.spec.ts` covering the scenario below
- Annotated with `{type: 'confluence', description: '1310294120 partial'}` per the coverage convention
- Adds `data-test-id` attributes to product source: `not-for-publication`, `legal`, `usage-terms`, `language`, `pubstatus`, `state`, `guid`, `unique-name` (all in `scripts/apps/authoring/metadata/views/metadata-widget.html`) (needs developer eyes)

### Steps to test
**Given** the article "test sports story" sits in Sports / Working Stage on the `main` snapshot.

**When**
1. Open the article from Monitoring and open its "Info" side widget.
2. Read the GUID, Pubstatus and State lines.
3. Edit Usage terms, pick "Deutsch" for Language and set a new Unique name, then close saving the changes and reopen the article.
4. Search for that Unique name in the Advanced Search parameters of the search view.
5. Back in the Info widget, switch "Not For Publication" and "Legal" on, save, and open the Send to / Publish pane.
6. Switch "Not For Publication" back off, save, and open the Send to / Publish pane again.

**Then**
- The GUID renders as plain, non-editable text, Pubstatus shows "usable" and State shows "In Progress".
- Usage terms, Language and Unique name still hold the edited values after the article is reopened.
- The Advanced Search by Unique Name returns exactly that one article.
- With both flags on, the State line and the article entry in the monitoring list are tagged "Not For Publication" and "Legal", and the send pane offers only "Send to", no "Publish" tab.
- With only "Legal" left on, the "Not For Publication" tag is gone, the "Legal" tag stays, and the send pane offers the "Publish" tab again.

The spec also checks that both flag switches start off, and that each switch reflects its on/off state right after being clicked.

Run it: `cd e2e/client && npx playwright test authoring-info-widget.spec.ts`

The spec passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
