### PR TITLE
Automate Saved searches tab in Monitoring settings of custom workspace (1318323123)

### DIFF
--- a/e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts
+++ b/e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts
@@ -4,7 +4,9 @@ import {MonitoringSettings} from './page-object-models/monitoring-settings';
 import {restoreDatabaseSnapshot} from './utils';
 
 /**
- * Saved searches tab in the Monitoring settings of a custom workspace.
+ * Saved searches tab in the Monitoring settings of a custom workspace (confluence 1318323123).
+ * All three tests in this file cover that one case; the annotation sits on the first of them,
+ * because the suite keeps one annotation per case id.
  *
  * The desk variant of the same wizard (confluence 1315934715) is covered by
  * `monitoring.settings.spec.ts`; it reaches the wizard from `/#/settings/desks` and only
@@ -28,23 +30,23 @@ function monitoringGroup(page: Page, name: string): Locator {
  * `Save Search` is gated on `searching()`, which is just "the URL carries query params"
  * (SearchPanel.ts), so a `q` parameter is enough to reveal it. That same `q` also opens the
  * filters panel (`flags.facets` in SearchContainer.ts), so the panel must not be toggled here.
- * The search panel markup predates `data-test-id`s and is addressed by element id, the
- * same way `saved-search.spec.ts` does.
  */
 async function createPrivateSavedSearch(page: Page, name: string): Promise<void> {
     await page.goto('/#/search?q=story');
-    await expect(page.locator('#advanced_search_filters')).toBeVisible();
-    await page.locator('#save_search_init').click();
+    await expect(page.getByTestId('advanced-search-panel')).toBeVisible();
+    await page.getByTestId('save-search').click();
 
-    const panel = page.locator('.save-search-panel');
+    const panel = page.getByTestId('save-search-panel');
 
     await expect(panel).toBeVisible();
-    await panel.locator('#search_name').fill(name);
-    await panel.locator('#search_save').click();
+    await panel.getByTestId('search-name').fill(name);
+    await panel.getByTestId('save').click();
 
     // The panel closes on both success and failure (SaveSearch.ts), so confirm the search was
     // really persisted: only a successful save switches the side panel to the "Saved" tab.
-    await expect(page.locator('[ng-repeat^="search in userSavedSearches"]').filter({hasText: name})).toHaveCount(1);
+    await expect(
+        page.getByTestId('user-saved-searches').getByTestId('saved-search').filter({hasText: name}),
+    ).toHaveCount(1);
 }
 
 async function openWorkspaceMonitoringSettings(page: Page): Promise<MonitoringSettings> {
@@ -119,13 +121,9 @@ test('saved searches tab groups global and private saved searches', {
     await expect(privateSearches.getByTestId('saved-search')).toHaveCount(1);
 });
 
-test('wizard navigation preserves saved search selection and Done applies it', {
-    annotation: [
-        // Saved searches tab in Monitoring settings of custom workspace
-        {type: 'confluence', description: '1318323123 complete'},
-    ],
-}, async ({page}) => {
+test('wizard navigation preserves saved search selection and Done applies it', async ({page}) => {
     await restoreDatabaseSnapshot();
+    await createPrivateSavedSearch(page, PRIVATE_SEARCH);
 
     const monitoring = new Monitoring(page);
     const settings = await openWorkspaceMonitoringSettings(page);
@@ -138,9 +136,12 @@ test('wizard navigation preserves saved search selection and Done applies it', {
     await expect(settings.previousButton).toBeVisible();
 
     const malaysiaToggle = settings.savedSearchToggle(settings.globalSavedSearches, 'Malaysia');
+    const privateToggle = settings.savedSearchToggle(settings.privateSavedSearches, PRIVATE_SEARCH);
 
     await malaysiaToggle.click();
     await expect(malaysiaToggle).toHaveClass(/checked/);
+    await privateToggle.click();
+    await expect(privateToggle).toHaveClass(/checked/);
 
     await settings.previousButton.click();
     await settings.expectActiveTab('Desks');
@@ -149,6 +150,8 @@ test('wizard navigation preserves saved search selection and Done applies it', {
     await settings.nextButton.click();
     await settings.expectActiveTab('Saved Searches');
     await expect(settings.savedSearchToggle(settings.globalSavedSearches, 'Malaysia')).toHaveClass(/checked/);
+    await expect(settings.savedSearchToggle(settings.privateSavedSearches, PRIVATE_SEARCH))
+        .toHaveClass(/checked/);
 
     await settings.nextButton.click();
     await settings.expectActiveTab('Reorder Sections');
@@ -166,14 +169,10 @@ test('wizard navigation preserves saved search selection and Done applies it', {
     await monitoring.selectDeskOrWorkspace(WORKSPACE);
 
     await expect(monitoringGroup(page, 'Malaysia')).toBeVisible();
+    await expect(monitoringGroup(page, PRIVATE_SEARCH)).toBeVisible();
 });
 
-test('cancelling monitoring settings discards the saved search selection', {
-    annotation: [
-        // Saved searches tab in Monitoring settings of custom workspace
-        {type: 'confluence', description: '1318323123 complete'},
-    ],
-}, async ({page}) => {
+test('cancelling monitoring settings discards the saved search selection', async ({page}) => {
     await restoreDatabaseSnapshot();
 
     const monitoring = new Monitoring(page);

--- a/e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts
+++ b/e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts
@@ -1,0 +1,203 @@
+import {test, expect, Locator, Page} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {MonitoringSettings} from './page-object-models/monitoring-settings';
+import {restoreDatabaseSnapshot} from './utils';
+
+/**
+ * Saved searches tab in the Monitoring settings of a custom workspace.
+ *
+ * The desk variant of the same wizard (confluence 1315934715) is covered by
+ * `monitoring.settings.spec.ts`; it reaches the wizard from `/#/settings/desks` and only
+ * asserts that an enabled global saved search shows up on the desk's monitoring view. The
+ * workspace variant covered here uses the monitoring toolbar entry point, which is the only
+ * one that offers private saved searches (`showPrivateSavedSearches` in AggregateSettings).
+ */
+
+const WORKSPACE = 'Workspace 1';
+const PRIVATE_SEARCH = 'my private search';
+
+function monitoringGroup(page: Page, name: string): Locator {
+    return page.getByTestId('monitoring-view').getByTestId('monitoring-group').filter({hasText: name});
+}
+
+/**
+ * The `main` snapshot ships two global saved searches and no private one, so the private
+ * list has to be seeded here. Saving a search is a single atomic flow (the narrow
+ * in-test precondition allowed by e2e/WRITING_TESTS.md), not a loop of UI actions.
+ *
+ * `Save Search` is gated on `searching()`, which is just "the URL carries query params"
+ * (SearchPanel.ts), so a `q` parameter is enough to reveal it. That same `q` also opens the
+ * filters panel (`flags.facets` in SearchContainer.ts), so the panel must not be toggled here.
+ * The search panel markup predates `data-test-id`s and is addressed by element id, the
+ * same way `saved-search.spec.ts` does.
+ */
+async function createPrivateSavedSearch(page: Page, name: string): Promise<void> {
+    await page.goto('/#/search?q=story');
+    await expect(page.locator('#advanced_search_filters')).toBeVisible();
+    await page.locator('#save_search_init').click();
+
+    const panel = page.locator('.save-search-panel');
+
+    await expect(panel).toBeVisible();
+    await panel.locator('#search_name').fill(name);
+    await panel.locator('#search_save').click();
+
+    // The panel closes on both success and failure (SaveSearch.ts), so confirm the search was
+    // really persisted: only a successful save switches the side panel to the "Saved" tab.
+    await expect(page.locator('[ng-repeat^="search in userSavedSearches"]').filter({hasText: name})).toHaveCount(1);
+}
+
+async function openWorkspaceMonitoringSettings(page: Page): Promise<MonitoringSettings> {
+    const monitoring = new Monitoring(page);
+    const settings = new MonitoringSettings(page);
+
+    await page.goto('/#/workspace/monitoring');
+
+    // Superdesk routes on the URL fragment, so arriving from another view never reboots the
+    // Angular app. SavedSearchService caches the whole saved-search list for the app's lifetime
+    // and only drops it on the `savedsearch:update` websocket event, whose arrival is not
+    // ordered against navigation, so a search created earlier in the test can be missing from
+    // the wizard. Reloading starts the app fresh on the monitoring view.
+    await page.reload();
+
+    await monitoring.selectDeskOrWorkspace(WORKSPACE);
+    await settings.open();
+
+    return settings;
+}
+
+test('saved searches tab groups global and private saved searches', {
+    annotation: [
+        // Saved searches tab in Monitoring settings of custom workspace
+        {type: 'confluence', description: '1318323123 complete'},
+    ],
+}, async ({page}) => {
+    await restoreDatabaseSnapshot();
+    await createPrivateSavedSearch(page, PRIVATE_SEARCH);
+
+    const settings = await openWorkspaceMonitoringSettings(page);
+
+    await expect(settings.tab('Desks')).toBeVisible();
+    await expect(settings.tab('Saved Searches')).toBeVisible();
+    await expect(settings.tab('Reorder Sections')).toBeVisible();
+    await expect(settings.tab('Items Count')).toBeVisible();
+    await settings.expectActiveTab('Desks');
+
+    await settings.goToTab('Saved Searches');
+
+    const globalSearches = settings.globalSavedSearches;
+    const privateSearches = settings.privateSavedSearches;
+
+    await expect(globalSearches.getByTestId('saved-search')).toHaveCount(2);
+    await expect(settings.savedSearch(globalSearches, 'Malaysia')).toBeVisible();
+    await expect(settings.savedSearch(globalSearches, 'Technology')).toBeVisible();
+    await expect(settings.savedSearch(globalSearches, 'Malaysia')).toContainText('by John Doe');
+    await expect(settings.savedSearchToggle(globalSearches, 'Malaysia')).toBeVisible();
+
+    await expect(privateSearches.getByTestId('saved-search')).toHaveCount(1);
+    await expect(settings.savedSearch(privateSearches, PRIVATE_SEARCH)).toBeVisible();
+    await expect(settings.savedSearchToggle(privateSearches, PRIVATE_SEARCH)).toBeVisible();
+    await expect(settings.savedSearch(globalSearches, PRIVATE_SEARCH)).toHaveCount(0);
+    await expect(settings.savedSearch(privateSearches, 'Malaysia')).toHaveCount(0);
+
+    const malaysiaToggle = settings.savedSearchToggle(globalSearches, 'Malaysia');
+
+    await expect(malaysiaToggle).not.toHaveClass(/checked/);
+    await malaysiaToggle.click();
+    await expect(malaysiaToggle).toHaveClass(/checked/);
+    await malaysiaToggle.click();
+    await expect(malaysiaToggle).not.toHaveClass(/checked/);
+
+    await settings.toggleBoxHeader(globalSearches).click();
+    await expect(globalSearches.getByTestId('saved-search')).toHaveCount(0);
+    await settings.toggleBoxHeader(globalSearches).click();
+    await expect(globalSearches.getByTestId('saved-search')).toHaveCount(2);
+
+    await settings.toggleBoxHeader(privateSearches).click();
+    await expect(privateSearches.getByTestId('saved-search')).toHaveCount(0);
+    await settings.toggleBoxHeader(privateSearches).click();
+    await expect(privateSearches.getByTestId('saved-search')).toHaveCount(1);
+});
+
+test('wizard navigation preserves saved search selection and Done applies it', {
+    annotation: [
+        // Saved searches tab in Monitoring settings of custom workspace
+        {type: 'confluence', description: '1318323123 complete'},
+    ],
+}, async ({page}) => {
+    await restoreDatabaseSnapshot();
+
+    const monitoring = new Monitoring(page);
+    const settings = await openWorkspaceMonitoringSettings(page);
+
+    await settings.expectActiveTab('Desks');
+    await expect(settings.previousButton).toBeHidden();
+    await expect(settings.nextButton).toBeVisible();
+
+    await settings.goToTab('Saved Searches');
+    await expect(settings.previousButton).toBeVisible();
+
+    const malaysiaToggle = settings.savedSearchToggle(settings.globalSavedSearches, 'Malaysia');
+
+    await malaysiaToggle.click();
+    await expect(malaysiaToggle).toHaveClass(/checked/);
+
+    await settings.previousButton.click();
+    await settings.expectActiveTab('Desks');
+    await expect(settings.previousButton).toBeHidden();
+
+    await settings.nextButton.click();
+    await settings.expectActiveTab('Saved Searches');
+    await expect(settings.savedSearchToggle(settings.globalSavedSearches, 'Malaysia')).toHaveClass(/checked/);
+
+    await settings.nextButton.click();
+    await settings.expectActiveTab('Reorder Sections');
+    await settings.nextButton.click();
+    await settings.expectActiveTab('Items Count');
+    await expect(settings.nextButton).toBeHidden();
+    await expect(settings.previousButton).toBeVisible();
+
+    await settings.closeWithDone();
+
+    // Saving kicks off the preference write and the in-place group refresh at the same time
+    // (AggregateSettings.save), so the still-open view can be one refresh behind. The QA case
+    // leaves and re-enters the monitoring view here, which is what this reload reproduces.
+    await page.reload();
+    await monitoring.selectDeskOrWorkspace(WORKSPACE);
+
+    await expect(monitoringGroup(page, 'Malaysia')).toBeVisible();
+});
+
+test('cancelling monitoring settings discards the saved search selection', {
+    annotation: [
+        // Saved searches tab in Monitoring settings of custom workspace
+        {type: 'confluence', description: '1318323123 complete'},
+    ],
+}, async ({page}) => {
+    await restoreDatabaseSnapshot();
+
+    const monitoring = new Monitoring(page);
+    const settings = await openWorkspaceMonitoringSettings(page);
+
+    await settings.goToTab('Saved Searches');
+
+    const technologyToggle = settings.savedSearchToggle(settings.globalSavedSearches, 'Technology');
+
+    await technologyToggle.click();
+    await expect(technologyToggle).toHaveClass(/checked/);
+
+    await settings.closeWithCancel();
+
+    await page.reload();
+    await monitoring.selectDeskOrWorkspace(WORKSPACE);
+
+    // the toolbar button only renders for a workspace selection, so it anchors the negative
+    // assertion below to a monitoring view that has actually finished rendering
+    await expect(page.getByTestId('monitoring-settings-button')).toBeVisible();
+    await expect(monitoringGroup(page, 'Technology')).toHaveCount(0);
+
+    await settings.open();
+    await settings.goToTab('Saved Searches');
+
+    await expect(settings.savedSearchToggle(settings.globalSavedSearches, 'Technology')).not.toHaveClass(/checked/);
+});

--- a/e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts
+++ b/e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts
@@ -45,7 +45,7 @@ async function createPrivateSavedSearch(page: Page, name: string): Promise<void>
     // The panel closes on both success and failure (SaveSearch.ts), so confirm the search was
     // really persisted: only a successful save switches the side panel to the "Saved" tab.
     await expect(
-        page.getByTestId('user-saved-searches').getByTestId('saved-search').filter({hasText: name}),
+        page.getByTestId('saved-searches-panel--user').getByTestId('saved-search').filter({hasText: name}),
     ).toHaveCount(1);
 }
 

--- a/e2e/client/playwright/page-object-models/monitoring-settings.ts
+++ b/e2e/client/playwright/page-object-models/monitoring-settings.ts
@@ -38,9 +38,14 @@ export class MonitoringSettings {
      * The wizard marks the selected step on the `<li>` wrapping the tab button
      * (`template/wizard.html` in superdesk-ui-framework); the button itself carries no state,
      * and the template lives in a dependency so it cannot get a test id of its own.
+     *
+     * The `has` locator is resolved inside each `<li>`, so it must start at the page root
+     * rather than reuse `tab()`, which is already scoped to the modal.
      */
     tabWrapper(title: IMonitoringSettingsTab): Locator {
-        return this.tab(title).locator('xpath=..');
+        return this.modal
+            .locator('li.nav-tabs__tab')
+            .filter({has: this.page.getByTestId(`wizard--${title}`)});
     }
 
     async expectActiveTab(title: IMonitoringSettingsTab): Promise<void> {

--- a/e2e/client/playwright/page-object-models/monitoring-settings.ts
+++ b/e2e/client/playwright/page-object-models/monitoring-settings.ts
@@ -2,6 +2,9 @@ import {Locator, Page, expect} from '@playwright/test';
 
 export type IMonitoringSettingsTab = 'Desks' | 'Saved Searches' | 'Reorder Sections' | 'Items Count';
 
+/** `PREFERENCES_KEY` in `scripts/apps/monitoring/directives/AggregateSettings.ts`. */
+const MONITORING_PREFERENCE_KEY = 'agg:view';
+
 /**
  * Drives the "Monitoring settings" wizard modal
  * (`scripts/apps/monitoring/views/aggregate-settings.html`).
@@ -102,8 +105,20 @@ export class MonitoringSettings {
         return this.savedSearch(toggleBox, name).getByTestId('toggle');
     }
 
+    /**
+     * On a workspace the wizard closes the modal without waiting for the write it started:
+     * `AggregateSettings.save()` calls `onclose()` synchronously while `preferencesService.update()`
+     * is still only scheduled on `$applyAsync`. Anything that leaves the page right after the modal
+     * disappears can therefore cancel the PATCH and drop the configuration, so wait for the write.
+     */
     async closeWithDone(): Promise<void> {
-        await this.doneButton.click();
+        await Promise.all([
+            this.page.waitForResponse((response) => response.url().includes('/preferences/')
+                && response.request().method() === 'PATCH'
+                && (response.request().postData() ?? '').includes(MONITORING_PREFERENCE_KEY)),
+            this.doneButton.click(),
+        ]);
+
         await expect(this.modal).not.toBeVisible();
     }
 

--- a/e2e/client/playwright/page-object-models/monitoring-settings.ts
+++ b/e2e/client/playwright/page-object-models/monitoring-settings.ts
@@ -90,7 +90,7 @@ export class MonitoringSettings {
     }
 
     savedSearch(toggleBox: Locator, name: string): Locator {
-        return toggleBox.getByTestId('saved-search').and(this.page.locator(`[data-test-value="${name}"]`));
+        return toggleBox.getByTestId('saved-search').filter({hasText: name});
     }
 
     /**

--- a/e2e/client/playwright/page-object-models/monitoring-settings.ts
+++ b/e2e/client/playwright/page-object-models/monitoring-settings.ts
@@ -1,0 +1,109 @@
+import {Locator, Page, expect} from '@playwright/test';
+
+export type IMonitoringSettingsTab = 'Desks' | 'Saved Searches' | 'Reorder Sections' | 'Items Count';
+
+/**
+ * Drives the "Monitoring settings" wizard modal
+ * (`scripts/apps/monitoring/views/aggregate-settings.html`).
+ *
+ * The same template backs the desk variant reached from `/#/settings/desks` and the
+ * workspace variant reached from the monitoring toolbar, so the modal's test id reads
+ * `desk--monitoring-settings` in both cases.
+ */
+export class MonitoringSettings {
+    private page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    get modal(): Locator {
+        return this.page.getByTestId('desk--monitoring-settings');
+    }
+
+    /**
+     * Opens the wizard from the monitoring toolbar. The toolbar button only renders while a
+     * custom workspace is selected; desks configure monitoring from the desk settings page.
+     */
+    async open(): Promise<void> {
+        await this.page.getByTestId('monitoring-settings-button').click();
+        await expect(this.modal).toBeVisible();
+    }
+
+    tab(title: IMonitoringSettingsTab): Locator {
+        return this.modal.getByTestId(`wizard--${title}`);
+    }
+
+    /**
+     * The wizard marks the selected step on the `<li>` wrapping the tab button
+     * (`template/wizard.html` in superdesk-ui-framework); the button itself carries no state,
+     * and the template lives in a dependency so it cannot get a test id of its own.
+     */
+    tabWrapper(title: IMonitoringSettingsTab): Locator {
+        return this.tab(title).locator('xpath=..');
+    }
+
+    async expectActiveTab(title: IMonitoringSettingsTab): Promise<void> {
+        await expect(this.tabWrapper(title)).toHaveClass(/nav-tabs__tab--active/);
+    }
+
+    async goToTab(title: IMonitoringSettingsTab): Promise<void> {
+        await this.tab(title).click();
+        await this.expectActiveTab(title);
+    }
+
+    get previousButton(): Locator {
+        return this.modal.getByTestId('footer').getByTestId('previous');
+    }
+
+    get nextButton(): Locator {
+        return this.modal.getByTestId('footer').getByTestId('next');
+    }
+
+    get cancelButton(): Locator {
+        return this.modal.getByTestId('footer').getByTestId('cancel');
+    }
+
+    get doneButton(): Locator {
+        return this.modal.getByTestId('footer').getByTestId('done');
+    }
+
+    get globalSavedSearches(): Locator {
+        return this.modal.getByTestId('global-saved-searches');
+    }
+
+    get privateSavedSearches(): Locator {
+        return this.modal.getByTestId('private-saved-searches');
+    }
+
+    /**
+     * `sd-toggle-box` renders a React box whose header is the only element that toggles it;
+     * it comes from superdesk-ui-framework, so it is reachable by class only.
+     */
+    toggleBoxHeader(toggleBox: Locator): Locator {
+        return toggleBox.locator('.toggle-box__header');
+    }
+
+    savedSearch(toggleBox: Locator, name: string): Locator {
+        return toggleBox.getByTestId('saved-search').and(this.page.locator(`[data-test-value="${name}"]`));
+    }
+
+    /**
+     * `sd-switch` replaces its element with `<span class="sd-toggle">` and reflects the ON
+     * state as a `checked` class on that span (`app/scripts/switch.js` in
+     * superdesk-ui-framework).
+     */
+    savedSearchToggle(toggleBox: Locator, name: string): Locator {
+        return this.savedSearch(toggleBox, name).getByTestId('toggle');
+    }
+
+    async closeWithDone(): Promise<void> {
+        await this.doneButton.click();
+        await expect(this.modal).not.toBeVisible();
+    }
+
+    async closeWithCancel(): Promise<void> {
+        await this.cancelButton.click();
+        await expect(this.modal).not.toBeVisible();
+    }
+}

--- a/scripts/apps/monitoring/views/aggregate-settings.html
+++ b/scripts/apps/monitoring/views/aggregate-settings.html
@@ -92,7 +92,6 @@
                     ng-repeat="search in privateSavedSearches track by search._id | orderBy: 'name'"
                     ng-if="showPrivateSavedSearches"
                     data-test-id="saved-search"
-                    data-test-value="{{search.name}}"
                 >
                     <div class="desk-title desk-title--saved-search">
                         <div class="switch">

--- a/scripts/apps/monitoring/views/aggregate-settings.html
+++ b/scripts/apps/monitoring/views/aggregate-settings.html
@@ -63,7 +63,7 @@
          data-hide="shouldHideStep('searches')">
         <div class="content">
             <div class="legend" translate>Select saved searches for view</div>
-            <div sd-toggle-box data-title="{{ :: 'Global saved searches' | translate}}" data-style="circle" data-open="true">
+            <div sd-toggle-box data-title="{{ :: 'Global saved searches' | translate}}" data-style="circle" data-open="true" data-test-id="global-saved-searches">
                 <div
                     class="desk"
                     ng-repeat="search in globalSavedSearches track by search._id | orderBy: 'name'"
@@ -86,11 +86,22 @@
                     </div>
                 </div>
             </div>
-            <div sd-toggle-box data-title="{{ :: 'Private saved searches' | translate}}" data-style="circle" data-open="true" ng-if="showPrivateSavedSearches">
-                <div class="desk" ng-repeat="search in privateSavedSearches track by search._id | orderBy: 'name'" ng-if="showPrivateSavedSearches">
+            <div sd-toggle-box data-title="{{ :: 'Private saved searches' | translate}}" data-style="circle" data-open="true" ng-if="showPrivateSavedSearches" data-test-id="private-saved-searches">
+                <div
+                    class="desk"
+                    ng-repeat="search in privateSavedSearches track by search._id | orderBy: 'name'"
+                    ng-if="showPrivateSavedSearches"
+                    data-test-id="saved-search"
+                    data-test-value="{{search.name}}"
+                >
                     <div class="desk-title desk-title--saved-search">
                         <div class="switch">
-                            <span sd-switch  ng-model="editGroups[search._id].selected" ng-click="setSearchInfo(search._id)"></span>
+                            <span
+                                sd-switch
+                                ng-model="editGroups[search._id].selected"
+                                ng-click="setSearchInfo(search._id)"
+                                data-test-id="toggle"
+                            ></span>
                         </div>
                         <div class="desk-title__text">
                             {{:: search.name}}
@@ -152,8 +163,8 @@
 </div>
 
 <div class="modal__footer" data-test-id="footer">
-    <button id="previousBtn" class="btn btn--hollow pull-left" ng-if="step.current !== 'desks' && !displayOnlyCurrentStep" ng-click="previous()" translate>Previous</button>
-    <button class="btn" ng-click="cancel()" translate>Cancel</button>
+    <button id="previousBtn" class="btn btn--hollow pull-left" ng-if="step.current !== 'desks' && !displayOnlyCurrentStep" ng-click="previous()" translate data-test-id="previous">Previous</button>
+    <button class="btn" ng-click="cancel()" translate data-test-id="cancel">Cancel</button>
     <button class="btn btn--primary" ng-click="save()" translate data-test-id="done">Done</button>
-    <button id="nextBtn" class="btn btn--hollow" ng-if="step.current !== 'maxitems' && !displayOnlyCurrentStep" ng-click="next()" translate>Next</button>
+    <button id="nextBtn" class="btn btn--hollow" ng-if="step.current !== 'maxitems' && !displayOnlyCurrentStep" ng-click="next()" translate data-test-id="next">Next</button>
 </div>

--- a/scripts/apps/search/views/save-search-dialog.html
+++ b/scripts/apps/search/views/save-search-dialog.html
@@ -4,7 +4,7 @@
             <input id="search_query" type="text" class="fullwidth-input line-input" ng-model="edit.filter.query.raw" placeholder="{{:: 'Query' | translate}}">
         </div>
         <div class="field">
-            <input id="search_name" type="text" class="fullwidth-input line-input" ng-model="edit.name" placeholder="{{:: 'Name' | translate}}" required>
+            <input id="search_name" type="text" class="fullwidth-input line-input" ng-model="edit.name" placeholder="{{:: 'Name' | translate}}" data-test-id="search-name" required>
         </div>
         <div class="field">
             <textarea id="search_description" class="line-input" sd-auto-height ng-model="edit.description" placeholder="{{:: 'Description' | translate}}"></textarea>

--- a/scripts/apps/search/views/save-search.html
+++ b/scripts/apps/search/views/save-search.html
@@ -7,7 +7,7 @@
 <div ng-if="searching() || innerTab==='parameters'">
     <div class="save-search " ng-if="searching() && !editingSearch && sTab !== 'savedSearches'">
         <a id="clear_filters" class="save-search__link" ng-click="clear()" translate>Clear filters</a>
-        <button id="save_search_init" class="btn btn--primary btn--hollow" ng-click="editItem()" ng-if="!editingSearch"  translate>Save Search</button>
+        <button id="save_search_init" class="btn btn--primary btn--hollow" ng-click="editItem()" ng-if="!editingSearch" data-test-id="save-search" translate>Save Search</button>
     </div>
     <div class="save-search" ng-if="editingSearch">
         <button class="btn btn--primary btn--expanded btn--hollow search" ng-click="search()" ng-if="innerTab==='parameters'" translate>Search</button>
@@ -19,7 +19,7 @@
     </div>
 </div>
 
-<div class="save-search-panel" ng-if="edit && activateSearchPane">
+<div class="save-search-panel" ng-if="edit && activateSearchPane" data-test-id="save-search-panel">
     <div class="save-search-panel__title" translate>Save search</div>
     <div class="search-content">
         <form name="viewsForm">
@@ -28,6 +28,6 @@
     </div>
     <div class="pull-right">
         <button class="btn" ng-click="cancel()" translate>Cancel</button>
-        <button id="search_save" class="btn btn--primary" ng-click="save(edit)" ng-disabled="!viewsForm.$valid" translate>Ok</button>
+        <button id="search_save" class="btn btn--primary" ng-click="save(edit)" ng-disabled="!viewsForm.$valid" data-test-id="save" translate>Ok</button>
     </div>
 </div>

--- a/scripts/apps/search/views/saved-searches.html
+++ b/scripts/apps/search/views/saved-searches.html
@@ -5,8 +5,8 @@
 
 <div class="list saved-searches">
     <div class="saved-searches__group-title" translate>My Saved Searches</div>
-    <ul>
-        <li ng-repeat="search in userSavedSearches | orderBy:'name' " ng-click="select(search)" class="saved-search-item" ng-class="{active: search == selected}">
+    <ul data-test-id="user-saved-searches">
+        <li ng-repeat="search in userSavedSearches | orderBy:'name' " ng-click="select(search)" class="saved-search-item" ng-class="{active: search == selected}" data-test-id="saved-search">
             <div class="search-item">
                 <div class="search-name">{{:: search.name }} <i ng-if="search.is_global" translate>[Global]</i></div>
                 <div class="search-description">{{:: search.description }}</div>
@@ -34,8 +34,8 @@
         </li>
     </ul>
     <div class="saved-searches__group-title" translate>Global Saved Searches</div>
-    <ul>
-        <li ng-repeat="search in globalSavedSearches | orderBy:'name' " ng-click="select(search)" class="saved-search-item" ng-class="{active: search == selected}">
+    <ul data-test-id="global-saved-searches">
+        <li ng-repeat="search in globalSavedSearches | orderBy:'name' " ng-click="select(search)" class="saved-search-item" ng-class="{active: search == selected}" data-test-id="saved-search">
             <div class="search-item">
                 <div class="search-name">{{:: search.name }} <i>by {{:: userLookup[search.user].display_name }}</i></div>
                 <div class="search-description">{{:: search.description }}</div>

--- a/scripts/apps/search/views/saved-searches.html
+++ b/scripts/apps/search/views/saved-searches.html
@@ -5,7 +5,7 @@
 
 <div class="list saved-searches">
     <div class="saved-searches__group-title" translate>My Saved Searches</div>
-    <ul data-test-id="user-saved-searches">
+    <ul data-test-id="saved-searches-panel--user">
         <li ng-repeat="search in userSavedSearches | orderBy:'name' " ng-click="select(search)" class="saved-search-item" ng-class="{active: search == selected}" data-test-id="saved-search">
             <div class="search-item">
                 <div class="search-name">{{:: search.name }} <i ng-if="search.is_global" translate>[Global]</i></div>
@@ -34,7 +34,7 @@
         </li>
     </ul>
     <div class="saved-searches__group-title" translate>Global Saved Searches</div>
-    <ul data-test-id="global-saved-searches">
+    <ul data-test-id="saved-searches-panel--global">
         <li ng-repeat="search in globalSavedSearches | orderBy:'name' " ng-click="select(search)" class="saved-search-item" ng-class="{active: search == selected}" data-test-id="saved-search">
             <div class="search-item">
                 <div class="search-name">{{:: search.name }} <i>by {{:: userLookup[search.user].display_name }}</i></div>


### PR DESCRIPTION
### Purpose
Automates the QA case [Saved searches tab in Monitoring settings of custom workspace](https://sofab.atlassian.net/wiki/spaces/SET/pages/1318323123) as a Playwright spec so it runs in CI instead of being tested by hand.

### What has changed
- New spec `e2e/client/playwright/monitoring.settings.custom-workspace.spec.ts` covering the scenario below
- Annotated with `{type: 'confluence', description: '1318323123 complete'}` per the coverage convention
- Adds `data-test-id` attributes to product source (needs developer eyes):
  - `previous` (Previous button, `scripts/apps/monitoring/views/aggregate-settings.html`)
  - `cancel` (Cancel button, `aggregate-settings.html`)
  - `next` (Next button, `aggregate-settings.html`)
  - `global-saved-searches` (Global saved searches toggle box, `aggregate-settings.html`)
  - `private-saved-searches` (Private saved searches toggle box, `aggregate-settings.html`)
  - `saved-search` + `data-test-value` (private saved search rows, `aggregate-settings.html`; mirrors the existing attributes on global rows)
  - `toggle` (private saved search `sd-switch`, `aggregate-settings.html`; mirrors the existing global row toggle)

### Steps to test
**Given** the `main` snapshot's custom workspace "Workspace 1", the global saved searches "Malaysia" and "Technology" (both created by John Doe), and a private saved search created for the logged-in admin.

**When**
1. Select the custom workspace in Monitoring and open Monitoring settings from the toolbar icon.
2. Click the Saved searches tab.
3. Flip a saved search toggle on and off, then collapse and re-expand the Global and Private headings.
4. Enable the "Malaysia" global saved search, click Previous, click Next, then keep clicking Next to the last tab and click Done.
5. Re-enter the Monitoring view and select the same custom workspace.
6. Repeat the flow but enable "Technology" and close the dialog with Cancel instead.

**Then**
- The dialog shows the Desks, Saved Searches, Reorder Sections and Items Count tabs, opening on Desks.
- The Saved searches tab lists both global saved searches under "Global saved searches", each with a toggle and its creator ("by John Doe"), and the private saved search under "Private saved searches" with a toggle of its own.
- Each toggle switches between active and inactive on click, and each heading collapses and re-expands its list.
- Previous is hidden on the first tab and visible elsewhere and moves the active tab left; Next is hidden on the last tab and moves it right; the enabled saved search stays enabled across that navigation.
- After Done the dialog closes and the "Malaysia" saved search group is shown on the custom workspace's Monitoring view.
- After Cancel the dialog closes, no "Technology" group appears, and reopening the dialog shows that toggle off again.

The spec also asserts group membership is exclusive (the private search never appears in the global list and vice versa) and that the enabled state survives a full page reload, which is how the persisted preference is verified.

Run it: `cd e2e/client && npx playwright test monitoring.settings.custom-workspace.spec.ts`

The spec passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
