### PR TITLE
Automate Translations (1344443573)

### DIFF
--- a/e2e/client/playwright/translate-article.authoring-react.spec.ts
+++ b/e2e/client/playwright/translate-article.authoring-react.spec.ts
@@ -1,0 +1,84 @@
+import {test, expect} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+import {getStorageState} from './utils/storage-state';
+
+/**
+ * QA case "Translations" (1344444573). Its only linked test case is "Translate item" (5707530482,
+ * space SDFIL), which carries the steps and the expected results.
+ *
+ * Not covered, with the blocker for each:
+ * - Steps 1-2 of the case: build an Edition package on a Creation desk, send it to a Circulation
+ *   desk, publish it, and translate from that desk's Output. Blocker: Creation/Circulation desks
+ *   and Editions are Superdesk Fidelity configuration that the e2e instance does not have, which
+ *   is also why the parent page says translation workflows are customer specific. The translate
+ *   action itself is the same one, reached from the same three-dot menu.
+ * - "duplicated in the same desk and stage as the original" as a general claim. Blocker: the
+ *   product never reads the original's stage. The client posts the *current* desk (`translate` in
+ *   scripts/api/article.ts) and the server files the copy in that desk's `working_stage`
+ *   (apps/duplication/archive_translate.py in superdesk-core). Original and copy share a stage
+ *   here only because "test sports story" already sits in the Sports working stage.
+ *
+ * The case words the second expected result as a list label ("as an original English item is
+ * marked by EN"). The default list config renders no language field (`DEFAULT_LIST_CONFIG` in
+ * scripts/apps/search/constants.ts), so the language code is asserted where this product does
+ * show it without customer config: the translations side widget.
+ */
+
+const ARTICLE = 'test sports story';
+const TARGET_LANGUAGE = {label: 'Deutsch', code: 'de'};
+
+test.use({
+    storageState: getStorageState({}, {authoringReact: true}),
+});
+
+test.describe('translate article', () => {
+    test('translates an article into another language from the monitoring actions menu', {
+        annotation: [
+            {type: 'confluence', description: '1344444573 partial'}, // Translations / Translate item
+        ],
+    }, async ({page}) => {
+        const monitoring = new Monitoring(page);
+
+        await restoreDatabaseSnapshot();
+        await page.goto('/#/workspace/monitoring');
+        await monitoring.selectDeskOrWorkspace('Sports');
+
+        // the copy keeps the original's headline, so counting this locator is what shows the
+        // translation landed in the same desk and stage rather than somewhere else
+        const copiesInWorkingStage = page
+            .getByTestId('monitoring-group')
+            .and(page.locator('[data-test-value="Sports / Working Stage"]'))
+            .getByTestId('article-item')
+            .and(page.locator(`[data-test-value="${ARTICLE}"]`));
+
+        await expect(copiesInWorkingStage).toHaveCount(1);
+
+        const [response] = await Promise.all([
+            page.waitForResponse(
+                (r) => r.url().endsWith('/archive/translate') && r.request().method() === 'POST',
+            ),
+            monitoring.executeSubmenuAction(copiesInWorkingStage, 'Translate', TARGET_LANGUAGE.label),
+        ]);
+
+        expect(response.status()).toBe(201);
+
+        // TranslationService.set opens the new item in authoring once the POST resolves, so the
+        // header below belongs to the translation, not to the article the menu was opened on
+        await expect(page.getByTestId('authoring-header-translated-from'))
+            .toHaveAttribute('data-test-value', 'en');
+
+        await page.getByTestId('authoring-header-translations-count').click();
+
+        const chain = page.getByTestId('translations-widget').getByTestId('translation-item');
+
+        await expect(chain).toHaveCount(2);
+        await expect(chain.and(page.locator('[data-test-value="en"]'))).toHaveCount(1);
+        await expect(chain.and(page.locator(`[data-test-value="${TARGET_LANGUAGE.code}"]`))).toHaveCount(1);
+
+        await page.goto('/#/workspace/monitoring');
+        await monitoring.selectDeskOrWorkspace('Sports');
+
+        await expect(copiesInWorkingStage).toHaveCount(2);
+    });
+});

--- a/e2e/client/playwright/utils/storage-state.ts
+++ b/e2e/client/playwright/utils/storage-state.ts
@@ -1,8 +1,28 @@
+import fs from 'fs';
+import path from 'path';
 import {BrowserContextOptions} from '@playwright/test';
 import {ISuperdeskGlobalConfig} from 'superdesk-api';
-import storageState from '../.auth/user.json';
+import committedStorageState from '../.auth/user.json';
 
 type StorageState = BrowserContextOptions['storageState'];
+
+/**
+ * localStorage is keyed by origin, and the committed storage state is keyed to
+ * http://localhost:9000. A slot serves the client from another port, so e2e-up.sh
+ * writes an origin-rewritten copy and points `PLAYWRIGHT_STORAGE_STATE` at it
+ * (playwright.config.ts resolves it relative to e2e/client). Patching the committed
+ * copy instead would put both the session and the config patch under an origin the
+ * browser never visits, leaving the test stuck on the login screen.
+ */
+function getBaseStorageState(): {origins: Array<{origin: string; localStorage: Array<unknown>}>} {
+    const slotStorageState = process.env.PLAYWRIGHT_STORAGE_STATE;
+
+    if (slotStorageState != null && slotStorageState !== '') {
+        return JSON.parse(fs.readFileSync(path.resolve(__dirname, '../..', slotStorageState), 'utf-8'));
+    }
+
+    return JSON.parse(JSON.stringify(committedStorageState));
+}
 
 /**
  * Allows to set custom application configs while preserving values defined in .auth/user.json
@@ -11,7 +31,7 @@ export function getStorageState(
     appConfigPatch: Partial<ISuperdeskGlobalConfig>,
     otherOptions?: {authoringReact?: boolean},
 ): StorageState {
-    const storageStateCopy = JSON.parse(JSON.stringify(storageState));
+    const storageStateCopy = getBaseStorageState();
 
     storageStateCopy['origins'][0].localStorage.push({name: 'TEST_APP_CONFIG', value: JSON.stringify(appConfigPatch)});
 
@@ -19,5 +39,5 @@ export function getStorageState(
         storageStateCopy['origins'][0].localStorage.push({name: 'auth-react', value: 'true'});
     }
 
-    return storageStateCopy;
+    return storageStateCopy as StorageState;
 }

--- a/scripts/apps/authoring-react/article-widgets/translations/translations.tsx
+++ b/scripts/apps/authoring-react/article-widgets/translations/translations.tsx
@@ -38,7 +38,11 @@ class Translations extends React.Component<IArticleSideWidgetComponentType> {
                         }
                         translationTemplate={({translation, getTranslatedFromLanguage}) => (
                             <Card key={translation._id}>
-                                <div onClick={() => openArticle(translation._id, 'edit')}>
+                                <div
+                                    onClick={() => openArticle(translation._id, 'edit')}
+                                    data-test-id="translation-item"
+                                    data-test-value={translation.language}
+                                >
                                     <div>
                                         <Spacer h gap="4" justifyContent="space-between" noWrap>
                                             <span className="label">{translation.language}</span>


### PR DESCRIPTION
### Purpose
Automates the following QA case(s) as Playwright coverage with per-test `confluence` annotations:
- [Translations](https://sofab.atlassian.net/wiki/spaces/SET/pages/1344443573)

Annotation levels: 1344444573: partial. Partial levels carry named blockers in the spec header.

### What has changed
- Spec file(s): `translate-article.spec.ts`
- data-test-id product additions where listed in the spec header (needs developer eyes)

### Steps to test
**Given**

1. The `main` database snapshot is restored and the browser is logged in as admin with authoring-react enabled.
2. The Sports desk is selected in Monitoring, and its Working Stage holds exactly one item, "test sports story" (`language: en`).
3. The `languages` vocabulary in `main` lists nl/fr/en/de/es; the backend's `languages` resource defaults every entry to `source: true` and `destination: true`, so the Translate action is offered.

**When**

1. The three-dot menu is opened on "test sports story" in Sports / Working Stage.
2. "Translate" is hovered and "Deutsch" is chosen from its submenu.
3. The translation opens in authoring and the translations count link in the header is clicked.
4. Monitoring is reopened on the Sports desk.

**Then**

- `POST /api/archive/translate` responds 201.
- The item that opens in authoring shows the "Translated from" pill with `data-test-value="en"`, i.e. it is the translation of the English original.
- The translations side widget lists exactly two items in the chain, one marked `en` and one marked `de`, so the newly created item carries the selected language code.
- Sports / Working Stage now holds two items labelled "test sports story", i.e. the translation was filed in the same desk and stage as the original.

Run it: `cd e2e/client && npx playwright test translate-article.spec.ts --workers=1`
Passed 3 consecutive local runs with no changes between them; the impartial review returned zero findings.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
