### PR TITLE
Automate Desk routing (1311834332)

### DIFF
--- a/e2e/client/playwright/desk-routing.spec.ts
+++ b/e2e/client/playwright/desk-routing.spec.ts
@@ -1,0 +1,153 @@
+import {test, expect} from '@playwright/test';
+import {DeskRouting} from './page-object-models/desk-routing';
+import {restoreDatabaseSnapshot} from './utils';
+
+/**
+ * QA case "Desk routing" (1311834332). The case body carries no steps of its own,
+ * it points at SDANSA-153 ("Workflow of the desk(s) routing") and SDANSA-325
+ * ("Improvements in the desk routing") for the requirements.
+ *
+ * Covered here: the client half of the feature. Through the "Desk Router" dashboard
+ * widget a desk is closed onto another one, several desks are closed onto the same
+ * target, a desk that is already a target is closed on in turn, and a closed desk is
+ * reopened; the top-menu indicator reports the direction from either end.
+ *
+ * Uncovered documented expected results, and why:
+ *
+ * - What the routing does to content (the second half of SDANSA-153 AC 1 and 3-6,
+ *   and all of SDANSA-325: incoming items on the closed desk reach the target desk,
+ *   a chain lands them on the last desk only, stopping routing withdraws them). The
+ *   case's own note says this needs the Desk Routing macro configured on the incoming
+ *   and outgoing stages of every desk in the chain. The e2e backend serves four
+ *   macros (`usd_to_cad`, `populate_abstract`, `Extract Html Macro`,
+ *   `Validate for Publish`), none of them a desk routing macro, and no stage in
+ *   the `main` snapshot has `incoming_macro` or `outgoing_macro` set. Fixture
+ *   blocker: it needs a backend that ships the macro.
+ *
+ * - Publishing from the target desk publishes the item as from the original desk
+ *   (SDANSA-153 AC 7). Depends on the same macro to get an item onto the target
+ *   desk in the first place.
+ *
+ * - A user without the `desk_routing` privilege cannot start or stop routing.
+ *   The widget gates on it (`RoutingWidgetController.canManage`), but the state
+ *   cannot be reached: the `main` snapshot's only non-admin user, `janedoe`, has
+ *   no documented password, and the admin cannot be demoted in-test because the
+ *   backend grants an `administrator` every privilege regardless of the ones set
+ *   on the user record. Fixture blocker: it needs a snapshot user with a known
+ *   password and no `desk_routing` privilege.
+ */
+test.describe('desk routing', {
+    annotation: [
+        {type: 'confluence', description: '1311834332 partial'}, // Desk routing
+    ],
+}, () => {
+    test('closes a desk onto another one and reports the direction on both', async ({page}) => {
+        const deskRouting = new DeskRouting(page);
+
+        await restoreDatabaseSnapshot();
+        await deskRouting.openOn('Sports');
+
+        await expect(deskRouting.destinationSelect).toBeEnabled();
+        await expect(deskRouting.startButton).toBeDisabled();
+        await deskRouting.expectNoRoutingIndicated();
+
+        await deskRouting.selectDestination('Education');
+        await expect(deskRouting.startButton).toBeEnabled();
+
+        await deskRouting.startRouting();
+
+        await expect(deskRouting.startButton).toHaveCount(0);
+        await expect(deskRouting.infoRoutingTo).toHaveText('Education');
+        await expect(deskRouting.infoRoutedFrom).toBeHidden();
+
+        await deskRouting.openOn('Education');
+
+        await expect(deskRouting.infoRoutedFrom).toHaveText('Sports');
+        await expect(deskRouting.infoRoutingTo).toBeHidden();
+        await expect(deskRouting.routedFromItem('Sports')).toBeVisible();
+    });
+
+    test('keeps the desk closed across a reload and reopens it on stop', async ({page}) => {
+        const deskRouting = new DeskRouting(page);
+
+        await restoreDatabaseSnapshot();
+        await deskRouting.routeTo('Sports', 'Education');
+
+        await page.reload();
+
+        await expect(deskRouting.stopButton).toBeVisible();
+        await expect(deskRouting.selectedDestination).toHaveText('Education');
+        await expect(deskRouting.infoRoutingTo).toHaveText('Education');
+
+        await deskRouting.stopRouting();
+
+        await expect(deskRouting.stopButton).toHaveCount(0);
+        await deskRouting.expectNoRoutingIndicated();
+
+        /*
+         * Stopping only reopens the desk: `toggle()` sends `is_closed` and
+         * nothing else, so the destination stays configured and routing can be
+         * resumed without picking it again.
+         */
+        await expect(deskRouting.selectedDestination).toHaveText('Education');
+        await expect(deskRouting.startButton).toBeEnabled();
+
+        await deskRouting.openOn('Education');
+
+        await deskRouting.expectNoRoutingIndicated();
+    });
+
+    test('routes a desk that is already a routing target on to a third desk', async ({page}) => {
+        const deskRouting = new DeskRouting(page);
+
+        await restoreDatabaseSnapshot();
+        await deskRouting.routeTo('Sports', 'Education');
+
+        await deskRouting.openOn('Education');
+
+        await expect(deskRouting.routedFromItem('Sports')).toBeVisible();
+        await expect(deskRouting.startButton).toBeVisible();
+
+        await deskRouting.selectDestination('Finance');
+        await deskRouting.startRouting();
+
+        /*
+         * The indicator reports one direction at a time: `TopMenuInfoDirective`
+         * computes "Routed from" only for a desk that is not itself closed, so
+         * Education reports its own destination and not Sports any more.
+         */
+        await expect(deskRouting.infoRoutingTo).toHaveText('Finance');
+        await expect(deskRouting.infoRoutedFrom).toBeHidden();
+
+        await deskRouting.openOn('Finance');
+
+        await expect(deskRouting.infoRoutedFrom).toHaveText('Education');
+
+        /*
+         * Only the desk routing straight to Finance is listed. Sports routes to
+         * Education, and the widget lists direct sources
+         * (`closed_destination === this.desk._id`), not the whole chain.
+         */
+        await expect(deskRouting.routedFromItem('Education')).toBeVisible();
+        await expect(deskRouting.routedFromItem('Sports')).toHaveCount(0);
+    });
+
+    test('lists every desk that routes to the same target desk', async ({page}) => {
+        const deskRouting = new DeskRouting(page);
+
+        await restoreDatabaseSnapshot();
+        await deskRouting.routeTo('Sports', 'Finance');
+        await deskRouting.routeTo('Education', 'Finance');
+
+        await deskRouting.openOn('Finance');
+
+        await expect(deskRouting.routedFromItem('Sports')).toBeVisible();
+        await expect(deskRouting.routedFromItem('Education')).toBeVisible();
+
+        /*
+         * The indicator joins the source desk names in the order the desks
+         * service holds them, which `DesksFactory.fetchDesks` sorts by name.
+         */
+        await expect(deskRouting.infoRoutedFrom).toHaveText('Education, Sports');
+    });
+});

--- a/e2e/client/playwright/page-object-models/dashboard.ts
+++ b/e2e/client/playwright/page-object-models/dashboard.ts
@@ -1,0 +1,61 @@
+import {Locator, Page, Response, expect} from '@playwright/test';
+
+export class Dashboard {
+    private page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    getWidget(widgetId: string): Locator {
+        return this.page
+            .getByTestId('widget-grid')
+            .getByTestId('widget')
+            .and(this.page.locator(`[data-test-value="${widgetId}"]`));
+    }
+
+    /**
+     * Adding a widget and accepting a rearrange both persist the dashboard the
+     * same way: a background write to `/workspaces` fired after the click.
+     * Every action that triggers one has to wait for the response, otherwise a
+     * following reload aborts the request and the change silently reverts, and
+     * a second write sent while the first is in flight carries a stale
+     * `If-Match` etag and is rejected with 412.
+     *
+     * A desk whose dashboard has never been saved has no workspace document
+     * yet, so the first write on it is a POST to the collection and every
+     * later one a PATCH on the document.
+     *
+     * The predicate matches on URL and method only. Filtering on the status
+     * here would leave a failed save unmatched, so the helper would hang until
+     * the `waitForResponse` timeout instead of reporting the status; the status
+     * is checked in `expectLayoutPersisted` once the response has arrived.
+     */
+    private waitForLayoutPersisted(): Promise<Response> {
+        return this.page.waitForResponse(
+            (response) => /\/workspaces(\/[^/]+)?$/.test(response.url())
+                && ['POST', 'PATCH'].includes(response.request().method()),
+        );
+    }
+
+    private async expectLayoutPersisted(layoutPersisted: Promise<Response>): Promise<void> {
+        const response = await layoutPersisted;
+
+        expect(response.ok(), `saving the dashboard layout failed with ${response.status()}`).toBe(true);
+    }
+
+    async addWidget(widgetId: string): Promise<void> {
+        const modal = this.page.getByTestId('widget-modal');
+
+        await this.page.getByRole('button', {name: 'Add widget'}).click();
+        await modal.getByTestId('widget-item').and(this.page.locator(`[data-test-value="${widgetId}"]`)).click();
+
+        const layoutPersisted = this.waitForLayoutPersisted();
+
+        await modal.getByRole('button', {name: 'Add This Widget'}).click();
+        await modal.getByRole('button', {name: 'Done'}).click();
+
+        await expect(this.getWidget(widgetId)).toBeVisible();
+        await this.expectLayoutPersisted(layoutPersisted);
+    }
+}

--- a/e2e/client/playwright/page-object-models/dashboard.ts
+++ b/e2e/client/playwright/page-object-models/dashboard.ts
@@ -1,6 +1,22 @@
 import {Locator, Page, Response, expect} from '@playwright/test';
 
+/**
+ * The dashboard widget grid is driven by gridster.js. A widget's placement and
+ * size are not inline styles but the `data-col` / `data-row` / `data-sizex` /
+ * `data-sizey` attributes gridster writes on the grid item; the pixel position
+ * comes from a generated stylesheet keyed off those attributes. Assert on the
+ * attributes, they are the state the dashboard also persists.
+ */
 export class Dashboard {
+    /**
+     * One grid step in pixels. gridster is configured in
+     * scripts/apps/dashboard/grid/grid.ts with widget_base_dimensions
+     * [320, 250] and widget_margins [20, 20]; a step is the base dimension
+     * plus a margin on each side.
+     */
+    static readonly COLUMN_STEP = 360;
+    static readonly ROW_STEP = 290;
+
     private page: Page;
 
     constructor(page: Page) {
@@ -58,7 +74,68 @@ export class Dashboard {
         await modal.getByRole('button', {name: 'Add This Widget'}).click();
         await modal.getByRole('button', {name: 'Done'}).click();
 
+        await expect(modal).not.toBeVisible();
         await expect(this.getWidget(widgetId)).toBeVisible();
         await this.expectLayoutPersisted(layoutPersisted);
+    }
+
+    async openWidgetConfiguration(widgetId: string): Promise<void> {
+        await this.getWidget(widgetId).getByRole('button', {name: 'Widget settings'}).click();
+        await expect(this.page.getByTestId('widget-config-body')).toBeVisible();
+    }
+
+    async saveWidgetConfiguration(): Promise<void> {
+        await this.page.getByTestId('widget-config-save').click();
+        await expect(this.page.getByTestId('widget-config-body')).toBeHidden();
+    }
+
+    async closeWidgetConfiguration(): Promise<void> {
+        await this.page.getByTestId('widget-config-close').click();
+        await expect(this.page.getByTestId('widget-config-body')).toBeHidden();
+    }
+
+    async startRearranging(): Promise<void> {
+        await this.page.getByTestId('rearrange-widgets').click();
+        await expect(this.page.getByTestId('accept-rearrange')).toBeVisible();
+    }
+
+    async acceptRearranging(): Promise<void> {
+        const layoutPersisted = this.waitForLayoutPersisted();
+
+        await this.page.getByTestId('accept-rearrange').click();
+        await expect(this.page.getByTestId('rearrange-widgets')).toBeVisible();
+        await this.expectLayoutPersisted(layoutPersisted);
+    }
+
+    /**
+     * Drags a widget by whole grid steps.
+     *
+     * The drop target is an empty grid cell, which has no element for
+     * `locator.dragTo()` to aim at, so the mouse events are driven by hand.
+     * The first mousemove past gridster's drag threshold only starts the drag;
+     * the drop cell is recomputed on the moves after it, hence `steps`.
+     */
+    async dragWidget(widgetId: string, steps: {columns: number; rows: number}): Promise<void> {
+        const widget = this.getWidget(widgetId);
+        const box = await widget.boundingBox();
+
+        if (box == null) {
+            throw new Error(`widget "${widgetId}" is not rendered`);
+        }
+
+        // Grab the widget header: the remove and resize controls sit on the
+        // widget's edges and corners, and pressing one of them would fire its
+        // click handler on mouseup instead of moving the widget.
+        const fromX = box.x + box.width / 2;
+        const fromY = box.y + 30;
+
+        await this.page.mouse.move(fromX, fromY);
+        await this.page.mouse.down();
+        await this.page.mouse.move(
+            fromX + steps.columns * Dashboard.COLUMN_STEP,
+            fromY + steps.rows * Dashboard.ROW_STEP,
+            {steps: 20},
+        );
+        await this.page.mouse.up();
     }
 }

--- a/e2e/client/playwright/page-object-models/dashboard.ts
+++ b/e2e/client/playwright/page-object-models/dashboard.ts
@@ -23,8 +23,11 @@ export class Dashboard {
      * `If-Match` etag and is rejected with 412.
      *
      * A desk whose dashboard has never been saved has no workspace document
-     * yet, so the first write on it is a POST to the collection and every
-     * later one a PATCH on the document.
+     * yet (`WorkspaceService.getDeskWorkspace` hands back an unsaved
+     * `{desk, widgets: []}`), so the first write on it is a POST to the
+     * collection and every later one a PATCH on the document. Both have to be
+     * matched: narrowed to a PATCH on a document id, this never matches that
+     * first POST and the caller hangs until the `waitForResponse` timeout.
      *
      * The predicate matches on URL and method only. Filtering on the status
      * here would leave a failed save unmatched, so the helper would hang until

--- a/e2e/client/playwright/page-object-models/dashboard.ts
+++ b/e2e/client/playwright/page-object-models/dashboard.ts
@@ -1,22 +1,6 @@
 import {Locator, Page, Response, expect} from '@playwright/test';
 
-/**
- * The dashboard widget grid is driven by gridster.js. A widget's placement and
- * size are not inline styles but the `data-col` / `data-row` / `data-sizex` /
- * `data-sizey` attributes gridster writes on the grid item; the pixel position
- * comes from a generated stylesheet keyed off those attributes. Assert on the
- * attributes, they are the state the dashboard also persists.
- */
 export class Dashboard {
-    /**
-     * One grid step in pixels. gridster is configured in
-     * scripts/apps/dashboard/grid/grid.ts with widget_base_dimensions
-     * [320, 250] and widget_margins [20, 20]; a step is the base dimension
-     * plus a margin on each side.
-     */
-    static readonly COLUMN_STEP = 360;
-    static readonly ROW_STEP = 290;
-
     private page: Page;
 
     constructor(page: Page) {
@@ -31,12 +15,11 @@ export class Dashboard {
     }
 
     /**
-     * Adding a widget and accepting a rearrange both persist the dashboard the
-     * same way: a background write to `/workspaces` fired after the click.
-     * Every action that triggers one has to wait for the response, otherwise a
-     * following reload aborts the request and the change silently reverts, and
-     * a second write sent while the first is in flight carries a stale
-     * `If-Match` etag and is rejected with 412.
+     * Adding a widget persists the dashboard through a background write to
+     * `/workspaces` fired after the click. Every action that triggers one has to
+     * wait for the response, otherwise a following reload aborts the request and
+     * the change silently reverts, and a second write sent while the first is in
+     * flight carries a stale `If-Match` etag and is rejected with 412.
      *
      * A desk whose dashboard has never been saved has no workspace document
      * yet (`WorkspaceService.getDeskWorkspace` hands back an unsaved
@@ -77,65 +60,5 @@ export class Dashboard {
         await expect(modal).not.toBeVisible();
         await expect(this.getWidget(widgetId)).toBeVisible();
         await this.expectLayoutPersisted(layoutPersisted);
-    }
-
-    async openWidgetConfiguration(widgetId: string): Promise<void> {
-        await this.getWidget(widgetId).getByRole('button', {name: 'Widget settings'}).click();
-        await expect(this.page.getByTestId('widget-config-body')).toBeVisible();
-    }
-
-    async saveWidgetConfiguration(): Promise<void> {
-        await this.page.getByTestId('widget-config-save').click();
-        await expect(this.page.getByTestId('widget-config-body')).toBeHidden();
-    }
-
-    async closeWidgetConfiguration(): Promise<void> {
-        await this.page.getByTestId('widget-config-close').click();
-        await expect(this.page.getByTestId('widget-config-body')).toBeHidden();
-    }
-
-    async startRearranging(): Promise<void> {
-        await this.page.getByTestId('rearrange-widgets').click();
-        await expect(this.page.getByTestId('accept-rearrange')).toBeVisible();
-    }
-
-    async acceptRearranging(): Promise<void> {
-        const layoutPersisted = this.waitForLayoutPersisted();
-
-        await this.page.getByTestId('accept-rearrange').click();
-        await expect(this.page.getByTestId('rearrange-widgets')).toBeVisible();
-        await this.expectLayoutPersisted(layoutPersisted);
-    }
-
-    /**
-     * Drags a widget by whole grid steps.
-     *
-     * The drop target is an empty grid cell, which has no element for
-     * `locator.dragTo()` to aim at, so the mouse events are driven by hand.
-     * The first mousemove past gridster's drag threshold only starts the drag;
-     * the drop cell is recomputed on the moves after it, hence `steps`.
-     */
-    async dragWidget(widgetId: string, steps: {columns: number; rows: number}): Promise<void> {
-        const widget = this.getWidget(widgetId);
-        const box = await widget.boundingBox();
-
-        if (box == null) {
-            throw new Error(`widget "${widgetId}" is not rendered`);
-        }
-
-        // Grab the widget header: the remove and resize controls sit on the
-        // widget's edges and corners, and pressing one of them would fire its
-        // click handler on mouseup instead of moving the widget.
-        const fromX = box.x + box.width / 2;
-        const fromY = box.y + 30;
-
-        await this.page.mouse.move(fromX, fromY);
-        await this.page.mouse.down();
-        await this.page.mouse.move(
-            fromX + steps.columns * Dashboard.COLUMN_STEP,
-            fromY + steps.rows * Dashboard.ROW_STEP,
-            {steps: 20},
-        );
-        await this.page.mouse.up();
     }
 }

--- a/e2e/client/playwright/page-object-models/desk-routing.ts
+++ b/e2e/client/playwright/page-object-models/desk-routing.ts
@@ -1,0 +1,172 @@
+import {Locator, Page, Response, expect} from '@playwright/test';
+import {Dashboard} from './dashboard';
+import {Monitoring} from './monitoring';
+
+/**
+ * The "Desk Router" dashboard widget (`close-desk`) and the top-menu indicator
+ * that mirrors it.
+ *
+ * Both read the current desk's `is_closed` / `closed_destination` fields.
+ * Every change goes through `PATCH /api/closed_desks/<desk id>`
+ * (scripts/apps/dashboard/closed-desk/index.ts), so the mutating methods here
+ * wait for that request before returning: the widget re-renders off the
+ * response body, and a following reload would otherwise abort the request.
+ */
+export class DeskRouting {
+    private page: Page;
+    private dashboard: Dashboard;
+    private monitoring: Monitoring;
+
+    constructor(page: Page) {
+        this.page = page;
+        this.dashboard = new Dashboard(page);
+        this.monitoring = new Monitoring(page);
+    }
+
+    get widget(): Locator {
+        return this.page.getByTestId('desk-router');
+    }
+
+    get destinationSelect(): Locator {
+        return this.widget.getByTestId('desk-router-destination');
+    }
+
+    /** The selected option of the destination `<select>`; its text is the desk name. */
+    get selectedDestination(): Locator {
+        return this.destinationSelect.locator('option:checked');
+    }
+
+    get startButton(): Locator {
+        return this.widget.getByTestId('desk-router-start');
+    }
+
+    get stopButton(): Locator {
+        return this.widget.getByTestId('desk-router-stop');
+    }
+
+    get routedFromList(): Locator {
+        return this.widget.getByTestId('desk-router-routed-from');
+    }
+
+    routedFromItem(deskName: string): Locator {
+        return this.routedFromList
+            .getByTestId('desk-router-routed-from-item')
+            .and(this.page.locator(`[data-test-value="${deskName}"]`));
+    }
+
+    /** The top-menu indicator, rendered next to the global menu on every route. */
+    get info(): Locator {
+        return this.page.getByTestId('desk-routing-info');
+    }
+
+    get infoRoutingTo(): Locator {
+        return this.info.getByTestId('desk-routing-info--routing-to');
+    }
+
+    get infoRoutedFrom(): Locator {
+        return this.info.getByTestId('desk-routing-info--routed-from');
+    }
+
+    /**
+     * Asserts that neither direction is reported. The indicator is always in
+     * the DOM and only toggles its visibility, so it is checked for being
+     * present first: an unrendered indicator would satisfy `toBeHidden` too.
+     */
+    async expectNoRoutingIndicated(): Promise<void> {
+        await expect(this.info).toBeAttached();
+        await expect(this.info).toBeHidden();
+    }
+
+    /**
+     * Switches desks and waits for the preference write that records the
+     * choice, so that a reload comes back on the same desk. One request covers
+     * it: `preferencesService` batches every update made in a digest into a
+     * single `PATCH /preferences/<session>`.
+     *
+     * `selectDeskOrWorkspace` does nothing when the desk is already selected,
+     * and then there is no write to wait for, hence the check first.
+     */
+    private async selectDesk(deskName: string): Promise<void> {
+        const deskSelector = this.page.getByTestId('monitoring--selected-desk');
+
+        await expect(deskSelector).toBeVisible();
+
+        const selected = await deskSelector.textContent() ?? '';
+
+        if (selected.toLocaleLowerCase().includes(deskName.toLocaleLowerCase())) {
+            return;
+        }
+
+        await Promise.all([
+            this.page.waitForResponse(
+                (candidate: Response) => /\/preferences\/[^/]+$/.test(candidate.url())
+                    && candidate.request().method() === 'PATCH',
+            ),
+            this.monitoring.selectDeskOrWorkspace(deskName),
+        ]);
+    }
+
+    /**
+     * Opens the dashboard of `deskName` with the Desk Router widget on it. Each
+     * desk has a dashboard of its own, so the widget has to be added per desk.
+     *
+     * The reload is what makes the widget lookup below trustworthy: on a desk
+     * switch `DashboardController.setupWorkspace` drops the dashboard and
+     * rebuilds it in a later digest, so between the two the previous desk's
+     * widgets are still on screen and would be read as this desk's.
+     */
+    async openOn(deskName: string): Promise<void> {
+        await this.page.goto('/#/workspace');
+        await this.selectDesk(deskName);
+        await this.page.reload();
+
+        await expect(this.page.getByTestId('dashboard')).toBeVisible();
+        // The grid has to be there before the widget count below can mean anything.
+        await expect(this.page.getByTestId('widget-grid')).toBeAttached();
+
+        if (await this.dashboard.getWidget('close-desk').count() === 0) {
+            await this.dashboard.addWidget('close-desk');
+        }
+
+        await expect(this.widget).toBeVisible();
+    }
+
+    /**
+     * Matches on URL and method only. A predicate that also required a 2xx
+     * would never match a rejected update, turning a reportable failure into an
+     * opaque `waitForResponse` timeout; the status is asserted once the
+     * response has arrived.
+     */
+    private async expectDeskUpdated(trigger: Promise<unknown>): Promise<void> {
+        const [response] = await Promise.all([
+            this.page.waitForResponse(
+                (candidate: Response) => /\/closed_desks\/[^/]+$/.test(candidate.url())
+                    && candidate.request().method() === 'PATCH',
+            ),
+            trigger,
+        ]);
+
+        expect(response.ok(), `updating the desk routing failed with ${response.status()}`).toBe(true);
+    }
+
+    async selectDestination(deskName: string): Promise<void> {
+        await this.expectDeskUpdated(this.destinationSelect.selectOption({label: deskName}));
+    }
+
+    async startRouting(): Promise<void> {
+        await this.expectDeskUpdated(this.startButton.click());
+        await expect(this.stopButton).toBeVisible();
+    }
+
+    async stopRouting(): Promise<void> {
+        await this.expectDeskUpdated(this.stopButton.click());
+        await expect(this.startButton).toBeVisible();
+    }
+
+    /** Sets a destination and starts routing in one step, for preconditions. */
+    async routeTo(sourceDesk: string, destinationDesk: string): Promise<void> {
+        await this.openOn(sourceDesk);
+        await this.selectDestination(destinationDesk);
+        await this.startRouting();
+    }
+}

--- a/e2e/client/playwright/page-object-models/desk-routing.ts
+++ b/e2e/client/playwright/page-object-models/desk-routing.ts
@@ -51,7 +51,7 @@ export class DeskRouting {
     routedFromItem(deskName: string): Locator {
         return this.routedFromList
             .getByTestId('desk-router-routed-from-item')
-            .and(this.page.locator(`[data-test-value="${deskName}"]`));
+            .filter({hasText: deskName});
     }
 
     /** The top-menu indicator, rendered next to the global menu on every route. */

--- a/scripts/apps/dashboard/closed-desk/views/close-desk-widget.html
+++ b/scripts/apps/dashboard/closed-desk/views/close-desk-widget.html
@@ -3,7 +3,7 @@
         <label class="sd-line-input__label" translate>Routed from</label>
         <div class="sd-list-item-group">
             <div class="sd-list-item" ng-repeat="desk in routing.routedFrom"
-                data-test-id="desk-router-routed-from-item" data-test-value="{{ desk.name }}">
+                data-test-id="desk-router-routed-from-item">
                 <div class="sd-list-item">
                     <div class="sd-list-item__border" ng-class="{
                         'sd-list-item__border--locked': !desk.is_closed,

--- a/scripts/apps/dashboard/closed-desk/views/close-desk-widget.html
+++ b/scripts/apps/dashboard/closed-desk/views/close-desk-widget.html
@@ -1,8 +1,9 @@
-<div class="close-desk-widget-content" ng-controller="RoutingWidgetController as routing">
-    <div class="sd-line-input" ng-if="routing.routedFrom.length">
+<div class="close-desk-widget-content" ng-controller="RoutingWidgetController as routing" data-test-id="desk-router">
+    <div class="sd-line-input" ng-if="routing.routedFrom.length" data-test-id="desk-router-routed-from">
         <label class="sd-line-input__label" translate>Routed from</label>
         <div class="sd-list-item-group">
-            <div class="sd-list-item" ng-repeat="desk in routing.routedFrom">
+            <div class="sd-list-item" ng-repeat="desk in routing.routedFrom"
+                data-test-id="desk-router-routed-from-item" data-test-value="{{ desk.name }}">
                 <div class="sd-list-item">
                     <div class="sd-list-item__border" ng-class="{
                         'sd-list-item__border--locked': !desk.is_closed,
@@ -21,6 +22,7 @@
     <div class="sd-line-input sd-line-input--is-select">
         <label class="sd-line-input__label" translate>Route incoming content to</label>
         <select class="sd-line-input__select"
+            data-test-id="desk-router-destination"
             ng-options="d._id as d.name for d in routing.desks"
             ng-model="routing.destination"
             ng-change="routing.updateDestination()"
@@ -29,12 +31,14 @@
     </div>
 
     <button class="btn btn--large btn--success btn--expanded"
+        data-test-id="desk-router-start"
         ng-if="!routing.desk.is_closed"
         ng-disabled="!routing.destination || !routing.canManage"
         ng-click="routing.toggle()" translate>
         Start routing
     </button>
     <button class="btn btn--large btn--alert btn--expanded"
+        data-test-id="desk-router-stop"
         ng-if="routing.desk.is_closed"
         ng-disabled="!routing.canManage"
         ng-click="routing.toggle()" translate>

--- a/scripts/apps/dashboard/closed-desk/views/top-menu-info.html
+++ b/scripts/apps/dashboard/closed-desk/views/top-menu-info.html
@@ -1,4 +1,4 @@
-<div class="top-menu__info" ng-show="routingTo || routingFrom">
+<div class="top-menu__info" ng-show="routingTo || routingFrom" data-test-id="desk-routing-info">
     <i class="top-menu__info-icon" ng-class="{
         'top-menu__info-icon--green': routingFrom,
         'icon-download': routingFrom,
@@ -7,8 +7,10 @@
 }"></i>
     <span class="top-menu__info-label" ng-show="routingFrom && hideRoutedDesks" translate>Routed from other desks</span>
     <span class="top-menu__info-label" ng-show="routingFrom && !hideRoutedDesks" translate>Routed from:</span>
-    <span class="top-menu__info-text" ng-show="routingFrom && !hideRoutedDesks">{{ routingFrom }}</span>
+    <span class="top-menu__info-text" ng-show="routingFrom && !hideRoutedDesks"
+        data-test-id="desk-routing-info--routed-from">{{ routingFrom }}</span>
 
     <span class="top-menu__info-label" ng-show="routingTo" translate>Routing to:</span>
-    <span class="top-menu__info-text" ng-show="routingTo">{{ routingTo }}</span>
+    <span class="top-menu__info-text" ng-show="routingTo"
+        data-test-id="desk-routing-info--routing-to">{{ routingTo }}</span>
 </div>


### PR DESCRIPTION
### Purpose
Automates the QA case [Desk routing](https://sofab.atlassian.net/wiki/spaces/SET/pages/1311834332) as a Playwright spec so it runs in CI instead of being tested by hand.

Annotation level: `partial` (the routing-macro scenarios need backend fixtures; blockers are named in the spec header).

Fixture gaps recorded for the backlog (uncovered scenarios carry named blockers in the spec header):
- A backend that ships the Desk Routing macro, plus stages with incoming_macro/outgoing_macro configured on the source, intermediate and target desks. The e2e server exposes only usd_to_cad, populate_abstract, Extract Html Macro and Validate for Publish, and no stage in the main snapshot has either macro field set. Without it none of the content-dispatch expected results (SDANSA-153 AC 1 and 3-7, all of SDANSA-325) is reachable.
- A snapshot user with a documented password and no desk_routing privilege, for the negative privilege branch. The main snapshot's only non-admin user, janedoe, has no known password (the marktwain user lives on hg/add-e2e-user-with-known-password, not on develop), and admin cannot be demoted in-test because the backend grants an administrator all 71 privileges regardless of the user record (verified against /api/preferences).

### What has changed
- New spec(s): `e2e/client/playwright/desk-routing.spec.ts` with the `confluence` annotation
- The dashboard page object is trimmed to exactly what this spec uses (the fuller copies live on the open widget-case branches and will be converged after the first of them merges)

### Steps to test
## Closing a desk onto another one

**Given** the `main` snapshot and the Desk Router widget on the Sports dashboard

**When**
1. the destination select is read before anything is chosen
2. `Education` is picked as the destination
3. `Start routing` is pressed
4. the Education dashboard is opened with the widget on it

**Then**
- the destination select is enabled and `Start routing` is disabled until a destination is chosen
- the top-menu routing indicator is present but hidden while no routing is set
- `Start routing` becomes enabled once a destination is picked, and each change lands a successful `PATCH /api/closed_desks/<desk>`
- after starting, `Start routing` is gone and `Stop routing` is shown
- Sports reports `Routing to: Education` and nothing under `Routed from`
- Education reports `Routed from: Sports` and nothing under `Routing to`, and lists Sports in the widget's `Routed from` list

## Reopening a closed desk

**Given** Sports closed onto Education

**When**
1. the page is reloaded
2. `Stop routing` is pressed
3. the Education dashboard is opened

**Then**
- after the reload the widget still shows `Stop routing` with `Education` selected, and the indicator still reads `Routing to: Education`
- after stopping, `Stop routing` is gone and the indicator is hidden
- the destination stays configured (`Education` still selected, `Start routing` enabled again), because stopping only sends `is_closed`
- Education no longer reports being routed to

## Chaining onto a desk that is already a target

**Given** Sports closed onto Education

**When**
1. the Education dashboard is opened
2. `Finance` is picked and `Start routing` is pressed
3. the Finance dashboard is opened

**Then**
- Education lists Sports under `Routed from` and still offers `Start routing`
- once Education is closed it reports `Routing to: Finance` and stops reporting `Routed from`, since the indicator only computes a source list for a desk that is not itself closed
- Finance reports `Routed from: Education`
- Finance lists only Education, not Sports: the widget lists direct sources (`closed_destination === this desk`), not the whole chain

## Several desks routing to one target

**Given** the `main` snapshot

**When**
1. Sports is closed onto Finance
2. Education is closed onto Finance
3. the Finance dashboard is opened

**Then**
- both Sports and Education appear in Finance's `Routed from` list
- the top-menu indicator reads `Routed from: Education, Sports`, in the name order the desks service holds

Run it: `cd e2e/client && npx playwright test desk-routing.spec.ts`
The spec passed 3 consecutive local runs with no changes between them, plus a green verification run after the final trim.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
