### PR TITLE
Automate Create new article with a keyboard shortcut (1310851155)

### DIFF
--- a/e2e/client/playwright/create-article-keyboard-shortcut.spec.ts
+++ b/e2e/client/playwright/create-article-keyboard-shortcut.spec.ts
@@ -1,0 +1,212 @@
+import {test, expect, type Locator, type Page} from '@playwright/test';
+import {Authoring} from './page-object-models/authoring';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+import {setEditor3FieldValue} from './utils/editor3';
+
+/**
+ * QA case "Create new article with a keyboard shortcut" (1310851155).
+ *
+ * Ctrl+M on the monitoring view creates an article from the active desk's default
+ * content template and opens it for editing. The case is split by what happens to
+ * that article: it is either thrown away (and then must exist nowhere) or kept.
+ *
+ * The article the shortcut creates already exists server-side before anything is
+ * typed into it, so "not created" means the discard actually removed it; that is
+ * why the discard test also queries global search rather than trusting the
+ * monitoring list alone.
+ */
+
+interface IArticleFields {
+    slugline: string;
+    headline: string;
+    abstract: string;
+    body: string;
+}
+
+const DISCARDED: IArticleFields = {
+    slugline: 'discarded shortcut slugline',
+    headline: 'discarded shortcut story',
+    abstract: 'discarded shortcut abstract',
+    body: 'discarded shortcut body',
+};
+
+const SAVED: IArticleFields = {
+    slugline: 'saved shortcut slugline',
+    headline: 'saved shortcut story',
+    abstract: 'saved shortcut abstract',
+    body: 'saved shortcut body',
+};
+
+const UPDATED_ABSTRACT = 'saved shortcut abstract, edited';
+
+/** Main-snapshot article of the Sports desk, used as the "list has loaded" anchor. */
+const ANCHOR_ARTICLE = 'test sports story';
+
+/** Matches ANCHOR_ARTICLE and both headlines above, so one query covers anchor and subject. */
+const SEARCH_TERM = 'story';
+
+/**
+ * Narrows a list of `article-item`s to the one labelled `label`.
+ *
+ * The label is the item's headline (`getArticleLabel` in core/utils), exposed as
+ * `data-test-value`, which is an attribute rather than text so it cannot be matched
+ * with `filter({hasText})`.
+ */
+function withLabel(items: Locator, label: string): Locator {
+    return items.and(items.page().locator(`[data-test-value="${label}"]`));
+}
+
+function monitoringItems(page: Page): Locator {
+    return page.getByTestId('monitoring-view').getByTestId('article-item');
+}
+
+/**
+ * Opens the Sports monitoring view and waits for its list to carry ANCHOR_ARTICLE,
+ * so that a later absence assertion cannot pass against a list that never loaded.
+ */
+async function openSportsMonitoring(page: Page, monitoring: Monitoring): Promise<void> {
+    await page.goto('/#/workspace/monitoring');
+    await monitoring.selectDeskOrWorkspace('Sports');
+
+    await expect(withLabel(monitoringItems(page), ANCHOR_ARTICLE)).toBeVisible();
+}
+
+/**
+ * Opens global search and returns its result items, with the unfiltered list
+ * awaited for the same reason as in `openSportsMonitoring`.
+ */
+async function openGlobalSearch(page: Page): Promise<Locator> {
+    await page.goto('/#/search');
+
+    const results = page.getByTestId('article-item');
+
+    await expect(results.first()).toBeVisible();
+
+    return results;
+}
+
+function sluglineField(page: Page): Locator {
+    return page.getByTestId('authoring').getByTestId('field-slugline');
+}
+
+async function fillArticleFields(authoring: Authoring, page: Page, fields: IArticleFields): Promise<void> {
+    await sluglineField(page).fill(fields.slugline);
+    await setEditor3FieldValue(authoring.field('field--headline'), fields.headline);
+    await setEditor3FieldValue(authoring.field('authoring-field=abstract'), fields.abstract);
+    await setEditor3FieldValue(authoring.field('authoring-field=body_html'), fields.body);
+}
+
+async function expectArticleFields(authoring: Authoring, page: Page, fields: IArticleFields): Promise<void> {
+    await expect(sluglineField(page)).toHaveValue(fields.slugline);
+    await expect(authoring.field('field--headline')).toHaveText(fields.headline);
+    await expect(authoring.field('authoring-field=abstract')).toHaveText(fields.abstract);
+    await expect(authoring.field('authoring-field=body_html')).toHaveText(fields.body);
+}
+
+test.describe('creating a new article with the Ctrl+M shortcut', {
+    annotation: [
+        // Create new article with a keyboard shortcut
+        {type: 'confluence', description: '1310851155 complete'},
+    ],
+}, () => {
+    test('Cancel returns to the article and Ignore discards it without creating anything', async ({page}) => {
+        const monitoring = new Monitoring(page);
+        const authoring = new Authoring(page);
+
+        await restoreDatabaseSnapshot();
+        await openSportsMonitoring(page, monitoring);
+
+        await monitoring.createArticleWithKeyboardShortcut();
+
+        const topbar = page.getByTestId('authoring-topbar');
+
+        // an article straight from the template has no edits of its own to persist
+        await expect(topbar.getByTestId('save')).toBeDisabled();
+
+        await fillArticleFields(authoring, page, DISCARDED);
+
+        await topbar.getByTestId('close').click();
+
+        const prompt = page.getByTestId('unsaved-changes-dialog');
+
+        await expect(prompt).toBeVisible();
+        await expect(prompt.getByRole('button', {name: 'Ignore', exact: true})).toBeVisible();
+        await expect(prompt.getByRole('button', {name: 'Cancel', exact: true})).toBeVisible();
+        await expect(prompt.getByRole('button', {name: 'Save', exact: true})).toBeVisible();
+
+        await prompt.getByRole('button', {name: 'Cancel', exact: true}).click();
+
+        await expect(prompt).toBeHidden();
+        await expect(page.getByTestId('authoring')).toBeVisible();
+        await expectArticleFields(authoring, page, DISCARDED);
+
+        await topbar.getByTestId('close').click();
+        await prompt.getByRole('button', {name: 'Ignore', exact: true}).click();
+
+        await expect(page.getByTestId('authoring')).toBeHidden();
+
+        await expect(withLabel(monitoringItems(page), ANCHOR_ARTICLE)).toBeVisible();
+        await expect(withLabel(monitoringItems(page), DISCARDED.headline)).toHaveCount(0);
+
+        const results = await openGlobalSearch(page);
+
+        await page.locator('#search-input').fill(SEARCH_TERM);
+        await page.locator('#search-button').click();
+
+        await expect(withLabel(results, ANCHOR_ARTICLE)).toBeVisible();
+        await expect(withLabel(results, DISCARDED.headline)).toHaveCount(0);
+    });
+
+    test('a saved article is listed, searchable, and reopens with its data', async ({page}) => {
+        // the global-search retry below can outlast the 30s default on its own
+        test.setTimeout(90000);
+
+        const monitoring = new Monitoring(page);
+        const authoring = new Authoring(page);
+
+        await restoreDatabaseSnapshot();
+        await openSportsMonitoring(page, monitoring);
+
+        await monitoring.createArticleWithKeyboardShortcut();
+        await fillArticleFields(authoring, page, SAVED);
+
+        await authoring.save();
+
+        // saving from the topbar keeps the article open; only Close leaves it
+        await expect(page.getByTestId('authoring')).toBeVisible();
+        await expect(withLabel(monitoringItems(page), SAVED.headline)).toBeVisible();
+
+        await setEditor3FieldValue(authoring.field('authoring-field=abstract'), UPDATED_ABSTRACT);
+
+        // Save re-enabling is the signal that the edit reached the article model,
+        // which is what makes the "Save changes?" prompt appear on close
+        await expect(page.getByTestId('authoring-topbar').getByTestId('save')).toBeEnabled();
+
+        await authoring.closeAndSave();
+
+        await expect(page.getByTestId('authoring')).toBeHidden();
+        await expect(withLabel(monitoringItems(page), SAVED.headline)).toBeVisible();
+
+        const results = await openGlobalSearch(page);
+
+        await page.locator('#search-input').fill(SEARCH_TERM);
+
+        // the article reaches the search index asynchronously, so re-run the query
+        // instead of waiting for a list that will not update on its own
+        await expect(async () => {
+            await page.locator('#search-button').click();
+            await expect(withLabel(results, SAVED.headline)).toBeVisible({timeout: 2000});
+        }).toPass({timeout: 30000});
+
+        await openSportsMonitoring(page, monitoring);
+        await withLabel(monitoringItems(page), SAVED.headline).dblclick();
+
+        await expect(page.getByTestId('authoring')).toBeVisible();
+        await expectArticleFields(authoring, page, {...SAVED, abstract: UPDATED_ABSTRACT});
+
+        await authoring.close();
+
+        await expect(page.getByTestId('authoring')).toBeHidden();
+    });
+});

--- a/e2e/client/playwright/create-article-keyboard-shortcut.spec.ts
+++ b/e2e/client/playwright/create-article-keyboard-shortcut.spec.ts
@@ -11,11 +11,15 @@ import {setEditor3FieldValue} from './utils/editor3';
  * content template and opens it for editing. The case is split by what happens to
  * that article: it is either thrown away (and then must exist nowhere) or kept.
  *
- * The article the shortcut creates already exists server-side before anything is
- * typed into it, so "not created" means the discard actually removed it; that is
- * why the discard test also queries global search rather than trusting the
- * monitoring list alone.
+ * The shortcut persists the article to `archive` before anything is typed into it,
+ * at version 0, and the typing that follows only reaches `archive_autosave`. Every
+ * monitoring and search query filters version-0 drafts out, so the article is
+ * missing from all lists whether or not the discard removed it. "Not created" is
+ * therefore checked against the `archive` resource, which is the only place a
+ * surviving stub would show.
  */
+
+const API_URL = (process.env.SUPERDESK_URL || 'http://localhost:5002/api').replace(/\/$/, '');
 
 interface IArticleFields {
     slugline: string;
@@ -43,7 +47,7 @@ const UPDATED_ABSTRACT = 'saved shortcut abstract, edited';
 /** Main-snapshot article of the Sports desk, used as the "list has loaded" anchor. */
 const ANCHOR_ARTICLE = 'test sports story';
 
-/** Matches ANCHOR_ARTICLE and both headlines above, so one query covers anchor and subject. */
+/** Matches SAVED.headline, and snapshot articles besides, so the filtered list is never empty. */
 const SEARCH_TERM = 'story';
 
 /**
@@ -90,6 +94,37 @@ function sluglineField(page: Page): Locator {
     return page.getByTestId('authoring').getByTestId('field-slugline');
 }
 
+/** Id of the article authoring has open, from the `item` parameter opening one writes into the URL. */
+function openArticleId(page: Page): string {
+    const match = page.url().match(/[?&]item=([^&]+)/);
+
+    if (match == null) {
+        throw new Error(`no article is open in ${page.url()}`);
+    }
+
+    return decodeURIComponent(match[1]);
+}
+
+/**
+ * Response status of `<resource>/<articleId>`, so 200 means the record exists and 404
+ * means it is gone. Authenticated with the session token the client keeps in
+ * localStorage, already in the form the API expects as an Authorization header.
+ */
+async function recordStatus(page: Page, resource: string, articleId: string): Promise<number> {
+    const token = await page.evaluate(() => window.localStorage.getItem('sess:token'));
+
+    if (token == null) {
+        throw new Error('no session token in localStorage');
+    }
+
+    const response = await page.request.get(`${API_URL}/${resource}/${articleId}`, {
+        headers: {Authorization: token},
+        failOnStatusCode: false,
+    });
+
+    return response.status();
+}
+
 async function fillArticleFields(authoring: Authoring, page: Page, fields: IArticleFields): Promise<void> {
     await sluglineField(page).fill(fields.slugline);
     await setEditor3FieldValue(authoring.field('field--headline'), fields.headline);
@@ -119,7 +154,12 @@ test.describe('creating a new article with the Ctrl+M shortcut', {
 
         await monitoring.createArticleWithKeyboardShortcut();
 
+        const articleId = openArticleId(page);
         const topbar = page.getByTestId('authoring-topbar');
+
+        // the article is already in archive at this point, which is what makes the
+        // absence check after Ignore mean something
+        expect(await recordStatus(page, 'archive', articleId)).toBe(200);
 
         // an article straight from the template has no edits of its own to persist
         await expect(topbar.getByTestId('save')).toBeDisabled();
@@ -145,17 +185,11 @@ test.describe('creating a new article with the Ctrl+M shortcut', {
         await prompt.getByRole('button', {name: 'Ignore', exact: true}).click();
 
         await expect(page.getByTestId('authoring')).toBeHidden();
-
         await expect(withLabel(monitoringItems(page), ANCHOR_ARTICLE)).toBeVisible();
-        await expect(withLabel(monitoringItems(page), DISCARDED.headline)).toHaveCount(0);
 
-        const results = await openGlobalSearch(page);
-
-        await page.locator('#search-input').fill(SEARCH_TERM);
-        await page.locator('#search-button').click();
-
-        await expect(withLabel(results, ANCHOR_ARTICLE)).toBeVisible();
-        await expect(withLabel(results, DISCARDED.headline)).toHaveCount(0);
+        // expected result 2 in full: Ignore took the stub back out of archive.
+        // Polled because the delete is still in flight while the view closes
+        await expect.poll(() => recordStatus(page, 'archive', articleId)).toBe(404);
     });
 
     test('a saved article is listed, searchable, and reopens with its data', async ({page}) => {
@@ -169,6 +203,9 @@ test.describe('creating a new article with the Ctrl+M shortcut', {
         await openSportsMonitoring(page, monitoring);
 
         await monitoring.createArticleWithKeyboardShortcut();
+
+        const articleId = openArticleId(page);
+
         await fillArticleFields(authoring, page, SAVED);
 
         await authoring.save();
@@ -177,26 +214,45 @@ test.describe('creating a new article with the Ctrl+M shortcut', {
         await expect(page.getByTestId('authoring')).toBeVisible();
         await expect(withLabel(monitoringItems(page), SAVED.headline)).toBeVisible();
 
+        const abstractAutosaved = page.waitForRequest(
+            (request) => request.method() === 'POST' && request.url().includes('/archive_autosave'),
+        );
+
         await setEditor3FieldValue(authoring.field('authoring-field=abstract'), UPDATED_ABSTRACT);
 
         // Save re-enabling is the signal that the edit reached the article model,
         // which is what makes the "Save changes?" prompt appear on close
         await expect(page.getByTestId('authoring-topbar').getByTestId('save')).toBeEnabled();
 
+        /*
+         * The edit also autosaves on a debounce. Waiting for that to fire before
+         * closing leaves nothing pending that could write a fresh autosave record
+         * after the prompt's Save has cleared the old one; such a record would make
+         * the article dirty the moment it is reopened, and the clean close at the
+         * end of this test is exactly what the case expects there.
+         */
+        await abstractAutosaved;
+
         await authoring.closeAndSave();
 
         await expect(page.getByTestId('authoring')).toBeHidden();
         await expect(withLabel(monitoringItems(page), SAVED.headline)).toBeVisible();
+        await expect.poll(() => recordStatus(page, 'archive_autosave', articleId)).toBe(404);
 
         const results = await openGlobalSearch(page);
 
         await page.locator('#search-input').fill(SEARCH_TERM);
+        await page.locator('#search-button').click();
 
-        // the article reaches the search index asynchronously, so re-run the query
-        // instead of waiting for a list that will not update on its own
+        /*
+         * The article reaches the search index asynchronously and the results list
+         * refetches only when the search parameters change, so clicking the button
+         * again with the same query would do nothing. Reloading re-runs the query
+         * that is now in the URL, which is what lets the retry see the new item.
+         */
         await expect(async () => {
-            await page.locator('#search-button').click();
-            await expect(withLabel(results, SAVED.headline)).toBeVisible({timeout: 2000});
+            await page.reload();
+            await expect(withLabel(results, SAVED.headline)).toBeVisible({timeout: 5000});
         }).toPass({timeout: 30000});
 
         await openSportsMonitoring(page, monitoring);

--- a/e2e/client/playwright/create-article-keyboard-shortcut.spec.ts
+++ b/e2e/client/playwright/create-article-keyboard-shortcut.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect, type Locator, type Page} from '@playwright/test';
 import {Authoring} from './page-object-models/authoring';
 import {Monitoring} from './page-object-models/monitoring';
-import {restoreDatabaseSnapshot} from './utils';
+import {restoreDatabaseSnapshot, SUPERDESK_API_URL} from './utils';
 import {setEditor3FieldValue} from './utils/editor3';
 
 /**
@@ -18,8 +18,6 @@ import {setEditor3FieldValue} from './utils/editor3';
  * therefore checked against the `archive` resource, which is the only place a
  * surviving stub would show.
  */
-
-const API_URL = (process.env.SUPERDESK_URL || 'http://localhost:5002/api').replace(/\/$/, '');
 
 interface IArticleFields {
     slugline: string;
@@ -117,7 +115,7 @@ async function recordStatus(page: Page, resource: string, articleId: string): Pr
         throw new Error('no session token in localStorage');
     }
 
-    const response = await page.request.get(`${API_URL}/${resource}/${articleId}`, {
+    const response = await page.request.get(`${SUPERDESK_API_URL}/${resource}/${articleId}`, {
         headers: {Authorization: token},
         failOnStatusCode: false,
     });

--- a/e2e/client/playwright/page-object-models/authoring.ts
+++ b/e2e/client/playwright/page-object-models/authoring.ts
@@ -88,7 +88,7 @@ export class Authoring {
      * for its absence, since it is absent for a moment either way. The topbar
      * hiding is the assertion that carries it: while the prompt is up the article
      * stays open, so a prompt here fails this method rather than being clicked
-     * away. Use `closeDiscardingChanges` when unsaved edits are expected.
+     * away.
      */
     async close(): Promise<void> {
         const {page} = this;
@@ -98,30 +98,6 @@ export class Authoring {
 
         await expect(topbar).toBeHidden();
         await expect(page.getByTestId('unsaved-changes-dialog')).toBeHidden();
-    }
-
-    /**
-     * Closes the article, discarding an autosave record if one is pending.
-     *
-     * Fields that autosave on a debounce can land a record after the item was
-     * saved, and the item then still counts as unsaved on the next close even
-     * if nothing was touched since. That makes the "Save changes?" prompt
-     * genuinely optional here, so it is answered only when it shows up.
-     */
-    async closeDiscardingChanges(): Promise<void> {
-        const {page} = this;
-        const topbar = page.getByTestId('authoring-topbar');
-        const unsavedChanges = page.getByTestId('unsaved-changes-dialog');
-
-        await topbar.getByTestId('close').click();
-
-        await expect(async () => {
-            if (await unsavedChanges.isVisible()) {
-                await unsavedChanges.getByRole('button', {name: 'Ignore', exact: true}).click();
-            }
-
-            await expect(topbar).toBeHidden({timeout: 1000});
-        }).toPass({timeout: 20000});
     }
 
     /**

--- a/e2e/client/playwright/page-object-models/authoring.ts
+++ b/e2e/client/playwright/page-object-models/authoring.ts
@@ -64,6 +64,69 @@ export class Authoring {
     }
 
     /**
+     * Saves from the topbar and waits for the save to land.
+     *
+     * The Save button is also disabled while the save is in flight, so it being
+     * disabled says nothing about the item having been persisted. The spinner
+     * inside the button is the completion signal: it is bound to the same flag
+     * the save promise clears when it settles.
+     */
+    async save(): Promise<void> {
+        const saveButton = this.page.getByTestId('authoring-topbar').getByTestId('save');
+        const spinner = saveButton.getByTestId('loading-indicator');
+
+        await saveButton.click();
+        await expect(spinner).toBeVisible();
+        await expect(spinner).toBeHidden();
+        await expect(saveButton).toBeDisabled();
+    }
+
+    /**
+     * Closes the article, discarding an autosave record if one is pending.
+     *
+     * Fields that autosave on a debounce can land a record after the item was
+     * saved, and the item then still counts as unsaved on the next close even
+     * if nothing was touched since. That makes the "Save changes?" prompt
+     * genuinely optional here, so it is answered only when it shows up.
+     */
+    async close(): Promise<void> {
+        const {page} = this;
+        const topbar = page.getByTestId('authoring-topbar');
+        const unsavedChanges = page.getByTestId('unsaved-changes-dialog');
+
+        await topbar.getByTestId('close').click();
+
+        await expect(async () => {
+            if (await unsavedChanges.isVisible()) {
+                await unsavedChanges.getByRole('button', {name: 'Ignore', exact: true}).click();
+            }
+
+            await expect(topbar).toBeHidden({timeout: 1000});
+        }).toPass({timeout: 20000});
+    }
+
+    /**
+     * Closes an article that has pending edits, answering the "Save changes?"
+     * prompt with Save.
+     *
+     * Use this instead of `save()` + `close()` after editing fields that
+     * autosave on a debounce: the debounced autosave can land after the topbar
+     * save, which raises the prompt anyway and leaves `close()` hanging on an
+     * article that never closes.
+     */
+    async closeAndSave(): Promise<void> {
+        const {page} = this;
+
+        await page.getByTestId('authoring-topbar').getByTestId('close').click();
+
+        await page.getByTestId('unsaved-changes-dialog')
+            .getByRole('button', {name: 'Save', exact: true})
+            .click();
+
+        await expect(page.getByTestId('authoring-topbar')).toBeHidden();
+    }
+
+    /**
      * editor3 field takes quite some time to initialize in authoring-react.
      * Until it initializes - typing inside it doesn't update `fieldsData` in authoring-react state.
      */

--- a/e2e/client/playwright/page-object-models/authoring.ts
+++ b/e2e/client/playwright/page-object-models/authoring.ts
@@ -82,6 +82,25 @@ export class Authoring {
     }
 
     /**
+     * Closes an article that has nothing left to save.
+     *
+     * There is no way to assert the "Save changes?" prompt stays away by looking
+     * for its absence, since it is absent for a moment either way. The topbar
+     * hiding is the assertion that carries it: while the prompt is up the article
+     * stays open, so a prompt here fails this method rather than being clicked
+     * away. Use `closeDiscardingChanges` when unsaved edits are expected.
+     */
+    async close(): Promise<void> {
+        const {page} = this;
+        const topbar = page.getByTestId('authoring-topbar');
+
+        await topbar.getByTestId('close').click();
+
+        await expect(topbar).toBeHidden();
+        await expect(page.getByTestId('unsaved-changes-dialog')).toBeHidden();
+    }
+
+    /**
      * Closes the article, discarding an autosave record if one is pending.
      *
      * Fields that autosave on a debounce can land a record after the item was
@@ -89,7 +108,7 @@ export class Authoring {
      * if nothing was touched since. That makes the "Save changes?" prompt
      * genuinely optional here, so it is answered only when it shows up.
      */
-    async close(): Promise<void> {
+    async closeDiscardingChanges(): Promise<void> {
         const {page} = this;
         const topbar = page.getByTestId('authoring-topbar');
         const unsavedChanges = page.getByTestId('unsaved-changes-dialog');

--- a/e2e/client/playwright/page-object-models/monitoring.ts
+++ b/e2e/client/playwright/page-object-models/monitoring.ts
@@ -115,6 +115,20 @@ export class Monitoring {
         await this.page.getByTestId('content-create-dropdown').getByTestId('default-desk-template').click();
     }
 
+    /**
+     * Creates an article with the Ctrl+M shortcut and waits for it to open for editing.
+     *
+     * The binding is a window-level keydown listener registered once at startup
+     * (`registerGlobalKeybindings` in core/keyboard/keyboard.ts). It builds the item
+     * from the active desk's default content template and only acts while the route
+     * is under `workspace` or `search`, so the caller must already be on one of them.
+     */
+    async createArticleWithKeyboardShortcut(): Promise<void> {
+        await this.page.keyboard.press('Control+m');
+
+        await expect(this.page.getByTestId('authoring-topbar')).toBeVisible();
+    }
+
     async openMediaUploadView(): Promise<void> {
         await this.page.locator(s('content-create')).click();
         await this.page.locator(s('content-create-dropdown')).getByRole('button', {name: 'Upload media'}).click();

--- a/e2e/client/playwright/utils/index.ts
+++ b/e2e/client/playwright/utils/index.ts
@@ -1,7 +1,7 @@
 import * as request from 'request';
 import {expect, Locator, Page} from '@playwright/test';
 
-const SUPERDESK_API_URL = (process.env.SUPERDESK_URL || 'http://localhost:5002/api').replace(/\/$/, '');
+export const SUPERDESK_API_URL = (process.env.SUPERDESK_URL || 'http://localhost:5002/api').replace(/\/$/, '');
 
 export function restoreDatabaseSnapshot(options?: {snapshotName?: string}): Promise<void> {
     return new Promise((resolve) => {


### PR DESCRIPTION
### Purpose
Automates the following QA case(s) as Playwright spec(s) so they run in CI instead of being tested by hand:
- [Create new article with a keyboard shortcut](https://sofab.atlassian.net/wiki/spaces/SET/pages/1310851155)

Annotation levels: 1310851155: complete

### What has changed
- New spec(s): `/Users/eos87/code/SourceFabric/Superdesk/Async/EndToEndTests/.worktrees/automate-create-article-shortcut/e2e/client/playwright/create-article-keyboard-shortcut.spec.ts` with per-test `confluence` annotations
- data-test-id product additions where listed in the spec header (needs developer eyes)

### Steps to test
GIVEN the Sports desk monitoring view WHEN Ctrl+M creates an article, fields are typed, Close is pressed and the "Save changes?" prompt is answered with Ignore THEN the article that the shortcut had already persisted to `archive` is deleted again (`archive/<id>` goes 200 -> 404), which is checked directly because a version-0 stub never appears in any monitoring or search list.

GIVEN a Ctrl+M article that has been filled in, saved, edited again and closed with the prompt's Save WHEN global search is queried for it THEN the reloaded results list shows it once the search index catches up, the item is listed in Sports monitoring, it reopens by double-click with slugline, headline, edited abstract and body intact, and closing it with the Close button raises no "Save changes?" prompt.

Run it: `cd e2e/client && npx playwright test create-article-keyboard-shortcut.spec.ts`
The spec(s) passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
