### PR TITLE
Automate the Monitoring settings Items count and Reorder sections tab cases

### DIFF
--- a/e2e/client/playwright/monitoring.settings.desk-tabs.spec.ts
+++ b/e2e/client/playwright/monitoring.settings.desk-tabs.spec.ts
@@ -1,0 +1,302 @@
+import {test, expect, Locator, Page} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {MonitoringSettings} from './page-object-models/monitoring-settings';
+import {restoreDatabaseSnapshot} from './utils';
+
+/**
+ * The "Reorder sections" (confluence 1315934717) and "Items count" (confluence 1315934719) tabs
+ * of a desk's Monitoring settings. Both cases open the same wizard from the desk card's 3-dot
+ * menu on `/#/settings/desks` and share their first two expected results (the actions menu and
+ * the list of tabs) plus the Previous / Next / Cancel / Done behaviour, so those are asserted
+ * once in a test annotated with both case ids.
+ *
+ * The custom-workspace entry point to the same wizard belongs to other cases and is covered by
+ * `monitoring.settings.custom-workspace.spec.ts`; the desk's Saved searches tab by
+ * `monitoring.settings.spec.ts`. Only the desk variant writes `monitoring_settings` on the desk
+ * itself (`AggregateSettings.save()`); the other two entry points write a user preference or a
+ * dashboard widget's configuration.
+ *
+ * Wording: the cases name the tabs "Saved searches", "Reorder sections" and "Items count"; the
+ * product renders them title-cased ("Saved Searches", "Reorder Sections", "Items Count") and
+ * those are the strings asserted here.
+ *
+ * Behaviour, 1315934719 expected result 4.1: the case reads the number field as "the maximum
+ * items count", but the product does not cap how many items a group holds. `MonitoringGroup.ts`
+ * queries `PAGE_SIZE` (25) items whatever the setting is and spends `max_items` on the group's
+ * `maxHeight` instead, so the setting is how many items are visible before the group scrolls.
+ * That is what the assertions below check.
+ *
+ * Not covered, 1315934719 expected result 4.3 ("up and down arrows are displayed when hovering
+ * over the number field"): the spinner of an `<input type="number">` is drawn by Chromium in the
+ * user-agent shadow DOM, so it has no node and no computed style a spec can reach, and visual
+ * snapshots are not used in this suite. What the arrows do (expected result 4.4) is asserted by
+ * stepping the field with ArrowUp / ArrowDown, which runs the same `stepUp` / `stepDown`.
+ */
+
+test.setTimeout(60000);
+
+const DESK = 'Sports';
+const SAVED_SEARCH = 'Malaysia';
+
+const WORKING_STAGE = `${DESK} : Working Stage`;
+const INCOMING_STAGE = `${DESK} : Incoming Stage`;
+const DESK_OUTPUT = `${DESK} : Desk Output`;
+
+/** `data-test-value` of the monitoring groups the sections above map to in the Monitoring view. */
+const WORKING_STAGE_GROUP = `${DESK} / Working Stage`;
+const INCOMING_STAGE_GROUP = `${DESK} / Incoming Stage`;
+const DESK_OUTPUT_GROUP = `${DESK} desk output`;
+
+/** Sports / Working Stage holds this many unspiked items in the `main` snapshot. */
+const WORKING_STAGE_ITEMS = 4;
+
+/**
+ * Height of one list row in pixels, `ITEM_HEIGHT` in
+ * `scripts/apps/monitoring/directives/MonitoringGroup.ts`. It is what the group multiplies the
+ * Items count setting by to get its `maxHeight`. Single-line lists use 29 instead, which needs
+ * `appConfig.list.singleLine`; `superdesk.config.js` does not set it.
+ */
+const ITEM_HEIGHT = 57;
+
+/** `defaultMaxItems` in `scripts/apps/monitoring/controllers/AggregateCtrl.ts`. */
+const DEFAULT_MAX_ITEMS = 10;
+
+function monitoringGroup(page: Page, testValue: string): Locator {
+    return page
+        .getByTestId('monitoring-view')
+        .getByTestId('monitoring-group')
+        .and(page.locator(`[data-test-value="${testValue}"]`));
+}
+
+function monitoringGroups(page: Page): Locator {
+    return page.getByTestId('monitoring-view').getByTestId('monitoring-group');
+}
+
+async function expectMonitoringGroupOrder(page: Page, testValues: Array<string>): Promise<void> {
+    const groups = monitoringGroups(page);
+
+    await expect(groups).toHaveCount(testValues.length);
+    await expect
+        .poll(() => groups.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-test-value'))))
+        .toEqual(testValues);
+}
+
+/**
+ * Enables a global saved search so the Reorder sections and Items count tabs list a saved search
+ * next to the desk stages. Only global searches are offered here: the wizard sets
+ * `showPrivateSavedSearches` from the active workspace type, and a desk is not a custom workspace
+ * (`AggregateSettings.ts`).
+ */
+async function enableSavedSearch(settings: MonitoringSettings, name: string): Promise<void> {
+    await settings.goToTab('Saved Searches');
+
+    const toggle = settings.savedSearchToggle(settings.globalSavedSearches, name);
+
+    await toggle.click();
+    await expect(toggle).toHaveClass(/checked/);
+}
+
+async function openMonitoringView(page: Page): Promise<void> {
+    await page.goto('/#/workspace/monitoring');
+
+    // Superdesk routes on the URL fragment, so arriving from the settings page never reboots the
+    // Angular app and the monitoring view can be built from a desk that the just-saved
+    // `monitoring_settings` have not reached yet. Reloading starts the app fresh.
+    await page.reload();
+
+    await new Monitoring(page).selectDeskOrWorkspace(DESK);
+}
+
+test('desk actions offer Monitoring settings and the wizard opens on the Desks tab', {
+    annotation: [
+        // Items count tab in Monitoring settings
+        {type: 'confluence', description: '1315934719 partial'},
+        // Reorder sections tab in Monitoring settings
+        {type: 'confluence', description: '1315934717 complete'},
+    ],
+}, async ({page}) => {
+    const settings = new MonitoringSettings(page);
+
+    await restoreDatabaseSnapshot();
+    await page.goto('/#/settings/desks');
+
+    await expect(settings.deskCard(DESK)).toBeVisible();
+    await expect(settings.deskCard('Finance')).toBeVisible();
+
+    const actions = await settings.openDeskActions(DESK);
+
+    await expect(actions.getByTestId('desk-actions--edit')).toBeVisible();
+    await expect(actions.getByTestId('desk-actions--monitoring-settings')).toBeVisible();
+    await expect(actions.getByTestId('desk-actions--remove')).toBeVisible();
+    await expect(actions.getByRole('button')).toHaveCount(3);
+
+    await actions.getByTestId('desk-actions--monitoring-settings').click();
+    await expect(settings.modal).toBeVisible();
+
+    await expect(settings.tabs).toHaveText(['Desks', 'Saved Searches', 'Reorder Sections', 'Items Count']);
+    await settings.expectActiveTab('Desks');
+});
+
+test('Previous and Next walk the tabs, are hidden at the ends and keep pending edits', {
+    annotation: [
+        {type: 'confluence', description: '1315934719 partial'},
+        {type: 'confluence', description: '1315934717 complete'},
+    ],
+}, async ({page}) => {
+    const settings = new MonitoringSettings(page);
+
+    await restoreDatabaseSnapshot();
+    await settings.openForDesk(DESK);
+
+    await settings.expectActiveTab('Desks');
+    await expect(settings.previousButton).toBeHidden();
+    await expect(settings.nextButton).toBeVisible();
+
+    await settings.nextButton.click();
+    await settings.expectActiveTab('Saved Searches');
+    await expect(settings.previousButton).toBeVisible();
+
+    await settings.nextButton.click();
+    await settings.expectActiveTab('Reorder Sections');
+    await expect(settings.previousButton).toBeVisible();
+    await expect(settings.nextButton).toBeVisible();
+
+    await settings.dragSectionOnto(DESK_OUTPUT, WORKING_STAGE);
+    await expect(settings.reorderSections)
+        .toHaveText([DESK_OUTPUT, WORKING_STAGE, INCOMING_STAGE]);
+
+    await settings.nextButton.click();
+    await settings.expectActiveTab('Items Count');
+    await expect(settings.nextButton).toBeHidden();
+    await expect(settings.previousButton).toBeVisible();
+
+    await settings.setMaxItems(WORKING_STAGE, 7);
+
+    await settings.previousButton.click();
+    await settings.expectActiveTab('Reorder Sections');
+    await expect(settings.reorderSections)
+        .toHaveText([DESK_OUTPUT, WORKING_STAGE, INCOMING_STAGE]);
+
+    await settings.nextButton.click();
+    await settings.expectActiveTab('Items Count');
+    await expect(settings.maxItemsInput(WORKING_STAGE)).toHaveValue('7');
+
+    await settings.tab('Desks').click();
+    await settings.expectActiveTab('Desks');
+    await expect(settings.previousButton).toBeHidden();
+});
+
+test('Reorder sections tab lists the active sections and drag and drop reorders the view', {
+    annotation: [
+        {type: 'confluence', description: '1315934717 complete'},
+    ],
+}, async ({page}) => {
+    const settings = new MonitoringSettings(page);
+
+    await restoreDatabaseSnapshot();
+    await settings.openForDesk(DESK);
+
+    await enableSavedSearch(settings, SAVED_SEARCH);
+
+    await settings.goToTab('Reorder Sections');
+    await expect(settings.reorderSections)
+        .toHaveText([WORKING_STAGE, INCOMING_STAGE, DESK_OUTPUT, SAVED_SEARCH]);
+
+    await settings.dragSectionOnto(SAVED_SEARCH, WORKING_STAGE);
+    await expect(settings.reorderSections)
+        .toHaveText([SAVED_SEARCH, WORKING_STAGE, INCOMING_STAGE, DESK_OUTPUT]);
+
+    await settings.closeWithDoneOnDesk();
+
+    await openMonitoringView(page);
+    await expectMonitoringGroupOrder(page, [
+        SAVED_SEARCH,
+        WORKING_STAGE_GROUP,
+        INCOMING_STAGE_GROUP,
+        DESK_OUTPUT_GROUP,
+    ]);
+});
+
+test('Items count tab sets how many items a monitoring group shows before it scrolls', {
+    annotation: [
+        {type: 'confluence', description: '1315934719 partial'},
+    ],
+}, async ({page}) => {
+    const settings = new MonitoringSettings(page);
+
+    await restoreDatabaseSnapshot();
+
+    await openMonitoringView(page);
+
+    const workingStageItems = monitoringGroup(page, WORKING_STAGE_GROUP).getByTestId('article-item');
+    const workingStageViewport = monitoringGroup(page, WORKING_STAGE_GROUP).getByTestId('item-list-viewport');
+
+    await expect(workingStageItems).toHaveCount(WORKING_STAGE_ITEMS);
+    await expect(workingStageViewport).toHaveCSS('max-height', `${DEFAULT_MAX_ITEMS * ITEM_HEIGHT}px`);
+
+    await settings.openForDesk(DESK);
+    await enableSavedSearch(settings, SAVED_SEARCH);
+
+    await settings.goToTab('Items Count');
+    await expect(settings.itemsCountSections)
+        .toHaveText([WORKING_STAGE, INCOMING_STAGE, DESK_OUTPUT, SAVED_SEARCH]);
+
+    const workingStageMax = settings.maxItemsInput(WORKING_STAGE);
+
+    await expect(workingStageMax).toHaveAttribute('type', 'number');
+    await expect(workingStageMax).toHaveAttribute('min', '1');
+    await expect(workingStageMax).toHaveAttribute('max', '25');
+    await expect(workingStageMax).toHaveValue(String(DEFAULT_MAX_ITEMS));
+    await expect(settings.maxItemsInput(SAVED_SEARCH)).toHaveValue(String(DEFAULT_MAX_ITEMS));
+
+    // the spinner arrows are not reachable from the DOM; the keyboard runs the same stepUp/stepDown
+    await workingStageMax.press('ArrowUp');
+    await expect(workingStageMax).toHaveValue('11');
+    await workingStageMax.press('ArrowDown');
+    await workingStageMax.press('ArrowDown');
+    await expect(workingStageMax).toHaveValue('9');
+
+    await settings.setMaxItems(WORKING_STAGE, 2);
+    await settings.setMaxItems(SAVED_SEARCH, 3);
+
+    await settings.closeWithDoneOnDesk();
+
+    await openMonitoringView(page);
+    await expect(workingStageViewport).toHaveCSS('max-height', `${2 * ITEM_HEIGHT}px`);
+    await expect(monitoringGroup(page, SAVED_SEARCH).getByTestId('item-list-viewport'))
+        .toHaveCSS('max-height', `${3 * ITEM_HEIGHT}px`);
+
+    // the setting sizes the group, it does not shrink the result set the group scrolls through
+    await expect(workingStageItems).toHaveCount(WORKING_STAGE_ITEMS);
+});
+
+test('Cancel closes the wizard and discards both the order and the items count', {
+    annotation: [
+        {type: 'confluence', description: '1315934719 partial'},
+        {type: 'confluence', description: '1315934717 complete'},
+    ],
+}, async ({page}) => {
+    const settings = new MonitoringSettings(page);
+
+    await restoreDatabaseSnapshot();
+    await settings.openForDesk(DESK);
+
+    await settings.goToTab('Reorder Sections');
+    await settings.dragSectionOnto(DESK_OUTPUT, WORKING_STAGE);
+    await expect(settings.reorderSections)
+        .toHaveText([DESK_OUTPUT, WORKING_STAGE, INCOMING_STAGE]);
+
+    await settings.goToTab('Items Count');
+    await settings.setMaxItems(WORKING_STAGE, 2);
+
+    await settings.closeWithCancel();
+
+    await settings.openForDesk(DESK);
+
+    await settings.goToTab('Reorder Sections');
+    await expect(settings.reorderSections)
+        .toHaveText([WORKING_STAGE, INCOMING_STAGE, DESK_OUTPUT]);
+
+    await settings.goToTab('Items Count');
+    await expect(settings.maxItemsInput(WORKING_STAGE)).toHaveValue(String(DEFAULT_MAX_ITEMS));
+});

--- a/e2e/client/playwright/monitoring.settings.desk-tabs.spec.ts
+++ b/e2e/client/playwright/monitoring.settings.desk-tabs.spec.ts
@@ -47,7 +47,10 @@ const WORKING_STAGE_GROUP = `${DESK} / Working Stage`;
 const INCOMING_STAGE_GROUP = `${DESK} / Incoming Stage`;
 const DESK_OUTPUT_GROUP = `${DESK} desk output`;
 
-/** Sports / Working Stage holds this many unspiked items in the `main` snapshot. */
+/**
+ * Number of items the Sports / Working Stage group lists in the `main` snapshot. The stage holds
+ * more than this in `archive`; its spiked, published and draft items are not listed.
+ */
 const WORKING_STAGE_ITEMS = 4;
 
 /**

--- a/e2e/client/playwright/page-object-models/monitoring-settings.ts
+++ b/e2e/client/playwright/page-object-models/monitoring-settings.ts
@@ -1,0 +1,250 @@
+import {Locator, Page, expect} from '@playwright/test';
+
+export type IMonitoringSettingsTab = 'Desks' | 'Saved Searches' | 'Reorder Sections' | 'Items Count';
+
+/** `PREFERENCES_KEY` in `scripts/apps/monitoring/directives/AggregateSettings.ts`. */
+const MONITORING_PREFERENCE_KEY = 'agg:view';
+
+/**
+ * Drives the "Monitoring settings" wizard modal
+ * (`scripts/apps/monitoring/views/aggregate-settings.html`).
+ *
+ * The same template backs the desk variant reached from `/#/settings/desks` and the
+ * workspace variant reached from the monitoring toolbar, so the modal's test id reads
+ * `desk--monitoring-settings` in both cases.
+ */
+export class MonitoringSettings {
+    private page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    get modal(): Locator {
+        return this.page.getByTestId('desk--monitoring-settings');
+    }
+
+    /**
+     * Opens the wizard from the monitoring toolbar. The toolbar button only renders while a
+     * custom workspace is selected; desks configure monitoring from the desk settings page.
+     */
+    async open(): Promise<void> {
+        await this.page.getByTestId('monitoring-settings-button').click();
+        await expect(this.modal).toBeVisible();
+    }
+
+    deskCard(deskName: string): Locator {
+        return this.page.getByTestId(`desk--${deskName}`);
+    }
+
+    /** Opens a desk card's 3-dot menu on `/#/settings/desks` and returns the menu itself. */
+    async openDeskActions(deskName: string): Promise<Locator> {
+        const card = this.deskCard(deskName);
+
+        await card.getByTestId('desk-actions').click();
+
+        const actions = card.getByTestId('desk-actions--options');
+
+        await expect(actions).toBeVisible();
+
+        return actions;
+    }
+
+    /**
+     * Opens the wizard for a desk from `/#/settings/desks`, the only entry point a desk has:
+     * `openMonitoringSettings` in `DeskConfigController.ts` is what sets `settings.desk`, which
+     * is what makes `save()` write the desk's `monitoring_settings` instead of a user preference.
+     *
+     * That handler assigns into `agg.settings`, which `AggregateCtrl` only creates once its own
+     * init chain (desks, saved searches, settings) has resolved. A click landing before that
+     * throws a TypeError inside Angular and no modal opens, and nothing in the DOM marks the
+     * controller as ready, so the open is retried until it takes.
+     */
+    async openForDesk(deskName: string): Promise<void> {
+        await this.page.goto('/#/settings/desks');
+
+        const actions = this.deskCard(deskName).getByTestId('desk-actions--options');
+
+        await expect(async () => {
+            if (!await actions.isVisible()) {
+                await this.deskCard(deskName).getByTestId('desk-actions').click();
+            }
+
+            await actions.getByTestId('desk-actions--monitoring-settings').click();
+            await expect(this.modal).toBeVisible({timeout: 3000});
+        }).toPass({timeout: 20000, intervals: [500]});
+    }
+
+    tab(title: IMonitoringSettingsTab): Locator {
+        return this.modal.getByTestId(`wizard--${title}`);
+    }
+
+    /**
+     * The wizard marks the selected step on the `<li>` wrapping the tab button
+     * (`template/wizard.html` in superdesk-ui-framework); the button itself carries no state,
+     * and the template lives in a dependency so it cannot get a test id of its own.
+     *
+     * The `has` locator is resolved inside each `<li>`, so it must start at the page root
+     * rather than reuse `tab()`, which is already scoped to the modal.
+     */
+    tabWrapper(title: IMonitoringSettingsTab): Locator {
+        return this.modal
+            .locator('li.nav-tabs__tab')
+            .filter({has: this.page.getByTestId(`wizard--${title}`)});
+    }
+
+    /** Every tab in the order the wizard renders them, for asserting the set and its order. */
+    get tabs(): Locator {
+        return this.modal.locator('li.nav-tabs__tab');
+    }
+
+    async expectActiveTab(title: IMonitoringSettingsTab): Promise<void> {
+        await expect(this.tabWrapper(title)).toHaveClass(/nav-tabs__tab--active/);
+    }
+
+    async goToTab(title: IMonitoringSettingsTab): Promise<void> {
+        await this.tab(title).click();
+        await this.expectActiveTab(title);
+    }
+
+    get previousButton(): Locator {
+        return this.modal.getByTestId('footer').getByTestId('previous');
+    }
+
+    get nextButton(): Locator {
+        return this.modal.getByTestId('footer').getByTestId('next');
+    }
+
+    get cancelButton(): Locator {
+        return this.modal.getByTestId('footer').getByTestId('cancel');
+    }
+
+    get doneButton(): Locator {
+        return this.modal.getByTestId('footer').getByTestId('done');
+    }
+
+    get globalSavedSearches(): Locator {
+        return this.modal.getByTestId('global-saved-searches');
+    }
+
+    get privateSavedSearches(): Locator {
+        return this.modal.getByTestId('private-saved-searches');
+    }
+
+    /**
+     * `sd-toggle-box` renders a React box whose header is the only element that toggles it;
+     * it comes from superdesk-ui-framework, so it is reachable by class only.
+     */
+    toggleBoxHeader(toggleBox: Locator): Locator {
+        return toggleBox.locator('.toggle-box__header');
+    }
+
+    savedSearch(toggleBox: Locator, name: string): Locator {
+        return toggleBox.getByTestId('saved-search').filter({hasText: name});
+    }
+
+    /**
+     * `sd-switch` replaces its element with `<span class="sd-toggle">` and reflects the ON
+     * state as a `checked` class on that span (`app/scripts/switch.js` in
+     * superdesk-ui-framework).
+     */
+    savedSearchToggle(toggleBox: Locator, name: string): Locator {
+        return this.savedSearch(toggleBox, name).getByTestId('toggle');
+    }
+
+    /**
+     * On a workspace the wizard closes the modal without waiting for the write it started:
+     * `AggregateSettings.save()` calls `onclose()` synchronously while `preferencesService.update()`
+     * is still only scheduled on `$applyAsync`. Anything that leaves the page right after the modal
+     * disappears can therefore cancel the PATCH and drop the configuration, so wait for the write.
+     */
+    async closeWithDone(): Promise<void> {
+        await Promise.all([
+            this.page.waitForResponse((response) => response.url().includes('/preferences/')
+                && response.request().method() === 'PATCH'
+                && (response.request().postData() ?? '').includes(MONITORING_PREFERENCE_KEY)),
+            this.doneButton.click(),
+        ]);
+
+        await expect(this.modal).not.toBeVisible();
+    }
+
+    async closeWithCancel(): Promise<void> {
+        await this.cancelButton.click();
+        await expect(this.modal).not.toBeVisible();
+    }
+
+    /**
+     * Done on a desk's monitoring settings PATCHes the desk
+     * (`AggregateSettings.save()` -> `desks.save(desk, {monitoring_settings})`) and only finishes
+     * the wizard once that write resolves, so a failed save leaves the modal open with nothing
+     * naming the cause. Waiting for the response reports the status instead.
+     *
+     * The predicate matches URL and method only; adding `response.ok()` to it would leave a
+     * failed save unmatched and turn the failure into an opaque `waitForResponse` timeout.
+     */
+    async closeWithDoneOnDesk(): Promise<void> {
+        const [response] = await Promise.all([
+            this.page.waitForResponse((res) => /\/desks\/[^/]+$/.test(res.url())
+                && res.request().method() === 'PATCH'),
+            this.doneButton.click(),
+        ]);
+
+        expect(response.ok(), `saving the desk monitoring settings failed with ${response.status()}`).toBe(true);
+        await expect(this.modal).not.toBeVisible();
+    }
+
+    get reorderSections(): Locator {
+        return this.modal.getByTestId('reorder-sections').getByTestId('reorder-section');
+    }
+
+    reorderSection(label: string): Locator {
+        return this.reorderSections.filter({hasText: label});
+    }
+
+    /**
+     * Reorders the list by dragging one section onto another.
+     *
+     * The list is a jQuery UI sortable (`SortGroups.ts`), which only reacts to raw mouse events:
+     * it starts a drag once the pointer passes its distance threshold and, under
+     * `tolerance: 'pointer'`, moves the placeholder as the pointer crosses another item.
+     * `locator.dragTo()` sends too few moves for either, so the drag is driven by hand and aimed
+     * at the target's far edge so the dragged item lands past it rather than on top of it.
+     */
+    async dragSectionOnto(sourceLabel: string, targetLabel: string): Promise<void> {
+        const sourceBox = await this.reorderSection(sourceLabel).boundingBox();
+        const targetBox = await this.reorderSection(targetLabel).boundingBox();
+
+        if (sourceBox == null || targetBox == null) {
+            throw new Error(`cannot drag "${sourceLabel}" onto "${targetLabel}": a section is not rendered`);
+        }
+
+        const x = sourceBox.x + sourceBox.width / 2;
+        const movingDown = targetBox.y > sourceBox.y;
+        const targetY = movingDown ? targetBox.y + targetBox.height - 1 : targetBox.y + 1;
+
+        await this.page.mouse.move(x, sourceBox.y + sourceBox.height / 2);
+        await this.page.mouse.down();
+        await this.page.mouse.move(x, targetY, {steps: 20});
+        await this.page.mouse.up();
+    }
+
+    get itemsCountSections(): Locator {
+        return this.modal.getByTestId('items-count-sections').getByTestId('items-count-section');
+    }
+
+    itemsCountSection(label: string): Locator {
+        return this.itemsCountSections.filter({hasText: label});
+    }
+
+    maxItemsInput(label: string): Locator {
+        return this.itemsCountSection(label).getByTestId('max-items-input');
+    }
+
+    async setMaxItems(label: string, maxItems: number): Promise<void> {
+        const input = this.maxItemsInput(label);
+
+        await input.fill(String(maxItems));
+        await expect(input).toHaveValue(String(maxItems));
+    }
+}

--- a/scripts/apps/monitoring/views/aggregate-settings.html
+++ b/scripts/apps/monitoring/views/aggregate-settings.html
@@ -63,7 +63,7 @@
          data-hide="shouldHideStep('searches')">
         <div class="content">
             <div class="legend" translate>Select saved searches for view</div>
-            <div sd-toggle-box data-title="{{ :: 'Global saved searches' | translate}}" data-style="circle" data-open="true">
+            <div sd-toggle-box data-title="{{ :: 'Global saved searches' | translate}}" data-style="circle" data-open="true" data-test-id="global-saved-searches">
                 <div
                     class="desk"
                     ng-repeat="search in globalSavedSearches track by search._id | orderBy: 'name'"
@@ -86,11 +86,21 @@
                     </div>
                 </div>
             </div>
-            <div sd-toggle-box data-title="{{ :: 'Private saved searches' | translate}}" data-style="circle" data-open="true" ng-if="showPrivateSavedSearches">
-                <div class="desk" ng-repeat="search in privateSavedSearches track by search._id | orderBy: 'name'" ng-if="showPrivateSavedSearches">
+            <div sd-toggle-box data-title="{{ :: 'Private saved searches' | translate}}" data-style="circle" data-open="true" ng-if="showPrivateSavedSearches" data-test-id="private-saved-searches">
+                <div
+                    class="desk"
+                    ng-repeat="search in privateSavedSearches track by search._id | orderBy: 'name'"
+                    ng-if="showPrivateSavedSearches"
+                    data-test-id="saved-search"
+                >
                     <div class="desk-title desk-title--saved-search">
                         <div class="switch">
-                            <span sd-switch  ng-model="editGroups[search._id].selected" ng-click="setSearchInfo(search._id)"></span>
+                            <span
+                                sd-switch
+                                ng-model="editGroups[search._id].selected"
+                                ng-click="setSearchInfo(search._id)"
+                                data-test-id="toggle"
+                            ></span>
                         </div>
                         <div class="desk-title__text">
                             {{:: search.name}}
@@ -107,9 +117,9 @@
         <div class="content">
             <p class="legend" translate>Reorder stages and saved searches for monitoring view</p>
             <p translate>You are changing you personal preferences. If you would like to set the default order for the desk, you can do so from the settings page.</p>
-            <ul class="groups draggable-list" sd-sort-groups>
+            <ul class="groups draggable-list" sd-sort-groups data-test-id="reorder-sections">
                 <li class="sort-item draggable-list__item draggable-list__item--small" ng-class="{'active': item.order < columnsLimit}"
-                 ng-repeat="item in getValues() track by item.order">
+                 ng-repeat="item in getValues() track by item.order" data-test-id="reorder-section">
                     <div class="group-title" ng-if="item.type === 'stage'">
                         {{deskLookup[stageLookup[item._id].desk].name}} : <span>{{labelForStage(stageLookup[item._id])}}</span>
                     </div>
@@ -129,8 +139,8 @@
          data-hide="shouldHideStep('maxitems')">
         <div class="content">
             <div class="legend" translate>Set maximum items per stages and saved searches for view</div>
-            <div class="groups">
-                <div ng-repeat="max in getValues()" class="desk desk--item-count" >
+            <div class="groups" data-test-id="items-count-sections">
+                <div ng-repeat="max in getValues()" class="desk desk--item-count" data-test-id="items-count-section">
                     <div class="desk-title" ng-if="max.type === 'stage'">
                         {{deskLookup[stageLookup[max._id].desk].name}} : <span>{{labelForStage(stageLookup[max._id])}}</span>
                     </div>
@@ -142,7 +152,7 @@
                     </div>
                     <div class="desk-title" ng-if="max.type === 'personal'" translate>Personal</div>
                     <div class="box-items-count sd-line-input sd-line-input--no-margin sd-line-input--no-label sd-line-input--boxed">
-                        <input class="sd-line-input__input" type="number" id="maxItems" ng-model="max.max_items" min="1" max="25" required>
+                        <input class="sd-line-input__input" type="number" id="maxItems" ng-model="max.max_items" min="1" max="25" data-test-id="max-items-input" required>
                     </div>
                 </div>
             </div>
@@ -152,8 +162,8 @@
 </div>
 
 <div class="modal__footer" data-test-id="footer">
-    <button id="previousBtn" class="btn btn--hollow pull-left" ng-if="step.current !== 'desks' && !displayOnlyCurrentStep" ng-click="previous()" translate>Previous</button>
-    <button class="btn" ng-click="cancel()" translate>Cancel</button>
+    <button id="previousBtn" class="btn btn--hollow pull-left" ng-if="step.current !== 'desks' && !displayOnlyCurrentStep" ng-click="previous()" translate data-test-id="previous">Previous</button>
+    <button class="btn" ng-click="cancel()" translate data-test-id="cancel">Cancel</button>
     <button class="btn btn--primary" ng-click="save()" translate data-test-id="done">Done</button>
-    <button id="nextBtn" class="btn btn--hollow" ng-if="step.current !== 'maxitems' && !displayOnlyCurrentStep" ng-click="next()" translate>Next</button>
+    <button id="nextBtn" class="btn btn--hollow" ng-if="step.current !== 'maxitems' && !displayOnlyCurrentStep" ng-click="next()" translate data-test-id="next">Next</button>
 </div>

--- a/scripts/apps/search/components/ItemListAngularWrapper.tsx
+++ b/scripts/apps/search/components/ItemListAngularWrapper.tsx
@@ -270,7 +270,7 @@ export class ItemListAngularWrapper extends React.Component<IProps, IState> {
 
         return (
             <SmoothLoader loading={this.state.loading}>
-                <div style={style}>
+                <div style={style} data-test-id="item-list-viewport">
                     <ItemList
                         itemsList={this.state.itemsList}
                         itemsById={this.state.itemsById}


### PR DESCRIPTION
### Purpose
Automates the following QA case(s) as Playwright spec(s) so they run in CI instead of being tested by hand:
- [Items count tab in Monitoring settings](https://sofab.atlassian.net/wiki/spaces/SET/pages/1315934719)
- [Reorder sections tab in Monitoring settings](https://sofab.atlassian.net/wiki/spaces/SET/pages/1315934717)

Annotation levels: 1315934717: complete; 1315934719: partial

### What has changed
- New spec(s): `/Users/eos87/code/SourceFabric/Superdesk/Async/EndToEndTests/.worktrees/automate-monitoring-settings-tabs/e2e/client/playwright/monitoring.settings.desk-tabs.spec.ts` with per-test `confluence` annotations
- data-test-id product additions where listed in the spec header (needs developer eyes)

### Steps to test
**Scenario 1 - entry point and tab set** (1315934719, 1315934717)
**Given** the `main` snapshot and the Sports desk on `/#/settings/desks`
**When** the user
1. opens the desk card's 3-dot menu, and
2. clicks Monitoring settings
**Then**
- the menu holds exactly three buttons: Edit, Monitoring settings, Remove
- the wizard opens and its tabs read `Desks`, `Saved Searches`, `Reorder Sections`, `Items Count` in that order
- `Desks` is the active tab

**Scenario 2 - Previous / Next navigation and pending edits** (1315934719, 1315934717)
**Given** the wizard open on the Sports desk
**When** the user
1. walks Next from Desks to Saved Searches to Reorder Sections to Items Count,
2. drags a section on Reorder Sections and types 7 on Items Count,
3. steps back with Previous and forward again with Next, and
4. jumps to Desks by clicking the tab header
**Then**
- Previous is hidden on Desks and visible on every other tab; Next is visible everywhere except Items Count
- each click moves the active tab exactly one step left or right
- the dragged order and the typed 7 both survive leaving the tab and coming back

**Scenario 3 - Reorder sections tab** (1315934717)
**Given** the wizard open on the Sports desk with the global saved search "Malaysia" enabled
**When** the user
1. opens the Reorder Sections tab, and
2. drags "Malaysia" above "Sports : Working Stage", and
3. presses Done
**Then**
- the tab lists every active stage, the desk output and the saved search
- the list re-renders in the dragged order
- Done PATCHes the desk, closes the wizard, and the Monitoring view for Sports renders its groups in that same order

**Scenario 4 - Items count tab** (1315934719)
**Given** the Sports monitoring view showing its four Working Stage items in a group ten rows tall
**When** the user
1. opens Monitoring settings, enables "Malaysia", opens the Items Count tab,
2. steps the Working Stage field with ArrowUp / ArrowDown,
3. sets Working Stage to 2 and Malaysia to 3, and
4. presses Done
**Then**
- every stage, the desk output and the saved search each get a `number` field defaulting to 10, bounded 1..25
- stepping the field raises and lowers the value
- back on the Monitoring view each group is sized to its setting (2 and 3 rows), while Working Stage still holds all four items: the setting sizes the group, it does not shrink the result set

**Scenario 5 - Cancel** (1315934719, 1315934717)
**Given** the wizard open on the Sports desk
**When** the user
1. reorders the sections and sets Working Stage to 2, and
2. presses Cancel and reopens the wizard
**Then**
- the wizard closes
- the section order and the items count are both back to their saved values

Run it: `cd e2e/client && npx playwright test monitoring.settings.desk-tabs.spec.ts`
The spec(s) passed 3 consecutive local runs with no changes between them.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
