### PR TITLE
[SDESK-7988] - Firefox: Disconnected from Notification server message blinks every time after items are exported

### DIFF
--- a/e2e/client/playwright/export.spec.ts
+++ b/e2e/client/playwright/export.spec.ts
@@ -1,0 +1,36 @@
+import {test, expect} from '@playwright/test';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+
+test('exporting selected items produces a downloadable file and closes the modal', async ({page}) => {
+    const monitoring = new Monitoring(page);
+
+    await restoreDatabaseSnapshot();
+    await page.goto('/#/workspace/monitoring');
+    await monitoring.selectDeskOrWorkspace('Sports');
+
+    await monitoring.executeBulkAction('Export', ['test sports story', 'story 2']);
+
+    const exportResponse = page.waitForResponse(
+        (r) => r.url().includes('/api/export') && r.request().method() === 'POST',
+    );
+
+    await monitoring.confirmExport();
+
+    const response = await exportResponse;
+
+    expect(response.status()).toBe(201);
+
+    const {url} = await response.json();
+
+    expect(url).toBeTruthy();
+
+    // The app downloads from a browser context; verify the artifact directly via
+    // an API request, which is not subject to the client<->server CORS boundary.
+    const file = await page.request.get(url);
+
+    expect(file.status()).toBe(200);
+    expect(file.headers()['content-disposition'] ?? '').toContain('attachment');
+
+    await expect(page.getByTestId('export-confirm')).not.toBeVisible();
+});

--- a/e2e/client/playwright/page-object-models/monitoring.ts
+++ b/e2e/client/playwright/page-object-models/monitoring.ts
@@ -114,6 +114,16 @@ export class Monitoring {
         await this.page.locator(s('multi-action-bar', 'multi-actions-inline', action)).click();
     }
 
+    async confirmExport(): Promise<void> {
+        // sd-modal moves the visible dialog out of its [sd-modal] host, so the
+        // host stays hidden; drive the dialog's own controls instead.
+        const confirm = this.page.getByTestId('export-confirm');
+
+        await expect(confirm).toBeVisible();
+        await this.page.getByTestId('export-formatter').selectOption({index: 0});
+        await confirm.click();
+    }
+
     async createArticleFromTemplate(template: string, options?: {slugline?:string, body_html?: string}): Promise<void> {
         await this.page.locator(s('content-create')).click();
         await this.page.locator(s('content-create-dropdown')).getByRole('button', {name: 'More Templates...'}).click();

--- a/scripts/apps/archive/directives/Export.ts
+++ b/scripts/apps/archive/directives/Export.ts
@@ -76,24 +76,57 @@ class LinkFunction {
         return this.api.save('export', {}, {item_ids: itemIdList, format_type: formatter.name, validate: validate})
             .then((item) => {
                 this.scope.failures = item.failures;
-                // Click the url to triger download of file
                 if (item.url) {
-                    let elem = $('#exportDownloadLink');
-
-                    if (elem[0]) {
-                        elem[0].href = item.url;
-                        elem[0].click();
-                    }
-
-                    if (this.scope.failures === 0) {
-                        this.scope.closeExport();
-                    }
+                    return this.downloadFile(item.url).then(() => {
+                        if (this.scope.failures === 0) {
+                            this.scope.closeExport();
+                        }
+                    });
                 }
             }, (error) => {
                 this.onError(error.data._message);
             })
             .finally(() => {
                 this.scope.loading = false;
+            });
+    }
+
+    /**
+     * @ngdoc method
+     * @name sdExport#downloadFile
+     * @private
+     * @param {string} url - url of the exported file
+     * @description Downloads the file as a blob to avoid a top-level navigation,
+     * which in Firefox tears down the notification websocket. Falls back to a
+     * direct link click if the file can't be fetched (e.g. cross-origin in dev).
+     * @return {Promise}
+     */
+    downloadFile(url) {
+        return fetch(url)
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error('Export download failed');
+                }
+                return response.blob();
+            })
+            .then((blob) => {
+                const objectUrl = window.URL.createObjectURL(blob);
+                const elem = document.createElement('a');
+
+                elem.href = objectUrl;
+                elem.download = 'export.zip';
+                document.body.appendChild(elem);
+                elem.click();
+                document.body.removeChild(elem);
+                window.URL.revokeObjectURL(objectUrl);
+            })
+            .catch(() => {
+                const elem = $('#exportDownloadLink');
+
+                if (elem[0]) {
+                    elem[0].href = url;
+                    elem[0].click();
+                }
             });
     }
 

--- a/scripts/apps/archive/views/export.html
+++ b/scripts/apps/archive/views/export.html
@@ -8,7 +8,7 @@
         <div class="form__row">
             <div class="sd-line-input sd-line-input--is-select">
                 <label class="sd-line-input__label">{{ :: 'Formatters' | translate }}</label>
-                <select selected="selectedFormatter" ng-model="selectedFormatter" class="sd-line-input__select">
+                <select selected="selectedFormatter" ng-model="selectedFormatter" class="sd-line-input__select" data-test-id="export-formatter">
                     <option value="{{formatter}}" ng-repeat="formatter in exportFormatters">{{:: formatter.name}}</option>
                 </select>
             </div>
@@ -29,7 +29,7 @@
         </div>
     </div>
     <div class="modal__footer">
-        <button class="btn btn--primary btn--pull-right" ng-disabled="!exportFormatters.length > 0" ng-click="exportFile(selectedFormatter, validate)" translate>Export</button>
+        <button class="btn btn--primary btn--pull-right" ng-disabled="!exportFormatters.length > 0" ng-click="exportFile(selectedFormatter, validate)" data-test-id="export-confirm" translate>Export</button>
         <button class="btn" ng-click="cancel()" translate>Cancel</button>
     </div>
 </div>


### PR DESCRIPTION
### Purpose
In Firefox, exporting items flashed a "Disconnected from Notification Server!" warning on every export. Clicking the export download link navigated the top-level document, which made Firefox tear down the notification websocket (reconnecting ~5s later). Chrome was unaffected.

### What has changed
- Export now downloads via a fetched blob URL instead of pointing an anchor at the export URL and clicking it, avoiding the top-level navigation. Falls back to the direct link if the fetch fails.
- Added a Playwright e2e regression test for the export → download flow.

### How to test
- Firefox: Monitoring / Global search → select a few items → Export → pick a formatter → confirm. The file downloads and no "Disconnected from Notification Server" warning appears. 

Resolves: https://sofab.atlassian.net/browse/SDESK-7988
