### PR TITLE
Automate Edit user profile (1311834348)

### DIFF
--- a/e2e/client/playwright/edit-user-profile.spec.ts
+++ b/e2e/client/playwright/edit-user-profile.spec.ts
@@ -1,0 +1,107 @@
+import {test, expect} from '@playwright/test';
+import {restoreDatabaseSnapshot} from './utils';
+import {Users} from './page-object-models/users';
+
+/**
+ * QA case "Edit user profile" (Confluence 1311834348, User management).
+ *
+ * An administrator edits another user's profile from the users list, and revokes
+ * that user's administrator status so the application stops marking them as one.
+ *
+ * Documented expected results not covered here, and why:
+ *
+ * - Downgrading through the Role field ("Administrator" role to an "Editor"
+ *   role). The `main` snapshot ships an empty `roles` collection, so the Role
+ *   select renders no options and no role tag is ever shown. Blocked on a
+ *   fixture with roles.
+ * - Observing the downgraded user's own effective privileges (what they can
+ *   still do once they are no longer an administrator). That needs a session as
+ *   that user, and no non-administrator account in the snapshot has a known
+ *   password; the admin UI can only trigger a reset-password email, not set one.
+ *   Blocked on a fixture with a non-administrator user whose password is known.
+ */
+test.describe('editing another user profile', {
+    annotation: [
+        // Edit user profile (pass 02.11)
+        {type: 'confluence', description: '1311834348 partial'},
+    ],
+}, () => {
+    test('profile edits are saved and shown across the profile and the users list', async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const users = new Users(page);
+
+        await users.openList();
+        await users.openFullProfile('Jane Doe');
+
+        const form = users.detailsForm;
+
+        await form.getByTestId('field--first_name').fill('Janet');
+        await form.getByTestId('field--last_name').fill('Roe');
+        await form.getByTestId('field--email').fill('janet.roe@example.com');
+        await form.getByLabel('phone number').fill('123456789');
+        await form.getByTestId('field--sign_off').fill('JR');
+        await form.getByLabel('Byline').fill('Janet Roe');
+
+        await users.saveProfile();
+
+        await page.reload();
+
+        await expect(form.getByTestId('field--first_name')).toHaveValue('Janet');
+        await expect(form.getByTestId('field--last_name')).toHaveValue('Roe');
+        await expect(form.getByTestId('field--email')).toHaveValue('janet.roe@example.com');
+        await expect(form.getByLabel('phone number')).toHaveValue('123456789');
+        await expect(form.getByTestId('field--sign_off')).toHaveValue('JR');
+        await expect(form.getByLabel('Byline')).toHaveValue('Janet Roe');
+
+        // The username is not editable here, so it stays the handle the row is
+        // still identified by after the rename.
+        await expect(form.getByTestId('field--username')).toHaveValue('janedoe');
+        await expect(page.getByTestId('page-nav-title')).toContainText('Janet Roe');
+
+        await users.openList();
+
+        const renamedRow = users.getListItem('Janet Roe');
+
+        await expect(renamedRow).toBeVisible();
+        await expect(renamedRow.getByTestId('username')).toHaveText('janedoe');
+        await expect(renamedRow).toContainText('janet.roe@example.com');
+    });
+
+    test('revoking administrator status clears the administrator markers', async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const users = new Users(page);
+        const administratorTag = users.detailsForm.getByTestId('administrator-label');
+        const administratorCheckbox = users.detailsForm.getByTestId('field--user_type');
+        // The crown the avatar renders for administrators; it carries no test id
+        // of its own because it comes from superdesk-ui-framework.
+        const administratorCrown = () => users.getListItem('Jane Doe').getByTitle('Administrator');
+
+        await users.openList();
+        await users.openFullProfile('Jane Doe');
+
+        await expect(administratorTag).toBeHidden();
+
+        // The logged-in admin is the only administrator in the snapshot and
+        // cannot demote itself, so the user under test is promoted first. The
+        // downgrade below is the behaviour under test.
+        await administratorCheckbox.click();
+        await users.saveProfile();
+        await expect(administratorTag).toBeVisible();
+
+        await users.openList();
+        await expect(administratorCrown()).toBeVisible();
+
+        await users.openFullProfile('Jane Doe');
+        await administratorCheckbox.click();
+        await users.saveProfile();
+        await expect(administratorTag).toBeHidden();
+
+        await page.reload();
+        await expect(administratorTag).toBeHidden();
+
+        await users.openList();
+        await expect(administratorCrown()).toBeHidden();
+    });
+});

--- a/e2e/client/playwright/edit-user-profile.spec.ts
+++ b/e2e/client/playwright/edit-user-profile.spec.ts
@@ -35,9 +35,9 @@ test.describe('editing another user profile', {
         await form.getByTestId('field--first_name').fill('Janet');
         await form.getByTestId('field--last_name').fill('Roe');
         await form.getByTestId('field--email').fill('janet.roe@example.com');
-        await form.getByLabel('phone number').fill('123456789');
+        await form.getByTestId('field--phone').fill('123456789');
         await form.getByTestId('field--sign_off').fill('JR');
-        await form.getByLabel('Byline').fill('Janet Roe');
+        await form.getByTestId('field--byline').fill('Janet Roe');
 
         await users.saveProfile();
 
@@ -46,9 +46,9 @@ test.describe('editing another user profile', {
         await expect(form.getByTestId('field--first_name')).toHaveValue('Janet');
         await expect(form.getByTestId('field--last_name')).toHaveValue('Roe');
         await expect(form.getByTestId('field--email')).toHaveValue('janet.roe@example.com');
-        await expect(form.getByLabel('phone number')).toHaveValue('123456789');
+        await expect(form.getByTestId('field--phone')).toHaveValue('123456789');
         await expect(form.getByTestId('field--sign_off')).toHaveValue('JR');
-        await expect(form.getByLabel('Byline')).toHaveValue('Janet Roe');
+        await expect(form.getByTestId('field--byline')).toHaveValue('Janet Roe');
 
         // The username is not editable here, so it stays the handle the row is
         // still identified by after the rename.
@@ -105,7 +105,11 @@ test.describe('editing another user profile', {
         await expect(administratorTag).toBeHidden();
 
         await users.openList();
-        await expect(users.getListItem('Jane Doe')).toBeVisible();
+
+        // The indicator sits inside the avatar, which UserAvatar.tsx renders
+        // through react-lazyload, so the row exists before the avatar does and
+        // waiting on the row alone would let `toBeHidden` pass on nothing.
+        await expect(users.getListItem('Jane Doe').getByTestId('user-avatar')).toBeVisible();
         await expect(administratorIndicator()).toBeHidden();
     });
 

--- a/e2e/client/playwright/edit-user-profile.spec.ts
+++ b/e2e/client/playwright/edit-user-profile.spec.ts
@@ -74,9 +74,10 @@ test.describe('editing another user profile', {
         const users = new Users(page);
         const administratorTag = users.detailsForm.getByTestId('administrator-label');
         const administratorCheckbox = users.detailsForm.getByTestId('field--user_type');
-        // The crown the avatar renders for administrators; it carries no test id
-        // of its own because it comes from superdesk-ui-framework.
-        const administratorCrown = () => users.getListItem('Jane Doe').getByTitle('Administrator');
+        // The indicator superdesk-ui-framework's AvatarWrapper overlays on the
+        // avatar of an administrator: a cog glyph with no test id of its own,
+        // only title="Administrator".
+        const administratorIndicator = () => users.getListItem('Jane Doe').getByTitle('Administrator');
 
         await users.openList();
         await users.openFullProfile('Jane Doe');
@@ -91,7 +92,7 @@ test.describe('editing another user profile', {
         await expect(administratorTag).toBeVisible();
 
         await users.openList();
-        await expect(administratorCrown()).toBeVisible();
+        await expect(administratorIndicator()).toBeVisible();
 
         await users.openFullProfile('Jane Doe');
         await administratorCheckbox.click();
@@ -99,9 +100,16 @@ test.describe('editing another user profile', {
         await expect(administratorTag).toBeHidden();
 
         await page.reload();
+
+        // `page.reload()` resolves on the load event, well before Angular has
+        // rendered the form. `toBeHidden` passes on a locator that resolves to no
+        // nodes, so without waiting for the form the assertion below would pass
+        // against a blank page whatever the server stored.
+        await expect(users.detailsForm).toBeVisible();
         await expect(administratorTag).toBeHidden();
 
         await users.openList();
-        await expect(administratorCrown()).toBeHidden();
+        await expect(users.getListItem('Jane Doe')).toBeVisible();
+        await expect(administratorIndicator()).toBeHidden();
     });
 });

--- a/e2e/client/playwright/edit-user-profile.spec.ts
+++ b/e2e/client/playwright/edit-user-profile.spec.ts
@@ -1,12 +1,13 @@
-import {test, expect} from '@playwright/test';
-import {restoreDatabaseSnapshot} from './utils';
+import {test, expect, Page} from '@playwright/test';
+import {restoreDatabaseSnapshot, setPasswordThroughResetEmail} from './utils';
 import {Users} from './page-object-models/users';
 
 /**
  * QA case "Edit user profile" (Confluence 1311834348, User management).
  *
  * An administrator edits another user's profile from the users list, and revokes
- * that user's administrator status so the application stops marking them as one.
+ * that user's administrator status so both the application and the user
+ * themselves stop treating them as one.
  *
  * Documented expected results not covered here, and why:
  *
@@ -14,11 +15,6 @@ import {Users} from './page-object-models/users';
  *   role). The `main` snapshot ships an empty `roles` collection, so the Role
  *   select renders no options and no role tag is ever shown. Blocked on a
  *   fixture with roles.
- * - Observing the downgraded user's own effective privileges (what they can
- *   still do once they are no longer an administrator). That needs a session as
- *   that user, and no non-administrator account in the snapshot has a known
- *   password; the admin UI can only trigger a reset-password email, not set one.
- *   Blocked on a fixture with a non-administrator user whose password is known.
  */
 test.describe('editing another user profile', {
     annotation: [
@@ -112,4 +108,75 @@ test.describe('editing another user profile', {
         await expect(users.getListItem('Jane Doe')).toBeVisible();
         await expect(administratorIndicator()).toBeHidden();
     });
+
+    test('the user loses the administrator privileges once the status is revoked', async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const users = new Users(page);
+        const profileSections = page.getByTestId('page-sections');
+
+        // Jane has no password anyone knows, so the test gives her one. It lives
+        // only until the next snapshot restore.
+        const janePassword = 'janedoe123.';
+
+        await toggleAdministrator(users);
+
+        await signOut(page);
+        await setPasswordThroughResetEmail(page, {email: 'janedoe@example.com', password: janePassword});
+        await signIn(page, {username: 'janedoe', password: janePassword});
+
+        // The Privileges tab of a profile is only offered to someone holding the
+        // `users` privilege, which nothing but the administrator flag grants in
+        // this snapshot (no roles, no per-user privileges), so it stands for
+        // "what this user may do" as the user themselves sees it.
+        await openOwnProfile(page, 'Jane Doe');
+        await expect(profileSections).toContainText('Privileges');
+
+        await signOut(page);
+        await signIn(page, {username: 'admin', password: 'admin'});
+
+        await toggleAdministrator(users);
+
+        await signOut(page);
+        await signIn(page, {username: 'janedoe', password: janePassword});
+
+        await openOwnProfile(page, 'Jane Doe');
+        await expect(profileSections).not.toContainText('Privileges');
+    });
 });
+
+async function toggleAdministrator(users: Users): Promise<void> {
+    await users.openList();
+    await users.openFullProfile('Jane Doe');
+    await users.detailsForm.getByTestId('field--user_type').click();
+    await users.saveProfile();
+}
+
+async function signOut(page: Page): Promise<void> {
+    await page.getByTestId('my-profile').click();
+    await page.getByTestId('my-profile-dropdown').getByRole('button', {name: 'Sign out'}).click();
+
+    await expect(page.getByTestId('login-page')).toBeVisible();
+}
+
+async function signIn(page: Page, {username, password}: {username: string; password: string}): Promise<void> {
+    const loginPage = page.getByTestId('login-page');
+
+    await loginPage.getByTestId('username').fill(username);
+    await loginPage.getByTestId('password').fill(password);
+    await loginPage.getByTestId('submit').click();
+
+    await expect(page.getByTestId('top-menu')).toBeVisible();
+}
+
+/**
+ * Opens the profile of whoever is signed in, checking on the way that it belongs
+ * to `displayName` and that its section tabs have rendered. Asserting a tab is
+ * absent before they render would pass for the wrong reason.
+ */
+async function openOwnProfile(page: Page, displayName: string): Promise<void> {
+    await page.goto('/#/profile');
+
+    await expect(page.getByTestId('page-nav-title')).toContainText(displayName);
+    await expect(page.getByTestId('page-sections')).toBeVisible();
+}

--- a/e2e/client/playwright/page-object-models/users.ts
+++ b/e2e/client/playwright/page-object-models/users.ts
@@ -22,14 +22,25 @@ export class Users {
     async openList(): Promise<void> {
         await this.page.goto('/#/users');
 
+        // UserListController.fetchUsers assigns the rows only once its query
+        // resolves and never clears them first, so the rows of the previous
+        // filter stay on screen while a new one loads: waiting on the rows alone
+        // would read the list the route opened on. Only the "All" filter leaves
+        // `is_active` out of its `where` clause, which is what tells its response
+        // apart from that initial fetch.
+        const allUsersFetched = this.page.waitForResponse(
+            (response) => response.url().includes('/api/users?')
+                && response.request().method() === 'GET'
+                && !decodeURIComponent(response.url()).includes('is_active'),
+        );
+
         // The list opens on a filtered subset; "All" makes the lookup independent
         // of whether the user under test is active, disabled or pending.
         await this.page.getByTestId('user-filter').selectOption('All');
+        await allUsersFetched;
 
-        // Both the route change and the filter change fetch the list, and until a
-        // fetch lands the table holds no rows at all. A negative assertion made
-        // against an empty table passes for the wrong reason, so hold every caller
-        // here until there is something to assert on.
+        // A negative assertion made against an empty table passes for the wrong
+        // reason, so hold every caller here until there is something to assert on.
         await expect(this.page.getByTestId('users-list').getByTestId('users-list-item')).not.toHaveCount(0);
     }
 

--- a/e2e/client/playwright/page-object-models/users.ts
+++ b/e2e/client/playwright/page-object-models/users.ts
@@ -1,0 +1,59 @@
+import {expect, Locator, Page} from '@playwright/test';
+
+export class Users {
+    private readonly page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    /**
+     * The same form backs the list preview pane and the full profile view, so
+     * only ever use it while exactly one of the two is on screen.
+     */
+    get detailsForm(): Locator {
+        return this.page.getByTestId('user-details-form');
+    }
+
+    getListItem(displayName: string): Locator {
+        return this.page.getByTestId('users-list').getByTestId('users-list-item').filter({hasText: displayName});
+    }
+
+    async openList(): Promise<void> {
+        await this.page.goto('/#/users');
+
+        // The list opens on a filtered subset; "All" makes the lookup independent
+        // of whether the user under test is active, disabled or pending.
+        await this.page.getByTestId('user-filter').selectOption('All');
+    }
+
+    async openFullProfile(displayName: string): Promise<void> {
+        await this.getListItem(displayName).click();
+        await this.page.getByTestId('view-full-profile').click();
+
+        // Selecting a row already renders the very same form in the list preview
+        // pane, so waiting for the form alone can match the pane that the route
+        // change is about to throw away, and edits typed into it are lost. The
+        // page title only exists in the full profile view, so wait for that first.
+        await expect(this.page.getByTestId('page-nav-title')).toContainText(displayName);
+        await expect(this.detailsForm).toBeVisible();
+    }
+
+    /**
+     * Username and email are checked for uniqueness by an async validator. While
+     * one is in flight Angular marks the form `ng-pending`: Save stays enabled
+     * (it only tracks `$invalid`) but its `userForm.$valid && save()` handler
+     * silently does nothing, so clicking too early loses the edit.
+     *
+     * Saving then destroys and re-creates the form while it re-reads the user
+     * from the server (`ng-if="!loading"`), so a persisted save is only
+     * observable once the action bar is back with Save clean again.
+     */
+    async saveProfile(): Promise<void> {
+        const save = this.detailsForm.getByTestId('action-bar').getByTestId('save');
+
+        await expect(this.detailsForm).not.toHaveClass(/ng-pending/);
+        await save.click();
+        await expect(save).toBeDisabled();
+    }
+}

--- a/e2e/client/playwright/page-object-models/users.ts
+++ b/e2e/client/playwright/page-object-models/users.ts
@@ -25,6 +25,12 @@ export class Users {
         // The list opens on a filtered subset; "All" makes the lookup independent
         // of whether the user under test is active, disabled or pending.
         await this.page.getByTestId('user-filter').selectOption('All');
+
+        // Both the route change and the filter change fetch the list, and until a
+        // fetch lands the table holds no rows at all. A negative assertion made
+        // against an empty table passes for the wrong reason, so hold every caller
+        // here until there is something to assert on.
+        await expect(this.page.getByTestId('users-list').getByTestId('users-list-item')).not.toHaveCount(0);
     }
 
     async openFullProfile(displayName: string): Promise<void> {

--- a/e2e/client/playwright/user-profile.spec.ts
+++ b/e2e/client/playwright/user-profile.spec.ts
@@ -1,7 +1,5 @@
 import {test, expect} from '@playwright/test';
-import {restoreDatabaseSnapshot, s} from './utils';
-
-const MAILCRAB = 'http://localhost:1080';
+import {restoreDatabaseSnapshot, s, setPasswordThroughResetEmail} from './utils';
 
 test('switching system language', async ({page}) => {
     await restoreDatabaseSnapshot();
@@ -92,57 +90,8 @@ test('can reset password', {
     await page.locator(s('my-profile')).click();
     await page.locator(s('my-profile-dropdown')).getByRole('button', {name: 'Sign Out'}).click();
     await page.locator(s('login-page')).getByRole('link', {name: 'Forgot password?'}).click();
-    await page.getByPlaceholder('Email').fill('admin@example.com');
 
-    // The next click triggers a POST that we must let finish before
-    // navigating — otherwise page.request cancels it and no email is sent.
-    const resetRequest = page.waitForResponse(
-        (resp) => resp.url().includes('/api/reset_user_password') && resp.request().method() === 'POST',
-    );
-
-    // Snapshot inbox so we can identify the email this run produced.
-    // Resetting admin's password invalidates every prior admin token, so
-    // picking a stale email between retries means the token won't validate.
-    const initialMessages = await page.request.get(`${MAILCRAB}/api/messages`)
-        .then((r) => r.json() as Promise<Array<{id: string}>>);
-
-    await page.getByRole('button', {name: 'Get token'}).click();
-    await resetRequest;
-
-    let newMessageId: string | null = null;
-
-    await expect.poll(async () => {
-        const messages = await page.request.get(`${MAILCRAB}/api/messages`)
-            .then((r) => r.json() as Promise<Array<{id: string; subject: string; date: string}>>);
-        const fresh = messages
-            .filter((m) => !initialMessages.find((seen) => seen.id === m.id))
-            .filter((m) => m.subject === 'Reset password')
-            .sort((a, b) => b.date.localeCompare(a.date));
-
-        if (fresh.length > 0) {
-            newMessageId = fresh[0].id;
-            return true;
-        }
-        return false;
-    }, {timeout: 20000, message: 'No new reset-password email arrived in MailCrab'}).toBe(true);
-
-    const message = await page.request.get(`${MAILCRAB}/api/message/${newMessageId}`)
-        .then((r) => r.json() as Promise<{text: string}>);
-    const linkMatch = message.text.match(/(https?:\/\/[^\s]+reset-password[^\s]+)/);
-
-    if (!linkMatch) throw new Error('Reset link was not found in the email body');
-    const resetPasswordLink = linkMatch[1];
-
-    await page.goto(resetPasswordLink);
-
-    // The form is hidden until the controller validates the token via an
-    // async POST and flips flowStep to 3.
-    const passwordInput = page.locator('form[name="resetForm"] input[name="password"]');
-
-    await expect(passwordInput).toBeVisible({timeout: 10000});
-    await passwordInput.fill('admin123.');
-    await page.locator('form[name="resetForm"] input[name="passwordConfirm"]').fill('admin123.');
-    await page.getByRole('button', {name: 'Reset password'}).click();
+    await setPasswordThroughResetEmail(page, {email: 'admin@example.com', password: 'admin123.'});
 
     // Login with new password
     await page.locator('form[name="loginForm"]').getByPlaceholder('username').fill('admin');

--- a/e2e/client/playwright/utils/index.ts
+++ b/e2e/client/playwright/utils/index.ts
@@ -47,6 +47,93 @@ export async function login(page: Page) {
     await expect(page.locator(s('dashboard'))).toBeVisible();
 }
 
+const MAILCRAB_URL = 'http://localhost:1080';
+
+interface IMailcrabMessage {
+    id: string;
+    subject: string;
+    date: string;
+    to: Array<{email: string}>;
+}
+
+/**
+ * Gives the account owning `email` a password by driving the "Forgot password?"
+ * flow and reading the token out of MailCrab. Must be called while signed out;
+ * it leaves the browser on the login form.
+ *
+ * The `main` snapshot stores only bcrypt hashes and documents a plaintext
+ * password for the admin alone, so this is the only way to get a session as any
+ * other user. There is no API to set a password directly: the admin UI can only
+ * trigger this same email.
+ *
+ * MailCrab is shared by every e2e slot on the machine, so a message only counts
+ * when it is addressed to `email`, was absent from the inbox before the request,
+ * and links back to the client origin this run is driving.
+ */
+export async function setPasswordThroughResetEmail(
+    page: Page,
+    {email, password}: {email: string; password: string},
+): Promise<void> {
+    const readInbox = () => page.request.get(`${MAILCRAB_URL}/api/messages`)
+        .then((response) => response.json() as Promise<Array<IMailcrabMessage>>);
+
+    await page.goto('/#/reset-password/');
+
+    const resetPage = page.getByTestId('reset-password-page');
+
+    await resetPage.getByTestId('email').fill(email);
+
+    const knownMessageIds = new Set((await readInbox()).map((message) => message.id));
+
+    // The click posts to /api/reset_user_password. A page.request call issued
+    // while that is in flight cancels it and no email is ever sent, so the
+    // polling below must not start before the response lands.
+    const tokenRequest = page.waitForResponse(
+        (response) => response.url().includes('/api/reset_user_password')
+            && response.request().method() === 'POST',
+    );
+
+    await resetPage.getByTestId('get-token').click();
+    await tokenRequest;
+
+    const clientOrigin = new URL(page.url()).origin;
+    let resetLink = '';
+
+    await expect.poll(async () => {
+        const candidates = (await readInbox())
+            .filter((message) => !knownMessageIds.has(message.id))
+            .filter((message) => message.subject === 'Reset password')
+            .filter((message) => message.to.some((recipient) => recipient.email === email))
+            .sort((a, b) => b.date.localeCompare(a.date));
+
+        for (const candidate of candidates) {
+            const body = await page.request.get(`${MAILCRAB_URL}/api/message/${candidate.id}`)
+                .then((response) => response.json() as Promise<{text: string}>);
+            const link = body.text.match(/(https?:\/\/[^\s]+reset-password[^\s]+)/)?.[1];
+
+            if (link != null && link.startsWith(clientOrigin)) {
+                resetLink = link;
+                break;
+            }
+        }
+
+        return resetLink;
+    }, {timeout: 20000, message: `No reset-password email for ${email} arrived in MailCrab`}).not.toBe('');
+
+    await page.goto(resetLink);
+
+    const newPassword = resetPage.getByTestId('password');
+
+    // The controller only reveals this form (flowStep 3) once it has validated
+    // the token against the server, which is an extra round trip after load.
+    await expect(newPassword).toBeVisible();
+    await newPassword.fill(password);
+    await resetPage.getByTestId('password-confirm').fill(password);
+    await resetPage.getByTestId('submit').click();
+
+    await expect(page.getByTestId('login-page')).toBeVisible();
+}
+
 /**
  * Test-side workaround for the "Your session has expired" overlay race that
  * only reproduces under the `legacy` DB snapshot.

--- a/e2e/client/playwright/utils/index.ts
+++ b/e2e/client/playwright/utils/index.ts
@@ -47,7 +47,10 @@ export async function login(page: Page) {
     await expect(page.locator(s('dashboard'))).toBeVisible();
 }
 
-const MAILCRAB_URL = 'http://localhost:1080';
+// One MailCrab instance serves every e2e slot on the machine, so unlike the
+// backend and client URLs it is not per slot; the env var is only an escape
+// hatch for a machine that publishes it on another port.
+const MAILCRAB_URL = (process.env.MAILCRAB_URL || 'http://localhost:1080').replace(/\/$/, '');
 
 interface IMailcrabMessage {
     id: string;
@@ -64,7 +67,9 @@ interface IMailcrabMessage {
  * The `main` snapshot stores only bcrypt hashes and documents a plaintext
  * password for the admin alone, so this is the only way to get a session as any
  * other user. There is no API to set a password directly: the admin UI can only
- * trigger this same email.
+ * trigger this same email. It doubles as the "reset password" flow itself, so
+ * keep it as the single encoding of the MailCrab contract rather than inlining
+ * a second copy in a spec.
  *
  * MailCrab is shared by every e2e slot on the machine, so a message only counts
  * when it is addressed to `email`, was absent from the inbox before the request,

--- a/scripts/apps/users/views/edit-form.html
+++ b/scripts/apps/users/views/edit-form.html
@@ -64,7 +64,7 @@
                             <div class="button-group button-group--center button-group--compact sd-margin-b--2 sd-flex--wrap sd-flex--justify-center">
                                 <div class="tag-label" ng-if="roles[user.role]" translate>{{roles[user.role].name}}</div>
                                 <div class="tag-label" ng-show="user.is_author" translate>Author</div>
-                                <div class="tag-label tag-label--highlight1" ng-show="user.user_type == 'administrator'" translate>Administrator</div>
+                                <div class="tag-label tag-label--highlight1" ng-show="user.user_type == 'administrator'" translate data-test-id="administrator-label">Administrator</div>
                             </div>
                         </div>
                         <div class="field__full_name form__group form__group--default form__group--mb-3" sd-info-item ng-show="user._id">
@@ -166,7 +166,7 @@
                         </div>
 
                         <div sd-info-item class="user_type sd-check__group-new sd-check__group-new--vertical" ng-if="privileges.users && isNetworkSubscription()" style="margin-bottom: 20px;">
-                            <sd-check ng-true-value="administrator" ng-false-value="user" ng-model="user.user_type" name="user_type" id="user_type" ng-if="currentSessionUser.user_type === 'administrator'">{{ :: 'Administrator'|translate }}</sd-check>
+                            <sd-check ng-true-value="administrator" ng-false-value="user" ng-model="user.user_type" name="user_type" id="user_type" ng-if="currentSessionUser.user_type === 'administrator'" data-test-id="field--user_type">{{ :: 'Administrator'|translate }}</sd-check>
                             <sd-check ng-model="user.is_author" name="user_author" id="user_author">{{ :: 'Author'|translate }}</sd-check>
                             <sd-check ng-if="user.is_author" ng-model="user.private" name="user_private" id="user_private">{{'Private' | translate }}</sd-check>
                         </div>

--- a/scripts/apps/users/views/edit-form.html
+++ b/scripts/apps/users/views/edit-form.html
@@ -175,7 +175,7 @@
                             <div class="form__item">
                                 <div class="sd-input">
                                     <label class="sd-input__label" for="phone" translate>phone number</label>
-                                    <input class="sd-input__input" type="text" name="phone" id="phone" ng-model="user.phone">
+                                    <input class="sd-input__input" type="text" name="phone" id="phone" ng-model="user.phone" data-test-id="field--phone">
                                 </div>
                             </div>
                         </div>
@@ -266,7 +266,7 @@
                             <div class="form__item">
                                 <div class="sd-input">
                                     <label class="sd-input__label" for="byline" translate>Byline</label>
-                                    <input class="sd-input__input" type="text" name="byline" id="byline" ng-model="user.byline">
+                                    <input class="sd-input__input" type="text" name="byline" id="byline" ng-model="user.byline" data-test-id="field--byline">
                                 </div>
                             </div>
                         </div>

--- a/scripts/core/auth/reset-password.html
+++ b/scripts/core/auth/reset-password.html
@@ -1,5 +1,5 @@
 <div class="login-screen">
-    <div class="login-form-container">
+    <div class="login-form-container" data-test-id="reset-password-page">
 
         <div class="logo-handler">
             <img src="images/superdesk-logo.svg" width="290" alt="Superdesk Logo">
@@ -10,10 +10,10 @@
             <form name="sendTokenForm" ng-submit="sendToken()" ng-show="flowStep == 1">
                 <p class="reset-info"><i class="icon-info-sign icon--white"></i> <span translate>Provide your email in order to get 'Reset Token'. Once you get it, use it to reset your password.</span></p>
                 <fieldset class="inputs">
-                    <input type="email" id="user-email" ng-model="email" placeholder="{{ 'Email'|translate }}" class="fullwidth-input" required />
+                    <input type="email" id="user-email" ng-model="email" placeholder="{{ 'Email'|translate }}" class="fullwidth-input" required data-test-id="email" />
                 </fieldset>
                 <fieldset class="buttons">
-                    <button ng-disabled="isSending || sendTokenForm.$invalid" type="submit" class="btn btn--sd-green">
+                    <button ng-disabled="isSending || sendTokenForm.$invalid" type="submit" class="btn btn--sd-green" data-test-id="get-token">
                         {{ 'Get token' | translate }}
                         <div class="spinner" ng-show="isSending">
                           <div class="dot1"></div>
@@ -45,17 +45,17 @@
 
             <form name="resetForm" ng-submit="resetPassword()"  ng-show="flowStep == 3">
                 <fieldset class="inputs">
-                    <input type="password" sd-password-strength name="password" ng-model="password" placeholder="{{ 'Enter new password'|translate }}" class="fullwidth-input" required />
+                    <input type="password" sd-password-strength name="password" ng-model="password" placeholder="{{ 'Enter new password'|translate }}" class="fullwidth-input" required data-test-id="password" />
                 </fieldset>
                 <fieldset class="inputs">
-                    <input type="password" name="passwordConfirm" ng-model="passwordConfirm" placeholder="{{ 'Confirm new password'|translate }}" class="fullwidth-input" sd-password-confirm data-password="password" required />
+                    <input type="password" name="passwordConfirm" ng-model="passwordConfirm" placeholder="{{ 'Confirm new password'|translate }}" class="fullwidth-input" sd-password-confirm data-password="password" required data-test-id="password-confirm" />
                     <i ng-show="userForm.passwordConfirm.$error.required" class="required-asteriks">*</i>
                     <div ng-show="resetForm.passwordConfirm.$error.confirm" sd-valid-info>
                         <span translate>passwords must be same</span>
                     </div>
                 </fieldset>
                 <fieldset class="buttons">
-                    <button ng-disabled="isReseting || resetForm.$invalid" type="submit" class="btn btn--sd-green">
+                    <button ng-disabled="isReseting || resetForm.$invalid" type="submit" class="btn btn--sd-green" data-test-id="submit">
                         {{ 'Reset password' | translate }}
                         <div class="spinner" ng-show="isReseting">
                           <div class="dot1"></div>


### PR DESCRIPTION
### Purpose
Automates the QA case [Edit user profile](https://sofab.atlassian.net/wiki/spaces/SET/pages/1311834348) as a Playwright spec so it runs in CI instead of being tested by hand.

### What has changed
- New spec `e2e/client/playwright/edit-user-profile.spec.ts` covering the scenario below
- Annotated with `{type: 'confluence', description: '1311834348 partial'}` per the coverage convention
- Adds `data-test-id` attributes to product source (needs developer eyes):
  - `administrator-label` (`scripts/apps/users/views/edit-form.html`, the "Administrator" tag in the profile header)
  - `field--user_type` (`scripts/apps/users/views/edit-form.html`, the Administrator `sd-check`)
  - `field--phone` (`scripts/apps/users/views/edit-form.html`, the phone number input; added this round)
  - `field--byline` (`scripts/apps/users/views/edit-form.html`, the Byline input; added this round)
  - `reset-password-page` (`scripts/core/auth/reset-password.html`, the form container)
  - `email` (`scripts/core/auth/reset-password.html`, the Get token email input)
  - `get-token` (`scripts/core/auth/reset-password.html`, the Get token button)
  - `password` (`scripts/core/auth/reset-password.html`, the new password input)
  - `password-confirm` (`scripts/core/auth/reset-password.html`, the confirm password input)
  - `submit` (`scripts/core/auth/reset-password.html`, the Reset password button)

### Steps to test
**Given** the `main` snapshot, logged in as the admin (John Doe), with Jane Doe present as a non-administrator user.

**When**
1. Open Settings > Users, set the filter to "All", select Jane Doe and click "View full profile".
2. Change First Name to "Janet", Last Name to "Roe", Email to "janet.roe@example.com", phone number to "123456789", Sign-Off to "JR" and Byline to "Janet Roe", then click Save.
3. Reload the page, then go back to the users list.
4. On a fresh snapshot, open Jane Doe's full profile again, tick the "Administrator" checkbox and Save.
5. Untick "Administrator" and Save again, then reload and return to the users list.

**Then**
- Every edited field keeps its new value after the save and after a page reload; the username stays `janedoe`.
- The profile title shows "Janet Roe", and the users list row shows the new name, the unchanged username and the new email.
- Ticking "Administrator" makes the "Administrator" tag appear on the profile and the administrator crown appear on the user's avatar in the list.
- Unticking it removes both markers, and they stay gone after a reload.

The spec also covers the reverse direction of the administrator toggle, since the snapshot's only administrator is the logged-in user and it cannot demote itself.

Run it: `cd e2e/client && npx playwright test edit-user-profile.spec.ts`

The spec passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
