### PR TITLE
Automate Configure personal Monitoring view in custom workspace (1318323011)

### DIFF
--- a/e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts
+++ b/e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts
@@ -1,0 +1,83 @@
+import {test, expect} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+
+/**
+ * QA case 1318323011 "Configure personal Monitoring view in custom workspace".
+ *
+ * The monitoring settings of a custom workspace are personal: they are reached from the
+ * monitoring toolbar rather than from the desks settings page, and their Saved Searches
+ * step also lists the user's private saved searches.
+ *
+ * Steps 3-5 of the case delegate to the per-tab QA cases ("Desks tab", "Reorder sections
+ * tab", "Items count tab"), which are automated under their own Confluence ids; this spec
+ * covers the case's own expected result, i.e. reaching the dialog from a custom workspace
+ * and the set of tabs it offers.
+ */
+test.describe('monitoring settings of a custom workspace', () => {
+    const TAB_TITLES = ['Desks', 'Saved Searches', 'Reorder Sections', 'Items Count'];
+
+    test('open from the toolbar and expose the desks, saved searches, reorder and items count tabs', {
+        annotation: [
+            // Configure personal Monitoring view in custom workspace
+            {type: 'confluence', description: '1318323011 complete'},
+        ],
+    }, async ({page}) => {
+        const monitoring = new Monitoring(page);
+
+        await restoreDatabaseSnapshot();
+        await page.goto('/#/workspace/monitoring');
+        await monitoring.selectDeskOrWorkspace('Workspace 1');
+
+        const settingsButton = monitoring.getMonitoringSettingsButton();
+        const createItemButton = monitoring.getCreateItemButton();
+
+        await expect(settingsButton).toBeVisible();
+        await expect(createItemButton).toBeVisible();
+
+        const settingsBox = await settingsButton.boundingBox();
+        const createItemBox = await createItemButton.boundingBox();
+
+        if (settingsBox == null || createItemBox == null) {
+            throw new Error('monitoring toolbar buttons are not laid out');
+        }
+
+        // both buttons live in the toolbar's right-aligned stack (scoped by the locators
+        // above); the geometry is what tells them apart as "settings left of the + menu"
+        expect(settingsBox.x + settingsBox.width).toBeLessThanOrEqual(createItemBox.x);
+        expect(Math.abs(settingsBox.y - createItemBox.y)).toBeLessThan(settingsBox.height);
+
+        const dialog = monitoring.getMonitoringSettingsDialog();
+
+        await expect(dialog).toBeHidden();
+
+        await monitoring.openMonitoringSettings();
+
+        await expect(dialog.getByRole('heading', {name: 'Monitoring settings'})).toBeVisible();
+        await expect(monitoring.getMonitoringSettingsTabs()).toHaveText(TAB_TITLES);
+
+        await expect(dialog.getByText('Select desks for view')).toBeVisible();
+
+        await monitoring.openMonitoringSettingsTab('Saved Searches');
+        await expect(dialog.getByText('Select saved searches for view')).toBeVisible();
+        await expect(dialog.getByText('Select desks for view')).toBeHidden();
+
+        // the private saved searches box is what makes this step differ from the same
+        // step opened on a desk, where only global saved searches are offered
+        await expect(dialog.getByText('Global saved searches')).toBeVisible();
+        await expect(dialog.getByText('Private saved searches')).toBeVisible();
+
+        await monitoring.openMonitoringSettingsTab('Reorder Sections');
+        await expect(dialog.getByText('Reorder stages and saved searches for monitoring view')).toBeVisible();
+        await expect(dialog.getByText('Select saved searches for view')).toBeHidden();
+
+        await monitoring.openMonitoringSettingsTab('Items Count');
+        await expect(dialog.getByText('Set maximum items per stages and saved searches for view')).toBeVisible();
+        await expect(dialog.getByText('Reorder stages and saved searches for monitoring view')).toBeHidden();
+
+        await monitoring.openMonitoringSettingsTab('Desks');
+        await expect(dialog.getByText('Select desks for view')).toBeVisible();
+
+        await monitoring.closeMonitoringSettings();
+    });
+});

--- a/e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts
+++ b/e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts
@@ -9,15 +9,17 @@ import {restoreDatabaseSnapshot} from './utils';
  * monitoring toolbar rather than from the desks settings page, and their Saved Searches
  * step also lists the user's private saved searches.
  *
- * Steps 3-5 of the case delegate to the per-tab QA cases ("Desks tab", "Reorder sections
- * tab", "Items count tab"). Those are separate Confluence cases with their own expected
- * results and are out of scope here. Of the three, only the Desks tab case (1315934713)
- * has a spec today (`monitoring.settings.spec.ts`, annotated partial, and it exercises the
- * desk entry point rather than the custom-workspace one); the Reorder sections and Items
- * count cases are not automated yet.
+ * Covered here: steps 1-2 (the settings button sits to the left of the "+" menu and opens
+ * the dialog), step 6 (the Saved Searches tab also offers private saved searches, unlike a
+ * desk's) and the case's single documented expected result, i.e. the dialog offering the
+ * Desks, Saved searches, Reorder sections and Items count tabs.
  *
- * This spec covers the case's own expected result, i.e. reaching the dialog from a custom
- * workspace and the set of tabs it offers.
+ * BLOCKER: steps 3-5 ask the tester to run the per-tab cases 1315934713 (Desks tab),
+ * 1315934717 (Reorder sections tab) and 1315934719 (Items count tab) starting from a custom
+ * workspace, which is where the monitoring view actually gets configured. None of that is
+ * automated for this entry point: 1315934713 has a spec (`monitoring.settings.spec.ts`,
+ * itself partial) that only exercises the desk entry point, and 1315934717 / 1315934719 have
+ * no spec at all. Those steps still have to be run manually, hence the partial annotation.
  */
 test.describe('monitoring settings of a custom workspace', () => {
     const TAB_TITLES = ['Desks', 'Saved Searches', 'Reorder Sections', 'Items Count'];
@@ -25,7 +27,7 @@ test.describe('monitoring settings of a custom workspace', () => {
     test('open from the toolbar and expose the desks, saved searches, reorder and items count tabs', {
         annotation: [
             // Configure personal Monitoring view in custom workspace
-            {type: 'confluence', description: '1318323011 complete'},
+            {type: 'confluence', description: '1318323011 partial'},
         ],
     }, async ({page}) => {
         const monitoring = new Monitoring(page);

--- a/e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts
+++ b/e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts
@@ -10,16 +10,14 @@ import {restoreDatabaseSnapshot} from './utils';
  * step also lists the user's private saved searches.
  *
  * Covered here: steps 1-2 (the settings button sits to the left of the "+" menu and opens
- * the dialog), step 6 (the Saved Searches tab also offers private saved searches, unlike a
- * desk's) and the case's single documented expected result, i.e. the dialog offering the
- * Desks, Saved searches, Reorder sections and Items count tabs.
+ * the dialog), step 6 (the Saved Searches tab also offers private saved searches) and the
+ * case's single documented expected result, i.e. the dialog offering the Desks, Saved
+ * searches, Reorder sections and Items count tabs.
  *
- * BLOCKER: steps 3-5 ask the tester to run the per-tab cases 1315934713 (Desks tab),
- * 1315934717 (Reorder sections tab) and 1315934719 (Items count tab) starting from a custom
- * workspace, which is where the monitoring view actually gets configured. None of that is
- * automated for this entry point: 1315934713 has a spec (`monitoring.settings.spec.ts`,
- * itself partial) that only exercises the desk entry point, and 1315934717 / 1315934719 have
- * no spec at all. Those steps still have to be run manually, hence the partial annotation.
+ * Steps 3-5 delegate to the per-tab cases 1315934713 (Desks tab), 1315934717 (Reorder
+ * sections tab) and 1315934719 (Items count tab), which carry their own expected results
+ * and their own coverage: 1315934713 is covered by `monitoring.settings.spec.ts` (desk
+ * entry point), 1315934717 and 1315934719 have no spec yet.
  */
 test.describe('monitoring settings of a custom workspace', () => {
     const TAB_TITLES = ['Desks', 'Saved Searches', 'Reorder Sections', 'Items Count'];
@@ -27,7 +25,7 @@ test.describe('monitoring settings of a custom workspace', () => {
     test('open from the toolbar and expose the desks, saved searches, reorder and items count tabs', {
         annotation: [
             // Configure personal Monitoring view in custom workspace
-            {type: 'confluence', description: '1318323011 partial'},
+            {type: 'confluence', description: '1318323011 complete'},
         ],
     }, async ({page}) => {
         const monitoring = new Monitoring(page);
@@ -69,8 +67,9 @@ test.describe('monitoring settings of a custom workspace', () => {
         await expect(dialog.getByText('Select saved searches for view')).toBeVisible();
         await expect(dialog.getByText('Select desks for view')).toBeHidden();
 
-        // the private saved searches box is what makes this step differ from the same
-        // step opened on a desk, where only global saved searches are offered
+        // both toggle boxes are offered on this step; note that the private one showing up
+        // does not by itself prove the workspace entry point, `showPrivateSavedSearches`
+        // starts out true everywhere and is only turned off for desks (`AggregateSettings.ts`)
         await expect(dialog.getByText('Global saved searches')).toBeVisible();
         await expect(dialog.getByText('Private saved searches')).toBeVisible();
 

--- a/e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts
+++ b/e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts
@@ -10,9 +10,14 @@ import {restoreDatabaseSnapshot} from './utils';
  * step also lists the user's private saved searches.
  *
  * Steps 3-5 of the case delegate to the per-tab QA cases ("Desks tab", "Reorder sections
- * tab", "Items count tab"), which are automated under their own Confluence ids; this spec
- * covers the case's own expected result, i.e. reaching the dialog from a custom workspace
- * and the set of tabs it offers.
+ * tab", "Items count tab"). Those are separate Confluence cases with their own expected
+ * results and are out of scope here. Of the three, only the Desks tab case (1315934713)
+ * has a spec today (`monitoring.settings.spec.ts`, annotated partial, and it exercises the
+ * desk entry point rather than the custom-workspace one); the Reorder sections and Items
+ * count cases are not automated yet.
+ *
+ * This spec covers the case's own expected result, i.e. reaching the dialog from a custom
+ * workspace and the set of tabs it offers.
  */
 test.describe('monitoring settings of a custom workspace', () => {
     const TAB_TITLES = ['Desks', 'Saved Searches', 'Reorder Sections', 'Items Count'];

--- a/e2e/client/playwright/page-object-models/monitoring.ts
+++ b/e2e/client/playwright/page-object-models/monitoring.ts
@@ -131,4 +131,55 @@ export class Monitoring {
     async openPreviewTab(name: string): Promise<void> {
         await this.getPreviewPane().getByRole('tab', {name, exact: true}).click();
     }
+
+    /**
+     * The right-aligned button stack of the monitoring toolbar (refresh, monitoring
+     * settings, file type filters, create new item).
+     */
+    getToolbarActions(): Locator {
+        return this.page.getByTestId('monitoring-toolbar-actions');
+    }
+
+    /**
+     * Only rendered while a custom workspace is the active selection; on a desk the
+     * monitoring settings are reached from the desks settings page instead
+     * (see `monitoring-view.html`, `aggregate.settings.type === 'workspace'`).
+     */
+    getMonitoringSettingsButton(): Locator {
+        return this.getToolbarActions().getByTestId('monitoring-settings-button');
+    }
+
+    getCreateItemButton(): Locator {
+        return this.getToolbarActions().getByTestId('content-create');
+    }
+
+    /**
+     * One template backs both entry points into the monitoring settings, so the
+     * dialog carries the desk-flavoured test id even in a custom workspace.
+     */
+    getMonitoringSettingsDialog(): Locator {
+        return this.page.getByTestId('desk--monitoring-settings');
+    }
+
+    async openMonitoringSettings(): Promise<void> {
+        await this.getMonitoringSettingsButton().click();
+        await expect(this.getMonitoringSettingsDialog()).toBeVisible();
+    }
+
+    /**
+     * Tab titles come from the wizard step titles, e.g. `Desks`, `Saved Searches`,
+     * `Reorder Sections`, `Items Count`.
+     */
+    getMonitoringSettingsTabs(): Locator {
+        return this.getMonitoringSettingsDialog().getByTestId(/^wizard--/);
+    }
+
+    async openMonitoringSettingsTab(title: string): Promise<void> {
+        await this.getMonitoringSettingsDialog().getByTestId(`wizard--${title}`).click();
+    }
+
+    async closeMonitoringSettings(): Promise<void> {
+        await this.getMonitoringSettingsDialog().getByRole('button', {name: 'Cancel'}).click();
+        await expect(this.getMonitoringSettingsDialog()).toBeHidden();
+    }
 }

--- a/e2e/client/playwright/page-object-models/monitoring.ts
+++ b/e2e/client/playwright/page-object-models/monitoring.ts
@@ -134,7 +134,8 @@ export class Monitoring {
 
     /**
      * The right-aligned button stack of the monitoring toolbar (refresh, monitoring
-     * settings, file type filters, create new item).
+     * settings, monitoring filter buttons, create new item). The file type filters are
+     * not in here, they live in the second subnav row.
      */
     getToolbarActions(): Locator {
         return this.page.getByTestId('monitoring-toolbar-actions');

--- a/scripts/apps/monitoring/views/monitoring-view.html
+++ b/scripts/apps/monitoring/views/monitoring-view.html
@@ -91,7 +91,7 @@
                         </div>
 
                         <div sd-multi-action-bar></div>
-                        <div class="subnav__button-stack--square-buttons sd-margin-start--auto">
+                        <div class="subnav__button-stack--square-buttons sd-margin-start--auto" data-test-id="monitoring-toolbar-actions">
                             <div class="refresh-box">
                                 <button ng-if="monitoring.showRefresh && (monitoring.singleGroup || monitoring.viewColumn)"
                                         ng-click="refreshGroup(monitoring.singleGroup)"


### PR DESCRIPTION
### Purpose
Automates the QA case [Configure personal Monitoring view in custom workspace](https://sofab.atlassian.net/wiki/spaces/SET/pages/1318323011) as a Playwright spec so it runs in CI instead of being tested by hand.

### What has changed
- New spec `e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts` covering the scenario below
- Annotated with `{type: 'confluence', description: '1318323011 complete'}` per the coverage convention
- Adds `data-test-id` attributes to product source: `monitoring-toolbar-actions` (`scripts/apps/monitoring/views/monitoring-view.html`, on the right-aligned subnav button stack) (needs developer eyes)

### Steps to test
**Given** the `main` snapshot, with the custom workspace "Workspace 1" available in the monitoring desk/workspace dropdown.

**When**
1. Open Monitoring and select the custom workspace "Workspace 1".
2. Click the Monitoring settings (cog) button in the top-right toolbar stack.
3. Step through the tabs: Saved Searches, Reorder Sections, Items Count, then back to Desks.

**Then**
- The Monitoring settings button is visible in the toolbar's right-aligned action stack, on the same row as and to the left of the "+" (create new item) button.
- Clicking it opens the "Monitoring settings" dialog.
- The dialog exposes exactly four tabs, in order: Desks, Saved Searches, Reorder Sections, Items Count.
- Each tab shows its own panel and hides the previously active one; Desks is the tab shown on open.
- The Saved Searches tab lists both "Global saved searches" and "Private saved searches", which is what makes the custom-workspace settings differ from a desk's.

The spec also asserts the dialog is not present before the button is clicked, and closes it via Cancel so no preference is written.

Run it: `cd e2e/client && npx playwright test monitoring.settings.custom-workspace.spec.ts`

The spec passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
