### PR TITLE
Automate Validate For Publish (1332117823)

### DIFF
--- a/e2e/client/playwright/page-object-models/authoring.ts
+++ b/e2e/client/playwright/page-object-models/authoring.ts
@@ -1,4 +1,4 @@
-import {Locator, Page, expect} from '@playwright/test';
+import {Locator, Page, Response, expect} from '@playwright/test';
 import {s} from '../utils';
 import {TreeSelectDriver} from '../utils/tree-select-driver';
 
@@ -61,6 +61,76 @@ export class Authoring {
             .check();
 
         await page.locator(s('interactive-actions-panel', 'send')).click();
+    }
+
+    /**
+     * Opens a side widget by its label and returns the widget panel.
+     *
+     * Both the tab and the panel carry the label in `data-test-value` while their
+     * visible content is an icon, so they are matched on the attribute.
+     *
+     * The tab toggles rather than opens: clicking it while its widget is active
+     * closes the panel. The tab is therefore only clicked when the panel is not
+     * already showing, so that calling this on an open widget is a no-op.
+     */
+    async openWidget(label: string): Promise<Locator> {
+        const {page} = this;
+        const withLabel = page.locator(`[data-test-value="${label}"]`);
+        const panel = page.getByTestId('authoring-widget-panel').and(withLabel);
+
+        if (!await panel.isVisible()) {
+            await page.getByTestId('authoring-widget').and(withLabel).click();
+        }
+
+        await expect(panel).toBeVisible();
+
+        return panel;
+    }
+
+    /**
+     * Saves through the topbar Save button and waits for the save to finish, leaving the
+     * article open and clean.
+     *
+     * Reach for it before closing when the last edit was made in an editor3 field. editor3
+     * pushes a field change into the authoring model on a debounce (100ms by default), and
+     * a close that beats the debounce closes the article as it was before that edit. The
+     * Save button is enabled only while the model carries unsaved changes, and the topbar's
+     * own `saveTopbar()` handler (`AuthoringTopbarDirective`) waits 600ms before saving the
+     * item, which outlasts the debounce.
+     */
+    async save(): Promise<void> {
+        const save = this.page.getByTestId('authoring-topbar').getByTestId('save');
+        const saving = save.getByTestId('loading-indicator');
+
+        await expect(save).toBeEnabled();
+        await save.click();
+
+        await expect(saving).toBeVisible();
+        await expect(saving).toBeHidden();
+        await expect(save).toBeDisabled();
+    }
+
+    /**
+     * Runs a macro from the already open Macros widget and resolves with the server's reply.
+     *
+     * Macros execute on the backend (`POST /api/macros`) and the widget reports the outcome
+     * only once that request settled, so waiting for the response is what makes a following
+     * assertion about the outcome meaningful. The status is deliberately not checked here:
+     * a macro that reports errors answers with an error status, which is a normal result.
+     */
+    async runMacro(macroLabel: string): Promise<Response> {
+        const {page} = this;
+        const macro = page.getByTestId('authoring-widget-panel')
+            .getByTestId('macro-item')
+            .filter({hasText: macroLabel});
+
+        const [response] = await Promise.all([
+            page.waitForResponse((res) =>
+                res.url().includes('/macros') && res.request().method() === 'POST'),
+            macro.click(),
+        ]);
+
+        return response;
     }
 
     /**

--- a/e2e/client/playwright/validate-for-publish-macro.spec.ts
+++ b/e2e/client/playwright/validate-for-publish-macro.spec.ts
@@ -1,0 +1,98 @@
+import {test, expect, Page} from '@playwright/test';
+import {Authoring} from './page-object-models/authoring';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+
+/**
+ * Covers the "Validate for Publish" macro: it runs publish validation on demand so an
+ * author learns about validation errors before the deadline instead of at publish time.
+ *
+ * Every documented expected result is asserted, so there is no blocker on this case.
+ * The in-flight state of the widget (the macro list sits behind `sd-loading` while the
+ * request runs) is not asserted: it is a mechanism of "waits for server response", not
+ * an outcome, and holding the response back to observe it buys no extra coverage.
+ */
+
+const ARTICLE = 'test sports story';
+const MACRO = 'Validate for Publish';
+
+/**
+ * `Story`, the content profile every article in the `main` snapshot carries, caps slugline
+ * at 24 characters, so a longer one fails publish validation while still saving fine: the
+ * authoring header renders slugline as a plain input with no maxlength of its own.
+ */
+const TOO_LONG_SLUGLINE = 'a slugline well past the profile limit';
+const SLUGLINE_ERROR = 'SLUGLINE is too long';
+
+test.setTimeout(60000);
+
+async function openArticleForEditing(page: Page): Promise<void> {
+    const monitoring = new Monitoring(page);
+
+    await page.goto('/#/workspace/monitoring');
+    await monitoring.selectDeskOrWorkspace('Sports');
+
+    const workingStage = page.getByTestId('monitoring-group')
+        .and(page.locator('[data-test-value="Sports / Working Stage"]'));
+
+    await monitoring.executeActionOnMonitoringItem(
+        workingStage.getByTestId('article-item').filter({hasText: ARTICLE}),
+        'Edit',
+    );
+}
+
+test.describe('validate for publish macro', {
+    annotation: [
+        {type: 'confluence', description: '1332117823 complete'}, // Validate For Publish
+    ],
+}, () => {
+    test('reports the validation errors a publish attempt would raise', async ({page}) => {
+        const authoring = new Authoring(page);
+
+        await restoreDatabaseSnapshot();
+        await openArticleForEditing(page);
+
+        await page.getByTestId('authoring').getByTestId('field-slugline').fill(TOO_LONG_SLUGLINE);
+
+        // the macro validates the item as stored in `archive`, not what sits in the editor,
+        // so the edit has to be persisted before the macro can see it
+        await authoring.save();
+
+        await authoring.openWidget('Macros');
+        await authoring.runMacro(MACRO);
+
+        const error = page.getByTestId('notification--error').filter({hasText: SLUGLINE_ERROR});
+
+        await expect(error).toBeVisible();
+
+        // notifications are de-duplicated by message text, so the macro's own toast has to be
+        // gone before publishing or the assertion after it would pass on the toast still shown
+        await error.click();
+        await expect(error).toBeHidden();
+
+        await authoring.publish({subscribers: []});
+
+        await expect(error).toBeVisible();
+
+        // a successful publish closes authoring, and the toast above is raised on the branch
+        // that leaves it open, so by now the publish is known to have been rejected
+        await expect(page.getByTestId('authoring')).toBeVisible();
+    });
+
+    test('reports no error when the item passes publish validation', async ({page}) => {
+        const authoring = new Authoring(page);
+
+        await restoreDatabaseSnapshot();
+        await openArticleForEditing(page);
+
+        const panel = await authoring.openWidget('Macros');
+        const response = await authoring.runMacro(MACRO);
+
+        // the macro raises no toast when validation passes, so the server's answer and the
+        // widget closing itself are the whole of the reported outcome
+        expect(response.ok()).toBe(true);
+
+        await expect(panel).toBeHidden();
+        await expect(page.getByTestId('notification--error')).toHaveCount(0);
+    });
+});

--- a/scripts/apps/authoring/macros/views/macros-widget.html
+++ b/scripts/apps/authoring/macros/views/macros-widget.html
@@ -6,7 +6,8 @@
     <div ng-show="!groupedList">
         <ul class="link-list" sd-loading="loading">
             <li ng-repeat="macro in macros">
-                <button class="btn btn--hollow" ng-click="call(macro)" translate>{{ macro.label }}</button>
+                <button class="btn btn--hollow" ng-click="call(macro)"
+                    data-test-id="macro-item" translate>{{ macro.label }}</button>
             </li>
         </ul>
     </div>
@@ -14,7 +15,8 @@
         <div sd-toggle-box data-title="{{:: 'quick list' | translate }}" data-open="true">
             <ul class="link-list" sd-loading="loading">
                 <li ng-repeat="macro in quickList | orderBy:'label'">
-                    <button class="btn btn--hollow" ng-click="call(macro)" translate>{{ macro.label }}</button>
+                    <button class="btn btn--hollow" ng-click="call(macro)"
+                        data-test-id="macro-item" translate>{{ macro.label }}</button>
                 </li>
             </ul>
         </div>
@@ -23,7 +25,8 @@
                 ng-click="setGroupStatus(key)" data-open="{{getGroupStatus(key)}}">
                 <ul class="link-list" sd-loading="loading">
                     <li ng-repeat="macro in value">
-                        <button class="btn btn--hollow" ng-click="call(macro)" translate>{{ macro.label }}</button>
+                        <button class="btn btn--hollow" ng-click="call(macro)"
+                            data-test-id="macro-item" translate>{{ macro.label }}</button>
                     </li>
                 </ul>
             </div>
@@ -32,7 +35,8 @@
             ng-click="setGroupStatus('miscellaneous')" data-open="{{getGroupStatus('miscellaneous')}}">
             <ul class="link-list" sd-loading="loading">
                 <li ng-repeat="macro in miscMacros | orderBy:'label'">
-                    <button class="btn btn--hollow" ng-click="call(macro)" translate>{{ macro.label }}</button>
+                    <button class="btn btn--hollow" ng-click="call(macro)"
+                        data-test-id="macro-item" translate>{{ macro.label }}</button>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
### Purpose
Automates the following QA case(s) as Playwright coverage with per-test `confluence` annotations:
- [Validate For Publish](https://sofab.atlassian.net/wiki/spaces/SET/pages/1332117823)

Annotation levels: 1332117823: complete. Partial levels carry named blockers in the spec header.

### What has changed
- Spec file(s): `validate-for-publish-macro.spec.ts`
- data-test-id product additions where listed in the spec header (needs developer eyes)

### Steps to test
**Given**
1. The `main` database snapshot is restored, so Sports / Working Stage holds `test sports story`, and every article carries the `Story` content profile, which caps `slugline` at 24 characters.
2. The backend exposes the server-side `Validate for Publish` macro (`superdesk/macros/validate_for_publish.py`), which re-reads the item from `archive` and runs the same `validate` service the publish action runs.
3. The article is opened for editing from Monitoring in authoring-angular.

**When**
1. (error path) The slugline is replaced with a value longer than the profile limit, the article is saved from the topbar, the `Macros` widget is opened and `Validate for Publish` is clicked; the resulting toast is then dismissed and a real publish is attempted from the send/publish pane.
2. (pass path) The `Macros` widget is opened on the unmodified article and `Validate for Publish` is clicked.

**Then**
- The macro reports the validation error as an error notification reading `SLUGLINE is too long`.
- Attempting to publish the same article raises the identical message, confirming the macro surfaces exactly the errors publishing would.
- Authoring stays open after the publish attempt, so the errors did block the publish.
- On the unmodified article the macro's `POST /api/macros` answers with a success status, the Macros widget closes itself, and no error notification is raised.

Run it: `cd e2e/client && npx playwright test validate-for-publish-macro.spec.ts --workers=1`
Passed 3 consecutive local runs with no changes between them; the impartial review returned zero findings.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works
