### PR TITLE
Match authoring-react field and panel styling to authoring-angular

### DIFF
--- a/e2e/client/playwright/authoring-field-styling.authoring-react.spec.ts
+++ b/e2e/client/playwright/authoring-field-styling.authoring-react.spec.ts
@@ -1,0 +1,470 @@
+import {test, expect, Locator, Page} from '@playwright/test';
+import {Authoring} from './page-object-models/authoring';
+import {Monitoring} from './page-object-models/monitoring';
+import {restoreDatabaseSnapshot} from './utils';
+import {getStorageState} from './utils/storage-state';
+
+test.use({
+    storageState: getStorageState({}, {authoringReact: true}),
+});
+
+const PANEL_BG = 'rgb(243, 245, 246)'; // --sd-colour-panel-bg--100
+const INTERACTIVE_ACTIVE = 'rgb(51, 122, 153)'; // --sd-colour-interactive--active
+const SUBNAV_BG = 'rgb(232, 234, 237)'; // --sd-colour-panel-bg--200
+
+async function openFromSports(
+    page: Page,
+    options: {group: string, item: string, action: string},
+): Promise<void> {
+    const monitoring = new Monitoring(page);
+    const authoring = new Authoring(page);
+
+    await page.goto('/#/workspace/monitoring');
+    await monitoring.waitUntilReady();
+    await monitoring.selectDeskOrWorkspace('Sports');
+    await monitoring.executeActionOnMonitoringItem(
+        page.getByTestId('monitoring-group')
+            .and(page.locator(`[data-test-value="${options.group}"]`))
+            .getByTestId('article-item')
+            .filter({hasText: options.item}),
+        options.action,
+    );
+    await authoring.waitForAuthoringReactToInitialize();
+}
+
+function openTestSportsStory(page: Page): Promise<void> {
+    return openFromSports(page, {
+        group: 'Sports / Working Stage',
+        item: 'test sports story',
+        action: 'Edit',
+    });
+}
+
+function field(page: Page, fieldId: string): Locator {
+    return page.getByTestId('authoring-field').and(page.locator(`[data-test-value="${fieldId}"]`));
+}
+
+function labelStyle(label: Locator, property: string): Promise<string> {
+    return label.evaluate(
+        (el, prop) => window.getComputedStyle(el).getPropertyValue(prop),
+        property,
+    );
+}
+
+test.describe('authoring-react field styling', () => {
+    test('lays a header field label out in a column to the left of its input', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await openTestSportsStory(page);
+
+        const slugline = field(page, 'slugline');
+        const label = slugline.getByTestId('authoring-field-label');
+        const input = slugline.getByTestId('authoring-field-input');
+
+        await expect(label).toBeVisible();
+
+        const labelBox = (await label.boundingBox())!;
+        const inputBox = (await input.boundingBox())!;
+
+        expect(labelBox.y).toBe(inputBox.y);
+        expect(labelBox.x + labelBox.width).toBe(inputBox.x);
+
+        // authoring-angular's `.authoring-header__item-label` column
+        expect(labelBox.width).toBe(90);
+        expect(await labelStyle(label, 'text-align')).toBe('end');
+        expect(await labelStyle(label, 'text-transform')).toBe('uppercase');
+    });
+
+    test('keeps a body field label above its input', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await openTestSportsStory(page);
+
+        const headline = field(page, 'headline');
+        const label = headline.getByTestId('authoring-field-label');
+
+        await expect(label).toBeVisible();
+
+        const labelBox = (await label.boundingBox())!;
+        const editorBox = (await headline.locator('[contenteditable]').first().boundingBox())!;
+
+        expect(labelBox.y + labelBox.height).toBeLessThanOrEqual(editorBox.y);
+    });
+
+    test('shows the item type icon to the left of the profile selector', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await openTestSportsStory(page);
+
+        const icon = page.getByTestId('item-type-icon');
+
+        await expect(icon).toBeVisible();
+        await expect(icon).toHaveAttribute('data-test-value', 'text');
+        await expect(icon).toHaveClass('filetype-icon-text');
+
+        const iconBox = (await icon.boundingBox())!;
+        const profileBox = (await page.getByTestId('content-profile-select').boundingBox())!;
+
+        expect(iconBox.x).toBeLessThan(profileBox.x);
+    });
+
+    test('greys a body field label, darkens it on hover and turns it blue on focus', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await openTestSportsStory(page);
+
+        const headline = field(page, 'headline');
+        const label = headline.getByTestId('authoring-field-label');
+
+        await expect(label).toBeVisible();
+
+        // the label transitions between states, so every reading has to be polled
+
+        // the pointer starts over the monitoring list, outside the article body
+        await expect.poll(() => labelStyle(label, 'opacity')).toBe('0.4');
+
+        await headline.hover();
+        await expect.poll(() => labelStyle(label, 'opacity')).toBe('1');
+        await expect.poll(() => labelStyle(label, 'background-color')).toBe('rgba(0, 0, 0, 0.4)');
+
+        await headline.locator('[contenteditable]').first().click();
+
+        // the click leaves the pointer on the field, so move it off to prove the blue is focus
+        await page.mouse.move(5, 5);
+
+        await expect.poll(() => labelStyle(label, 'background-color')).toBe(INTERACTIVE_ACTIVE);
+        await expect.poll(() => labelStyle(label, 'opacity')).toBe('1');
+
+        // a field that is neither hovered nor focused stays grey
+        const bylineLabel = field(page, 'byline').getByTestId('authoring-field-label');
+
+        await expect.poll(() => labelStyle(bylineLabel, 'opacity')).toBe('0.4');
+    });
+
+    /**
+     * Every side widget paints its body rather than its panel, which is what keeps the header
+     * white. Read off the panel in one go: `PanelContentBlock` takes no test id.
+     */
+    for (const widgetId of ['related-item', 'comments', 'suggestions', 'versioning']) {
+        test(`paints the ${widgetId} widget body and leaves its header white`, async ({page}) => {
+            await restoreDatabaseSnapshot();
+            await openTestSportsStory(page);
+
+            await page.getByTestId('widget-icon').and(page.locator(`[data-test-value="${widgetId}"]`)).click();
+
+            const panel = page.getByTestId('authoring-widget-panel').first();
+
+            await expect(panel).toBeVisible();
+
+            const styles = await panel.evaluate((el) => {
+                const read = (selector: string) => {
+                    const target = el.querySelector(selector);
+
+                    if (target == null) {
+                        return null;
+                    }
+
+                    const computed = window.getComputedStyle(target);
+
+                    return {background: computed.backgroundColor, padding: computed.padding};
+                };
+
+                return {header: read('.side-panel__header'), body: read('.side-panel__content-block')};
+            });
+
+            expect(styles.header?.background).toBe('rgb(255, 255, 255)');
+            expect(styles.body?.background).toBe(PANEL_BG);
+            expect(styles.body?.padding).toBe('16px');
+        });
+    }
+});
+
+/**
+ * The header collapse. authoring-angular runs a 150ms linear height slide from `slideUpDown`
+ * (core/ui/slide-up-down.ts); the ui-framework transitions a `max-height` ceiling instead, which is
+ * why this asserts the property as well as the timing.
+ */
+test.describe('authoring-react header collapse', () => {
+    function header(page: Page): Locator {
+        return page.locator('.sd-editor-content__authoring-header');
+    }
+
+    function holder(page: Page): Locator {
+        return page.locator('.sd-editor-content__authoring-header > .authoring-header__holder');
+    }
+
+    test('slides the header on the row track over the same 150ms linear as angular', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await openTestSportsStory(page);
+
+        const transition = await header(page).evaluate((el) => {
+            const computed = window.getComputedStyle(el);
+
+            return {
+                property: computed.transitionProperty,
+                duration: computed.transitionDuration,
+                timing: computed.transitionTimingFunction,
+            };
+        });
+
+        expect(transition.property.split(', ')).toContain('grid-template-rows');
+        expect(new Set(transition.duration.split(', '))).toEqual(new Set(['0.15s']));
+        expect(new Set(transition.timing.split(', '))).toEqual(new Set(['linear']));
+
+        // the declared transition proves the intent; this proves one actually runs on collapse
+        const running = await header(page).evaluate((el) => {
+            (el.querySelector('.authoring-header__toggle') as HTMLElement).click();
+
+            return el.getAnimations().map((animation) => ({
+                property: (animation as CSSTransition).transitionProperty,
+                duration: animation.effect?.getTiming().duration ?? null,
+            }));
+        });
+
+        expect(running).toContainEqual({property: 'grid-template-rows', duration: 150});
+    });
+
+    test('collapses the header to nothing and restores it', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await openTestSportsStory(page);
+
+        const expandedHeight = (await header(page).boundingBox())!.height;
+
+        expect(expandedHeight).toBeGreaterThan(100);
+
+        await page.locator('.sd-editor-content__authoring-header .authoring-header__toggle').click();
+        await expect.poll(async () => (await header(page).boundingBox())!.height).toBe(0);
+
+        await page.locator('.sd-editor-content__authoring-header .authoring-header__toggle').click();
+        await expect.poll(async () => (await header(page).boundingBox())!.height).toBe(expandedHeight);
+    });
+
+    test('clips the header while collapsed and releases it once expanded', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await openTestSportsStory(page);
+
+        const overflow = () => holder(page).evaluate((el) => window.getComputedStyle(el).overflow);
+
+        // header fields open their dropdowns inline, so anything but `visible` here clips them
+        await expect.poll(overflow).toBe('visible');
+
+        await page.locator('.sd-editor-content__authoring-header .authoring-header__toggle').click();
+        await expect.poll(overflow).toBe('hidden');
+
+        await page.locator('.sd-editor-content__authoring-header .authoring-header__toggle').click();
+        await expect.poll(overflow).toBe('visible');
+    });
+});
+
+test.describe('authoring-react item state badge', () => {
+    test('shows the state badge to the left of the created and modified info', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await openTestSportsStory(page);
+
+        const badge = page.getByTestId('authoring-item-state');
+
+        await expect(badge).toBeVisible();
+        await expect(badge).toHaveText('In Progress');
+
+        const badgeBox = (await badge.boundingBox())!;
+        const created = page.getByTestId('authoring-toolbar-1').filter({hasText: 'Created'}).getByText('Created');
+        const createdBox = (await created.boundingBox())!;
+
+        expect(badgeBox.x + badgeBox.width).toBeLessThanOrEqual(createdBox.x);
+    });
+
+    test('reads the badge from the item state, not a fixed label', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await openFromSports(page, {group: 'Sports desk output', item: 'Story 5', action: 'Open'});
+
+        await expect(page.getByTestId('authoring-item-state')).toHaveText('Published');
+    });
+});
+
+/**
+ * `sd-width` is a basis in authoring-angular (`[sd-width="quarter"] {flex-basis: 25%}` in
+ * styles/sass/mixins.scss), on an item that grows, so a short row is filled by the fields on it.
+ */
+test.describe('authoring-react field row widths', () => {
+    test('fills a header row that the configured widths leave short', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await openTestSportsStory(page);
+
+        // priority and urgency are configured `quarter`, so their bases cover only half the row
+        const priority = (await field(page, 'priority').boundingBox())!;
+        const urgency = (await field(page, 'urgency').boundingBox())!;
+        const wholeRow = (await field(page, 'slugline').boundingBox())!;
+
+        expect(priority.width).toBe(urgency.width);
+        expect(priority.x).toBe(wholeRow.x);
+        expect(Math.round(urgency.x + urgency.width)).toBe(Math.round(wholeRow.x + wholeRow.width));
+    });
+
+    test('leaves a full-width field and an already full row at their configured widths', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await openTestSportsStory(page);
+
+        const slugline = (await field(page, 'slugline').boundingBox())!;
+        const categories = (await field(page, 'anpa_category').boundingBox())!;
+        const genre = (await field(page, 'genre').boundingBox())!;
+        const place = (await field(page, 'place').boundingBox())!;
+
+        expect(categories.width).toBe(slugline.width);
+        expect(genre.width).toBe(place.width);
+        expect(genre.width).toBeLessThan(slugline.width);
+        expect(Math.round(place.x + place.width)).toBe(Math.round(slugline.x + slugline.width));
+    });
+
+    /**
+     * The packages profile is built in code and sets no width on its fields, so it is the reachable
+     * case for the missing fallback.
+     */
+    test('gives a field with no configured width the whole row', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await openFromSports(page, {
+            group: 'Sports / Working Stage',
+            item: 'Package Highlight 1',
+            action: 'Edit',
+        });
+
+        const headline = field(page, 'headline');
+
+        await expect(headline).toBeVisible();
+
+        const box = (await headline.boundingBox())!;
+        const rowWidth = await headline.evaluate(
+            (el) => (el.parentElement!.parentElement as HTMLElement).getBoundingClientRect().width,
+        );
+
+        expect(Math.round(box.width)).toBe(Math.round(rowWidth));
+    });
+});
+
+test.describe('authoring-react top bar', () => {
+    const topBar = '.sd-editor-grid__editor-subnav';
+
+    test('paints the top bar without repainting the bar below it', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await openTestSportsStory(page);
+
+        const bar = await page.locator(topBar).evaluate((el) => {
+            const computed = window.getComputedStyle(el);
+            // the framework's own subnav carries `--sd-shadow__subnav`, which is the seam
+            // authoring-angular draws, so compare against it rather than a resolved colour triple
+            const reference = window.getComputedStyle(document.querySelector('.subnav--light')!);
+
+            return {
+                background: computed.backgroundColor,
+                borderBottomWidth: computed.borderBottomWidth,
+                borderBottomStyle: computed.borderBottomStyle,
+                boxShadow: computed.boxShadow,
+                referenceShadow: reference.boxShadow,
+                position: computed.position,
+                zIndex: Number(computed.zIndex),
+                referenceZIndex: Number(reference.zIndex),
+            };
+        });
+
+        expect(bar.background).toBe(SUBNAV_BG);
+
+        // neither implementation uses a border here; the seam is a shadow
+        expect(bar.borderBottomWidth).toBe('0px');
+        expect(bar.borderBottomStyle).toBe('none');
+        expect(bar.boxShadow).not.toBe('none');
+        expect(bar.boxShadow).toBe(bar.referenceShadow);
+
+        // the bar below is opaque and positioned, so the shadow only shows while the top bar
+        // outranks it
+        expect(bar.position).not.toBe('static');
+        expect(bar.zIndex).toBeGreaterThan(bar.referenceZIndex);
+
+        // the created/modified bar keeps its own lighter background
+        const secondary = await page.getByTestId('authoring-item-state').evaluate(
+            (el) => window.getComputedStyle(el.closest('.subnav')!).backgroundColor,
+        );
+
+        expect(secondary).not.toBe(SUBNAV_BG);
+    });
+
+    /**
+     * authoring-angular swaps the close label for an icon once the top bar drops below 880px, via
+     * the `sd-media-query` directive on the bar itself. Both viewports here are far from that edge:
+     * the bar measures 691px at 1280 and 968px at 2200.
+     */
+    test('swaps the close label for an icon when the top bar gets narrow', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await page.setViewportSize({width: 1280, height: 800});
+        await openTestSportsStory(page);
+
+        // the opened-articles bar at the bottom carries `close` buttons too
+        const close = page.getByTestId('authoring').getByTestId('close');
+        const icon = close.locator('[class*="icon-close-small"]');
+
+        await expect(close).toBeVisible();
+        await expect(icon).toBeVisible();
+        await expect(close).toHaveText('');
+
+        // square and hollow like angular's, and level with the save button beside it
+        const shape = await close.evaluate((el) => {
+            const button = el.querySelector('button')!;
+            const save = Array.from(el.closest('div')!.parentElement!.querySelectorAll('button'))
+                .find((b) => (b.textContent ?? '').trim().toLowerCase() === 'save');
+            const rect = button.getBoundingClientRect();
+            const saveRect = save?.getBoundingClientRect();
+
+            return {
+                borderRadius: window.getComputedStyle(button).borderRadius,
+                height: Math.round(rect.height),
+                centerY: Math.round(rect.y + rect.height / 2),
+                saveCenterY: saveRect == null ? null : Math.round(saveRect.y + saveRect.height / 2),
+            };
+        });
+
+        expect(shape.borderRadius).toBe('3px');
+        expect(shape.height).toBe(32);
+        expect(shape.centerY).toBe(shape.saveCenterY);
+
+        await page.setViewportSize({width: 2200, height: 800});
+
+        await expect(close).toHaveText('Close');
+        await expect(icon).toHaveCount(0);
+
+        // it tracks the bar rather than rendering once, so it swaps back
+        await page.setViewportSize({width: 1280, height: 800});
+
+        await expect(icon).toBeVisible();
+        await expect(close).toHaveText('');
+    });
+});
+
+/**
+ * The shadow down the article column's left edge is not declared on the column. It is the monitoring
+ * pane's own right-hand shadow falling across it, which is how authoring-angular gets the same edge,
+ * so what has to hold is the painting order between the two.
+ */
+test.describe('authoring-react column edge', () => {
+    test('keeps the authoring root under the pane that casts the column shadow', async ({page}) => {
+        await restoreDatabaseSnapshot();
+        await openTestSportsStory(page);
+
+        const order = await page.evaluate(() => {
+            const root = document.querySelector('.sd-authoring-react')!;
+            const columnLeft = root.getBoundingClientRect().left;
+            const pane = Array.from(document.querySelectorAll('*')).find((el) => {
+                const computed = window.getComputedStyle(el);
+                const rect = el.getBoundingClientRect();
+
+                return computed.boxShadow !== 'none'
+                    && rect.height > 400
+                    && Math.abs(rect.right - columnLeft) < 2;
+            });
+
+            return {
+                rootZIndex: Number(window.getComputedStyle(root).zIndex),
+                paneZIndex: pane == null ? null : Number(window.getComputedStyle(pane).zIndex),
+                paneShadow: pane == null ? null : window.getComputedStyle(pane).boxShadow,
+            };
+        });
+
+        // a blurred shadow off the pane's right edge is what reaches the column
+        expect(order.paneShadow).toContain('10px');
+        expect(order.paneZIndex).not.toBeNull();
+        expect(order.rootZIndex).toBeLessThan(order.paneZIndex!);
+    });
+});

--- a/scripts/apps/authoring-react/article-widgets/demo-widget.tsx
+++ b/scripts/apps/authoring-react/article-widgets/demo-widget.tsx
@@ -14,6 +14,7 @@ class DemoWidget extends React.PureComponent<IArticleSideWidgetComponentType> {
     render() {
         return (
             <AuthoringWidgetLayout
+                bodyClassName="authoring-widget__body"
                 header={(
                     <AuthoringWidgetHeading
                         widgetId={DEMO_WIDGET_ID}

--- a/scripts/apps/authoring-react/article-widgets/find-and-replace.tsx
+++ b/scripts/apps/authoring-react/article-widgets/find-and-replace.tsx
@@ -64,6 +64,7 @@ class FindAndReplaceWidget extends React.PureComponent<IArticleSideWidgetCompone
     render() {
         return (
             <AuthoringWidgetLayout
+                bodyClassName="authoring-widget__body"
                 header={(
                     <AuthoringWidgetHeading
                         widgetId={FIND_AND_REPLACE_WIDGET_ID}

--- a/scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx
+++ b/scripts/apps/authoring-react/article-widgets/metadata/metadata.tsx
@@ -93,6 +93,7 @@ class MetadataWidget extends React.PureComponent<IArticleSideWidgetComponentType
 
         return (
             <AuthoringWidgetLayout
+                bodyClassName="authoring-widget__body"
                 header={(
                     <AuthoringWidgetHeading
                         widgetId={METADATA_WIDGET_ID}

--- a/scripts/apps/authoring-react/article-widgets/related-items/related-items.tsx
+++ b/scripts/apps/authoring-react/article-widgets/related-items/related-items.tsx
@@ -370,9 +370,7 @@ export class RelatedItemsWidget
 
         return (
             <AuthoringWidgetLayout
-                // the list sits on its own background, which the body paints rather than the panel,
-                // whose own would take the header with it
-                bodyClassName="related-items-widget__body"
+                bodyClassName="authoring-widget__body"
                 header={(
                     <AuthoringWidgetHeading
                         widgetId={RELATED_ITEMS_WIDGET_ID}

--- a/scripts/apps/authoring-react/article-widgets/suggestions.tsx
+++ b/scripts/apps/authoring-react/article-widgets/suggestions.tsx
@@ -212,6 +212,7 @@ class SuggestionsWidget extends React.PureComponent<IArticleSideWidgetComponentT
 
         return (
             <AuthoringWidgetLayout
+                bodyClassName="authoring-widget__body"
                 header={(
                     <AuthoringWidgetHeading
                         widgetId={SUGGESTIONS_WIDGET_ID}
@@ -220,7 +221,6 @@ class SuggestionsWidget extends React.PureComponent<IArticleSideWidgetComponentT
                     />
                 )}
                 body={widgetBody}
-                background="grey"
             />
         );
     }

--- a/scripts/apps/authoring-react/article-widgets/translations/translations.tsx
+++ b/scripts/apps/authoring-react/article-widgets/translations/translations.tsx
@@ -18,6 +18,7 @@ class Translations extends React.Component<IArticleSideWidgetComponentType> {
     render() {
         return (
             <AuthoringWidgetLayout
+                bodyClassName="authoring-widget__body"
                 header={(
                     <AuthoringWidgetHeading
                         widgetId={TRANSLATIONS_WIDGET_ID}

--- a/scripts/apps/authoring-react/article-widgets/versions-and-item-history/index.tsx
+++ b/scripts/apps/authoring-react/article-widgets/versions-and-item-history/index.tsx
@@ -29,6 +29,7 @@ class VersionsAndItemHistoryWidget extends React.PureComponent<IArticleSideWidge
     render() {
         return (
             <AuthoringWidgetLayout
+                bodyClassName="authoring-widget__body"
                 header={(
                     <AuthoringWidgetHeading
                         widgetId={VERSIONS_AND_HISTORY_WIDGET_ID}
@@ -61,7 +62,6 @@ class VersionsAndItemHistoryWidget extends React.PureComponent<IArticleSideWidge
                         assertNever(this.state.selectedTab);
                     }
                 })()}
-                background="grey"
             />
         );
     }

--- a/scripts/apps/authoring-react/authoring-integration-wrapper.tsx
+++ b/scripts/apps/authoring-react/authoring-integration-wrapper.tsx
@@ -62,6 +62,7 @@ import {
     ToggleThemeButton,
     ConfigureThemeButton,
     CreatedModifiedInfoWidget,
+    ItemStateWidget,
     ContentProfileDropdownWidget,
     HeaderGeneralInfoWidget,
 } from './toolbar-components/integration-wrapper';
@@ -128,6 +129,12 @@ function getAuthoringCosmeticActions(exposed: IExposedFromAuthoring<IArticle>): 
 }
 
 const secondaryToolbarWidgetsStable: Array<ITopBarWidget<IArticle>> = [
+    {
+        availableOffline: true,
+        component: ItemStateWidget,
+        group: 'start',
+        priority: 0,
+    },
     {
         availableOffline: true,
         component: CreatedModifiedInfoWidget,

--- a/scripts/apps/authoring-react/authoring-react.scss
+++ b/scripts/apps/authoring-react/authoring-react.scss
@@ -5,7 +5,11 @@
     width: 100%;
     height: calc(100% - #{$nav-height} - #{$authoring-opened-articles});
     overflow-y: auto;
-    z-index: 100;
+
+    // Under the monitoring pane (z-index 100) so the shadow off its right edge falls across this
+    // column, which is where authoring-angular's edge comes from (`main-section` sits at 1 there).
+    // Still above the angular authoring view underneath, which carries no z-index of its own.
+    z-index: 1;
     background: $white;
 }
 
@@ -74,13 +78,104 @@
     @include text-semibold();
 }
 
-// Authoring-angular renders the related items on a coloured holder that fills the panel, and
-// insets the cards by less than the panel default.
+// Authoring-angular colours the widget body rather than the panel, which leaves the header white,
+// and insets the content by less than the panel default.
 // The panel's own padding rule is `.side-panel .side-panel__content-block--padding-3`, so this
 // has to carry one class more to win.
-.side-panel .side-panel__content-block.related-items-widget__body {
+.side-panel .side-panel__content-block.authoring-widget__body {
     background: var(--sd-colour-panel-bg--100);
     padding: 16px;
-    block-size: 100%;
+    min-block-size: 100%;
     box-sizing: border-box;
+}
+
+// Header fields put the label in a fixed column to the left of the input, as authoring-angular
+// does. Angular's own `.authoring-header__item` is not reused: it carries that view's row padding,
+// which would stack on the gaps `AuthoringSection` already sets.
+.authoring-header-field {
+    display: flex;
+    align-items: flex-start;
+
+    .authoring-header__item-label {
+        gap: var(--gap-0-5);
+    }
+
+    // `.authoring-header__item-label` is compiled after the framework's `.form-label--invalid` and
+    // has the same specificity, so the invalid colour has to be restated to survive.
+    .authoring-header__item-label.form-label--invalid {
+        color: var(--sd-colour-alert);
+    }
+}
+
+// Content field labels follow authoring-angular (`.main-article` in authoring/styles/themes.scss):
+// grey by default, darker while the pointer is anywhere over the article body, blue on the field
+// that has focus.
+.authoring-section {
+    .field-label--base {
+        opacity: 0.4;
+    }
+
+    &:hover .field-label--base {
+        opacity: 1;
+    }
+
+    .authoring-section__field:focus-within .field-label--base {
+        background: var(--sd-colour-interactive--active);
+        opacity: 1;
+    }
+}
+
+// The ui-framework collapses the header by transitioning `max-height` between a 1400px ceiling and
+// 0 over 120ms ease-in. The header is only about 400px tall, so nearly the whole transition is
+// spent above its real height: collapsing lands in a single frame and expanding is over in ~60ms.
+// Transition the grid row instead, which tracks the real height, over the same 150ms linear slide
+// authoring-angular runs (`slideUpDown` in core/ui/slide-up-down.ts).
+$authoring-header-collapse-duration: 150ms;
+
+.sd-editor-content__authoring-header.sd-editor-content__authoring-header--collapsible {
+    display: grid;
+    grid-template-rows: 1fr;
+    max-height: none;
+    transition:
+        grid-template-rows $authoring-header-collapse-duration linear,
+        padding-block-start $authoring-header-collapse-duration linear,
+        padding-block-end $authoring-header-collapse-duration linear;
+
+    > .authoring-header__holder {
+        height: auto;
+        min-height: 0;
+
+        // Header fields open their dropdowns inline, so the holder may only clip while the slide is
+        // running. `overflow` is a discrete property: the zero-length transition flips it in one
+        // step, and the delay puts that step at the end of the slide.
+        overflow: visible;
+        transition:
+            overflow 0s $authoring-header-collapse-duration allow-discrete,
+            opacity 0.4s 0.1s;
+    }
+
+    &.authoring-header--collapsed {
+        grid-template-rows: 0fr;
+        max-height: none;
+
+        > .authoring-header__holder {
+            height: auto;
+            overflow: hidden;
+            transition: opacity 0.4s 0.1s;
+        }
+    }
+}
+
+// The framework leaves the top bar slot transparent and flat. authoring-angular paints the same bar
+// and casts the seam under it (`.subnav--authoring` and `.subnav` in styles/sass/navs.scss).
+//
+// The bar has to be lifted for the shadow to show at all. It is a static grid item, so it paints
+// below every positioned box: the grid slot beneath it is `position: relative` and opaque, and so
+// are that slot's toolbar (z-index 3) and secondary subnav (z-index 5). 6 clears all three and
+// stays under the side tabs rail at 11.
+.sd-editor-grid__editor-subnav {
+    background-color: var(--sd-colour-panel-bg--200);
+    box-shadow: var(--sd-shadow__subnav);
+    position: relative;
+    z-index: 6;
 }

--- a/scripts/apps/authoring-react/authoring-section/authoring-section.tsx
+++ b/scripts/apps/authoring-react/authoring-section/authoring-section.tsx
@@ -1,5 +1,11 @@
 import React, {RefObject} from 'react';
-import {IAuthoringSectionTheme, IFieldsV2, IVocabularyItem, IAuthoringValidationErrors} from 'superdesk-api';
+import {
+    IAuthoringFieldV2,
+    IAuthoringSectionTheme,
+    IFieldsV2,
+    IVocabularyItem,
+    IAuthoringValidationErrors,
+} from 'superdesk-api';
 import {Map} from 'immutable';
 import {IToggledFields} from '../authoring-react';
 import {AuthoringSectionField} from './authoring-section-field';
@@ -69,6 +75,15 @@ function groupItemsToRows<T>(items: Array<T>, getWidth: (item: T) => number) {
 }
 
 /**
+ * Percentage of the row the field asks for. A field with no configured width takes the whole row:
+ * `getContentProfile` defaults it that way too, but profiles built in code (packages, the
+ * description field on media items) leave it unset.
+ */
+function getFieldWidth(field: IAuthoringFieldV2): number {
+    return field.fieldConfig.width ?? 100;
+}
+
+/**
  * A variable is needed in order to use the same object reference
  * and allow PureComponent to skip re-renders.
  */
@@ -92,10 +107,11 @@ export class AuthoringSection<T> extends React.PureComponent<IPropsAuthoringSect
         const {toggledFields} = this.props;
         const themeApplies: boolean
             = this.props.fields.find((field) => this.props.uiTheme?.fieldTheme[field.id] != null) != null;
-        const grouped = groupItemsToRows(this.props.fields.toArray(), (field) => field.fieldConfig.width ?? 100);
+        const grouped = groupItemsToRows(this.props.fields.toArray(), getFieldWidth);
 
         return (
             <div
+                className="authoring-section"
                 style={{
                     backgroundColor: themeApplies ? this.props.uiTheme.backgroundColor : undefined,
                     display: 'flex',
@@ -112,8 +128,14 @@ export class AuthoringSection<T> extends React.PureComponent<IPropsAuthoringSect
                                     const canBeToggled = toggledFields[field.id] != null;
                                     const toggledOn = toggledFields[field.id];
 
+                                    // the configured width is a basis rather than a fixed width, so
+                                    // fields fill a row the widths leave short, as
+                                    // authoring-angular's `sd-width` does
                                     return (
-                                        <div key={field.id} style={{width: `${field.fieldConfig.width}%`}}>
+                                        <div
+                                            key={field.id}
+                                            style={{flex: `1 1 ${getFieldWidth(field)}%`}}
+                                        >
                                             <AuthoringSectionField
                                                 fieldRef={this.props.fieldRefs[field.id]}
                                                 uiTheme={themeApplies ? this.props.uiTheme : undefined}

--- a/scripts/apps/authoring-react/authoring-section/get-field-container.tsx
+++ b/scripts/apps/authoring-react/authoring-section/get-field-container.tsx
@@ -81,25 +81,24 @@ export function getFieldContainer(options: IGetFieldContainerOptions) {
             const {miniToolbar} = this.props;
 
             return (
-                <Spacer v gap="0">
+                <div className="authoring-header-field">
                     <span
+                        data-test-id="authoring-field-label"
                         className={classNames(
-                            'form-label',
+                            'authoring-header__item-label',
                             {'form-label--invalid': validationError != null},
                         )}
                     >
-                        <Spacer h gap="8" noGrow noWrap>
-                            <Spacer h gap="4" noGrow noWrap>
-                                {field.name}
-                                {field.fieldConfig.required && (
-                                    <RequiredIndicatorForHeader />
-                                )}
-                            </Spacer>
-                            <span>{toggle}</span>
-                        </Spacer>
+                        {field.name}
+                        {field.fieldConfig.required && (
+                            <RequiredIndicatorForHeader />
+                        )}
                     </span>
 
-                    <div style={{flexGrow: 1}}>
+                    <div className="authoring-header__input-holder" data-test-id="authoring-field-input">
+                        {/* the label column is a fixed width, so the toggle rides with the input */}
+                        {canBeToggled && <div>{toggle}</div>}
+
                         {this.props.children}
 
                         <Spacer h gap="8" justifyContent="end" noGrow noWrap>
@@ -116,7 +115,7 @@ export function getFieldContainer(options: IGetFieldContainerOptions) {
                             }
                         </Spacer>
                     </div>
-                </Spacer>
+                </div>
             );
         }
     }
@@ -126,7 +125,7 @@ export function getFieldContainer(options: IGetFieldContainerOptions) {
             const {miniToolbar} = this.props;
 
             return (
-                <div>
+                <div className="authoring-section__field">
                     <div
                         style={{
                             display: 'flex',
@@ -137,6 +136,7 @@ export function getFieldContainer(options: IGetFieldContainerOptions) {
                         <Spacer h gap="8" noGrow>
                             <Spacer h gap="8" noGrow noWrap>
                                 <span
+                                    data-test-id="authoring-field-label"
                                     className={classNames(
                                         'field-label--base',
                                         {'field-label--base--invalid': validationError != null},

--- a/scripts/apps/authoring-react/fields/attachments/authoring-widget.tsx
+++ b/scripts/apps/authoring-react/fields/attachments/authoring-widget.tsx
@@ -70,6 +70,7 @@ export class AuthoringAttachmentsWidget extends React.PureComponent<IArticleSide
 
         return (
             <AuthoringWidgetLayout
+                bodyClassName="authoring-widget__body"
                 header={(
                     <AuthoringWidgetHeading
                         widgetId={ATTACHMENTS_WIDGET_ID}

--- a/scripts/apps/authoring-react/generic-widgets/comments/CommentsWidget.tsx
+++ b/scripts/apps/authoring-react/generic-widgets/comments/CommentsWidget.tsx
@@ -224,6 +224,7 @@ class CommentsWidget<T> extends React.PureComponent<IProps<T>, IState> {
 
         return (
             <AuthoringWidgetLayout
+                bodyClassName="authoring-widget__body"
                 header={(
                     <AuthoringWidgetHeading
                         widgetId={COMMENTS_WIDGET_GENERIC_ID}
@@ -232,7 +233,6 @@ class CommentsWidget<T> extends React.PureComponent<IProps<T>, IState> {
                     />
                 )}
                 body={widgetBody}
-                background="grey"
                 footer={widgetFooter}
             />
         );

--- a/scripts/apps/authoring-react/generic-widgets/inline-comments.tsx
+++ b/scripts/apps/authoring-react/generic-widgets/inline-comments.tsx
@@ -220,6 +220,7 @@ export class InlineCommentsWidget<T> extends React.PureComponent<IProps<T>, ISta
 
         return (
             <AuthoringWidgetLayout
+                bodyClassName="authoring-widget__body"
                 header={(
                     <AuthoringWidgetHeading
                         widgetId={COMMENTS_WIDGET_ID}
@@ -228,7 +229,6 @@ export class InlineCommentsWidget<T> extends React.PureComponent<IProps<T>, ISta
                     />
                 )}
                 body={widgetBody}
-                background="grey"
             />
         );
     }

--- a/scripts/apps/authoring-react/macros/macros.tsx
+++ b/scripts/apps/authoring-react/macros/macros.tsx
@@ -306,6 +306,7 @@ class MacrosWidget extends React.PureComponent<IArticleSideWidgetComponentType, 
         if (this.state.macros == null) {
             return (
                 <AuthoringWidgetLayout
+                    bodyClassName="authoring-widget__body"
                     header={(
                         <AuthoringWidgetHeading
                             widgetId={MACROS_WIDGET_ID}
@@ -343,6 +344,7 @@ class MacrosWidget extends React.PureComponent<IArticleSideWidgetComponentType, 
 
         return (
             <AuthoringWidgetLayout
+                bodyClassName="authoring-widget__body"
                 header={(
                     <AuthoringWidgetHeading
                         widgetId={MACROS_WIDGET_ID}

--- a/scripts/apps/authoring-react/packages.tsx
+++ b/scripts/apps/authoring-react/packages.tsx
@@ -80,6 +80,7 @@ class PackagesWidget extends React.Component<IArticleSideWidgetComponentType, IS
 
         return (
             <AuthoringWidgetLayout
+                bodyClassName="authoring-widget__body"
                 header={(
                     <AuthoringWidgetHeading
                         widgetId={PACKAGES_WIDGET_ID}

--- a/scripts/apps/authoring-react/toolbar-components/angular-integration/close-button.tsx
+++ b/scripts/apps/authoring-react/toolbar-components/angular-integration/close-button.tsx
@@ -3,15 +3,29 @@ import {IArticle} from 'superdesk-api';
 import {Button} from 'superdesk-ui-framework/react';
 import {gettext} from 'core/utils';
 import {useInlineToolbarContext} from './inline-toolbar-context';
+import {CloseIconButtonComponent} from './close-icon-button';
+import {useCompactToolbar} from './use-compact-toolbar';
 
-export const CloseButtonComponent: React.ComponentType<{entity: IArticle}> = () => {
+/**
+ * Shows the label while the top bar has room for it and the icon once it does not, which is what
+ * authoring-angular does with the two spans inside its single close button.
+ */
+export const CloseButtonComponent: React.ComponentType<{entity: IArticle}> = ({entity}) => {
     const {exposed} = useInlineToolbarContext<IArticle>();
+    const ref = React.useRef<HTMLDivElement>(null);
+    const compact = useCompactToolbar(ref);
 
     return (
-        <Button
-            text={gettext('Close')}
-            style="hollow"
-            onClick={() => exposed?.initiateClosing()}
-        />
+        <div ref={ref} data-test-id="close">
+            {
+                compact ? <CloseIconButtonComponent entity={entity} /> : (
+                    <Button
+                        text={gettext('Close')}
+                        style="hollow"
+                        onClick={() => exposed?.initiateClosing()}
+                    />
+                )
+            }
+        </div>
     );
 };

--- a/scripts/apps/authoring-react/toolbar-components/angular-integration/close-icon-button.tsx
+++ b/scripts/apps/authoring-react/toolbar-components/angular-integration/close-icon-button.tsx
@@ -1,18 +1,24 @@
 import React from 'react';
 import {IArticle} from 'superdesk-api';
-import {IconButton} from 'superdesk-ui-framework/react';
+import {Button} from 'superdesk-ui-framework/react';
 import {gettext} from 'core/utils';
 import {useInlineToolbarContext} from './inline-toolbar-context';
 
+/**
+ * The icon-only close control. Square and hollow to sit beside the save button the way
+ * authoring-angular's `#closeAuthoringBtn` does, rather than as a round icon button.
+ */
 export const CloseIconButtonComponent: React.ComponentType<{entity: IArticle}> = () => {
     const {exposed} = useInlineToolbarContext<IArticle>();
 
     return (
-        <IconButton
-            ariaValue={gettext('Close')}
+        <Button
+            text={gettext('Close')}
             icon="close-small"
+            iconOnly
+            shape="square"
+            style="hollow"
             onClick={() => exposed?.initiateClosing()}
-            style="outline"
         />
     );
 };

--- a/scripts/apps/authoring-react/toolbar-components/angular-integration/use-compact-toolbar.ts
+++ b/scripts/apps/authoring-react/toolbar-components/angular-integration/use-compact-toolbar.ts
@@ -1,0 +1,37 @@
+import React from 'react';
+
+/**
+ * authoring-angular swaps top bar button labels for icons below this width. It is the
+ * `sd-media-query min-width="880"` on the top bar in authoring/views/authoring-topbar.html, applied
+ * by the directive in core/ui/ui.ts, which measures the bar itself rather than the viewport.
+ */
+const COMPACT_TOOLBAR_WIDTH = 880;
+
+const TOOLBAR_SELECTOR = '.sd-editor-grid__editor-subnav';
+
+/**
+ * Whether the authoring top bar the element sits in is too narrow for button labels. Tracks the bar,
+ * not the viewport: it is the article column that runs out of room, and it changes width on its own
+ * when a side panel opens or the list is collapsed.
+ */
+export function useCompactToolbar(ref: React.RefObject<HTMLElement>): boolean {
+    const [compact, setCompact] = React.useState(false);
+
+    React.useEffect(() => {
+        const toolbar = ref.current?.closest(TOOLBAR_SELECTOR);
+
+        if (toolbar == null) {
+            return;
+        }
+
+        const observer = new ResizeObserver(([entry]) => {
+            setCompact(entry.contentRect.width < COMPACT_TOOLBAR_WIDTH);
+        });
+
+        observer.observe(toolbar);
+
+        return () => observer.disconnect();
+    }, [ref]);
+
+    return compact;
+}

--- a/scripts/apps/authoring-react/toolbar-components/integration-wrapper/content-profile-dropdown-widget.tsx
+++ b/scripts/apps/authoring-react/toolbar-components/integration-wrapper/content-profile-dropdown-widget.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {IArticle} from 'superdesk-api';
+import {gettext, translateArticleType} from 'core/utils';
 import {ContentProfileDropdown} from '../../subcomponents/content-profile-dropdown';
 import {useToolbarContext} from './toolbar-context';
 
@@ -8,6 +9,15 @@ export const ContentProfileDropdownWidget: React.ComponentType<{entity: IArticle
 
     return (
         <div className="authoring-header__general-info">
+            <div>
+                <i
+                    className={`filetype-icon-${entity.type}`}
+                    title={gettext('Article Type: {{type}}', {type: translateArticleType(entity.type)})}
+                    data-test-id="item-type-icon"
+                    data-test-value={entity.type}
+                />
+            </div>
+
             <ContentProfileDropdown
                 item={entity}
                 reinitialize={(itemWithNewProfile) => {

--- a/scripts/apps/authoring-react/toolbar-components/integration-wrapper/index.ts
+++ b/scripts/apps/authoring-react/toolbar-components/integration-wrapper/index.ts
@@ -8,5 +8,6 @@ export {PrintPreviewButton} from './print-preview-button';
 export {ToggleThemeButton} from './toggle-theme-button';
 export {ConfigureThemeButton} from './configure-theme-button';
 export {CreatedModifiedInfoWidget} from './created-modified-info-widget';
+export {ItemStateWidget} from './item-state-widget';
 export {ContentProfileDropdownWidget} from './content-profile-dropdown-widget';
 export {HeaderGeneralInfoWidget} from './header-general-info-widget';

--- a/scripts/apps/authoring-react/toolbar-components/integration-wrapper/item-state-widget.tsx
+++ b/scripts/apps/authoring-react/toolbar-components/integration-wrapper/item-state-widget.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import {IArticle} from 'superdesk-api';
+import {StatusInfo} from 'apps/search/components/fields/state';
+
+export const ItemStateWidget: React.ComponentType<{entity: IArticle}> = ({entity}) => {
+    if (entity.state == null) {
+        return null;
+    }
+
+    return (
+        <span data-test-id="authoring-item-state">
+            <StatusInfo item={entity} clickable={false} />
+        </span>
+    );
+};


### PR DESCRIPTION
### Purpose

Authoring-react drifted visually from authoring-angular in a number of small ways that add up: labels in the wrong place, missing controls, colours and shadows that were never ported, and a collapse animation that only played in one direction. This closes the gap so the two views look the same.

Stacked on #5366, so review that one first.

### What has changed

**Header**
- Field labels render inline in a 90px right-aligned column, as in angular, instead of stacked above the input.
- The content profile icon is back, to the left of PROFILE.
- The item state badge ("IN PROGRESS") is back in the secondary toolbar. It was simply never registered.
- Fields now grow to fill their row. Angular treats the configured width as a `flex-basis`; react used a fixed `width`, so a row of quarter-width fields (PRIORITY, URGENCY) left half the row empty.
- The collapse animation now plays in both directions over 150ms. The framework transitions `max-height` against a 1400px ceiling on a ~400px header, so collapsing never visibly travelled.

**Body**
- Field labels are grey by default, darken on hover and turn blue on focus. React had dark labels by default and no focus colour.

**Top bar**
- Painted `--sd-colour-panel-bg--200` to match angular.
- The divider under it now renders. The shadow was missing, and the bar is a static grid item under three positioned boxes, so declaring it alone painted nothing.
- The close button swaps its label for an icon below 880px, matching angular's `sd-media-query`. It is now a square hollow button rather than a round one.

**Panels**
- Every side widget now matches the Related Items panel from #5366: white header, `--sd-colour-panel-bg--100` body, 16px inset.
- The column's left edge gets the monitoring pane's shadow back. React's authoring root sat at `z-index: 100`, the same as the pane, so its opaque background swallowed it.

**One bug found along the way**: `authoring-section.tsx` read a field's configured width in two places but defaulted it in only one, so a field without one rendered `width: "undefined%"` and collapsed to its content. A package's headline was rendering at 57% of its row and a picture's description at 61%.

### Steps to test

1. Open an article in Sports / Working Stage, with and without the `auth-react` localStorage flag, and compare the two side by side.
2. Header: labels sit inline, the profile icon is left of PROFILE, the state badge is left of "Created", and PRIORITY/URGENCY fill their row.
3. Click the chevron between header and body: it should slide both ways, not snap shut.
4. Hover the body: labels darken. Focus a field: its label turns blue.
5. Narrow the window below ~880px: the CLOSE button becomes an X.
6. Open any side widget: white header, grey body, cards inset.

### Checklist
- [x] I reviewed my code
- [x] I tested all affected functionality and made sure it works

Resolves:
