### PR TITLE
Automate Create new empty package (1308524902)

### DIFF
--- a/e2e/client/playwright/create-empty-package.spec.ts
+++ b/e2e/client/playwright/create-empty-package.spec.ts
@@ -1,0 +1,165 @@
+import {test, expect, type Locator, type Page} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+
+/**
+ * QA case "Create new empty package" (1308524902).
+ *
+ * An empty package is created from the "+" menu in Monitoring, its fields are
+ * filled in, and the unsaved-changes dialog raised by Close is exercised in all
+ * three directions (Cancel / Ignore / Save).
+ *
+ * Two documented expected results are not covered, both blocked on the product
+ * rather than on the test:
+ *
+ * - "Packages can be created in Monitoring view and Personal space". Personal
+ *   space has no package creation entry point. `InitialView` renders the
+ *   "Create package" option behind `!sdApi.navigation.isPersonalSpace()`
+ *   (scripts/core/ui/components/content-create-dropdown/initial-view.tsx), and
+ *   on top of that the whole "+" dropdown fails to render there: its
+ *   componentDidMount reads `getCurrentDesk().default_content_template` and
+ *   `getCurrentDesk()` is null in personal space, so the popup stays empty.
+ *   That second half is a live regression which also fails the existing
+ *   `monitoring.personal-space.spec.ts` "creating an article" test on develop.
+ * - "Packages cannot be created in Custom Workspace". The option is offered in a
+ *   custom workspace exactly as it is on a desk, and clicking it opens a package
+ *   editor. The documented restriction does not exist in the product, and
+ *   asserting the behaviour as it stands would encode the contradiction.
+ */
+test.setTimeout(90000);
+
+test.describe('creating a new empty package', {
+    annotation: [
+        {type: 'confluence', description: '1308524902 partial'}, // Create new empty package
+    ],
+}, () => {
+    const HEADLINE = 'empty package headline';
+    const SLUGLINE = 'empty-package-slugline';
+
+    function monitoringItem(page: Page): Locator {
+        return page.getByTestId('monitoring-view')
+            .getByTestId('article-item')
+            .and(page.locator(`[data-test-value="${HEADLINE}"]`));
+    }
+
+    function packageHeadline(page: Page): Locator {
+        return page.getByTestId('authoring').getByTestId('package-title');
+    }
+
+    function packageSlugline(page: Page): Locator {
+        return page.getByTestId('authoring').getByTestId('field-slugline');
+    }
+
+    /**
+     * Opens an empty package from the "+" menu on the Sports desk and fills the
+     * two fields the package editor exposes: Headline (the package header) and
+     * Slugline (the authoring header).
+     */
+    async function createAndFillPackage(page: Page): Promise<void> {
+        const monitoring = new Monitoring(page);
+
+        await page.goto('/#/workspace/monitoring');
+        await monitoring.selectDeskOrWorkspace('Sports');
+        await monitoring.createEmptyPackage();
+
+        await expect(page.getByTestId('authoring')).toBeVisible();
+        await expect(packageHeadline(page)).toBeVisible();
+
+        await packageHeadline(page).fill(HEADLINE);
+        await packageSlugline(page).fill(SLUGLINE);
+
+        await expect(page.getByTestId('authoring-topbar').getByTestId('save')).toBeEnabled();
+    }
+
+    // The global search bar carries no data-test-id; #search-input plus ENTER is
+    // the established way to drive it (search.spec.ts, monitoring.misc.spec.ts).
+    async function runGlobalSearch(page: Page, query: string): Promise<void> {
+        await page.goto('/#/search');
+
+        // Assert the unfiltered result list first: without it a search that never
+        // ran is indistinguishable from a search that returned nothing.
+        await expect(page.getByTestId('article-item').first()).toBeVisible();
+
+        const input = page.locator('#search-input');
+
+        await input.click();
+        await input.fill(query);
+        await input.press('Enter');
+    }
+
+    test('Cancel returns to the package and Ignore discards it without creating anything', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await createAndFillPackage(page);
+
+        const topbar = page.getByTestId('authoring-topbar');
+        const prompt = page.getByTestId('unsaved-changes-dialog');
+
+        await topbar.getByTestId('close').click();
+        await expect(prompt).toBeVisible();
+
+        await prompt.getByRole('button', {name: 'Cancel', exact: true}).click();
+        await expect(prompt).toBeHidden();
+        await expect(page.getByTestId('authoring')).toBeVisible();
+        await expect(packageHeadline(page)).toHaveValue(HEADLINE);
+        await expect(packageSlugline(page)).toHaveValue(SLUGLINE);
+
+        await topbar.getByTestId('close').click();
+        await prompt.getByRole('button', {name: 'Ignore', exact: true}).click();
+
+        await expect(page.getByTestId('authoring')).toBeHidden();
+        await expect(monitoringItem(page)).toHaveCount(0);
+
+        await runGlobalSearch(page, HEADLINE);
+        await expect(page.getByTestId('article-item')).toHaveCount(0);
+    });
+
+    test('Save in the unsaved changes dialog creates the package and closes it', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await createAndFillPackage(page);
+
+        const prompt = page.getByTestId('unsaved-changes-dialog');
+
+        await page.getByTestId('authoring-topbar').getByTestId('close').click();
+        await expect(prompt).toBeVisible();
+
+        await prompt.getByRole('button', {name: 'Save', exact: true}).click();
+
+        await expect(page.getByTestId('authoring')).toBeHidden();
+        await expect(monitoringItem(page)).toBeVisible();
+    });
+
+    test('the topbar Save keeps the package open, deactivates Save and persists the fields', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await createAndFillPackage(page);
+
+        const topbar = page.getByTestId('authoring-topbar');
+
+        await topbar.getByTestId('save').click();
+
+        await expect(topbar.getByTestId('save')).toBeDisabled();
+        await expect(page.getByTestId('authoring')).toBeVisible();
+        await expect(monitoringItem(page)).toBeVisible();
+
+        // A saved package is no longer dirty, so Close must go through without
+        // raising the unsaved-changes dialog.
+        await topbar.getByTestId('close').click();
+        await expect(page.getByTestId('authoring')).toBeHidden();
+        await expect(page.getByTestId('unsaved-changes-dialog')).toHaveCount(0);
+
+        await runGlobalSearch(page, HEADLINE);
+        await expect(
+            page.getByTestId('article-item').and(page.locator(`[data-test-value="${HEADLINE}"]`)),
+        ).toHaveCount(1);
+
+        // Reopening is the last step on purpose: a reopened package intermittently
+        // reports itself dirty with no edit made, so closing it again raises the
+        // unsaved-changes dialog. Nothing needs asserting past this point, so the
+        // test ends with the package open instead of racing that dialog.
+        await page.goto('/#/workspace/monitoring');
+        await monitoringItem(page).dblclick();
+
+        await expect(page.getByTestId('authoring')).toBeVisible();
+        await expect(packageHeadline(page)).toHaveValue(HEADLINE);
+        await expect(packageSlugline(page)).toHaveValue(SLUGLINE);
+    });
+});

--- a/e2e/client/playwright/create-empty-package.spec.ts
+++ b/e2e/client/playwright/create-empty-package.spec.ts
@@ -36,10 +36,17 @@ test.describe('creating a new empty package', {
     const HEADLINE = 'empty package headline';
     const SLUGLINE = 'empty-package-slugline';
 
+    // Sports carries five items in the `main` snapshot. Pinning the number is
+    // what lets the discard test prove nothing was left behind: a locator
+    // matched on HEADLINE cannot see an untitled leftover.
+    const SPORTS_ITEM_COUNT = 5;
+
+    function monitoringItems(page: Page): Locator {
+        return page.getByTestId('monitoring-view').getByTestId('article-item');
+    }
+
     function monitoringItem(page: Page): Locator {
-        return page.getByTestId('monitoring-view')
-            .getByTestId('article-item')
-            .and(page.locator(`[data-test-value="${HEADLINE}"]`));
+        return monitoringItems(page).and(page.locator(`[data-test-value="${HEADLINE}"]`));
     }
 
     function packageHeadline(page: Page): Locator {
@@ -50,17 +57,22 @@ test.describe('creating a new empty package', {
         return page.getByTestId('authoring').getByTestId('field-slugline');
     }
 
-    /**
-     * Opens an empty package from the "+" menu on the Sports desk and fills the
-     * two fields the package editor exposes: Headline (the package header) and
-     * Slugline (the authoring header).
-     */
-    async function createAndFillPackage(page: Page): Promise<void> {
+    async function openSportsMonitoring(page: Page): Promise<void> {
         const monitoring = new Monitoring(page);
 
         await page.goto('/#/workspace/monitoring');
         await monitoring.selectDeskOrWorkspace('Sports');
-        await monitoring.createEmptyPackage();
+
+        await expect(monitoringItems(page)).toHaveCount(SPORTS_ITEM_COUNT);
+    }
+
+    /**
+     * Opens an empty package from the "+" menu and fills the two fields the
+     * package editor exposes: Headline (the package header) and Slugline (the
+     * authoring header).
+     */
+    async function createAndFillPackage(page: Page): Promise<void> {
+        await new Monitoring(page).createEmptyPackage();
 
         await expect(page.getByTestId('authoring')).toBeVisible();
         await expect(packageHeadline(page)).toBeVisible();
@@ -89,6 +101,7 @@ test.describe('creating a new empty package', {
 
     test('Cancel returns to the package and Ignore discards it without creating anything', async ({page}) => {
         await restoreDatabaseSnapshot();
+        await openSportsMonitoring(page);
         await createAndFillPackage(page);
 
         const topbar = page.getByTestId('authoring-topbar');
@@ -107,6 +120,7 @@ test.describe('creating a new empty package', {
         await prompt.getByRole('button', {name: 'Ignore', exact: true}).click();
 
         await expect(page.getByTestId('authoring')).toBeHidden();
+        await expect(monitoringItems(page)).toHaveCount(SPORTS_ITEM_COUNT);
         await expect(monitoringItem(page)).toHaveCount(0);
 
         await runGlobalSearch(page, HEADLINE);
@@ -115,6 +129,7 @@ test.describe('creating a new empty package', {
 
     test('Save in the unsaved changes dialog creates the package and closes it', async ({page}) => {
         await restoreDatabaseSnapshot();
+        await openSportsMonitoring(page);
         await createAndFillPackage(page);
 
         const prompt = page.getByTestId('unsaved-changes-dialog');
@@ -130,6 +145,7 @@ test.describe('creating a new empty package', {
 
     test('the topbar Save keeps the package open, deactivates Save and persists the fields', async ({page}) => {
         await restoreDatabaseSnapshot();
+        await openSportsMonitoring(page);
         await createAndFillPackage(page);
 
         const topbar = page.getByTestId('authoring-topbar');
@@ -147,9 +163,14 @@ test.describe('creating a new empty package', {
         await expect(page.getByTestId('unsaved-changes-dialog')).toHaveCount(0);
 
         await runGlobalSearch(page, HEADLINE);
-        await expect(
-            page.getByTestId('article-item').and(page.locator(`[data-test-value="${HEADLINE}"]`)),
-        ).toHaveCount(1);
+
+        const results = page.getByTestId('article-item');
+
+        // The unfiltered listing already holds the package, so "one item with
+        // this Headline is present" is true before the query is applied. Only
+        // the whole result list being that single item proves the search ran.
+        await expect(results).toHaveCount(1);
+        await expect(results).toHaveAttribute('data-test-value', HEADLINE);
 
         // Reopening is the last step on purpose: a reopened package intermittently
         // reports itself dirty with no edit made, so closing it again raises the

--- a/e2e/client/playwright/create-empty-package.spec.ts
+++ b/e2e/client/playwright/create-empty-package.spec.ts
@@ -31,12 +31,25 @@ test.describe('creating a new empty package', {
     const HEADLINE = 'empty package headline';
     const SLUGLINE = 'empty-package-slugline';
 
+    /**
+     * Everything the Sports desk lists in Monitoring on the `main` snapshot:
+     * four items in the Working Stage plus the published one in the desk output
+     * group. The Incoming Stage group is empty.
+     */
+    const SPORTS_MONITORING_ITEMS = [
+        'test sports story',
+        'story 2',
+        'Story 3',
+        'Package Highlight 1',
+        'Story 5',
+    ];
+
     function monitoringItems(page: Page): Locator {
         return page.getByTestId('monitoring-view').getByTestId('article-item');
     }
 
-    function monitoringItem(page: Page): Locator {
-        return monitoringItems(page).and(page.locator(`[data-test-value="${HEADLINE}"]`));
+    function monitoringItem(page: Page, label: string): Locator {
+        return monitoringItems(page).and(page.locator(`[data-test-value="${label}"]`));
     }
 
     function packageHeadline(page: Page): Locator {
@@ -48,20 +61,27 @@ test.describe('creating a new empty package', {
     }
 
     /**
-     * Opens Monitoring on the Sports desk and returns how many items it lists.
-     * The discard test compares against that number: `createEmptyPackage` saves
-     * the package with an empty headline, so a leftover could never be matched
-     * by a HEADLINE locator and only the total can show it.
+     * Opens Monitoring on the Sports desk and waits for the listing to be
+     * complete, not merely started.
+     *
+     * Every `sd-monitoring-group` runs its own debounced query
+     * (scripts/apps/monitoring/directives/MonitoringGroup.ts) and a desk switch
+     * leaves the previous desk's items in the DOM until the new groups answer,
+     * so the first visible item says nothing about the rest of the list.
+     * Waiting for each expected item and then for the exact total is what makes
+     * the discard test's count assertion mean anything.
      */
-    async function openSportsMonitoring(page: Page): Promise<number> {
+    async function openSportsMonitoring(page: Page): Promise<void> {
         const monitoring = new Monitoring(page);
 
         await page.goto('/#/workspace/monitoring');
         await monitoring.selectDeskOrWorkspace('Sports');
 
-        await expect(monitoringItems(page).first()).toBeVisible();
+        for (const label of SPORTS_MONITORING_ITEMS) {
+            await expect(monitoringItem(page, label)).toBeVisible();
+        }
 
-        return monitoringItems(page).count();
+        await expect(monitoringItems(page)).toHaveCount(SPORTS_MONITORING_ITEMS.length);
     }
 
     /**
@@ -111,8 +131,8 @@ test.describe('creating a new empty package', {
         await openGlobalSearch(page);
 
         const searchItemsBefore = await globalSearchItems(page).count();
-        const monitoringItemsBefore = await openSportsMonitoring(page);
 
+        await openSportsMonitoring(page);
         await createAndFillPackage(page);
 
         const topbar = page.getByTestId('authoring-topbar');
@@ -131,8 +151,15 @@ test.describe('creating a new empty package', {
         await prompt.getByRole('button', {name: 'Ignore', exact: true}).click();
 
         await expect(page.getByTestId('authoring')).toBeHidden();
-        await expect(monitoringItems(page)).toHaveCount(monitoringItemsBefore);
-        await expect(monitoringItem(page)).toHaveCount(0);
+
+        // `createEmptyPackage` posts the package with an empty headline, so a
+        // leftover could never be matched by a HEADLINE locator. The total is
+        // the guard: the discarded package stays at `version: 0`, which
+        // apps/archive/resource.py filters out of every archive query, so the
+        // listing can only grow if the product starts persisting it as a real
+        // version.
+        await expect(monitoringItems(page)).toHaveCount(SPORTS_MONITORING_ITEMS.length);
+        await expect(monitoringItem(page, HEADLINE)).toHaveCount(0);
 
         // The unfiltered total is what proves nothing was persisted; a query for
         // HEADLINE cannot, since the headline only ever reached the autosave
@@ -157,7 +184,7 @@ test.describe('creating a new empty package', {
         await prompt.getByRole('button', {name: 'Save', exact: true}).click();
 
         await expect(page.getByTestId('authoring')).toBeHidden();
-        await expect(monitoringItem(page)).toBeVisible();
+        await expect(monitoringItem(page, HEADLINE)).toBeVisible();
     });
 
     test('the topbar Save keeps the package open, deactivates Save and persists the fields', async ({page}) => {
@@ -176,7 +203,7 @@ test.describe('creating a new empty package', {
         await expect(topbar.getByTestId('save').getByTestId('loading-indicator')).toBeHidden();
         await expect(topbar.getByTestId('save')).toBeDisabled();
         await expect(page.getByTestId('authoring')).toBeVisible();
-        await expect(monitoringItem(page)).toBeVisible();
+        await expect(monitoringItem(page, HEADLINE)).toBeVisible();
 
         // A saved package is no longer dirty, so Close must go through without
         // raising the unsaved-changes dialog.
@@ -199,7 +226,7 @@ test.describe('creating a new empty package', {
         // unsaved-changes dialog. Nothing needs asserting past this point, so the
         // test ends with the package open instead of racing that dialog.
         await page.goto('/#/workspace/monitoring');
-        await monitoringItem(page).dblclick();
+        await monitoringItem(page, HEADLINE).dblclick();
 
         await expect(page.getByTestId('authoring')).toBeVisible();
         await expect(packageHeadline(page)).toHaveValue(HEADLINE);

--- a/e2e/client/playwright/create-empty-package.spec.ts
+++ b/e2e/client/playwright/create-empty-package.spec.ts
@@ -13,14 +13,9 @@ import {restoreDatabaseSnapshot} from './utils';
  * rather than on the test:
  *
  * - "Packages can be created in Monitoring view and Personal space". Personal
- *   space has no package creation entry point. `InitialView` renders the
+ *   space has no package creation entry point: `InitialView` renders the
  *   "Create package" option behind `!sdApi.navigation.isPersonalSpace()`
- *   (scripts/core/ui/components/content-create-dropdown/initial-view.tsx), and
- *   on top of that the whole "+" dropdown fails to render there: its
- *   componentDidMount reads `getCurrentDesk().default_content_template` and
- *   `getCurrentDesk()` is null in personal space, so the popup stays empty.
- *   That second half is a live regression which also fails the existing
- *   `monitoring.personal-space.spec.ts` "creating an article" test on develop.
+ *   (scripts/core/ui/components/content-create-dropdown/initial-view.tsx).
  * - "Packages cannot be created in Custom Workspace". The option is offered in a
  *   custom workspace exactly as it is on a desk, and clicking it opens a package
  *   editor. The documented restriction does not exist in the product, and
@@ -35,11 +30,6 @@ test.describe('creating a new empty package', {
 }, () => {
     const HEADLINE = 'empty package headline';
     const SLUGLINE = 'empty-package-slugline';
-
-    // Sports carries five items in the `main` snapshot. Pinning the number is
-    // what lets the discard test prove nothing was left behind: a locator
-    // matched on HEADLINE cannot see an untitled leftover.
-    const SPORTS_ITEM_COUNT = 5;
 
     function monitoringItems(page: Page): Locator {
         return page.getByTestId('monitoring-view').getByTestId('article-item');
@@ -57,13 +47,21 @@ test.describe('creating a new empty package', {
         return page.getByTestId('authoring').getByTestId('field-slugline');
     }
 
-    async function openSportsMonitoring(page: Page): Promise<void> {
+    /**
+     * Opens Monitoring on the Sports desk and returns how many items it lists.
+     * The discard test compares against that number: `createEmptyPackage` saves
+     * the package with an empty headline, so a leftover could never be matched
+     * by a HEADLINE locator and only the total can show it.
+     */
+    async function openSportsMonitoring(page: Page): Promise<number> {
         const monitoring = new Monitoring(page);
 
         await page.goto('/#/workspace/monitoring');
         await monitoring.selectDeskOrWorkspace('Sports');
 
-        await expect(monitoringItems(page)).toHaveCount(SPORTS_ITEM_COUNT);
+        await expect(monitoringItems(page).first()).toBeVisible();
+
+        return monitoringItems(page).count();
     }
 
     /**
@@ -83,14 +81,22 @@ test.describe('creating a new empty package', {
         await expect(page.getByTestId('authoring-topbar').getByTestId('save')).toBeEnabled();
     }
 
-    // The global search bar carries no data-test-id; #search-input plus ENTER is
-    // the established way to drive it (search.spec.ts, monitoring.misc.spec.ts).
-    async function runGlobalSearch(page: Page, query: string): Promise<void> {
+    function globalSearchItems(page: Page): Locator {
+        return page.getByTestId('article-item');
+    }
+
+    async function openGlobalSearch(page: Page): Promise<void> {
         await page.goto('/#/search');
 
         // Assert the unfiltered result list first: without it a search that never
         // ran is indistinguishable from a search that returned nothing.
-        await expect(page.getByTestId('article-item').first()).toBeVisible();
+        await expect(globalSearchItems(page).first()).toBeVisible();
+    }
+
+    // The global search bar carries no data-test-id; #search-input plus ENTER is
+    // the established way to drive it (search.spec.ts, monitoring.misc.spec.ts).
+    async function runGlobalSearch(page: Page, query: string): Promise<void> {
+        await openGlobalSearch(page);
 
         const input = page.locator('#search-input');
 
@@ -101,7 +107,12 @@ test.describe('creating a new empty package', {
 
     test('Cancel returns to the package and Ignore discards it without creating anything', async ({page}) => {
         await restoreDatabaseSnapshot();
-        await openSportsMonitoring(page);
+
+        await openGlobalSearch(page);
+
+        const searchItemsBefore = await globalSearchItems(page).count();
+        const monitoringItemsBefore = await openSportsMonitoring(page);
+
         await createAndFillPackage(page);
 
         const topbar = page.getByTestId('authoring-topbar');
@@ -120,11 +131,17 @@ test.describe('creating a new empty package', {
         await prompt.getByRole('button', {name: 'Ignore', exact: true}).click();
 
         await expect(page.getByTestId('authoring')).toBeHidden();
-        await expect(monitoringItems(page)).toHaveCount(SPORTS_ITEM_COUNT);
+        await expect(monitoringItems(page)).toHaveCount(monitoringItemsBefore);
         await expect(monitoringItem(page)).toHaveCount(0);
 
+        // The unfiltered total is what proves nothing was persisted; a query for
+        // HEADLINE cannot, since the headline only ever reached the autosave
+        // record that Ignore drops.
+        await openGlobalSearch(page);
+        await expect(globalSearchItems(page)).toHaveCount(searchItemsBefore);
+
         await runGlobalSearch(page, HEADLINE);
-        await expect(page.getByTestId('article-item')).toHaveCount(0);
+        await expect(globalSearchItems(page)).toHaveCount(0);
     });
 
     test('Save in the unsaved changes dialog creates the package and closes it', async ({page}) => {
@@ -152,6 +169,11 @@ test.describe('creating a new empty package', {
 
         await topbar.getByTestId('save').click();
 
+        // `saveTopbarLoading` disables Save on its own for the length of the
+        // request (authoring-topbar.html), so a disabled Save only means the
+        // package is clean once the spinner has gone.
+        await expect(topbar.getByTestId('save').getByTestId('loading-indicator')).toBeVisible();
+        await expect(topbar.getByTestId('save').getByTestId('loading-indicator')).toBeHidden();
         await expect(topbar.getByTestId('save')).toBeDisabled();
         await expect(page.getByTestId('authoring')).toBeVisible();
         await expect(monitoringItem(page)).toBeVisible();
@@ -164,7 +186,7 @@ test.describe('creating a new empty package', {
 
         await runGlobalSearch(page, HEADLINE);
 
-        const results = page.getByTestId('article-item');
+        const results = globalSearchItems(page);
 
         // The unfiltered listing already holds the package, so "one item with
         // this Headline is present" is true before the query is applied. Only

--- a/e2e/client/playwright/page-object-models/monitoring.ts
+++ b/e2e/client/playwright/page-object-models/monitoring.ts
@@ -115,6 +115,21 @@ export class Monitoring {
         await this.page.getByTestId('content-create-dropdown').getByTestId('default-desk-template').click();
     }
 
+    async openContentCreateDropdown(): Promise<Locator> {
+        const dropdown = this.page.getByTestId('content-create-dropdown');
+
+        await this.page.getByTestId('content-create').click();
+        await expect(dropdown).toBeVisible();
+
+        return dropdown;
+    }
+
+    async createEmptyPackage(): Promise<void> {
+        const dropdown = await this.openContentCreateDropdown();
+
+        await dropdown.getByTestId('create-package').click();
+    }
+
     async openMediaUploadView(): Promise<void> {
         await this.page.locator(s('content-create')).click();
         await this.page.locator(s('content-create-dropdown')).getByRole('button', {name: 'Upload media'}).click();


### PR DESCRIPTION
### Purpose
Automates the QA case [Create new empty package](https://sofab.atlassian.net/wiki/spaces/SET/pages/1308524902) as a Playwright spec so it runs in CI instead of being tested by hand.

### What has changed
- New spec `e2e/client/playwright/create-empty-package.spec.ts` covering the scenario below
- Annotated with `{type: 'confluence', description: '1308524902 partial'}` per the coverage convention

### Steps to test
**Given** the `main` snapshot is restored and Monitoring is open on the Sports desk.

**When**
1. Open the "+" (new item) menu and choose "Create package"
2. Fill in the package Headline and the Slugline
3. Click Close and use each button of the "Save changes?" dialog in turn (Cancel, then Ignore)
4. Repeat steps 1-2, click Close and choose Save in the dialog
5. Repeat steps 1-2, click Save in the authoring topbar, then Close, then reopen the package from Monitoring

**Then**
- Cancel closes the dialog and leaves the package open with both fields still filled
- Ignore closes the package without creating it: it is absent from Monitoring and returns no hit in Global search
- Save in the dialog saves the package and closes it, and the package appears in the Monitoring list
- Save in the topbar leaves the package open and greys out the Save button, and the package appears in the Monitoring list
- A saved package closes through the Close button without raising the dialog again, is found in Global search, and still carries the Headline and Slugline when reopened

The spec also asserts that Save is enabled once the fields are filled, and scopes the Monitoring assertions to the monitoring view so a stale preview cannot satisfy them.

Run it: `cd e2e/client && npx playwright test create-empty-package.spec.ts`

The spec passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
