### PR TITLE
Use a plain path string for the closed-desk widget thumbnail

### DIFF
--- a/scripts/apps/dashboard/closed-desk/index.ts
+++ b/scripts/apps/dashboard/closed-desk/index.ts
@@ -157,7 +157,7 @@ export default angular.module('superdesk.apps.dashboard.closed-desk', [])
             sizey: 1,
             template: 'scripts/apps/dashboard/closed-desk/views/close-desk-widget.html',
             description: gettext('Close desk widget'),
-            thumbnail: require('./thumbnail.svg').default,
+            thumbnail: 'scripts/apps/dashboard/closed-desk/thumbnail.svg',
         });
     }])
 ;


### PR DESCRIPTION
## Summary

The closed-desk dashboard widget registered its thumbnail with
`require('./thumbnail.svg').default`. With webpack 5 the `.svg` rule is
`type: 'asset/resource'`, which returns the emitted URL as the module itself,
not under a `default` export. The expression therefore resolved to `undefined`
and the widget showed no thumbnail in the dashboard widget picker.

Every other widget in the client (user-activity, world-clock, ingest stats,
aggregate) registers its thumbnail as a plain path string, so this change
aligns the closed-desk widget with the existing convention.

## Changes

- `scripts/apps/dashboard/closed-desk/index.ts`: replace the `require(...).default`
  expression with the literal path `scripts/apps/dashboard/closed-desk/thumbnail.svg`.

## How to test

1. Open the dashboard and click **Add widget**.
2. Locate the **Close desk widget** in the list.
3. Verify the thumbnail image renders both in the widget list and in the
   detail panel when the widget is selected.

Resolves: [SDESK-7660](https://sofab.atlassian.net/browse/SDESK-7660)


[SDESK-7660]: https://sofab.atlassian.net/browse/SDESK-7660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ