### PR TITLE
Automate Edit item in new window (1311835229)

### DIFF
--- a/e2e/client/playwright/edit-item-in-new-window.spec.ts
+++ b/e2e/client/playwright/edit-item-in-new-window.spec.ts
@@ -1,0 +1,212 @@
+import {test, expect, type Page, type Locator} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+import {setEditor3FieldValue} from './utils/editor3';
+
+/**
+ * QA case "Edit item in new window" (1311835229).
+ *
+ * The monitoring 3-dot menu offers "Edit in new Window", which opens the article
+ * for editing in a second browser window. The item is locked while that window is
+ * open, closing with unsaved changes raises the Ignore/Cancel/Save prompt, and the
+ * saved values survive a reopen.
+ *
+ * Not covered:
+ * - Step 6 repeats the whole flow for image, audio and video items. The `main`
+ *   snapshot's archive holds text and composite items only, so no media item is
+ *   reachable; covering it needs a media fixture in the snapshot.
+ *
+ * Wording note: the case calls the action "Edit in new window"; the product label
+ * is "Edit in new Window" (`edit.item.popup` in apps/authoring/authoring/index.ts),
+ * which is what the assertions use.
+ */
+
+// Every test here restores the snapshot and then loads the whole client a second
+// time in the popup window. That takes about 10s on an idle machine but has been
+// measured past the 30s default with other e2e instances competing for the host.
+test.setTimeout(60000);
+
+test.describe('editing an item in a new window', () => {
+    const ARTICLE = 'test sports story';
+    const ACTION_LABEL = 'Edit in new Window';
+
+    async function openMonitoring(page: Page): Promise<Monitoring> {
+        const monitoring = new Monitoring(page);
+
+        await page.goto('/#/workspace/monitoring');
+        await monitoring.selectDeskOrWorkspace('Sports');
+
+        const item = monitoring.getArticleLocator(ARTICLE);
+
+        // The list is filled asynchronously after the snapshot restore, so wait for
+        // the item before any caller hovers or double clicks it.
+        await expect(item).toBeVisible();
+
+        return monitoring;
+    }
+
+    /**
+     * Runs the documented entry point (3-dot menu > "Edit in new Window") and returns
+     * the window it opens, once the article is editable in it.
+     */
+    async function editInNewWindow(page: Page, monitoring: Monitoring): Promise<Page> {
+        const menu = await monitoring.openArticleActionsMenu(monitoring.getArticleLocator(ARTICLE));
+        const action = menu.getByRole('button', {name: ACTION_LABEL, exact: true});
+
+        await expect(action).toBeVisible();
+
+        const [popup] = await Promise.all([
+            page.waitForEvent('popup'),
+            action.click(),
+        ]);
+
+        // The popup boots the client from scratch, which outlasts the 15s default.
+        await expect(popup.getByTestId('authoring')).toBeVisible({timeout: 30000});
+
+        // The topbar Save button is rendered only when the action is 'edit' (or a
+        // correction) and only shown while the item is editable, so its presence is
+        // what separates an edit window from the read-only "Open in new Window" one.
+        await expect(popup.getByTestId('authoring-topbar').getByTestId('save')).toBeVisible();
+
+        return popup;
+    }
+
+    function slugline(authoringPage: Page): Locator {
+        return authoringPage.getByTestId('authoring').getByTestId('field-slugline');
+    }
+
+    function body(authoringPage: Page): Locator {
+        return authoringPage.getByTestId('authoring')
+            .getByTestId('authoring-field')
+            .and(authoringPage.locator('[data-test-value="body_html"]'));
+    }
+
+    /**
+     * The popup closes itself through `window.close()` (AuthoringWorkspaceService.close
+     * does that whenever `$rootScope.popup` is set), and the close path only reaches it
+     * once its own requests have resolved: save or autosave-discard, then unlock.
+     * Waiting for the window to be gone is therefore the sync point for those writes.
+     */
+    async function expectWindowClosed(popup: Page): Promise<void> {
+        await expect.poll(() => popup.isClosed(), {timeout: 30000}).toBe(true);
+    }
+
+    /**
+     * Reopens the article in the window that started the flow. The lock indicator
+     * clearing is what tells us this window has processed the popup's unlock, so the
+     * reopen reads the item after the close finished rather than mid-flight.
+     */
+    async function reopenInOpener(page: Page, monitoring: Monitoring): Promise<void> {
+        const item = monitoring.getArticleLocator(ARTICLE);
+
+        await expect(item).toBeVisible();
+        await expect(item.getByTestId('article-item-locked')).toHaveCount(0);
+
+        await item.dblclick();
+        await expect(page.getByTestId('authoring-topbar').getByTestId('save')).toBeVisible();
+    }
+
+    test('opens the article for editing in a second window and locks it in the list; Cancel returns'
+        + ' to the article and Ignore discards the changes', {
+        annotation: [
+            {type: 'confluence', description: '1311835229 partial'}, // Edit item in new window
+        ],
+    }, async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const monitoring = await openMonitoring(page);
+        const popup = await editInNewWindow(page, monitoring);
+        const item = monitoring.getArticleLocator(ARTICLE);
+
+        await expect(item).toBeVisible();
+        await expect(item.getByTestId('article-item-locked')).toHaveCount(1);
+
+        await expect(slugline(popup)).toHaveValue(ARTICLE);
+        await slugline(popup).fill('edited in new window');
+
+        const topbar = popup.getByTestId('authoring-topbar');
+        const prompt = popup.getByTestId('unsaved-changes-dialog');
+
+        await topbar.getByTestId('close').click();
+        await expect(prompt).toBeVisible();
+
+        await prompt.getByRole('button', {name: 'Cancel', exact: true}).click();
+        await expect(prompt).toBeHidden();
+        await expect(popup.getByTestId('authoring')).toBeVisible();
+        await expect(slugline(popup)).toHaveValue('edited in new window');
+
+        await topbar.getByTestId('close').click();
+        await expect(prompt).toBeVisible();
+
+        await prompt.getByRole('button', {name: 'Ignore', exact: true}).click();
+        await expectWindowClosed(popup);
+
+        await reopenInOpener(page, monitoring);
+        await expect(slugline(page)).toHaveValue(ARTICLE);
+    });
+
+    test('Save keeps the article open with Save inactive, Close then closes the window and the'
+        + ' saved values survive a reopen', {
+        annotation: [
+            {type: 'confluence', description: '1311835229 partial'}, // Edit item in new window
+        ],
+    }, async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const monitoring = await openMonitoring(page);
+        const popup = await editInNewWindow(page, monitoring);
+
+        const topbar = popup.getByTestId('authoring-topbar');
+        const save = topbar.getByTestId('save');
+
+        await slugline(popup).fill('saved in new window');
+        await setEditor3FieldValue(body(popup).getByRole('textbox'), 'body edited in the new window');
+
+        await expect(save).toBeEnabled();
+
+        const [saveResponse] = await Promise.all([
+            popup.waitForResponse((response) => /\/api\/archive\/[^/]+$/.test(response.url())
+                && response.request().method() === 'PATCH'),
+            save.click(),
+        ]);
+
+        expect(saveResponse.status()).toBe(200);
+
+        await expect(popup.getByTestId('authoring')).toBeVisible();
+        await expect(save).toBeDisabled();
+
+        await topbar.getByTestId('close').click();
+        await expectWindowClosed(popup);
+
+        await reopenInOpener(page, monitoring);
+        await expect(slugline(page)).toHaveValue('saved in new window');
+
+        // editor3 renders its content a beat after the topbar is up, so this needs a
+        // retrying assertion rather than a one-shot read of the field's paragraphs.
+        await expect(body(page)).toContainText('body edited in the new window');
+    });
+
+    test('the unsaved changes prompt saves and closes the article when Save is chosen', {
+        annotation: [
+            {type: 'confluence', description: '1311835229 partial'}, // Edit item in new window
+        ],
+    }, async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const monitoring = await openMonitoring(page);
+        const popup = await editInNewWindow(page, monitoring);
+
+        await slugline(popup).fill('saved from the prompt');
+
+        const prompt = popup.getByTestId('unsaved-changes-dialog');
+
+        await popup.getByTestId('authoring-topbar').getByTestId('close').click();
+        await expect(prompt).toBeVisible();
+
+        await prompt.getByRole('button', {name: 'Save', exact: true}).click();
+        await expectWindowClosed(popup);
+
+        await reopenInOpener(page, monitoring);
+        await expect(slugline(page)).toHaveValue('saved from the prompt');
+    });
+});

--- a/e2e/client/playwright/page-object-models/monitoring.ts
+++ b/e2e/client/playwright/page-object-models/monitoring.ts
@@ -26,6 +26,21 @@ export class Monitoring {
     }
 
     /**
+     * Opens the 3-dot menu for an article and returns it, for tests that assert on
+     * which actions are offered instead of executing one.
+     */
+    async openArticleActionsMenu(item: Locator): Promise<Locator> {
+        await item.hover();
+        await item.getByTestId('context-menu-button').click();
+
+        const menu = this.page.getByTestId('context-menu');
+
+        await expect(menu).toBeVisible();
+
+        return menu;
+    }
+
+    /**
      * opens 3-dot menu for an article and clicks on an action(supports nested actions)
      */
     async executeActionOnMonitoringItem(item: Locator, ...actionPath: Array<string>): Promise<void> {

--- a/scripts/apps/search/components/Item.tsx
+++ b/scripts/apps/search/components/Item.tsx
@@ -484,6 +484,7 @@ export class Item extends React.Component<IProps, IState> {
             },
             (
                 <div
+                    data-test-id={isLocked ? 'article-item-locked' : undefined}
                     className={classNames(classes, {
                         active: itemSelected,
                         locked: isLocked,


### PR DESCRIPTION
### Purpose
Automates the following QA case(s) as Playwright spec(s) so they run in CI instead of being tested by hand:
- [Edit item in new window](https://sofab.atlassian.net/wiki/spaces/SET/pages/1311835229)

Annotation levels: 1311835229: partial

### What has changed
- New spec(s): `e2e/client/playwright/edit-item-in-new-window.spec.ts` with per-test `confluence` annotations
- data-test-id product additions where listed in the spec header (needs developer eyes)

Fixture gaps recorded for the backlog (uncovered scenarios carry named blockers in the spec header):
- media-items snapshot (image/audio/video archive items) — the `main` snapshot's archive holds only text and composite items, so step 6 of the case (repeat the flow for image, audio and video) is unreachable on this base. Such a snapshot exists on origin/hg/add-e2e-media-and-user-fixtures (e2e/server/dump/records/media-items.json.bz2) but is not on develop, which is this branch's base per the SETUP instructions.

### Steps to test
**Scenario A — opening in a new window, and the Cancel / Ignore branches of the unsaved-changes prompt**

**Given** the `main` snapshot is restored and Sports monitoring is open with "test sports story" listed

**When**
1. the article's 3-dot menu is opened and "Edit in new Window" is chosen
2. the slugline is changed in the new window and Close is clicked
3. Cancel is chosen in the prompt
4. Close is clicked again and Ignore is chosen
5. the article is reopened in the original window

**Then**
- the action menu is displayed and offers "Edit in new Window"
- a second window opens with the article in authoring and a topbar Save button (i.e. opened for editing, not read-only)
- the item in the original window's list carries the locked marker (`article-item-locked`, the red stripe)
- Close raises the "Save changes?" prompt
- Cancel dismisses the prompt and leaves the article open with the edited slugline still in the field
- Ignore closes the window
- the reopened article shows the original slugline, so the change was not saved

**Scenario B — topbar Save keeps the article open, Close then closes the window, values persist**

**Given** the `main` snapshot is restored and "test sports story" has been opened with "Edit in new Window"

**When**
1. the slugline and the body field are changed
2. the topbar Save button is clicked
3. Close is clicked
4. the article is reopened in the original window

**Then**
- Save is enabled before the click and the `PATCH /api/archive/<id>` returns 200
- the article stays open in the new window and Save is disabled afterwards
- Close closes the window without raising the prompt
- the reopened article carries the new slugline and the new body text

**Scenario C — the unsaved-changes prompt's Save**

**Given** the `main` snapshot is restored and "test sports story" has been opened with "Edit in new Window"

**When**
1. the slugline is changed and Close is clicked
2. Save is chosen in the prompt
3. the article is reopened in the original window

**Then**
- the prompt is displayed
- Save closes the window
- the reopened article carries the new slugline, so the change was saved

Run it: `cd e2e/client && npx playwright test edit-item-in-new-window.spec.ts`
The spec(s) passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
