### PR TITLE
Automate the content expiry QA cases as a consolidated spec

### DIFF
--- a/e2e/client/playwright/content-expiry.spec.ts
+++ b/e2e/client/playwright/content-expiry.spec.ts
@@ -1,0 +1,337 @@
+import {test, expect, Locator, Page} from '@playwright/test';
+import {restoreDatabaseSnapshot} from './utils';
+import {Authoring} from './page-object-models/authoring';
+import {Monitoring} from './page-object-models/monitoring';
+import {IContentExpiry} from './page-object-models/content-expiry';
+import {DeskSettings} from './page-object-models/settings/desks';
+import {IngestSettings} from './page-object-models/settings/ingest';
+
+/**
+ * Content expiry at desk, stage and ingest level.
+ *
+ * Covered: setting an expiry at each level and it persisting, the inherited
+ * ("Using <Desk|System> default" / "OFF") expiry the settings UI shows for a
+ * level that has none of its own, and the expiry the backend stamps on an item
+ * from the desk and stage it is created on or sent to, read from the item
+ * preview's Metadata tab.
+ *
+ * Uncovered expected results and why:
+ *
+ * - "Check again after expiry date and time is reached - items are removed"
+ *   (1344444534 step 3, 1344444536 CASE 1 step 4 / CASE 2 step 4) and "item is
+ *   removed when expiry date and time is reached" (1344444532 step 1): removal
+ *   is done by a backend background job (SDESK-5932), and the shortest expiry
+ *   the form accepts is one minute. Reaching the expected result means waiting
+ *   for wall-clock time to pass, which no spec here may do.
+ * - "Published items have automatically set content expiry = 7 days. This is
+ *   not expected to be overwritten by desk content expiry" (1344444534): the
+ *   rule is driven by the backend's `publish_content_expiry_minutes`, which the
+ *   e2e stack reports as 0 in `/api/client_config`. Published items get no
+ *   expiry at all here, so the rule cannot be observed.
+ *
+ * Deliberate departures from the case steps:
+ *
+ * - The desk and stage cases say "create a new desk". These tests configure the
+ *   snapshot's Sports desk instead: creating a desk is already covered by
+ *   desks.spec.ts, and a new desk would also need members before its stages
+ *   appear in monitoring, which is not what these cases are about.
+ * - They also say "create a few items with different workflow states". The
+ *   effective expiry is derived from the item's desk and stage, so the tests
+ *   vary the desk / stage configuration instead and assert one item per
+ *   configuration. The one state that does have its own rule, published, is the
+ *   `publish_content_expiry_minutes` case named above.
+ * - 1344444532 step 1 says the new ingest source's expiry works; only the
+ *   "set it while creating the source" half is deterministic, and it is
+ *   asserted on a File feed source rather than a live feed, because creating a
+ *   source whose feeding service must be reachable fails without one.
+ */
+
+const MINUTE = 60 * 1000;
+
+const DESK_EXPIRY: IContentExpiry = {days: 1, hours: 2, minutes: 0};
+const DESK_EXPIRY_MINUTES = 26 * 60;
+
+const STAGE_EXPIRY: IContentExpiry = {days: 0, hours: 3, minutes: 0};
+const STAGE_EXPIRY_MINUTES = 3 * 60;
+
+const INGEST_EXPIRY: IContentExpiry = {days: 0, hours: 5, minutes: 30};
+
+const INGEST_PROVIDER = 'Antara news provider';
+const INGESTED_ITEM = 'Indonesia opens pasteurized milk facility to back free meals program';
+
+/**
+ * Both timestamps come from the same document, so the comparison does not
+ * depend on the test host's clock agreeing with the backend's. The backend
+ * stamps `expiry` as "now + effective expiry" when the item is written, so the
+ * gap is the configured expiry plus however long the test spent in authoring.
+ */
+async function getExpiryOffsetMinutes(preview: Locator): Promise<number> {
+    const created = preview.getByTestId('metadata-created').locator('time');
+    const expiry = preview.getByTestId('metadata-expiry').locator('time');
+
+    await expect(created).toHaveAttribute('datetime', /\d/);
+    await expect(expiry).toHaveAttribute('datetime', /\d/);
+
+    const [createdAt, expiresAt] = await Promise.all([
+        created.getAttribute('datetime'),
+        expiry.getAttribute('datetime'),
+    ]);
+
+    return (Date.parse(expiresAt as string) - Date.parse(createdAt as string)) / MINUTE;
+}
+
+async function expectExpiryOffset(preview: Locator, expectedMinutes: number): Promise<void> {
+    const offset = await getExpiryOffsetMinutes(preview);
+
+    expect(offset).toBeGreaterThanOrEqual(expectedMinutes);
+    expect(offset).toBeLessThan(expectedMinutes + 5);
+}
+
+/**
+ * Creates an article on Sports, saves it and closes authoring.
+ *
+ * Autosave is debounced, so saving before the typed slugline has been autosaved
+ * leaves the queued autosave to re-dirty the item and raise the "Save changes?"
+ * prompt on close. Waiting for the autosave first keeps the close deterministic.
+ */
+async function createArticle(page: Page, slugline: string): Promise<void> {
+    const monitoring = new Monitoring(page);
+
+    await page.goto('/#/workspace/monitoring');
+    await monitoring.selectDeskOrWorkspace('Sports');
+
+    const [autosave] = await Promise.all([
+        page.waitForResponse(
+            (r) => /\/archive_autosave$/.test(new URL(r.url()).pathname) && r.request().method() === 'POST',
+        ),
+        monitoring.createArticleFromTemplate('story', {slugline}),
+    ]);
+
+    expect(autosave.status()).toBe(201);
+
+    await page.getByTestId('authoring-topbar').getByTestId('save').click();
+    await expect(monitoring.getArticleLocator(slugline)).toBeVisible();
+
+    await page.getByTestId('authoring-topbar').getByTestId('close').click();
+    await expect(page.getByTestId('authoring-topbar')).toBeHidden();
+}
+
+async function openMetadataPreview(page: Page, articleLabel: string): Promise<Locator> {
+    const monitoring = new Monitoring(page);
+    const item = monitoring.getArticleLocator(articleLabel);
+    const preview = monitoring.getPreviewPane();
+
+    await expect(item).toBeVisible();
+
+    // A click that lands while monitoring is re-rendering its groups (as it
+    // does after an item changes stage) leaves no preview open, so retry the
+    // whole open until the Metadata tab is up.
+    await expect(async () => {
+        await item.click();
+        await expect(preview).toBeVisible({timeout: 5000});
+        await monitoring.openPreviewTab('Metadata');
+        await expect(preview.getByTestId('metadata-created')).toBeVisible({timeout: 5000});
+    }).toPass({timeout: 20000});
+
+    return preview;
+}
+
+test.describe('content expiry', () => {
+    // These tests walk the settings wizards and then authoring, which does not
+    // fit the 30s default.
+    test.describe.configure({timeout: 90000});
+
+    test('a desk content expiry is stored and applied to items created on the desk', {
+        annotation: [
+            {type: 'confluence', description: '1344444534 partial'}, // Content expiry on desk level
+        ],
+    }, async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const desks = new DeskSettings(page);
+
+        await desks.open();
+        await desks.openEdit('Sports');
+
+        const deskExpiry = desks.deskContentExpiry;
+
+        // Sports ships with `content_expiry: 0`, which the directive reads as
+        // "expiry on, nothing set", so the badge falls back to the system
+        // default `content_expiry_minutes` (0 in the e2e backend, hence "OFF").
+        await expect(deskExpiry.effective).toHaveText('OFF');
+
+        await deskExpiry.set(DESK_EXPIRY);
+
+        // A desk-level value replaces the inherited one, so the badge goes away.
+        await deskExpiry.expectValue(DESK_EXPIRY);
+        await expect(deskExpiry.effective).toHaveCount(0);
+
+        await desks.saveAndClose();
+
+        await desks.openEdit('Sports');
+        await desks.deskContentExpiry.expectValue(DESK_EXPIRY);
+        await desks.closeModal();
+
+        const slugline = 'desk expiry story';
+
+        await createArticle(page, slugline);
+        await expectExpiryOffset(await openMetadataPreview(page, slugline), DESK_EXPIRY_MINUTES);
+    });
+
+    test('a stage content expiry overrides the desk one, other stages keep the desk one', {
+        annotation: [
+            {type: 'confluence', description: '1344444536 partial'}, // Content expiry on stage level
+        ],
+    }, async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const desks = new DeskSettings(page);
+
+        await desks.open();
+        await desks.openEdit('Sports');
+        await desks.deskContentExpiry.set(DESK_EXPIRY);
+        await desks.saveAndContinueToStages();
+
+        await desks.openStageEdit('Working Stage');
+        await desks.stageContentExpiry.set(STAGE_EXPIRY);
+        await desks.saveStage();
+
+        await desks.selectStage('Working Stage');
+        await expect(desks.stageExpirySummary).toHaveText('0 day 3 hr 0 min');
+
+        await desks.selectStage('Incoming Stage');
+        await expect(desks.stageExpirySummary).toHaveText('Using Desk default (days:1 hr:2 min:0)');
+
+        await desks.closeModal();
+
+        const slugline = 'stage expiry story';
+
+        await createArticle(page, slugline);
+        await expectExpiryOffset(await openMetadataPreview(page, slugline), STAGE_EXPIRY_MINUTES);
+
+        // Moving the item onto a stage without its own expiry re-derives it
+        // from the desk.
+        const monitoring = new Monitoring(page);
+        const authoring = new Authoring(page);
+
+        await monitoring.executeActionOnMonitoringItem(monitoring.getArticleLocator(slugline), 'Edit');
+        await authoring.sendTo({desk: 'Sports', stage: 'Incoming Stage'});
+
+        // Preview only after the item is listed under the new stage: until the
+        // list refreshes it still holds the pre-move document, expiry included.
+        const incomingStage = page.getByTestId('monitoring-group')
+            .and(page.locator('[data-test-value="Sports / Incoming Stage"]'));
+
+        await expect(incomingStage.getByTestId('article-item')
+            .and(page.locator(`[data-test-value="${slugline}"]`))).toBeVisible();
+
+        await expectExpiryOffset(await openMetadataPreview(page, slugline), DESK_EXPIRY_MINUTES);
+    });
+
+    test('a stage content expiry applies while the desk has none', {
+        annotation: [
+            {type: 'confluence', description: '1344444536 partial'}, // Content expiry on stage level
+        ],
+    }, async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const desks = new DeskSettings(page);
+
+        await desks.open();
+        await desks.openEdit('Sports');
+        await desks.deskContentExpiry.turnOff();
+        await desks.saveAndContinueToStages();
+
+        await desks.openStageEdit('Working Stage');
+        await desks.stageContentExpiry.set(STAGE_EXPIRY);
+        await desks.saveStage();
+
+        await desks.selectStage('Working Stage');
+        await expect(desks.stageExpirySummary).toHaveText('0 day 3 hr 0 min');
+
+        // With the desk expiry off the fallback is the system default, 0 in the
+        // e2e backend, so the other stages show "OFF" rather than a desk value.
+        await desks.selectStage('Incoming Stage');
+        await expect(desks.stageExpirySummary).toHaveText('OFF');
+
+        await desks.closeModal();
+
+        const slugline = 'stage only expiry story';
+
+        await createArticle(page, slugline);
+        await expectExpiryOffset(await openMetadataPreview(page, slugline), STAGE_EXPIRY_MINUTES);
+    });
+
+    test('a content expiry set while creating an ingest source is stored on it', {
+        annotation: [
+            {type: 'confluence', description: '1344444532 partial'}, // Content expiry on Ingest
+        ],
+    }, async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        const ingest = new IngestSettings(page);
+        const sourceName = 'Expiry source';
+
+        await ingest.open();
+        await ingest.addNewSource();
+
+        await ingest.modal.getByTestId('ingest-source-modal--field--name').fill(sourceName);
+        await ingest.modal.getByTestId('ingest-source-modal--field--source').fill('expiry-src');
+
+        // A File feed saves without the backend reaching the configured
+        // endpoint. An RSS source is rejected with "API ingest connection
+        // error" unless its URL answers, which no e2e run can guarantee.
+        await ingest.modal.locator('#provider-feeding-service').selectOption({label: 'File feed'});
+        await ingest.modal.locator('#file-path').fill('/tmp');
+
+        // A source with no expiry of its own inherits the backend's
+        // `ingest_expiry_minutes`, 2880 in the e2e stack.
+        await expect(ingest.contentExpiry.effective).toHaveText('Using System default');
+        await expect(ingest.contentExpiry.effective).toHaveAttribute('title', 'days:2 hr:0 min:0');
+
+        await ingest.contentExpiry.set(INGEST_EXPIRY);
+        await expect(ingest.contentExpiry.effective).toHaveCount(0);
+
+        await ingest.save();
+
+        await ingest.openEdit(sourceName);
+        await ingest.contentExpiry.expectValue(INGEST_EXPIRY);
+    });
+
+    test('changing an ingest source content expiry leaves already ingested items untouched', {
+        annotation: [
+            {type: 'confluence', description: '1344444532 partial'}, // Content expiry on Ingest
+        ],
+    }, async ({page}) => {
+        await restoreDatabaseSnapshot();
+
+        await page.goto('/#/workspace/ingest');
+
+        const expiryBefore = await (await openMetadataPreview(page, INGESTED_ITEM))
+            .getByTestId('metadata-expiry').locator('time').getAttribute('datetime');
+
+        expect(expiryBefore).not.toBeNull();
+
+        const ingest = new IngestSettings(page);
+
+        await ingest.open();
+        // The snapshot's only provider is closed, which the default Active
+        // filter hides.
+        await ingest.filterByStatus('Closed');
+        await ingest.openEdit(INGEST_PROVIDER);
+        await ingest.contentExpiry.set(INGEST_EXPIRY);
+        await ingest.save();
+
+        await ingest.openEdit(INGEST_PROVIDER);
+        await ingest.contentExpiry.expectValue(INGEST_EXPIRY);
+        await ingest.modal.getByRole('button', {name: 'Cancel'}).click();
+        await expect(ingest.modal).toBeHidden();
+
+        await page.goto('/#/workspace/ingest');
+
+        const expiryAfter = await (await openMetadataPreview(page, INGESTED_ITEM))
+            .getByTestId('metadata-expiry').locator('time').getAttribute('datetime');
+
+        expect(expiryAfter).toBe(expiryBefore);
+    });
+});

--- a/e2e/client/playwright/page-object-models/content-expiry.ts
+++ b/e2e/client/playwright/page-object-models/content-expiry.ts
@@ -1,0 +1,63 @@
+import {Locator, expect} from '@playwright/test';
+
+export interface IContentExpiry {
+    days: number;
+    hours: number;
+    minutes: number;
+}
+
+/**
+ * Driver for the `sd-content-expiry` directive, which renders the Content
+ * Expiry control identically for desks, stages and ingest sources.
+ */
+export class ContentExpiryField {
+    private root: Locator;
+
+    constructor(root: Locator) {
+        this.root = root;
+    }
+
+    get row(): Locator {
+        return this.root.getByTestId('content-expiry');
+    }
+
+    /**
+     * The "Using <Desk|System> default" / "OFF" badge. It only renders while
+     * this level has no expiry of its own, so it shows what the level inherits.
+     */
+    get effective(): Locator {
+        return this.row.getByTestId('content-expiry--effective');
+    }
+
+    /** The days / hours / minutes inputs only render while the toggle is on. */
+    async set(expiry: IContentExpiry): Promise<void> {
+        const days = this.row.getByTestId('content-expiry--days');
+
+        await expect(this.row).toBeVisible();
+
+        if (await days.count() === 0) {
+            await this.row.getByTestId('content-expiry--toggle').click();
+        }
+
+        await days.fill(String(expiry.days));
+        await this.row.getByTestId('content-expiry--hours').fill(String(expiry.hours));
+        await this.row.getByTestId('content-expiry--minutes').fill(String(expiry.minutes));
+    }
+
+    /** Switching the toggle off stores `-1`, the directive's "no expiry here". */
+    async turnOff(): Promise<void> {
+        await expect(this.row).toBeVisible();
+
+        if (await this.row.getByTestId('content-expiry--days').count() > 0) {
+            await this.row.getByTestId('content-expiry--toggle').click();
+        }
+
+        await expect(this.row.getByTestId('content-expiry--days')).toHaveCount(0);
+    }
+
+    async expectValue(expiry: IContentExpiry): Promise<void> {
+        await expect(this.row.getByTestId('content-expiry--days')).toHaveValue(String(expiry.days));
+        await expect(this.row.getByTestId('content-expiry--hours')).toHaveValue(String(expiry.hours));
+        await expect(this.row.getByTestId('content-expiry--minutes')).toHaveValue(String(expiry.minutes));
+    }
+}

--- a/e2e/client/playwright/page-object-models/settings/desks.ts
+++ b/e2e/client/playwright/page-object-models/settings/desks.ts
@@ -1,0 +1,125 @@
+import {Locator, Page, expect} from '@playwright/test';
+import {ContentExpiryField} from '../content-expiry';
+
+/**
+ * Desk settings (`#/settings/desks`) and the desk configuration modal.
+ */
+export class DeskSettings {
+    private page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    get modal(): Locator {
+        return this.page.getByTestId('desk-config-modal');
+    }
+
+    /**
+     * `sd-wizard` keeps every step in the DOM and only shows the current one,
+     * so anything the steps have in common has to be looked up per step.
+     */
+    get generalStep(): Locator {
+        return this.modal.locator('[sd-deskedit-basic]');
+    }
+
+    get stagesStep(): Locator {
+        return this.modal.locator('[sd-deskedit-stages]');
+    }
+
+    get deskContentExpiry(): ContentExpiryField {
+        return new ContentExpiryField(this.generalStep);
+    }
+
+    get stageContentExpiry(): ContentExpiryField {
+        return new ContentExpiryField(this.stagesStep);
+    }
+
+    async open(): Promise<void> {
+        await this.page.goto('/#/settings/desks');
+        await expect(this.page.getByTestId('add-new-desk')).toBeVisible();
+    }
+
+    async openEdit(deskName: string): Promise<void> {
+        const row = this.page.getByTestId(`desk--${deskName}`);
+
+        await expect(row).toBeVisible();
+        await row.getByTestId('desk-actions').click();
+        await row.getByTestId('desk-actions--options').getByTestId('desk-actions--edit').click();
+        await expect(this.modal).toBeVisible();
+    }
+
+    /**
+     * Saves the General step and closes the modal. The modal hiding does not
+     * mean the PATCH landed, so wait for the response too.
+     */
+    async saveAndClose(): Promise<void> {
+        const [response] = await Promise.all([
+            this.page.waitForResponse(
+                (r) => /\/desks\/[^/]+$/.test(new URL(r.url()).pathname) && r.request().method() === 'PATCH',
+            ),
+            this.modal.getByTestId('done').click(),
+        ]);
+
+        expect(response.status()).toBe(200);
+        await expect(this.modal).not.toBeVisible();
+    }
+
+    /** Saves the General step and moves the wizard on to Stages. */
+    async saveAndContinueToStages(): Promise<void> {
+        const [response] = await Promise.all([
+            this.page.waitForResponse(
+                (r) => /\/desks\/[^/]+$/.test(new URL(r.url()).pathname) && r.request().method() === 'PATCH',
+            ),
+            this.modal.getByTestId('save-and-continue').click(),
+        ]);
+
+        expect(response.status()).toBe(200);
+        await expect(this.stagesStep.getByTestId('new-stage')).toBeVisible();
+    }
+
+    getStageRow(stageName: string): Locator {
+        return this.stagesStep.getByTestId(`stage--${stageName}`);
+    }
+
+    /** Selects a stage so its read-only Stage Details column renders. */
+    async selectStage(stageName: string): Promise<void> {
+        const row = this.getStageRow(stageName);
+
+        await row.click();
+        await expect(row).toHaveClass(/active/);
+    }
+
+    async openStageEdit(stageName: string): Promise<void> {
+        const row = this.getStageRow(stageName);
+
+        await this.selectStage(stageName);
+        await row.getByTestId('stage-actions--edit').click();
+        await expect(this.stagesStep.getByTestId('save-edited-stage')).toBeVisible();
+    }
+
+    async saveStage(): Promise<void> {
+        const [response] = await Promise.all([
+            this.page.waitForResponse(
+                (r) => /\/stages\/[^/]+$/.test(new URL(r.url()).pathname) && r.request().method() === 'PATCH',
+            ),
+            this.stagesStep.getByTestId('save-edited-stage').click(),
+        ]);
+
+        expect(response.status()).toBe(200);
+        await expect(this.stagesStep.getByTestId('save-edited-stage')).toHaveCount(0);
+    }
+
+    /**
+     * The read-only "Content expiry" line of the selected stage: the stage's
+     * own value when it has one, the inherited desk or system default otherwise.
+     */
+    get stageExpirySummary(): Locator {
+        return this.stagesStep.getByTestId('content-expiry-summary');
+    }
+
+    async closeModal(): Promise<void> {
+        await this.modal.getByTestId('close-modal').click();
+        await expect(this.modal).not.toBeVisible();
+    }
+}

--- a/e2e/client/playwright/page-object-models/settings/ingest.ts
+++ b/e2e/client/playwright/page-object-models/settings/ingest.ts
@@ -1,0 +1,71 @@
+import {Locator, Page, expect} from '@playwright/test';
+import {ContentExpiryField} from '../content-expiry';
+
+/**
+ * Ingest settings (`#/settings/ingest`), Sources tab.
+ */
+export class IngestSettings {
+    private page: Page;
+
+    constructor(page: Page) {
+        this.page = page;
+    }
+
+    get modal(): Locator {
+        return this.page.getByTestId('ingest-source-modal');
+    }
+
+    get contentExpiry(): ContentExpiryField {
+        return new ContentExpiryField(this.modal);
+    }
+
+    async open(): Promise<void> {
+        await this.page.goto('/#/settings/ingest');
+        await expect(this.page.getByTestId('ingest-sources-status-filter')).toBeVisible();
+    }
+
+    /**
+     * The Add New button only opens the modal once the feeding services have
+     * loaded, and nothing on the page reflects that, so retry the click.
+     */
+    async addNewSource(): Promise<void> {
+        await expect(async () => {
+            await this.page.getByRole('button', {name: 'Add New'}).click();
+            await expect(this.modal).toBeVisible({timeout: 3000});
+        }).toPass({timeout: 30000});
+    }
+
+    /** The source list is filtered by status; closed sources need the filter. */
+    async filterByStatus(status: 'Active' | 'All' | 'Closed'): Promise<void> {
+        await this.page.getByTestId('ingest-sources-status-filter').click();
+        await this.page.getByTestId('ingest-sources-status-filter--option')
+            .and(this.page.locator(`[data-test-value="${status}"]`))
+            .click();
+    }
+
+    getSourceRow(name: string): Locator {
+        return this.page.getByTestId('ingest-source').and(this.page.locator(`[data-test-value="${name}"]`));
+    }
+
+    async openEdit(name: string): Promise<void> {
+        const row = this.getSourceRow(name);
+
+        await expect(row).toBeVisible();
+        await row.hover();
+        await row.getByTestId('ingest-source--edit').click();
+        await expect(this.modal).toBeVisible();
+    }
+
+    async save(): Promise<void> {
+        const [response] = await Promise.all([
+            this.page.waitForResponse(
+                (r) => /\/ingest_providers(\/[^/]+)?$/.test(new URL(r.url()).pathname)
+                    && ['POST', 'PATCH'].includes(r.request().method()),
+            ),
+            this.modal.getByRole('button', {name: 'Save', exact: true}).click(),
+        ]);
+
+        expect(response.status()).toBeLessThan(300);
+        await expect(this.modal).toBeHidden();
+    }
+}

--- a/scripts/apps/archive/views/metadata-view.html
+++ b/scripts/apps/archive/views/metadata-view.html
@@ -87,7 +87,7 @@
         </dl>
         <dl ng-if="item.firstcreated">
             <dt translate>Created</dt>
-            <dd sd-reldate-complex datetime="item.firstcreated"></dd>
+            <dd sd-reldate-complex datetime="item.firstcreated" data-test-id="metadata-created"></dd>
         </dl>
         <dl ng-if="item.versioncreated">
             <dt translate>Last updated</dt>
@@ -96,7 +96,7 @@
 
         <dl ng-if="item.expiry">
             <dt translate>Expiry</dt>
-            <dd sd-reldate-complex datetime="item.expiry"></dd>
+            <dd sd-reldate-complex datetime="item.expiry" data-test-id="metadata-expiry"></dd>
         </dl>
         <dl ng-if="item.original_id">
             <dt translate>Original ID</dt>

--- a/scripts/apps/desks/views/content-expiry.html
+++ b/scripts/apps/desks/views/content-expiry.html
@@ -1,4 +1,4 @@
-<span ng-if="preview && contentExpiry.expire">
+<span ng-if="preview && contentExpiry.expire" data-test-id="content-expiry-summary">
     <span ng-if="!contentExpiry.actualExpiry">{{contentExpiry.header | translate}}
     {{ contentExpiry.days}} <span class="helper-text" translate>day</span>
     {{ contentExpiry.hours}} <span class="helper-text" translate>hr</span>
@@ -9,23 +9,25 @@
     </span>
 </span>
 
-<label ng-if="preview && !contentExpiry.expire">{{contentExpiry.header | translate}}
+<label ng-if="preview && !contentExpiry.expire"
+       data-test-id="content-expiry-summary">{{contentExpiry.header | translate}}
   {{contentExpiry.actualExpiry.text | translate}} {{contentExpiry.actualExpiry.expiry | translate}}
 </label>
 
-<div ng-if="!preview && contentExpiry.expire" class="form__row">
+<div ng-if="!preview && contentExpiry.expire" class="form__row" data-test-id="content-expiry">
     <div class="">
-        <span sd-switch ng-model="contentExpiry.expire"></span>
+        <span sd-switch ng-model="contentExpiry.expire" data-test-id="content-expiry--toggle"></span>
         <label class="inline-label">{{contentExpiry.header | translate}}
             <span class="label label--primary label--hollow"
                   ng-if="contentExpiry.actualExpiry"
+                  data-test-id="content-expiry--effective"
                   title="{{ contentExpiry.actualExpiry.expiry | translate}}">{{ contentExpiry.actualExpiry.text | translate }}</span>
         </label>
     </div>
     <div class="form__row form__row--flex form__row--no-padding">
         <div class="form__row-item form__row-item--no-grow">
             <div class="sd-line-input sd-line-input--no-margin">
-                <input class="sd-line-input__input sd-line-input__input--mini" type="number" ng-model="contentExpiry.days" min ="0" required>
+                <input class="sd-line-input__input sd-line-input__input--mini" type="number" ng-model="contentExpiry.days" min ="0" required data-test-id="content-expiry--days">
             </div>
         </div>
         <div class="form__row-item form__row-item--no-grow">
@@ -33,7 +35,7 @@
         </div>
         <div class="form__row-item form__row-item--no-grow">
             <div class="sd-line-input sd-line-input--no-margin">
-                <input class="sd-line-input__input sd-line-input__input--mini" type="number" ng-model="contentExpiry.hours" min ="0" max="23" required>
+                <input class="sd-line-input__input sd-line-input__input--mini" type="number" ng-model="contentExpiry.hours" min ="0" max="23" required data-test-id="content-expiry--hours">
             </div>
         </div>
         <div class="form__row-item form__row-item--no-grow">
@@ -41,7 +43,7 @@
         </div>
         <div class="form__row-item form__row-item--no-grow">
             <div class="sd-line-input sd-line-input--no-margin">
-                <input class="sd-line-input__input sd-line-input__input--mini" type="number" ng-model="contentExpiry.minutes" min ="0" max="59" required>
+                <input class="sd-line-input__input sd-line-input__input--mini" type="number" ng-model="contentExpiry.minutes" min ="0" max="59" required data-test-id="content-expiry--minutes">
             </div>
         </div>
         <div class="form__row-item form__row-item--no-grow">
@@ -51,12 +53,13 @@
 </div>
 
 
-<div ng-if="!preview && !contentExpiry.expire" class="form__row">
+<div ng-if="!preview && !contentExpiry.expire" class="form__row" data-test-id="content-expiry">
     <div class="form__row-item" style="padding-bottom: 1.4rem;">
-        <span sd-switch ng-model="contentExpiry.expire"></span>
+        <span sd-switch ng-model="contentExpiry.expire" data-test-id="content-expiry--toggle"></span>
         <label class="inline-label">{{contentExpiry.header | translate}}
             <span class="label label--primary label--hollow"
                   ng-if="contentExpiry.actualExpiry"
+                  data-test-id="content-expiry--effective"
                   title="{{ contentExpiry.actualExpiry.expiry | translate}}">{{ contentExpiry.actualExpiry.text | translate }}</span>
         </label>
     </div>

--- a/scripts/apps/desks/views/desk-config-modal.html
+++ b/scripts/apps/desks/views/desk-config-modal.html
@@ -3,7 +3,7 @@
     <div class="modal__header modal__header--flex">
         <h3 class="modal__heading" ng-show="!desk.edit._id" translate>Add New Desk</h3>
         <h3 class="modal__heading" ng-show="desk.edit._id" translate translate-params-name="desk.edit.name">Edit "{{name}}" Desk</h3>
-        <a href="" class="icn-btn close-modal" ng-click="cancel()"><i class="icon-close-small"></i></a>
+        <a href="" class="icn-btn close-modal" ng-click="cancel()" data-test-id="close-modal"><i class="icon-close-small"></i></a>
     </div>
 
     <div class="modal__body" sd-wizard data-name="desks" data-current-step="step.current" data-finish="cancel()" data-can-tab-change="canTabChange()">

--- a/scripts/apps/ingest/views/settings/ingest-sources-content.html
+++ b/scripts/apps/ingest/views/settings/ingest-sources-content.html
@@ -83,7 +83,7 @@
                     <div class="form__row form__row--s-padding">
                         <div class="sd-line-input sd-line-input--required">
                             <label class="sd-line-input__label" for="source-name" translate>Source Name</label>
-                            <input class="sd-line-input__input" type="text" id="source-name" ng-model="provider.source" required>
+                            <input class="sd-line-input__input" type="text" id="source-name" ng-model="provider.source" required data-test-id="ingest-source-modal--field--source">
                         </div>
                     </div>
 


### PR DESCRIPTION
### Purpose
Automates the following QA case(s) as Playwright coverage with per-test `confluence` annotations:
- [Content expiry on desk level](https://sofab.atlassian.net/wiki/spaces/SET/pages/1344444534)
- [Content expiry on stage level](https://sofab.atlassian.net/wiki/spaces/SET/pages/1344444536)
- [Content expiry on Ingest](https://sofab.atlassian.net/wiki/spaces/SET/pages/1344444532)

Annotation levels: 1344444532: partial; 1344444534: partial; 1344444536: partial. Partial levels carry named blockers in the spec header.

### What has changed
- Spec file(s): `content-expiry.spec.ts`
- data-test-id product additions where listed in the spec header (needs developer eyes)

### Steps to test
**Given** the `main` snapshot (Sports desk with `content_expiry: 0`, the closed "Antara news provider" with 50 already-ingested items), a backend reporting `content_expiry_minutes: 0`, `ingest_expiry_minutes: 2880` and `publish_content_expiry_minutes: 0`, and the committed admin `storageState`

**When**

1. Desk level (1344444534): open Settings > Desks > Sports > Edit, read the inherited-expiry badge, set Content Expiry to 1 day 2 hr 0 min, save and close, reopen and re-read the fields, then create an article from the `story` template on Sports, save it, close authoring and open its preview Metadata tab.
2. Stage level, CASE 2 (1344444536): set the desk expiry to 1 day 2 hr, continue to Stages, edit Working Stage and give it its own 3 hr expiry, save the stage, then select Working Stage and Incoming Stage in turn and read each one's read-only "Content expiry" line; close the modal, create an article on Sports and read its preview expiry, then reopen it and Send to Sports / Incoming Stage and read the expiry again once it is listed under that stage.
3. Stage level, CASE 1 (1344444536): switch the desk Content Expiry toggle off, give Working Stage a 3 hr expiry, read both stages' "Content expiry" lines, then create an article on Sports and read its preview expiry.
4. Ingest, creation (1344444532 step 1): open Settings > Ingest, Add New, fill name / source / File feed path, read the inherited-expiry badge, set 0 day 5 hr 30 min, save, reopen the source.
5. Ingest, edit (1344444532 step 2): read an already-ingested item's Expiry in the ingest preview's Metadata tab, then edit "Antara news provider" (via the Closed status filter), change its Content Expiry, save, reopen to confirm it stuck, and read the same ingested item's Expiry again.

**Then**

- Before a desk-level value is set, the desk's effective-expiry badge reads `OFF` (system default is 0); after 1 day 2 hr is entered the badge disappears, and the value is still 1 / 2 / 0 after save and reopen.
- An article created on that desk gets an expiry 26 h after its creation timestamp (both read from the same document, so the assertion does not depend on host-vs-backend clock agreement).
- With both a desk and a stage expiry, the stage's own line reads `0 day 3 hr 0 min` while a stage without one reads `Using Desk default (days:1 hr:2 min:0)`; an item created on Working Stage expires 3 h after creation and the same item, once moved to Incoming Stage, expires 26 h after creation.
- With the desk expiry off, Working Stage still reads `0 day 3 hr 0 min`, Incoming Stage falls back to `OFF`, and an item created on Working Stage expires 3 h after creation.
- A new ingest source shows `Using System default` with title `days:2 hr:0 min:0` before an expiry is set; after 0 / 5 / 30 is entered the badge disappears and the values are still 0 / 5 / 30 when the source is reopened.
- Changing an existing provider's Content Expiry persists on the provider and leaves the expiry of items ingested before the change byte-identical.

Run it: `cd e2e/client && npx playwright test content-expiry.spec.ts --workers=1`
Passed 3 consecutive local runs with no changes between them; the impartial review returned zero findings.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
