### PR TITLE
Use a plain path string for the closed-desk widget thumbnail [3.6]

### DIFF
--- a/scripts/apps/dashboard/closed-desk/index.ts
+++ b/scripts/apps/dashboard/closed-desk/index.ts
@@ -157,7 +157,7 @@ export default angular.module('superdesk.apps.dashboard.closed-desk', [])
             sizey: 1,
             template: 'scripts/apps/dashboard/closed-desk/views/close-desk-widget.html',
             description: gettext('Close desk widget'),
-            thumbnail: require('./thumbnail.svg').default,
+            thumbnail: 'scripts/apps/dashboard/closed-desk/thumbnail.svg',
         });
     }])
 ;


### PR DESCRIPTION
### Purpose
Porting [#5375](https://github.com/superdesk/superdesk-client-core/pull/5375) to `release/3.6`

Resolves: [SDESK-7660](https://sofab.atlassian.net/browse/SDESK-7660)]


[SDESK-7660]: https://sofab.atlassian.net/browse/SDESK-7660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ