### PR TITLE
Automate the custom-field removal and URL-field QA cases as a consolidated spec

### DIFF
--- a/e2e/client/playwright/metadata.custom-fields.spec.ts
+++ b/e2e/client/playwright/metadata.custom-fields.spec.ts
@@ -1,0 +1,374 @@
+import {test, expect, Page} from '@playwright/test';
+import {restoreDatabaseSnapshot} from './utils';
+import {MetadataSettings} from './page-object-models/settings/metadata';
+import {ContentProfileSettings} from './page-object-models/settings/content-profile';
+
+/*
+ * Removing a custom field of every type Settings -> Metadata offers a tab for, and editing a
+ * custom URL field. Creating those fields is covered by authoring.custom-fields.spec.ts.
+ *
+ * Where the cases and the product disagree, the product is asserted:
+ * - The delete confirmation the cases describe ("Confirm" / "Please confirm you want to delete
+ *   the vocabulary." / Cancel + OK) has been redesigned: the dialog is headed "Delete
+ *   vocabulary?" and its buttons are Cancel and Delete (VocabularyDeletionModal.tsx).
+ * - The in-use message the cases quote ("The vocabulary is used in the following content types:")
+ *   is now a separate "Cannot delete vocabulary" dialog that lists the content profiles.
+ * - 1311835081 calls Label a multiselect; the control takes a single label (`data-max-items="1"`
+ *   in vocabulary-config-modal.html) and its own hint says so.
+ * - 1311835081's "Close button" is the footer's "Cancel"; the close icon sits in the dialog
+ *   header. Its expected results are also copied from the related content case ("Edit dialog for
+ *   a custom related content field"); the controls asserted here are the ones the URL dialog
+ *   renders.
+ *
+ * Expected results left uncovered:
+ * - The two content profile consequences every removal case documents ("cannot be used in Content
+ *   profiles configuration anymore", and the refusal to delete a field a profile uses) are
+ *   asserted once, on a custom text field. Neither VocabularyConfigController.remove nor
+ *   VocabularyDeletionModal branches on the field type, and the content profile field picker
+ *   lists fields by vocabulary id, so both are the same code path for every type on this page.
+ * - That first consequence is asserted on the Header section of the field picker only. Both
+ *   sections offer the field ids of the content type response, and after a deletion the client
+ *   can still be served a copy of that response carrying the deleted id, even across a reload - a
+ *   direct API read no longer returns it, but deleting a vocabulary does not change the content
+ *   type document itself. The field then stays on offer in the Content section, with its type
+ *   label gone. Header options are filtered further, through the vocabulary list
+ *   (`getAllCustomVocabulariesForArticleHeader` in apps/authoring/metadata/metadata.ts), which a
+ *   fresh page rebuilds from the API.
+ * - 1311835081's "ID text field (required) ... spaces are not allowed". The ID input is read-only
+ *   once the field exists (`ng-readonly="!!vocabulary._links"`), so the Edit dialog cannot
+ *   exercise it.
+ */
+
+interface ICustomFieldType {
+    /** Confluence case id of the "Remove ..." case for this type. */
+    caseId: string;
+    tabName: string;
+    /** Reads inside the test title, after "a custom" and before "field". */
+    label: string;
+    id: string;
+    name: string;
+    /** How the content profile field picker labels the type, where a test needs it. */
+    pickerTypeLabel?: string;
+    /** Input the type needs in the create dialog on top of an id and a name. */
+    configureDialog?: (metadata: MetadataSettings) => Promise<void>;
+}
+
+const TEXT_FIELD: ICustomFieldType = {
+    caseId: '1311835048', // Remove custom text field (AUTOMATED)
+    tabName: 'Custom text fields',
+    label: 'text',
+    id: 'removable_text_field',
+    name: 'Removable text field',
+    pickerTypeLabel: 'text',
+};
+
+const REMOVABLE_FIELD_TYPES: Array<ICustomFieldType> = [
+    TEXT_FIELD,
+    {
+        caseId: '1311835058', // Remove custom date field (AUTOMATED)
+        tabName: 'Custom date fields',
+        label: 'date',
+        id: 'removable_date_field',
+        name: 'Removable date field',
+    },
+    {
+        caseId: '1311835066', // Remove custom embed field (AUTOMATED)
+        tabName: 'Custom embed fields',
+        label: 'embed',
+        id: 'removable_embed_field',
+        name: 'Removable embed field',
+    },
+    {
+        caseId: '1311835074', // Remove related content field (AUTOMATED)
+        tabName: 'Related content',
+        label: 'related content',
+        id: 'removable_related_content_field',
+        name: 'Removable related content field',
+        configureDialog: (metadata) => metadata.setAllowedContentTypes(['Image']),
+    },
+    {
+        caseId: '1311835083', // Remove URL field (AUTOMATED)
+        tabName: 'URLs',
+        label: 'URL',
+        id: 'removable_url_field',
+        name: 'Removable URL field',
+    },
+];
+
+const URL_FIELD_ID = 'editable_url_field';
+const URL_FIELD_NAME = 'Editable URL field';
+
+const URL_FIELD_VALUES = {
+    id: URL_FIELD_ID,
+    name: URL_FIELD_NAME,
+    description: 'Where the story was first published',
+    helperText: 'Paste a full URL',
+};
+
+/** How the content profile field picker labels the URL field: display name plus its type. */
+const URL_FIELD_PICKER_OPTION = `${URL_FIELD_NAME} (custom vocabulary)`;
+
+/** What the field picker offers in the Story profile's Header section, minus any custom field. */
+const STOCK_HEADER_FIELD_OPTIONS = ['Company Codes', 'Keywords', 'Language', 'Take Key'];
+
+/** Every removal case documents the same content profile consequences. */
+const REMOVAL_CASE_ANNOTATIONS = REMOVABLE_FIELD_TYPES.map((fieldType) => ({
+    type: 'confluence',
+    description: `${fieldType.caseId} partial`,
+}));
+
+test.describe.configure({timeout: 120000});
+
+async function createCustomField(page: Page, fieldType: ICustomFieldType): Promise<void> {
+    const metadata = new MetadataSettings(page);
+
+    await metadata.openTab(fieldType.tabName);
+    await metadata.createCustomField(
+        {id: fieldType.id, name: fieldType.name},
+        async () => {
+            await fieldType.configureDialog?.(metadata);
+        },
+    );
+}
+
+for (const fieldType of REMOVABLE_FIELD_TYPES) {
+    test(`a custom ${fieldType.label} field is removed only after confirming`, {
+        annotation: [
+            {type: 'confluence', description: `${fieldType.caseId} partial`},
+        ],
+    }, async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await createCustomField(page, fieldType);
+
+        const metadata = new MetadataSettings(page);
+        const item = metadata.getListItem(fieldType.name);
+
+        await expect(item).toBeVisible();
+        await item.hover();
+        await expect(item.getByTestId('vocabulary-item--start-editing')).toBeVisible();
+        await expect(item.getByTestId('vocabulary-item--start-removing')).toBeVisible();
+
+        await metadata.openDeletionModal(fieldType.name);
+
+        const confirmation = metadata.getDeletionModal();
+
+        await expect(confirmation).toBeVisible();
+        await expect(confirmation).toContainText('Delete vocabulary?');
+        await expect(confirmation).toContainText(
+            `You are about to delete the vocabulary ${fieldType.name}. This action can't be undone.`,
+        );
+        await expect(confirmation).toContainText(
+            'This vocabulary is not currently used in any Content Profile and can be safely removed.',
+        );
+
+        await confirmation.getByRole('button', {name: 'Cancel'}).click();
+        await expect(confirmation).toHaveCount(0);
+        await expect(metadata.getListItem(fieldType.name)).toBeVisible();
+
+        await metadata.openDeletionModal(fieldType.name);
+        await metadata.confirmDeletion(fieldType.id);
+
+        await expect(metadata.getAddNewButton()).toBeVisible();
+        await expect(metadata.getListItem(fieldType.name)).toHaveCount(0);
+    });
+}
+
+test('a removed custom field is no longer offered by the content profile header section', {
+    annotation: REMOVAL_CASE_ANNOTATIONS,
+}, async ({page}) => {
+    await restoreDatabaseSnapshot();
+    await createCustomField(page, TEXT_FIELD);
+
+    const contentProfileSettings = new ContentProfileSettings(page);
+
+    await page.goto('/#/settings/content-profiles');
+    await contentProfileSettings.openEditor('Story');
+    await contentProfileSettings.openSection('Header');
+
+    const pickerBeforeRemoval = await contentProfileSettings.openFieldPicker();
+
+    // Both option sets are asserted whole: the field must go missing from a loaded list, not
+    // from a list that has not rendered yet.
+    await expect(pickerBeforeRemoval.getByRole('treeitem')).toHaveText([
+        'Company Codes',
+        'Keywords',
+        'Language',
+        `${TEXT_FIELD.name} (${TEXT_FIELD.pickerTypeLabel})`,
+        'Take Key',
+    ]);
+
+    const metadata = new MetadataSettings(page);
+
+    await metadata.openTab(TEXT_FIELD.tabName);
+    await metadata.openDeletionModal(TEXT_FIELD.name);
+    await metadata.confirmDeletion(TEXT_FIELD.id);
+
+    /*
+     * The reload is load-bearing. What the Header section offers is filtered through the
+     * vocabulary list `getAllActiveVocabularies` (VocabularyService.ts) caches for the lifetime of
+     * the page, and a deletion refreshes only the separate list the metadata page renders, so
+     * without a fresh page the picker keeps offering the deleted field.
+     */
+    await page.goto('/#/settings/content-profiles');
+    await page.reload();
+    await contentProfileSettings.openEditor('Story');
+    await contentProfileSettings.openSection('Header');
+
+    const pickerAfterRemoval = await contentProfileSettings.openFieldPicker();
+
+    await expect(pickerAfterRemoval.getByRole('treeitem')).toHaveText(STOCK_HEADER_FIELD_OPTIONS);
+});
+
+test('a custom field used in a content profile cannot be removed', {
+    annotation: REMOVAL_CASE_ANNOTATIONS,
+}, async ({page}) => {
+    await restoreDatabaseSnapshot();
+    await createCustomField(page, TEXT_FIELD);
+
+    const contentProfileSettings = new ContentProfileSettings(page);
+
+    await page.goto('/#/settings/content-profiles');
+    await contentProfileSettings.addFieldsToContentProfileAndWait('Story', [
+        {tabName: 'Content', fieldId: TEXT_FIELD.name, fieldType: TEXT_FIELD.pickerTypeLabel},
+    ]);
+
+    /*
+     * The deletion modal decides which variant to show from `sdApi.contentProfiles.getAll()`,
+     * which reads the in-memory dataStore, refreshed only by websocket resource messages. Reload
+     * so it is guaranteed to see the profile that now uses the field. The reload has to happen on
+     * the destination route: reloading first and navigating by hash straight after leaves the
+     * settings view half built.
+     */
+    await page.goto('/#/settings/vocabularies');
+    await page.reload();
+
+    const metadata = new MetadataSettings(page);
+
+    await metadata.openTab(TEXT_FIELD.tabName);
+    await metadata.openDeletionModal(TEXT_FIELD.name);
+
+    const refusal = metadata.getDeletionRefusal();
+
+    await expect(refusal).toBeVisible();
+    await expect(refusal).toContainText('Cannot delete vocabulary');
+    await expect(refusal).toContainText(
+        `The vocabulary ${TEXT_FIELD.name} can't be deleted because it is currently used `
+        + 'in the following Content Profile:',
+    );
+    await expect(refusal.getByRole('listitem')).toHaveText(['Story']);
+    await expect(refusal).toContainText(
+        'To delete this vocabulary, you must first remove it from all Content Profiles listed above.',
+    );
+
+    await refusal.getByRole('button', {name: 'Go back'}).click();
+    await expect(refusal).toHaveCount(0);
+    await expect(metadata.getListItem(TEXT_FIELD.name)).toBeVisible();
+});
+
+test('the edit dialog only persists changes to a custom URL field from its Save button', {
+    annotation: [
+        {type: 'confluence', description: '1311835081 partial'}, // Edit URL field (AUTOMATED)
+    ],
+}, async ({page}) => {
+    await restoreDatabaseSnapshot();
+
+    const metadata = new MetadataSettings(page);
+
+    await metadata.openTab('URLs');
+    await metadata.createCustomField(URL_FIELD_VALUES);
+
+    const item = metadata.getListItem(URL_FIELD_NAME);
+
+    await expect(item).toBeVisible();
+    await item.hover();
+    await expect(item.getByTestId('vocabulary-item--start-editing')).toBeVisible();
+    await expect(item.getByTestId('vocabulary-item--start-removing')).toBeVisible();
+
+    await metadata.openEditDialog(URL_FIELD_NAME);
+
+    const dialog = metadata.getDialog();
+
+    await expect(dialog.getByRole('heading', {name: `Edit ${URL_FIELD_NAME}`, exact: true})).toBeVisible();
+    await expect(page.getByTestId('vocabulary-edit--id')).toHaveJSProperty('readOnly', true);
+    await expect(page.getByTestId('vocabulary-edit-field--name')).toBeVisible();
+    await expect(dialog.getByLabel('Description')).toBeVisible();
+    await expect(dialog.getByRole('textbox', {name: 'Type to search or create a new label'})).toBeVisible();
+    await expect(dialog.getByLabel('Helper text')).toBeVisible();
+    await expect(dialog.getByTestId('vocabulary-edit-modal--cancel')).toBeVisible();
+    await expect(dialog.getByTestId('vocabulary-edit-modal--close')).toBeVisible();
+
+    await expect(metadata.getSaveButton()).toBeDisabled();
+
+    await metadata.fillDialog({description: 'discarded by Cancel'});
+    await expect(metadata.getSaveButton()).toBeEnabled();
+    await metadata.cancel();
+
+    await metadata.openEditDialog(URL_FIELD_NAME);
+    expect((await metadata.readSharedDialogValues()).description).toEqual(URL_FIELD_VALUES.description);
+
+    await metadata.fillDialog({description: 'discarded by the close icon'});
+    await metadata.closeWithIcon();
+
+    await metadata.openEditDialog(URL_FIELD_NAME);
+    expect((await metadata.readSharedDialogValues()).description).toEqual(URL_FIELD_VALUES.description);
+
+    await metadata.fillDialog({name: 'Renamed URL field', helperText: 'Paste a shortened URL'});
+    await metadata.save();
+
+    await expect(metadata.getListItem('Renamed URL field')).toBeVisible();
+    await metadata.openEditDialog('Renamed URL field');
+    expect(await metadata.readSharedDialogValues()).toEqual({
+        id: URL_FIELD_ID,
+        name: 'Renamed URL field',
+        description: URL_FIELD_VALUES.description,
+        helperText: 'Paste a shortened URL',
+    });
+});
+
+test('a saved custom URL field is offered to the content profile content section only', {
+    annotation: [
+        {type: 'confluence', description: '1311835081 partial'}, // Edit URL field (AUTOMATED)
+    ],
+}, async ({page}) => {
+    await restoreDatabaseSnapshot();
+
+    const metadata = new MetadataSettings(page);
+
+    await metadata.openTab('URLs');
+    await metadata.createCustomField(URL_FIELD_VALUES);
+
+    const contentProfileSettings = new ContentProfileSettings(page);
+
+    await page.goto('/#/settings/content-profiles');
+    await contentProfileSettings.openEditor('Story');
+    await contentProfileSettings.openSection('Header');
+
+    const headerPicker = await contentProfileSettings.openFieldPicker();
+
+    // Gate on the full stock option set: the URL field must be absent from a loaded list, not
+    // from a list that has not rendered yet.
+    await expect(headerPicker.getByRole('treeitem')).toHaveText(STOCK_HEADER_FIELD_OPTIONS);
+
+    /*
+     * The editor is reopened from a fresh load rather than switching tabs in place, because the
+     * open field picker swallows clicks on the section tabs.
+     */
+    await page.goto('/#/settings/content-profiles');
+    await page.reload();
+    await contentProfileSettings.openEditor('Story');
+    await contentProfileSettings.openSection('Content');
+
+    const contentPicker = await contentProfileSettings.openFieldPicker();
+
+    await expect(contentPicker.getByRole('treeitem', {name: URL_FIELD_PICKER_OPTION, exact: true})).toBeVisible();
+
+    await page.goto('/#/settings/content-profiles');
+    await page.reload();
+    await contentProfileSettings.addFieldsToContentProfileAndWait('Story', [
+        {tabName: 'Content', fieldId: URL_FIELD_NAME, fieldType: 'custom vocabulary'},
+    ]);
+
+    await contentProfileSettings.openEditor('Story');
+    await contentProfileSettings.openSection('Content');
+    await expect(contentProfileSettings.getConfiguredField(URL_FIELD_NAME)).toBeVisible();
+});

--- a/e2e/client/playwright/page-object-models/settings/content-profile.ts
+++ b/e2e/client/playwright/page-object-models/settings/content-profile.ts
@@ -1,4 +1,4 @@
-import {Page, expect} from '@playwright/test';
+import {Page, Locator, expect} from '@playwright/test';
 import {s} from '../../utils';
 import {TreeSelectDriver} from '../../utils/tree-select-driver';
 
@@ -73,5 +73,84 @@ export class ContentProfileSettings {
         }
 
         await this.page.locator(s('content-profile-editing-modal')).getByRole('button', {name: 'Save'}).click();
+    }
+
+    /**
+     * `addFieldsToContentProfile` returns as soon as Save is clicked, so a caller that re-reads
+     * the profile straight after can race the PATCH that click triggers. This variant waits for
+     * that write and for the editor to close.
+     */
+    async addFieldsToContentProfileAndWait(
+        contentProfile: string,
+        fields: Array<{tabName: string; fieldId: string, fieldType?: string}>,
+    ): Promise<void> {
+        await Promise.all([
+            this.page.waitForResponse(
+                (response) => response.url().includes('/api/content_types/')
+                    && response.request().method() === 'PATCH',
+            ),
+            this.addFieldsToContentProfile(contentProfile, fields),
+        ]);
+
+        // sd-modal keeps its element in the DOM once opened, so closure shows as hidden, not absent.
+        await expect(this.page.getByTestId('content-profile-editing-modal')).toBeHidden();
+    }
+
+    /**
+     * Opens a content profile's field editor from the profile list. `addFieldsToContentProfile`
+     * does the same inline; this exists for tests that only need to read the configured fields
+     * back, or to open the field picker without adding anything.
+     */
+    async openEditor(contentProfile: string): Promise<void> {
+        await this.page
+            .getByTestId('content-profile')
+            .and(this.page.locator(`[data-test-value="${contentProfile}"]`))
+            .getByTestId('content-profile-actions')
+            .click();
+        await this.page
+            .getByTestId('content-profile-actions--options')
+            .getByRole('button', {name: 'Edit'})
+            .click();
+        await expect(this.page.getByTestId('content-profile-editing-modal')).toBeVisible();
+    }
+
+    /** `sectionName` is the tab label without the " fields" suffix, e.g. 'Header' or 'Content'. */
+    async openSection(sectionName: string): Promise<void> {
+        await this.page
+            .getByTestId('content-profile-editing-modal')
+            .getByTestId('content-profile-tabs')
+            .getByRole('tab', {name: `${sectionName} fields`})
+            .click();
+    }
+
+    getConfiguredField(fieldName: string): Locator {
+        return this.page
+            .getByTestId('content-profile-editing-modal')
+            .getByTestId('content-profile-item')
+            .and(this.page.locator(`[data-test-value="${fieldName}"]`));
+    }
+
+    /**
+     * Opens the "Add new field" picker and returns its popover. The picker only lists fields that
+     * are allowed in the open section and not configured on it yet, so it is also how a test
+     * checks that a field is no longer available at all.
+     */
+    async openFieldPicker(): Promise<Locator> {
+        await this.page
+            .getByTestId('content-profile-editing-modal')
+            .getByRole('button', {name: 'Add new field'})
+            .first()
+            .click();
+
+        /*
+         * The popover is a zero-size portal wrapper (WithPortal in superdesk-ui-framework's
+         * TreeMenu) that only positions its content, so it never satisfies toBeVisible itself.
+         * Wait on the options it renders instead.
+         */
+        const popover = this.page.getByTestId('tree-menu-popover');
+
+        await expect(popover.getByRole('treeitem').first()).toBeVisible();
+
+        return popover;
     }
 }

--- a/e2e/client/playwright/page-object-models/settings/metadata.ts
+++ b/e2e/client/playwright/page-object-models/settings/metadata.ts
@@ -1,0 +1,190 @@
+import {Page, Locator, expect} from '@playwright/test';
+
+export interface ICustomFieldValues {
+    id?: string;
+    name?: string;
+    fieldTypeLabel?: string;
+    description?: string;
+    helperText?: string;
+}
+
+/**
+ * Settings -> Metadata (`#/settings/vocabularies`): the tab strip and the vocabulary
+ * create/edit dialog shared by every metadata tab, including "Other fields".
+ */
+export class MetadataSettings {
+    private page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    async openTab(tabName: string): Promise<void> {
+        await this.page.goto('/#/settings/vocabularies');
+        await this.page.getByTestId('metadata-tabs').getByRole('button', {name: tabName}).click();
+        await expect(this.getAddNewButton()).toBeVisible();
+    }
+
+    getAddNewButton(): Locator {
+        return this.page.getByTestId('metadata-content').getByRole('button', {name: 'Add new'});
+    }
+
+    getListItem(name: string): Locator {
+        return this.page.getByTestId('metadata-content').getByTestId('vocabulary-item').filter({hasText: name});
+    }
+
+    getDialog(): Locator {
+        return this.page.getByTestId('vocabulary-modal');
+    }
+
+    getSaveButton(): Locator {
+        return this.getDialog().getByTestId('vocabulary-edit-modal--save');
+    }
+
+    async openCreateDialog(): Promise<void> {
+        await this.getAddNewButton().click();
+        await expect(this.getDialog()).toBeVisible();
+    }
+
+    async openEditDialog(name: string): Promise<void> {
+        const item = this.getListItem(name);
+
+        await item.hover();
+        await item.getByTestId('vocabulary-item--start-editing').click();
+        await expect(this.getDialog()).toBeVisible();
+    }
+
+    async openDeletionModal(name: string): Promise<void> {
+        const item = this.getListItem(name);
+
+        await item.hover();
+        await item.getByTestId('vocabulary-item--start-removing').click();
+    }
+
+    async fillDialog(values: ICustomFieldValues): Promise<void> {
+        const dialog = this.getDialog();
+
+        if (values.fieldTypeLabel != null) {
+            await dialog.getByLabel('Field type').selectOption({label: values.fieldTypeLabel});
+        }
+
+        if (values.id != null) {
+            await this.page.getByTestId('vocabulary-edit--id').fill(values.id);
+        }
+
+        if (values.name != null) {
+            await this.page.getByTestId('vocabulary-edit-field--name').fill(values.name);
+        }
+
+        if (values.description != null) {
+            await dialog.getByLabel('Description').fill(values.description);
+        }
+
+        if (values.helperText != null) {
+            await dialog.getByLabel('Helper text').fill(values.helperText);
+        }
+    }
+
+    /**
+     * Reads the inputs every metadata tab renders. `readDialogValues` also reads the "Field type"
+     * select, which only the "Other fields" tab has.
+     */
+    async readSharedDialogValues(): Promise<Required<Omit<ICustomFieldValues, 'fieldTypeLabel'>>> {
+        const dialog = this.getDialog();
+
+        return {
+            id: await this.page.getByTestId('vocabulary-edit--id').inputValue(),
+            name: await this.page.getByTestId('vocabulary-edit-field--name').inputValue(),
+            description: await dialog.getByLabel('Description').inputValue(),
+            helperText: await dialog.getByLabel('Helper text').inputValue(),
+        };
+    }
+
+    async readDialogValues(): Promise<Required<Omit<ICustomFieldValues, 'fieldTypeLabel'>> & {fieldType: string}> {
+        return {
+            ...await this.readSharedDialogValues(),
+            fieldType: await this.getDialog().getByLabel('Field type').inputValue(),
+        };
+    }
+
+    /**
+     * Waits for the vocabularies write the Save click triggers, so a caller that navigates or
+     * reloads straight after cannot race it.
+     */
+    async save(): Promise<void> {
+        await Promise.all([
+            this.page.waitForResponse(
+                (response) => response.url().includes('/api/vocabularies')
+                    && ['POST', 'PATCH'].includes(response.request().method()),
+            ),
+            this.getSaveButton().click(),
+        ]);
+        await expect(this.getDialog()).toHaveCount(0);
+    }
+
+    async cancel(): Promise<void> {
+        await this.getDialog().getByTestId('vocabulary-edit-modal--cancel').click();
+        await expect(this.getDialog()).toHaveCount(0);
+    }
+
+    async closeWithIcon(): Promise<void> {
+        await this.getDialog().getByTestId('vocabulary-edit-modal--close').click();
+        await expect(this.getDialog()).toHaveCount(0);
+    }
+
+    /**
+     * Creates a custom field through the create dialog. No vocabulary in the `main` snapshot has
+     * a field type, so every custom field tab starts empty and there is no per-test fixture API;
+     * every test that needs a custom field builds it here first (one dialog, one save - the
+     * atomic-precondition exception in e2e/WRITING_TESTS.md).
+     */
+    async createCustomField(
+        values: ICustomFieldValues & {id: string; name: string},
+        configureDialog?: () => Promise<void>,
+    ): Promise<void> {
+        await this.openCreateDialog();
+        await this.fillDialog(values);
+        await configureDialog?.();
+        await this.save();
+        await expect(this.getListItem(values.name)).toBeVisible();
+    }
+
+    /**
+     * Ticks content types on the "Related content" dialog. At least one is required there:
+     * `requireAllowedTypesSelection` in VocabularyEditController.tsx keeps Save disabled while
+     * none is ticked.
+     *
+     * The controls are `sd-check` spans carrying the label, not checkbox inputs, so they are
+     * clicked rather than checked.
+     */
+    async setAllowedContentTypes(typeLabels: Array<string>): Promise<void> {
+        for (const typeLabel of typeLabels) {
+            await this.getDialog().getByLabel(typeLabel).click();
+        }
+    }
+
+    /** The deletion confirmation shown for a field no content profile uses. */
+    getDeletionModal(): Locator {
+        return this.page.getByTestId('vocabulary-deletion-modal--can-delete');
+    }
+
+    /** The variant shown instead when at least one content profile uses the field. */
+    getDeletionRefusal(): Locator {
+        return this.page.getByTestId('vocabulary-deletion-modal--cannot-delete');
+    }
+
+    /**
+     * Confirms the open deletion modal and waits for the DELETE it triggers, so a caller that
+     * re-reads the list or navigates straight after cannot race it.
+     */
+    async confirmDeletion(fieldId: string): Promise<void> {
+        await Promise.all([
+            this.page.waitForResponse(
+                (response) => response.url().includes(`/api/vocabularies/${fieldId}`)
+                    && response.request().method() === 'DELETE',
+            ),
+            this.getDeletionModal().getByRole('button', {name: 'Delete'}).click(),
+        ]);
+        await expect(this.getDeletionModal()).toHaveCount(0);
+    }
+}

--- a/scripts/apps/vocabularies/views/vocabulary-config-modal.html
+++ b/scripts/apps/vocabularies/views/vocabulary-config-modal.html
@@ -4,7 +4,14 @@
             <h3 class="modal__heading" ng-show="vocabulary._id"><span translate>Edit</span> {{vocabulary.display_name}}
             </h3>
             <h3 class="modal__heading" ng-show="!vocabulary._id"><span translate>Create</span></h3>
-            <a href="" class="icn-btn close-modal" ng-click="cancel()"><i class="icon-close-small"></i></a>
+            <a
+                href=""
+                class="icn-btn close-modal"
+                ng-click="cancel()"
+                data-test-id="vocabulary-edit-modal--close"
+            >
+                <i class="icon-close-small"></i>
+            </a>
         </div>
         <div class="modal__body modal__body--with-navigation" data-test-id="vocabulary-edit-content">
             <ul class="modal__navigation" ng-if="matchFieldTypeToTab('vocabularies', vocabulary.field_type)" data-test-id="vocabulary-tabs">
@@ -365,6 +372,7 @@
                     ng-click="save()"
                     ng-disabled="!editForm.$dirty || editForm.$invalid || !itemsValidation.valid || requireAllowedTypesSelection()"
                     translate
+                    data-test-id="vocabulary-edit-modal--save"
                 >
                     Save
                 </button>


### PR DESCRIPTION
### Purpose
Six QA cases whose titles carry an "(AUTOMATED)" marker turned out to have no actual Playwright coverage anywhere in the repo, so this automates all of them as one consolidated spec (9 tests) with per-test `confluence` annotations:
- [Remove custom text field](https://sofab.atlassian.net/wiki/spaces/SET/pages/1311835048), [date](https://sofab.atlassian.net/wiki/spaces/SET/pages/1311835058), [embed](https://sofab.atlassian.net/wiki/spaces/SET/pages/1311835066), [related content](https://sofab.atlassian.net/wiki/spaces/SET/pages/1311835074), [URL](https://sofab.atlassian.net/wiki/spaces/SET/pages/1311835083) - all `partial`
- [Edit URL field](https://sofab.atlassian.net/wiki/spaces/SET/pages/1311835081) - `partial`

All `partial` levels carry named blockers in the spec header: the cases document a "Confirm" dialog the product replaced with "Delete vocabulary?" / "Cannot delete vocabulary" dialogs, and the Edit case's read-only ID cannot exercise its required/no-spaces sub-steps.

### What has changed
- New spec `e2e/client/playwright/metadata.custom-fields.spec.ts` (removal lifecycle per field type, in-use refusal, picker consequences, URL-field edit dialog semantics)
- New `settings/metadata.ts` page object (a strict superset of the one on the custom-datetime branch #5339; if that merges first, resolve the add/add conflict by taking this version) and additive `content-profile.ts` methods
- Two `data-test-id` attributes in `vocabulary-config-modal.html`, byte-identical to #5339 so the branches merge cleanly

Two product issues found and documented in the spec header (assertions route around them):
1. A deleted vocabulary is still offered in the Content section of the content-profile field picker (stale until reload, and unreliably even then)
2. Deleting a vocabulary never broadcasts `vocabularies:updated`, so the in-page vocabulary cache keeps serving the removed field until a reload (the save path does broadcast)

### Steps to test
See the spec header for the per-case mapping. Run it: `cd e2e/client && npx playwright test metadata.custom-fields.spec.ts --workers=1`
27/27 green over `--repeat-each 3` plus a clean single run; the impartial review returned zero findings. (Local runs need `--workers=1`: the default 3 workers share one backend and clobber each other's snapshot restores; CI already pins 1.)

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
