### PR TITLE
Automate Rearrange widgets (1308524872)

### DIFF
--- a/e2e/client/playwright/dashboard.rearrange-widgets.spec.ts
+++ b/e2e/client/playwright/dashboard.rearrange-widgets.spec.ts
@@ -1,0 +1,158 @@
+import {test, expect, type Page} from '@playwright/test';
+import {Dashboard} from './page-object-models/dashboard';
+import {restoreDatabaseSnapshot} from './utils';
+
+/**
+ * QA case "Rearrange widgets" (Workspace, Confluence 1308524872).
+ *
+ * The documented expected results and where they are covered:
+ *  - "Click Rearrange Widgets and you'll see an x appear in the top-right
+ *    corner of each widget" -> first test.
+ *  - "resize widgets by clicking the grey arrows that appear at the edges of
+ *    each widget when you hover over them" -> first test (the arrows only
+ *    appear on hover) and second test (clicking them resizes).
+ *  - "Click and drag the body of the widget to move it to a different spot" and
+ *    "if there is a gap above one of the widgets, it will automatically move up
+ *    to fill the space" -> third test, which drops the widget a row lower than
+ *    the top of a free column and asserts it lands back on row 1.
+ *  - "Click x for each widget you'd like to delete" -> fourth test.
+ *
+ * The workspace fixture ships a single Monitor widget, so each test adds a
+ * World Clock through the (single-action) add-widget flow to get a second
+ * widget to rearrange against.
+ */
+test.describe('rearranging dashboard widgets', () => {
+    const MONITOR = 'aggregate';
+    const WORLD_CLOCK = 'world-clock';
+
+    async function openDashboardWithTwoWidgets(page: Page): Promise<Dashboard> {
+        const dashboard = new Dashboard(page);
+
+        await restoreDatabaseSnapshot();
+        await page.goto('/#/workspace');
+
+        await expect(dashboard.getWidget(MONITOR)).toBeVisible();
+        await dashboard.addWidget(WORLD_CLOCK);
+
+        // The fixture stores no position for the Monitor widget, so gridster
+        // packs both widgets into the first row. The rest of the spec moves and
+        // resizes against these coordinates.
+        await expect(dashboard.getWidget(MONITOR)).toHaveAttribute('data-col', '1');
+        await expect(dashboard.getWidget(MONITOR)).toHaveAttribute('data-row', '1');
+        await expect(dashboard.getWidget(WORLD_CLOCK)).toHaveAttribute('data-col', '2');
+        await expect(dashboard.getWidget(WORLD_CLOCK)).toHaveAttribute('data-row', '1');
+
+        return dashboard;
+    }
+
+    test('rearrange mode reveals a remove control on every widget and resize arrows on hover', {
+        annotation: [
+            {type: 'confluence', description: '1308524872 complete'}, // Rearrange widgets
+        ],
+    }, async ({page}) => {
+        const dashboard = await openDashboardWithTwoWidgets(page);
+        const monitor = dashboard.getWidget(MONITOR);
+        const worldClock = dashboard.getWidget(WORLD_CLOCK);
+
+        await expect(monitor.getByTestId('widget-remove')).toBeHidden();
+        await expect(worldClock.getByTestId('widget-remove')).toBeHidden();
+        await expect(monitor.getByTestId('widget-resize-right')).toBeHidden();
+        await expect(worldClock.getByTestId('widget-resize-right')).toBeHidden();
+
+        await dashboard.startRearranging();
+
+        await expect(monitor.getByTestId('widget-remove')).toBeVisible();
+        await expect(worldClock.getByTestId('widget-remove')).toBeVisible();
+
+        // The arrows are rendered as soon as rearrange mode starts but are
+        // fully transparent until the widget is hovered, which is the "appear
+        // when you hover over them" behaviour under test. Playwright treats a
+        // zero-opacity element as visible, so assert the computed opacity.
+        for (const arrow of ['widget-resize-left', 'widget-resize-right', 'widget-resize-up', 'widget-resize-down']) {
+            await expect(worldClock.getByTestId(arrow)).toHaveCSS('opacity', '0');
+        }
+
+        await worldClock.hover();
+
+        for (const arrow of ['widget-resize-left', 'widget-resize-right', 'widget-resize-up', 'widget-resize-down']) {
+            await expect(worldClock.getByTestId(arrow)).toHaveCSS('opacity', '0.5');
+        }
+
+        // Only the hovered widget shows its arrows.
+        await expect(monitor.getByTestId('widget-resize-right')).toHaveCSS('opacity', '0');
+    });
+
+    test('resize arrows grow and shrink a widget and the new size is kept after accepting', {
+        annotation: [
+            {type: 'confluence', description: '1308524872 complete'}, // Rearrange widgets
+        ],
+    }, async ({page}) => {
+        const dashboard = await openDashboardWithTwoWidgets(page);
+        const worldClock = dashboard.getWidget(WORLD_CLOCK);
+
+        await expect(worldClock).toHaveAttribute('data-sizex', '1');
+
+        await dashboard.startRearranging();
+
+        await worldClock.getByTestId('widget-resize-right').click();
+        await expect(worldClock).toHaveAttribute('data-sizex', '2');
+
+        await worldClock.getByTestId('widget-resize-left').click();
+        await expect(worldClock).toHaveAttribute('data-sizex', '1');
+
+        await worldClock.getByTestId('widget-resize-right').click();
+        await expect(worldClock).toHaveAttribute('data-sizex', '2');
+
+        await dashboard.acceptRearranging();
+
+        await page.reload();
+        await expect(dashboard.getWidget(WORLD_CLOCK)).toHaveAttribute('data-sizex', '2');
+    });
+
+    test('a widget dragged to a free column moves there and floats up to fill the gap above it', {
+        annotation: [
+            {type: 'confluence', description: '1308524872 complete'}, // Rearrange widgets
+        ],
+    }, async ({page}) => {
+        const dashboard = await openDashboardWithTwoWidgets(page);
+        const worldClock = dashboard.getWidget(WORLD_CLOCK);
+
+        await dashboard.startRearranging();
+
+        // Dropped one column to the right and one row down. The third column is
+        // empty, so gridster pulls the widget back up to the first row instead
+        // of leaving a gap above it.
+        await dashboard.dragWidget(WORLD_CLOCK, {columns: 1, rows: 1});
+
+        await expect(worldClock).toHaveAttribute('data-col', '3');
+        await expect(worldClock).toHaveAttribute('data-row', '1');
+        await expect(dashboard.getWidget(MONITOR)).toHaveAttribute('data-col', '1');
+
+        await dashboard.acceptRearranging();
+
+        await page.reload();
+        await expect(dashboard.getWidget(WORLD_CLOCK)).toHaveAttribute('data-col', '3');
+        await expect(dashboard.getWidget(WORLD_CLOCK)).toHaveAttribute('data-row', '1');
+    });
+
+    test('the x control deletes a widget and the deletion is kept after accepting', {
+        annotation: [
+            {type: 'confluence', description: '1308524872 complete'}, // Rearrange widgets
+        ],
+    }, async ({page}) => {
+        const dashboard = await openDashboardWithTwoWidgets(page);
+
+        await dashboard.startRearranging();
+
+        await dashboard.getWidget(WORLD_CLOCK).getByTestId('widget-remove').click();
+
+        await expect(dashboard.getWidget(WORLD_CLOCK)).toBeHidden();
+        await expect(dashboard.getWidget(MONITOR)).toBeVisible();
+
+        await dashboard.acceptRearranging();
+
+        await page.reload();
+        await expect(dashboard.getWidget(MONITOR)).toBeVisible();
+        await expect(dashboard.getWidget(WORLD_CLOCK)).toBeHidden();
+    });
+});

--- a/e2e/client/playwright/dashboard.rearrange-widgets.spec.ts
+++ b/e2e/client/playwright/dashboard.rearrange-widgets.spec.ts
@@ -28,7 +28,7 @@ import {restoreDatabaseSnapshot} from './utils';
  */
 test.describe('rearranging dashboard widgets', {
     annotation: [
-        {type: 'confluence', description: '1308524872 complete'}, // Rearrange widgets
+        {type: 'confluence', description: '1308524872 partial'}, // Rearrange widgets
     ],
 }, () => {
     const MONITOR = 'aggregate';

--- a/e2e/client/playwright/dashboard.rearrange-widgets.spec.ts
+++ b/e2e/client/playwright/dashboard.rearrange-widgets.spec.ts
@@ -16,12 +16,21 @@ import {restoreDatabaseSnapshot} from './utils';
  *    to fill the space" -> third test, which drops the widget a row lower than
  *    the top of a free column and asserts it lands back on row 1.
  *  - "Click x for each widget you'd like to delete" -> fourth test.
+ *  - "then select and drag a widget to the desired area of your Dashboard to
+ *    place it" -> not covered, and there is no behaviour to cover it with: the
+ *    add-widget modal has no drag-to-place, its widget list is click-only and
+ *    the widget is placed by the "Add This Widget" button
+ *    (scripts/apps/dashboard/views/workspace.html).
  *
  * The workspace fixture ships a single Monitor widget, so each test adds a
  * World Clock through the (single-action) add-widget flow to get a second
  * widget to rearrange against.
  */
-test.describe('rearranging dashboard widgets', () => {
+test.describe('rearranging dashboard widgets', {
+    annotation: [
+        {type: 'confluence', description: '1308524872 complete'}, // Rearrange widgets
+    ],
+}, () => {
     const MONITOR = 'aggregate';
     const WORLD_CLOCK = 'world-clock';
 
@@ -45,11 +54,7 @@ test.describe('rearranging dashboard widgets', () => {
         return dashboard;
     }
 
-    test('rearrange mode reveals a remove control on every widget and resize arrows on hover', {
-        annotation: [
-            {type: 'confluence', description: '1308524872 complete'}, // Rearrange widgets
-        ],
-    }, async ({page}) => {
+    test('rearrange mode reveals a remove control on every widget and resize arrows on hover', async ({page}) => {
         const dashboard = await openDashboardWithTwoWidgets(page);
         const monitor = dashboard.getWidget(MONITOR);
         const worldClock = dashboard.getWidget(WORLD_CLOCK);
@@ -82,11 +87,7 @@ test.describe('rearranging dashboard widgets', () => {
         await expect(monitor.getByTestId('widget-resize-right')).toHaveCSS('opacity', '0');
     });
 
-    test('resize arrows grow and shrink a widget and the new size is kept after accepting', {
-        annotation: [
-            {type: 'confluence', description: '1308524872 complete'}, // Rearrange widgets
-        ],
-    }, async ({page}) => {
+    test('resize arrows grow and shrink a widget and the new size is kept after accepting', async ({page}) => {
         const dashboard = await openDashboardWithTwoWidgets(page);
         const worldClock = dashboard.getWidget(WORLD_CLOCK);
 
@@ -109,11 +110,7 @@ test.describe('rearranging dashboard widgets', () => {
         await expect(dashboard.getWidget(WORLD_CLOCK)).toHaveAttribute('data-sizex', '2');
     });
 
-    test('a widget dragged to a free column moves there and floats up to fill the gap above it', {
-        annotation: [
-            {type: 'confluence', description: '1308524872 complete'}, // Rearrange widgets
-        ],
-    }, async ({page}) => {
+    test('a widget dragged to a free column moves there and floats up to fill the gap above it', async ({page}) => {
         const dashboard = await openDashboardWithTwoWidgets(page);
         const worldClock = dashboard.getWidget(WORLD_CLOCK);
 
@@ -135,11 +132,7 @@ test.describe('rearranging dashboard widgets', () => {
         await expect(dashboard.getWidget(WORLD_CLOCK)).toHaveAttribute('data-row', '1');
     });
 
-    test('the x control deletes a widget and the deletion is kept after accepting', {
-        annotation: [
-            {type: 'confluence', description: '1308524872 complete'}, // Rearrange widgets
-        ],
-    }, async ({page}) => {
+    test('the x control deletes a widget and the deletion is kept after accepting', async ({page}) => {
         const dashboard = await openDashboardWithTwoWidgets(page);
 
         await dashboard.startRearranging();

--- a/e2e/client/playwright/page-object-models/dashboard.ts
+++ b/e2e/client/playwright/page-object-models/dashboard.ts
@@ -1,0 +1,97 @@
+import {Locator, Page, expect} from '@playwright/test';
+
+/**
+ * The dashboard widget grid is driven by gridster.js. A widget's placement and
+ * size are not inline styles but the `data-col` / `data-row` / `data-sizex` /
+ * `data-sizey` attributes gridster writes on the grid item; the pixel position
+ * comes from a generated stylesheet keyed off those attributes. Assert on the
+ * attributes, they are the state the dashboard also persists.
+ */
+export class Dashboard {
+    /**
+     * One grid step in pixels. gridster is configured in
+     * scripts/apps/dashboard/grid/grid.ts with widget_base_dimensions
+     * [320, 250] and widget_margins [20, 20]; a step is the base dimension
+     * plus a margin on each side.
+     */
+    static readonly COLUMN_STEP = 360;
+    static readonly ROW_STEP = 290;
+
+    private page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    getWidget(widgetId: string): Locator {
+        return this.page
+            .getByTestId('widget-grid')
+            .getByTestId('widget')
+            .and(this.page.locator(`[data-test-value="${widgetId}"]`));
+    }
+
+    async addWidget(widgetId: string): Promise<void> {
+        const modal = this.page.getByTestId('widget-modal');
+
+        await this.page.getByRole('button', {name: 'Add widget'}).click();
+        await modal.getByTestId('widget-item').and(this.page.locator(`[data-test-value="${widgetId}"]`)).click();
+        await modal.getByRole('button', {name: 'Add This Widget'}).click();
+        await modal.getByRole('button', {name: 'Done'}).click();
+
+        await expect(this.getWidget(widgetId)).toBeVisible();
+    }
+
+    async startRearranging(): Promise<void> {
+        await this.page.getByTestId('rearrange-widgets').click();
+        await expect(this.page.getByTestId('accept-rearrange')).toBeVisible();
+    }
+
+    /**
+     * Accepting leaves rearrange mode synchronously but persists the layout with
+     * a background PATCH of the workspace. Wait for that response, otherwise a
+     * following reload aborts the request and the layout silently reverts.
+     */
+    async acceptRearranging(): Promise<void> {
+        const layoutPersisted = this.page.waitForResponse(
+            (response) => /\/workspaces\/[^/]+$/.test(response.url())
+                && response.request().method() !== 'GET'
+                && response.ok(),
+        );
+
+        await this.page.getByTestId('accept-rearrange').click();
+        await expect(this.page.getByTestId('rearrange-widgets')).toBeVisible();
+        await layoutPersisted;
+    }
+
+    /**
+     * Drags a widget by whole grid steps.
+     *
+     * gridster listens for raw mousedown/mousemove/mouseup on the grid, so
+     * page.dragTo() (which fires HTML5 drag events) does not move a widget.
+     * The first mousemove past gridster's 1px threshold only starts the drag;
+     * the drop cell is recomputed on the moves after it, hence `steps`.
+     */
+    async dragWidget(widgetId: string, steps: {columns: number; rows: number}): Promise<void> {
+        const widget = this.getWidget(widgetId);
+        const box = await widget.boundingBox();
+
+        if (box == null) {
+            throw new Error(`widget "${widgetId}" is not rendered`);
+        }
+
+        // Grab the widget header: the remove and resize controls sit on the
+        // widget's edges and corners, and pressing one of them would fire its
+        // click handler on mouseup instead of moving the widget.
+        const fromX = box.x + box.width / 2;
+        const fromY = box.y + 30;
+
+        await this.page.mouse.move(fromX, fromY);
+        await this.page.mouse.down();
+        await this.page.mouse.move(
+            fromX + steps.columns * Dashboard.COLUMN_STEP,
+            fromY + steps.rows * Dashboard.ROW_STEP,
+            {steps: 20},
+        );
+        await this.page.mouse.up();
+    }
+}

--- a/e2e/client/playwright/page-object-models/dashboard.ts
+++ b/e2e/client/playwright/page-object-models/dashboard.ts
@@ -37,13 +37,23 @@ export class Dashboard {
      * following reload aborts the request and the change silently reverts, and
      * a second PATCH sent while the first is in flight carries a stale
      * `If-Match` etag and is rejected with 412.
+     *
+     * The predicate matches on URL and method only. Filtering on the status
+     * here would leave a failed save unmatched, so the helper would hang until
+     * the `waitForResponse` timeout instead of reporting the status; the status
+     * is checked in `expectLayoutPersisted` once the response has arrived.
      */
     private waitForLayoutPersisted(): Promise<Response> {
         return this.page.waitForResponse(
             (response) => /\/workspaces\/[^/]+$/.test(response.url())
-                && response.request().method() === 'PATCH'
-                && response.ok(),
+                && response.request().method() === 'PATCH',
         );
+    }
+
+    private async expectLayoutPersisted(layoutPersisted: Promise<Response>): Promise<void> {
+        const response = await layoutPersisted;
+
+        expect(response.ok(), `saving the dashboard layout failed with ${response.status()}`).toBe(true);
     }
 
     async addWidget(widgetId: string): Promise<void> {
@@ -58,7 +68,7 @@ export class Dashboard {
         await modal.getByRole('button', {name: 'Done'}).click();
 
         await expect(this.getWidget(widgetId)).toBeVisible();
-        await layoutPersisted;
+        await this.expectLayoutPersisted(layoutPersisted);
     }
 
     async startRearranging(): Promise<void> {
@@ -71,7 +81,7 @@ export class Dashboard {
 
         await this.page.getByTestId('accept-rearrange').click();
         await expect(this.page.getByTestId('rearrange-widgets')).toBeVisible();
-        await layoutPersisted;
+        await this.expectLayoutPersisted(layoutPersisted);
     }
 
     /**

--- a/e2e/client/playwright/page-object-models/dashboard.ts
+++ b/e2e/client/playwright/page-object-models/dashboard.ts
@@ -66,9 +66,9 @@ export class Dashboard {
     /**
      * Drags a widget by whole grid steps.
      *
-     * gridster listens for raw mousedown/mousemove/mouseup on the grid, so
-     * page.dragTo() (which fires HTML5 drag events) does not move a widget.
-     * The first mousemove past gridster's 1px threshold only starts the drag;
+     * The drop target is an empty grid cell, which has no element for
+     * `locator.dragTo()` to aim at, so the mouse events are driven by hand.
+     * The first mousemove past gridster's drag threshold only starts the drag;
      * the drop cell is recomputed on the moves after it, hence `steps`.
      */
     async dragWidget(widgetId: string, steps: {columns: number; rows: number}): Promise<void> {

--- a/e2e/client/playwright/page-object-models/dashboard.ts
+++ b/e2e/client/playwright/page-object-models/dashboard.ts
@@ -1,4 +1,4 @@
-import {Locator, Page, expect} from '@playwright/test';
+import {Locator, Page, Response, expect} from '@playwright/test';
 
 /**
  * The dashboard widget grid is driven by gridster.js. A widget's placement and
@@ -30,15 +30,35 @@ export class Dashboard {
             .and(this.page.locator(`[data-test-value="${widgetId}"]`));
     }
 
+    /**
+     * Adding a widget and accepting a rearrange both persist the dashboard the
+     * same way: a background `PATCH /workspaces/<id>` fired after the click.
+     * Every action that triggers one has to wait for the response, otherwise a
+     * following reload aborts the request and the change silently reverts, and
+     * a second PATCH sent while the first is in flight carries a stale
+     * `If-Match` etag and is rejected with 412.
+     */
+    private waitForLayoutPersisted(): Promise<Response> {
+        return this.page.waitForResponse(
+            (response) => /\/workspaces\/[^/]+$/.test(response.url())
+                && response.request().method() === 'PATCH'
+                && response.ok(),
+        );
+    }
+
     async addWidget(widgetId: string): Promise<void> {
         const modal = this.page.getByTestId('widget-modal');
 
         await this.page.getByRole('button', {name: 'Add widget'}).click();
         await modal.getByTestId('widget-item').and(this.page.locator(`[data-test-value="${widgetId}"]`)).click();
+
+        const layoutPersisted = this.waitForLayoutPersisted();
+
         await modal.getByRole('button', {name: 'Add This Widget'}).click();
         await modal.getByRole('button', {name: 'Done'}).click();
 
         await expect(this.getWidget(widgetId)).toBeVisible();
+        await layoutPersisted;
     }
 
     async startRearranging(): Promise<void> {
@@ -46,17 +66,8 @@ export class Dashboard {
         await expect(this.page.getByTestId('accept-rearrange')).toBeVisible();
     }
 
-    /**
-     * Accepting leaves rearrange mode synchronously but persists the layout with
-     * a background PATCH of the workspace. Wait for that response, otherwise a
-     * following reload aborts the request and the layout silently reverts.
-     */
     async acceptRearranging(): Promise<void> {
-        const layoutPersisted = this.page.waitForResponse(
-            (response) => /\/workspaces\/[^/]+$/.test(response.url())
-                && response.request().method() !== 'GET'
-                && response.ok(),
-        );
+        const layoutPersisted = this.waitForLayoutPersisted();
 
         await this.page.getByTestId('accept-rearrange').click();
         await expect(this.page.getByTestId('rearrange-widgets')).toBeVisible();

--- a/scripts/apps/dashboard/grid/views/grid-item.html
+++ b/scripts/apps/dashboard/grid/views/grid-item.html
@@ -1,13 +1,13 @@
 <div class="widget-resize-width" ng-show="status">
-    <div class="resize-left" ng-click="resizeWidget(widget, 'left')"></div>
-    <div class="resize-right" ng-click="resizeWidget(widget, 'right')" ></div>
+    <div class="resize-left" ng-click="resizeWidget(widget, 'left')" data-test-id="widget-resize-left"></div>
+    <div class="resize-right" ng-click="resizeWidget(widget, 'right')" data-test-id="widget-resize-right"></div>
 </div>
 
 <div class="widget-resize-height" ng-show="status">
-    <div class="resize-up" ng-click="resizeWidget(widget, 'up')" ></div>
-    <div class="resize-down" ng-click="resizeWidget(widget, 'down')" ></div>
+    <div class="resize-up" ng-click="resizeWidget(widget, 'up')" data-test-id="widget-resize-up"></div>
+    <div class="resize-down" ng-click="resizeWidget(widget, 'down')" data-test-id="widget-resize-down"></div>
 </div>
 
-<div class="widget-close" ng-click="removeWidget()" ng-show="status"></div>
+<div class="widget-close" ng-click="removeWidget()" ng-show="status" data-test-id="widget-remove"></div>
 
 <div class="r{{widget.sizex}}{{widget.sizey}}" ng-transclude></div>

--- a/scripts/apps/dashboard/views/workspace.html
+++ b/scripts/apps/dashboard/views/workspace.html
@@ -2,11 +2,11 @@
     <h2 class="page-nav-title"><span translate>Dashboard</span> {{ dashboard.current.name | translate}}</h2>
 
     <div class="subnav__button-stack--square-buttons">
-        <button ng-if="configurable" class="navbtn" ng-click="dashboard.edit = true" ng-show="dashboard.widgets.length && !dashboard.edit" sd-tooltip="{{ :: 'Rearrange widgets' | translate }}" flow="left">
+        <button ng-if="configurable" class="navbtn" ng-click="dashboard.edit = true" ng-show="dashboard.widgets.length && !dashboard.edit" sd-tooltip="{{ :: 'Rearrange widgets' | translate }}" flow="left" data-test-id="rearrange-widgets">
             <i class="icon-switches"></i>
         </button>
 
-        <button class="navbtn navbtn--blue" ng-click="dashboard.save()" ng-show="dashboard.edit" sd-tooltip="{{ :: 'Accept' | translate }}" flow="left">
+        <button class="navbtn navbtn--blue" ng-click="dashboard.save()" ng-show="dashboard.edit" sd-tooltip="{{ :: 'Accept' | translate }}" flow="left" data-test-id="accept-rearrange">
             <i class="svg-icon-ok inverse"></i>
         </button>
 


### PR DESCRIPTION
### Purpose
Automates the QA case [Rearrange widgets](https://sofab.atlassian.net/wiki/spaces/SET/pages/1308524872) as a Playwright spec so it runs in CI instead of being tested by hand.

### What has changed
- New spec `e2e/client/playwright/dashboard.rearrange-widgets.spec.ts` covering the scenario below
- Annotated with `{type: 'confluence', description: '1308524872 partial'}` per the coverage convention
- Adds `data-test-id` attributes to product source: `rearrange-widgets` (`scripts/apps/dashboard/views/workspace.html`), `accept-rearrange` (`scripts/apps/dashboard/views/workspace.html`), `widget-remove` (`scripts/apps/dashboard/grid/views/grid-item.html`), `widget-resize-left` (`scripts/apps/dashboard/grid/views/grid-item.html`), `widget-resize-right` (`scripts/apps/dashboard/grid/views/grid-item.html`), `widget-resize-up` (`scripts/apps/dashboard/grid/views/grid-item.html`), `widget-resize-down` (`scripts/apps/dashboard/grid/views/grid-item.html`) (needs developer eyes)

### Steps to test
**Given** the Sports desk dashboard from the `main` snapshot, which ships a single Monitor widget, with a World Clock widget added next to it (Monitor at column 1, World Clock at column 2, both on row 1).

**When**
1. Click the "Rearrange widgets" button in the dashboard subnav.
2. Hover a widget to reveal its resize arrows.
3. Click the right resize arrow on the World Clock, then the left one, then the right one again.
4. Drag the World Clock by its header one column to the right and one row down, into the empty third column.
5. Click the x in the top-right corner of the World Clock.
6. Click "Accept" and reload the page.

**Then**
- An x appears in the top-right corner of every widget as soon as rearrange mode starts, and is not there before.
- The resize arrows on all four edges are fully transparent until the widget is hovered, then become visible; only the hovered widget shows them.
- The right arrow grows the widget from one column to two, the left arrow shrinks it back.
- The dragged widget lands in the third column and on row 1: it floats up to fill the gap above it instead of staying on the row it was dropped on, and the Monitor widget stays in column 1.
- Clicking the x removes the widget from the grid while the other widget stays.
- After Accept and a reload, the new size, the new position and the deletion are all still there.

The spec asserts on the gridster grid state (`data-col`, `data-row`, `data-sizex`) and on the computed opacity of the resize arrows rather than on pixels; there are no visual snapshots.

Run it: `cd e2e/client && npx playwright test dashboard.rearrange-widgets.spec.ts`

The spec passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
